### PR TITLE
OSGI manifest patch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,11 +184,12 @@
               <instructions>
                 <_versionpolicy>$(@)</_versionpolicy>
                 <Import-Package>
-                  bsh.*;version="[2.0.0,3.0.0)",
-                  com.beust.jcommander.*;version="[1.7.0,3.0.0)",
-                  com.google.inject.*;version="[2.0.0,3.0.0)",
-                  junit.framework;version="[3.8.1, 4.0.0)";resolution:="optional",
-                  org.apache.tools.ant.*;version="[1.6.5, 2.0.0)";resolution:="optional",
+                  bsh.*;version="[2.0.0,3.0.0)";resolution:=optional,
+                  com.beust.jcommander.*;version="[1.7.0,3.0.0)";resolution:=optional,
+                  com.google.inject.*;version="[1.2,1.3)";resolution:=optional,
+                  junit.framework;version="[3.8.1, 4.0.0)";resolution:=optional,
+                  org.apache.tools.ant.*;version="[1.6.5, 2.0.0)";resolution:=optional,
+                  org.yaml.*;version="[1.6,2.0)";resolution:=optional,
                   !com.sun.*,
                   *
                 </Import-Package>


### PR DESCRIPTION
OSGi manifest: fixed guice package versions and made most imports optional

See http://groups.google.com/group/testng-users/browse_thread/thread/ab5560851ca269d4

Best regards,
Harald
