### PR TITLE
Output ITestResult attributes in xml report

### DIFF
--- a/doc/documentation-main.html
+++ b/doc/documentation-main.html
@@ -2600,6 +2600,15 @@ TestNG offers an XML reporter capturing TestNG specific information that is not 
     <td>false</td>
   </tr>
   <tr>
+    <td>generateTestResultAttributes</td>
+    <td>
+      A boolean indicating if an <tt>&lt;attributes&gt;</tt> tag should be generated for each <tt>&lt;test-method&gt;</tt> element, containing the test result
+      attributes (See <tt>ITestResult.setAttribute()</tt> about setting test result attributes). Each attribute <tt>toString()</tt> representation will be
+      written in a <tt>&lt;attribute name="[attribute name]"&gt;</tt> tag.
+    </td>
+    <td>false</td>
+  </tr>
+  <tr>
     <td>stackTraceOutputMethod</td>
     <td>Specifies the type of stack trace that is to be generated for exceptions and has the following values:
          <br>

--- a/src/main/java/org/testng/reporters/XMLReporter.java
+++ b/src/main/java/org/testng/reporters/XMLReporter.java
@@ -258,4 +258,13 @@ public class XMLReporter implements IReporter {
   public boolean isGenerateDependsOnGroups() {
     return config.isGenerateDependsOnGroups();
   }
+
+  public void setGenerateTestResultAttributes(boolean generateTestResultAttributes) {
+    config.setGenerateTestResultAttributes(generateTestResultAttributes);
+  }
+
+  public boolean isGenerateTestResultAttributes() {
+    return config.isGenerateTestResultAttributes();
+  }
+
 }

--- a/src/main/java/org/testng/reporters/XMLReporterConfig.java
+++ b/src/main/java/org/testng/reporters/XMLReporterConfig.java
@@ -29,6 +29,8 @@ public class XMLReporterConfig {
   public static final String TAG_PARAM_VALUE = "value";
   public static final String TAG_REPORTER_OUTPUT = "reporter-output";
   public static final String TAG_LINE = "line";
+  public static final String TAG_ATTRIBUTES = "attributes";
+  public static final String TAG_ATTRIBUTE = "attribute";
 
   public static final String ATTR_URL = "url";
   public static final String ATTR_NAME = "name";
@@ -158,6 +160,12 @@ public class XMLReporterConfig {
   private boolean generateDependsOnGroups = true;
 
   /**
+   * Indicates whether {@link ITestResult} attributes should be generated for
+   * each <code>test-method</code> element
+   */
+  private boolean generateTestResultAttributes = false;
+
+  /**
    * The output format for timestamps
    */
   private static String timestampFormat = FMT_DEFAULT;
@@ -224,5 +232,13 @@ public class XMLReporterConfig {
 
   public void setGenerateDependsOnGroups(boolean generateDependsOnGroups) {
     this.generateDependsOnGroups = generateDependsOnGroups;
+  }
+
+  public void setGenerateTestResultAttributes(boolean generateTestResultAttributes) {
+    this.generateTestResultAttributes = generateTestResultAttributes;
+  }
+
+  public boolean isGenerateTestResultAttributes() {
+    return generateTestResultAttributes;
   }
 }

--- a/src/main/java/org/testng/reporters/XMLSuiteResultWriter.java
+++ b/src/main/java/org/testng/reporters/XMLSuiteResultWriter.java
@@ -134,6 +134,9 @@ public class XMLSuiteResultWriter {
     xmlBuffer.push(XMLReporterConfig.TAG_TEST_METHOD, attribs);
     addTestMethodParams(xmlBuffer, testResult);
     addTestResultException(xmlBuffer, testResult);
+    if (config.isGenerateTestResultAttributes()) {
+      addTestResultAttributes(xmlBuffer, testResult);
+    }
     xmlBuffer.pop();
   }
 
@@ -261,6 +264,30 @@ public class XMLSuiteResultWriter {
         xmlBuffer.pop();
       }
 
+      xmlBuffer.pop();
+    }
+  }
+
+  private void addTestResultAttributes(XMLStringBuffer xmlBuffer, ITestResult testResult) {
+    if (testResult.getAttributeNames() != null && testResult.getAttributeNames().size() > 0) {
+      xmlBuffer.push(XMLReporterConfig.TAG_ATTRIBUTES);
+      for (String attrName: testResult.getAttributeNames()) {
+        if (attrName == null) {
+          continue;
+        }
+        Object attrValue = testResult.getAttribute(attrName);
+
+        Properties attributeAttrs = new Properties();
+        attributeAttrs.setProperty(XMLReporterConfig.ATTR_NAME, attrName);
+        if (attrValue == null) {
+          attributeAttrs.setProperty(XMLReporterConfig.ATTR_IS_NULL, "true");
+          xmlBuffer.addEmptyElement(XMLReporterConfig.TAG_ATTRIBUTE, attributeAttrs);
+        } else {
+          xmlBuffer.push(XMLReporterConfig.TAG_ATTRIBUTE, attributeAttrs);
+          xmlBuffer.addCDATA(attrValue.toString());
+          xmlBuffer.pop();
+        }
+      }
       xmlBuffer.pop();
     }
   }


### PR DESCRIPTION
Hi,

Please find a patch adding an option to `XMLReporter` to output test result attributes:

``` xml
<test-method status="PASS" signature="successTest()" name="successTest" duration-ms="1" started-at="2011-06-29T22:07:08Z" finished-at="2011-06-29T22:07:08Z">
  <attributes>
    <attribute name="TestContextObject">
      <![CDATA[TestNGTest.successTest() 1975260912]]>
    </attribute>
    <attribute name="SucessAttribute">
      <![CDATA[All right !]]>
    </attribute>
    <attribute name="Null value" is-null="true"/>
  </attributes>
</test-method>
```

The idea is to be able to attach data to a test result using `ITestResult.setAttribute()` in a listener and output this data in the test report (In my case I was interested in attaching the current URL for Selenium 2 test failures).

I'm not sure it's the best way to go, feel free to comment / amend / ignore :)

Cheers,

Nico
