### PR TITLE
removed all occurences of "".equals(...) except in Utils

### DIFF
--- a/src/main/java/org/testng/TestNGAntTask.java
+++ b/src/main/java/org/testng/TestNGAntTask.java
@@ -1,6 +1,7 @@
 package org.testng;
 
 
+import static org.testng.internal.Utils.isStringNotBlank;
 import static org.testng.internal.Utils.isStringNotEmpty;
 
 import org.apache.tools.ant.BuildException;
@@ -601,25 +602,10 @@ public class TestNGAntTask extends Task {
       argv.add(m_dataproviderthreadCount);
     }
 
-    if(!"".equals(m_suiteName)) {
-      argv.add(CommandLineArgs.SUITE_NAME);
-      argv.add(m_suiteName);
-    }
-
-    if(!"".equals(m_testName)) {
-      argv.add(CommandLineArgs.TEST_NAME);
-      argv.add(m_testName);
-    }
-
-    if (! Utils.isStringEmpty(m_testNames)) {
-      argv.add(CommandLineArgs.TEST_NAMES);
-      argv.add(m_testNames);
-    }
-
-    if (! Utils.isStringEmpty(m_methods)) {
-      argv.add("-methods");
-      argv.add(m_methods);
-    }
+    addArgumentIfNotBlank(argv, CommandLineArgs.SUITE_NAME, m_suiteName);
+    addArgumentIfNotBlank(argv, CommandLineArgs.TEST_NAME, m_testName);
+    addArgumentIfNotBlank(argv, CommandLineArgs.TEST_NAMES, m_testNames);
+    addArgumentIfNotBlank(argv, "-methods", m_methods);
 
     if (!reporterConfigs.isEmpty()) {
       for (ReporterConfig reporterConfig : reporterConfigs) {
@@ -695,6 +681,13 @@ public class TestNGAntTask extends Task {
     }
 
     actOnResult(exitValue, wasKilled);
+  }
+  
+  private void addArgumentIfNotBlank(List<String> argv, String name, String value) {
+	  if (isStringNotBlank(value)) {
+		  argv.add(name);
+		  argv.add(value);
+	  }
   }
 
   /**

--- a/src/main/java/org/testng/internal/Utils.java
+++ b/src/main/java/org/testng/internal/Utils.java
@@ -622,7 +622,7 @@ public final class Utils {
       return "null";
     }
     final String toString= object.toString();
-    if("".equals(toString)) {
+    if(isStringEmpty(toString)) {
       return "\"\"";
     }
     else if (String.class.equals(objectClass)) {

--- a/src/main/java/org/testng/reporters/TextReporter.java
+++ b/src/main/java/org/testng/reporters/TextReporter.java
@@ -1,5 +1,7 @@
 package org.testng.reporters;
 
+import static org.testng.internal.Utils.isStringNotBlank;
+
 import org.testng.ITestContext;
 import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
@@ -126,7 +128,7 @@ public class TextReporter extends TestListenerAdapter {
 
   private void logResult(String status, String message) {
     StringBuffer buf= new StringBuffer();
-    if(!"".equals(status)) {
+    if(isStringNotBlank(status)) {
       buf.append(status).append(": ");
     }
     buf.append(message);

--- a/src/main/java/org/testng/xml/LaunchSuite.java
+++ b/src/main/java/org/testng/xml/LaunchSuite.java
@@ -1,6 +1,8 @@
 package org.testng.xml;
 
 
+import static org.testng.internal.Utils.isStringNotBlank;
+
 import org.testng.collections.Lists;
 import org.testng.internal.AnnotationTypeEnum;
 import org.testng.internal.Utils;
@@ -357,7 +359,7 @@ public abstract class LaunchSuite {
 
       List<String> result= Lists.newArrayList();
       for(String name: source) {
-        if(!"".equals(name)) {
+        if(isStringNotBlank(name)) {
           result.add(name);
         }
       }


### PR DESCRIPTION
This is the second step mentioned in my last commit. From now on isStringBlank and isStringEmpty are the only methods using 

``` java
"".equals(someString)
```
