### PR TITLE
Fix for Issue 47

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -31,6 +31,7 @@ Fixed: ConcurrentModificationException when using parallel data providers.
 Fixed: TESTNG-282: Problem when including+excluding packages (addicted)
 Fixed: TESTNG-471: assertEquals(Map, Map) fails if a map is a subset of the other
 Fixed: JUnitReporter generates an <error> tag for successful expectedExceptions tests
+Fixed: ISSUE-47: Don't allow two <test>s with same name within same suite
 
 Eclipse:
 

--- a/src/main/java/org/testng/TestNG.java
+++ b/src/main/java/org/testng/TestNG.java
@@ -101,7 +101,7 @@ public class TestNG {
   public static final String DEFAULT_COMMAND_LINE_SUITE_NAME = "Command line suite";
 
   /** The default name for a test launched from the command line */
-  private static final String DEFAULT_COMMAND_LINE_TEST_NAME = "Command line test";
+  public static final String DEFAULT_COMMAND_LINE_TEST_NAME = "Command line test";
 
   /** The default name of the result's output directory (keep public, used by Eclipse). */
   public static final String DEFAULT_OUTPUTDIR = "test-output";
@@ -889,6 +889,37 @@ public class TestNG {
   }
 
   /**
+   * Before suites are executed, do a sanity check to ensure all required
+   * conditions are met. If not, throw an exception to stop test execution
+   *
+   * @throws TestNGException if the sanity check fails
+   */
+  private void sanityCheck()
+  {
+    checkTestNames(m_suites);
+  }
+
+  /**
+   * Ensure that two XmlTest within the same XmlSuite don't have the same name
+   */
+  private void checkTestNames(List<XmlSuite> suites)
+  {
+    for (XmlSuite suite : suites) {
+      List<String> testNames = Lists.newArrayList();
+      for (XmlTest test : suite.getTests()) {
+        if (testNames.contains(test.getName())) {
+          throw new TestNGException("Two tests in the same suite "
+              + "can not have the same name. Invalid test name: "
+              + test.getName());
+        } else {
+          testNames.add(test.getName());
+        }
+      }
+      checkTestNames(suite.getChildSuites());
+    }
+  }
+
+  /**
    * Run TestNG.
    */
   public void run() {
@@ -898,6 +929,8 @@ public class TestNG {
     initializeCommandLineSuites();
     initializeCommandLineSuitesParams();
     initializeCommandLineSuitesGroups();
+
+    sanityCheck();
 
     List<ISuite> suiteRunners = null;
 
@@ -1163,7 +1196,7 @@ public class TestNG {
    * The TestNG entry point for command line execution.
    *
    * @param argv the TestNG command line parameters.
-   * @throws FileNotFoundException 
+   * @throws FileNotFoundException
    */
   public static void main(String[] argv) {
     TestNG testng = privateMain(argv, null);

--- a/src/main/java/org/testng/TestNG.java
+++ b/src/main/java/org/testng/TestNG.java
@@ -894,18 +894,16 @@ public class TestNG {
    *
    * @throws TestNGException if the sanity check fails
    */
-  private void sanityCheck()
-  {
+  private void sanityCheck() {
     checkTestNames(m_suites);
   }
 
   /**
    * Ensure that two XmlTest within the same XmlSuite don't have the same name
    */
-  private void checkTestNames(List<XmlSuite> suites)
-  {
+  private void checkTestNames(List<XmlSuite> suites) {
     for (XmlSuite suite : suites) {
-      List<String> testNames = Lists.newArrayList();
+      Set<String> testNames = Sets.newHashSet();
       for (XmlTest test : suite.getTests()) {
         if (testNames.contains(test.getName())) {
           throw new TestNGException("Two tests in the same suite "

--- a/src/main/java/org/testng/xml/XmlTest.java
+++ b/src/main/java/org/testng/xml/XmlTest.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.UUID;
 
 /**
  * This class describes the tag &lt;test&gt;  in testng.xml.
@@ -27,7 +28,7 @@ public class XmlTest implements Serializable, Cloneable {
   public static int DEFAULT_TIMEOUT_MS = Integer.MAX_VALUE;
 
   private XmlSuite m_suite;
-  private String m_name = TestNG.DEFAULT_COMMAND_LINE_SUITE_NAME;
+  private String m_name;
   private Integer m_verbose = XmlSuite.DEFAULT_VERBOSE;
   private Boolean m_isJUnit = XmlSuite.DEFAULT_JUNIT;
   private int m_threadCount= -1;
@@ -76,6 +77,10 @@ public class XmlTest implements Serializable, Cloneable {
     m_suite = suite;
     m_suite.getTests().add(this);
     m_index = index;
+    //no two tests in the same suite should have the same name.
+    //so, make the default test name unique
+    m_name = TestNG.DEFAULT_COMMAND_LINE_TEST_NAME
+      + " " + UUID.randomUUID().toString();
   }
 
   // For YAML

--- a/src/test/java/test/sanitycheck/CheckTestNames.java
+++ b/src/test/java/test/sanitycheck/CheckTestNames.java
@@ -1,0 +1,97 @@
+package test.sanitycheck;
+
+import org.testng.Assert;
+import org.testng.TestListenerAdapter;
+import org.testng.TestNG;
+import org.testng.TestNGException;
+import org.testng.annotations.Test;
+import org.testng.xml.XmlClass;
+import org.testng.xml.XmlSuite;
+import org.testng.xml.XmlTest;
+
+import test.SimpleBaseTest;
+
+import java.util.Arrays;
+
+public class CheckTestNames extends SimpleBaseTest {
+
+  /**
+   * Child suites and same suite has two tests with same name
+   */
+  @Test
+  public void checkWithChildSuites() {
+    runSuite("sanitycheck/test-a.xml");
+  }
+
+  /**
+   * Simple suite with two tests with same name
+   */
+  @Test
+  public void checkWithoutChildSuites() {
+    runSuite("sanitycheck/test1.xml");
+  }
+
+  private void runSuite(String suitePath)
+  {
+    TestListenerAdapter tla = new TestListenerAdapter();
+    boolean exceptionRaised = false;
+    try {
+      TestNG tng = create();
+      String testngXmlPath = getPathToResource(suitePath);
+      tng.setTestSuites(Arrays.asList(testngXmlPath));
+      tng.addListener(tla);
+      tng.run();
+    } catch (TestNGException ex) {
+      exceptionRaised = true;
+      Assert.assertEquals(tla.getPassedTests().size(), 0);
+      Assert.assertEquals(tla.getFailedTests().size(), 0);
+    }
+    Assert.assertTrue(exceptionRaised);
+  }
+
+  /**
+   * Simple suite with no two tests with same name
+   */
+  @Test
+  public void checkNoError() {
+    TestListenerAdapter tla = new TestListenerAdapter();
+    TestNG tng = create();
+    String testngXmlPath = getPathToResource("sanitycheck/test2.xml");
+    tng.setTestSuites(Arrays.asList(testngXmlPath));
+    tng.addListener(tla);
+    tng.run();
+    Assert.assertEquals(tla.getPassedTests().size(), 2);
+  }
+
+  /**
+   * Child suites and tests within different suites have same names
+   */
+  @Test
+  public void checkNoErrorWtihChildSuites() {
+    TestListenerAdapter tla = new TestListenerAdapter();
+    TestNG tng = create();
+    String testngXmlPath = getPathToResource("sanitycheck/test-b.xml");
+    tng.setTestSuites(Arrays.asList(testngXmlPath));
+    tng.addListener(tla);
+    tng.run();
+    Assert.assertEquals(tla.getPassedTests().size(), 4);
+  }
+
+  /**
+   * Checks that suites created programmatically also run as expected
+   */
+  @Test
+  public void checkTestNamesForProgrammaticSuites() {
+    XmlSuite xmlSuite = new XmlSuite();
+    xmlSuite.setName("SanityCheckSuite");
+    XmlTest result = new XmlTest(xmlSuite);
+    result.getXmlClasses().add(new XmlClass(SampleTest1.class.getCanonicalName()));
+    result = new XmlTest(xmlSuite);
+    result.getXmlClasses().add(new XmlClass(SampleTest2.class.getCanonicalName()));
+
+    TestNG tng = new TestNG();
+    tng.setVerbose(0);
+    tng.setXmlSuites(Arrays.asList(new XmlSuite[] { xmlSuite }));
+    tng.run();
+  }
+}

--- a/src/test/java/test/sanitycheck/CheckTestNamesTest.java
+++ b/src/test/java/test/sanitycheck/CheckTestNamesTest.java
@@ -13,7 +13,7 @@ import test.SimpleBaseTest;
 
 import java.util.Arrays;
 
-public class CheckTestNames extends SimpleBaseTest {
+public class CheckTestNamesTest extends SimpleBaseTest {
 
   /**
    * Child suites and same suite has two tests with same name

--- a/src/test/java/test/sanitycheck/SampleTest1.java
+++ b/src/test/java/test/sanitycheck/SampleTest1.java
@@ -1,0 +1,9 @@
+package test.sanitycheck;
+
+import org.testng.annotations.Test;
+
+public class SampleTest1
+{
+   @Test()
+   public void test1() {}
+}

--- a/src/test/java/test/sanitycheck/SampleTest2.java
+++ b/src/test/java/test/sanitycheck/SampleTest2.java
@@ -1,0 +1,9 @@
+package test.sanitycheck;
+
+import org.testng.annotations.Test;
+
+public class SampleTest2
+{
+   @Test()
+   public void test2() {}
+}

--- a/src/test/java/test/sanitycheck/SampleTest3.java
+++ b/src/test/java/test/sanitycheck/SampleTest3.java
@@ -1,0 +1,9 @@
+package test.sanitycheck;
+
+import org.testng.annotations.Test;
+
+public class SampleTest3
+{
+   @Test()
+   public void test3() {}
+}

--- a/src/test/resources/sanitycheck/test-a.xml
+++ b/src/test/resources/sanitycheck/test-a.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suite name="SanityCheck tests">
+   <suite-files>
+      <suite-file path="./test1.xml"/>
+      <suite-file path="./test2.xml"/>
+   </suite-files>
+</suite>

--- a/src/test/resources/sanitycheck/test-b.xml
+++ b/src/test/resources/sanitycheck/test-b.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suite name="SanityCheck tests">
+   <suite-files>
+      <suite-file path="./test2.xml"/>
+      <suite-file path="./test3.xml"/>
+   </suite-files>
+</suite>

--- a/src/test/resources/sanitycheck/test1.xml
+++ b/src/test/resources/sanitycheck/test1.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suite name="SanityCheck tests">
+  <test name="SanityCheck:Tests" preserve-order="true">
+    <classes>
+      <class name="test.sanitycheck.SampleTest1"/>
+      <class name="test.sanitycheck.SampleTest3"/>
+    </classes>
+  </test>
+  <test name="SanityCheck:Tests:Another" preserve-order="true">
+    <classes>
+      <class name="test.sanitycheck.SampleTest2"/>
+    </classes>
+  </test>
+  <test name="SanityCheck:Tests">
+    <parameter name="foo" value="bar"/>
+    <classes>
+      <class name="test.sanitycheck.SampleTest3"/>
+    </classes>
+  </test>
+</suite>

--- a/src/test/resources/sanitycheck/test2.xml
+++ b/src/test/resources/sanitycheck/test2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suite name="SanityCheck tests">
+  <test name="SanityCheck:Tests" preserve-order="true">
+    <classes>
+      <class name="test.sanitycheck.SampleTest1"/>
+    </classes>
+  </test>
+  <test name="SanityCheck:Tests:Another" preserve-order="true">
+    <classes>
+      <class name="test.sanitycheck.SampleTest3"/>
+    </classes>
+  </test>
+</suite>

--- a/src/test/resources/sanitycheck/test3.xml
+++ b/src/test/resources/sanitycheck/test3.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suite name="SanityCheck tests">
+  <test name="SanityCheck:Tests" preserve-order="true">
+    <classes>
+      <class name="test.sanitycheck.SampleTest1"/>
+    </classes>
+  </test>
+  <test name="SanityCheck:Tests:Another" preserve-order="true">
+    <classes>
+      <class name="test.sanitycheck.SampleTest3"/>
+    </classes>
+  </test>
+</suite>

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -632,7 +632,7 @@
 
   <test name="Sanity Check">
     <classes>
-      <class name="test.sanitycheck.CheckTestNames" />
+      <class name="test.sanitycheck.CheckTestNamesTest" />
     </classes>
   </test>
 </suite>

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -482,9 +482,9 @@
       </run>
     </groups>
 
-	  <packages>
-	    <package name="test.nested.*"/>
-	  </packages>
+     <packages>
+       <package name="test.nested.*"/>
+     </packages>
   </test>
 
   <test name="Hookable" >
@@ -602,7 +602,7 @@
       <class name="test.configurationfailurepolicy.FailurePolicyTest" />
     </classes>
   </test>
-  
+
   <test name="Nested2">
     <packages>
       <package name="test.nested2" />
@@ -617,7 +617,7 @@
       <class name="test.guice.GuiceModuleFactoryTest" />
     </classes>
   </test>
-  
+
   <test name="Listener invokers">
     <packages>
       <package name="org.testng.internal.invokers"/>
@@ -627,6 +627,12 @@
   <test name="YAML">
     <classes>
       <class name="test.yaml.YamlTest" />
+    </classes>
+  </test>
+
+  <test name="Sanity Check">
+    <classes>
+      <class name="test.sanitycheck.CheckTestNames" />
     </classes>
   </test>
 </suite>


### PR DESCRIPTION
Reporters can't handle multiple XmlTest with same name within
the same suite. This leads to results being reported weirdly.

Because there is no defined guidelines w.r.t. XmlTest names, we
are just going to disallow two XmlTests within the same suite to
have the same name.

Testing Done: Added new tests for this. After fixing how XmlTest
sets it's name when one isnt given, all tests exception 1 passed.
Failing test 'test.thread.MultiThreadedDependentTest.test3Threads'
doesnt seem related to this change.
