### PR TITLE
added methods for handling empty and blank strings

### DIFF
--- a/src/main/java/org/testng/SuiteRunner.java
+++ b/src/main/java/org/testng/SuiteRunner.java
@@ -1,5 +1,7 @@
 package org.testng;
 
+import static org.testng.internal.Utils.isStringBlank;
+
 import org.testng.collections.Lists;
 import org.testng.collections.Maps;
 import org.testng.internal.AnnotationTypeEnum;
@@ -202,9 +204,8 @@ public class SuiteRunner implements ISuite, Serializable, IInvokedMethodListener
   }
 
   private void setOutputDir(String outputdir) {
-    if (((null == outputdir) || "".equals(outputdir.trim()))
-        && m_useDefaultListeners) {
-      outputdir= DEFAULT_OUTPUT_DIR;
+    if (isStringBlank(outputdir) && m_useDefaultListeners) {
+      outputdir = DEFAULT_OUTPUT_DIR;
     }
 
     m_outputDir = (null != outputdir) ? new File(outputdir).getAbsolutePath()

--- a/src/main/java/org/testng/TestNG.java
+++ b/src/main/java/org/testng/TestNG.java
@@ -1,5 +1,9 @@
 package org.testng;
 
+import static org.testng.internal.Utils.defaultIfStringEmpty;
+import static org.testng.internal.Utils.isStringEmpty;
+import static org.testng.internal.Utils.isStringNotEmpty;
+
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
 
@@ -223,7 +227,7 @@ public class TestNG {
    * @param outputdir The directory.
    */
   public void setOutputDirectory(final String outputdir) {
-    if ((null != outputdir) && !"".equals(outputdir)) {
+    if (isStringNotEmpty(outputdir)) {
       m_outputDir = outputdir;
     }
   }
@@ -254,7 +258,7 @@ public class TestNG {
    * default to TestNG.JDK_ANNOTATION_TYPE.
    */
   public void setAnnotations(String annotationType) {
-    if(null != annotationType && !"".equals(annotationType)) {
+    if(isStringNotEmpty(annotationType)) {
       setAnnotations(AnnotationTypeEnum.valueOf(annotationType));
     }
   }
@@ -344,7 +348,7 @@ public class TestNG {
           + suites + " instead");
       return;
     }
-    if ((null == m_jarPath) || "".equals(m_jarPath)) {
+    if (isStringEmpty(m_jarPath)) {
       return;
     }
 
@@ -552,14 +556,8 @@ public class TestNG {
       String suiteName = getDefaultSuiteName();
       String testName = getDefaultTestName();
       if (test != null) {
-        final String candidateSuiteName = test.getSuiteName();
-        if (candidateSuiteName != null && !"".equals(candidateSuiteName)) {
-          suiteName = candidateSuiteName;
-        }
-        final String candidateTestName = test.getTestName();
-        if (candidateTestName != null && !"".equals(candidateTestName)) {
-            testName = candidateTestName;
-        }
+        suiteName = defaultIfStringEmpty(test.getSuiteName(), suiteName);
+        testName = defaultIfStringEmpty(test.getTestName(), testName);
       }
       XmlSuite xmlSuite = suites.get(suiteName);
       if (xmlSuite == null) {

--- a/src/main/java/org/testng/TestNGAntTask.java
+++ b/src/main/java/org/testng/TestNGAntTask.java
@@ -1,6 +1,8 @@
 package org.testng;
 
 
+import static org.testng.internal.Utils.isStringNotEmpty;
+
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.DirectoryScanner;
 import org.apache.tools.ant.Project;
@@ -517,12 +519,12 @@ public class TestNGAntTask extends Task {
       argv.add(m_testjar.getAbsolutePath());
     }
 
-    if((null != m_includedGroups) && !"".equals(m_includedGroups)) {
+    if(isStringNotEmpty(m_includedGroups)) {
       argv.add(CommandLineArgs.GROUPS);
       argv.add(m_includedGroups);
     }
 
-    if((null != m_excludedGroups) && !"".equals(m_excludedGroups)) {
+    if(isStringNotEmpty(m_excludedGroups)) {
       argv.add(CommandLineArgs.EXCLUDED_GROUPS);
       argv.add(m_excludedGroups);
     }

--- a/src/main/java/org/testng/internal/Utils.java
+++ b/src/main/java/org/testng/internal/Utils.java
@@ -87,7 +87,7 @@ public final class Utils {
 
   public static String[] parseMultiLine(String line) {
     List<String> vResult = Lists.newArrayList();
-    if ((null != line) && !"".equals(line.trim())) {
+    if (isStringNotBlank(line)) {
       StringTokenizer st = new StringTokenizer(line, " ");
       while (st.hasMoreTokens()) {
         vResult.add(st.nextToken());
@@ -473,8 +473,24 @@ public final class Utils {
     }
   }
 
+  public static String defaultIfStringEmpty(String s, String defaultValue) {
+    return isStringEmpty(s) ? defaultValue : s;
+  }
+
+  public static boolean isStringBlank(String s) {
+    return s == null || "".equals(s.trim());
+  }
+
   public static boolean isStringEmpty(String s) {
     return s == null || "".equals(s);
+  }
+
+  public static boolean isStringNotBlank(String s) {
+    return !isStringBlank(s);
+  }
+
+  public static boolean isStringNotEmpty(String s) {
+    return !isStringEmpty(s);
   }
 
   public static String[] stackTrace(Throwable t, boolean tohtml) {

--- a/src/main/java/org/testng/remote/RemoteTestNG.java
+++ b/src/main/java/org/testng/remote/RemoteTestNG.java
@@ -1,5 +1,6 @@
 package org.testng.remote;
 
+import static org.testng.internal.Utils.defaultIfStringEmpty;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
@@ -60,12 +61,7 @@ public class RemoteTestNG extends TestNG {
   private static boolean m_dontExit;
 
   public void setHost(String host) {
-    if((null == host) || "".equals(host)) {
-      m_host= LOCALHOST;
-    }
-    else {
-      m_host= host;
-    }
+    m_host = defaultIfStringEmpty(host, LOCALHOST);
   }
 
   private void calculateAllSuites(List<XmlSuite> suites, List<XmlSuite> outSuites) {

--- a/src/main/java/org/testng/remote/strprotocol/TestResultMessage.java
+++ b/src/main/java/org/testng/remote/strprotocol/TestResultMessage.java
@@ -1,5 +1,6 @@
 package org.testng.remote.strprotocol;
 
+import static org.testng.internal.Utils.isStringEmpty;
 
 import org.testng.ITestContext;
 import org.testng.ITestResult;
@@ -304,7 +305,7 @@ public class TestResultMessage implements IStringMessage {
       }
       else {
         String tostring= o.toString();
-        if("".equals(tostring)) {
+        if(isStringEmpty(tostring)) {
           result.add("\"\"");
         }
         else {

--- a/src/main/java/org/testng/reporters/SuiteHTMLReporter.java
+++ b/src/main/java/org/testng/reporters/SuiteHTMLReporter.java
@@ -1,5 +1,7 @@
 package org.testng.reporters;
 
+import static org.testng.internal.Utils.isStringNotEmpty;
+
 import org.testng.IInvokedMethod;
 import org.testng.IReporter;
 import org.testng.ISuite;
@@ -168,8 +170,9 @@ public class SuiteHTMLReporter implements IReporter {
         if (m != null) {
           sb2.append("<tr><td>")
           .append(m.getDeclaringClass().getName() + "." + m.getName());
-          if(null != method.getDescription() && !"".equals(method.getDescription())) {
-            sb2.append("<br/>").append(SP2).append("<i>").append(method.getDescription()).append("</i>");
+          String description = method.getDescription();
+          if(isStringNotEmpty(description)) {
+            sb2.append("<br/>").append(SP2).append("<i>").append(description).append("</i>");
           }
           sb2.append("</td></tr>\n");
         }

--- a/src/main/java/org/testng/xml/TestNGContentHandler.java
+++ b/src/main/java/org/testng/xml/TestNGContentHandler.java
@@ -1,5 +1,7 @@
 package org.testng.xml;
 
+import static org.testng.internal.Utils.isStringBlank;
+
 import org.testng.ITestObjectFactory;
 import org.testng.TestNGException;
 import org.testng.collections.Lists;
@@ -246,7 +248,7 @@ public class TestNGContentHandler extends DefaultHandler {
       m_currentTest = new XmlTest(m_currentSuite, m_currentTestIndex++);
       m_currentTestParameters = Maps.newHashMap();
       final String testName= attributes.getValue("name");
-      if(null == testName || "".equals(testName.trim())) {
+      if(isStringBlank(testName)) {
         throw new TestNGException("Test <test> element must define the name attribute");
       }
       m_currentTest.setName(attributes.getValue("name"));

--- a/src/main/java/org/testng/xml/XmlSuite.java
+++ b/src/main/java/org/testng/xml/XmlSuite.java
@@ -1,5 +1,7 @@
 package org.testng.xml;
 
+import static org.testng.internal.Utils.isStringNotEmpty;
+
 import org.testng.ITestObjectFactory;
 import org.testng.TestNG;
 import org.testng.collections.Lists;
@@ -452,7 +454,7 @@ public class XmlSuite implements Serializable, Cloneable {
       XmlUtils.setProperty(p, "verbose", getVerbose().toString(), DEFAULT_VERBOSE.toString());
     }
     final String parallel= getParallel();
-    if(null != parallel && !"".equals(parallel) && !DEFAULT_PARALLEL.equals(parallel)) {
+    if(isStringNotEmpty(parallel) && !DEFAULT_PARALLEL.equals(parallel)) {
       p.setProperty("parallel", parallel);
     }
     XmlUtils.setProperty(p, "configfailurepolicy", getConfigFailurePolicy(),


### PR DESCRIPTION
I added defaultIfStringEmpty, isStringBlank, isStringNotBlank and isStringNotEmpty to Utils. Every occurence of the extracted code is replaced by calls to the new methods.

There're still a few lines with "".equals(...). I think they should be replaced by isStringEmpty, but I didn't want to change the behaviour.

Additionally there're some parts of the code, which use isStringEmpty and isStringNotEmpty, although isStringBlank and isStringNotBlank should be used. Again, I didn't want to change the behaviour.

I change the parts of the code mentioned above, if you're interested.
