### PR TITLE
Fix for "Too many listeners" issue

### DIFF
--- a/src/main/java/org/testng/TestRunner.java
+++ b/src/main/java/org/testng/TestRunner.java
@@ -279,7 +279,7 @@ public class TestRunner
     // Find all the listener factories and collect all the listeners requested in a
     // @Listeners annotation.
     //
-    List<Class<? extends ITestNGListener>> listenerClasses = Lists.newArrayList();
+    Set<Class<? extends ITestNGListener>> listenerClasses = Sets.newHashSet();
     Class<? extends ITestNGListenerFactory> listenerFactoryClass = null;
 
     for (IClass cls : getTestClasses()) {

--- a/src/test/java/test/listeners/BaseWithListener.java
+++ b/src/test/java/test/listeners/BaseWithListener.java
@@ -1,0 +1,12 @@
+package test.listeners;
+
+import org.testng.annotations.Listeners;
+
+@Listeners(value = L3.class)
+class BaseWithListener {
+  static int m_count = 0;
+
+  public static void incrementCount() {
+    m_count++;
+  }
+}

--- a/src/test/java/test/listeners/Derived1.java
+++ b/src/test/java/test/listeners/Derived1.java
@@ -1,0 +1,9 @@
+package test.listeners;
+
+import org.testng.annotations.Test;
+
+class Derived1 extends BaseWithListener {
+  @Test
+  public void t() {
+  }
+}

--- a/src/test/java/test/listeners/Derived2.java
+++ b/src/test/java/test/listeners/Derived2.java
@@ -1,0 +1,9 @@
+package test.listeners;
+
+import org.testng.annotations.Test;
+
+class Derived2 extends BaseWithListener {
+  @Test
+  public void s() {
+  }
+}

--- a/src/test/java/test/listeners/L3.java
+++ b/src/test/java/test/listeners/L3.java
@@ -1,0 +1,11 @@
+package test.listeners;
+
+import org.testng.ITestResult;
+import org.testng.TestListenerAdapter;
+
+public class L3 extends TestListenerAdapter {
+  @Override
+  public void onTestStart(ITestResult result) {
+    BaseWithListener.incrementCount();
+  }
+}

--- a/src/test/java/test/listeners/ListenerTest.java
+++ b/src/test/java/test/listeners/ListenerTest.java
@@ -40,6 +40,14 @@ public class ListenerTest extends SimpleBaseTest {
     Assert.assertEquals(AggregateSampleTest.m_count, 2);
   }
 
+  @Test(description = "Should attach only one instance of the same @Listener class per test")
+  public void shouldAttachOnlyOneInstanceOfTheSameListenerClassPerTest() {
+    TestNG tng = create(new Class [] {Derived1.class, Derived2.class});
+    BaseWithListener.m_count = 0;
+    tng.run();
+    Assert.assertEquals(BaseWithListener.m_count, 2);
+  }
+
   @Test(description = "@Listeners with an ISuiteListener")
   public void suiteListenersShouldWork() {
     TestNG tng = create(SuiteListenerSample.class);


### PR DESCRIPTION
Hi folks,

I encountered a problem when attempting to attach a logging listener to the base class of my test inheritance hierarchy -- I ended up with log statements that were duplicated as many times as I had subclassed the base class.  This is the same problem that came up on the testng-users list last year:

http://groups.google.com/group/testng-users/browse_thread/thread/6202a5f0292160b1/dbe3f0c0b84377c6

Like the author of that message, I noticed that there were too many listener instances being created.  There's a simple fix for the issue, which is to use a Set instead of List when aggregating the Listener classes to be attached to a given test instance.

I've made two commits; the first contains the test I wrote to expose the bug; the second contains the fix.

Let me know how this looks!

Best,

Dante
