### PR TITLE
Documentation Improvements

### DIFF
--- a/doc/ant.html
+++ b/doc/ant.html
@@ -68,6 +68,11 @@ accepts the following attributes: <br>
 		<td>&nbsp; </td>
 	</tr>
 	<tr>
+		<td><tt>configFailurePolicy</tt> </td>
+		<td>Whether TestNG should <tt>continue</tt> to execute the remaining tests in the suite or <tt>skip</tt> them if an @Before* method fails.</td>
+		<td>No. Defaults to <tt>skip</tt></td>
+	</tr>
+	<tr>
 		<td><tt>dataProviderThreadCount</tt> </td>
 		<td>The number of threads to use for data providers
 		for this run. Ignored unless the parallel mode is also specified</td>

--- a/doc/ant.html
+++ b/doc/ant.html
@@ -210,7 +210,7 @@ accepts the following attributes: <br>
 	<tr>
 		<td><tt>testnames</tt> </td>
 		<td>A comma separated list of test names, as defined
-		in the &lt;test&gt; tag.</td> Only these tests will be run.
+		in the &lt;test&gt; tag. Only these tests will be run.</td>
 		<td>No. defaults to "Ant test"</td>
 	</tr>
 

--- a/doc/documentation-main.html
+++ b/doc/documentation-main.html
@@ -707,6 +707,13 @@ You need to specify at least one XML file describing the TestNG suite you are tr
 
     <tbody>
         <tr>
+            <td>-configfailurepolicy</td>
+	    <td><tt>skip</tt>|<tt>continue</tt></td>
+	    <td>Whether TestNG should <tt>continue</tt> to execute the remaining tests in the suite or <tt>skip</tt> them if
+            an @Before* method fails.  Default behavior is <tt>skip</tt>.</td>
+        </tr>
+
+        <tr>
             <td>-d</td>
 	    <td>A directory</td>
 	    <td>The directory where the reports will be generated (defaults to <tt>test-output</tt>).</td>


### PR DESCRIPTION
Hi folks,

I've made two small changes to the docs:
1. fixed a misplaced </td> tag that was causing some of the documentation for the ant task to appear outside the table
2. added documentation for the configfailurepolicy option

Hope this is helpful -- the latter change would have saved me a trip to the google group :)
