### PR TITLE
HTML report if ITest implemented

### DIFF
--- a/src/main/java/org/testng/reporters/TestHTMLReporter.java
+++ b/src/main/java/org/testng/reporters/TestHTMLReporter.java
@@ -82,9 +82,9 @@ public class TestHTMLReporter extends TestListenerAdapter {
       ITestNGMethod method = tr.getMethod();
 
       sb.append("<td title='").append(tr.getTestClass().getName()).append(".")
-        .append(tr.getName())
+        .append(method.getMethodName())
         .append("()'>")
-        .append("<b>").append(tr.getName()).append("</b>");
+        .append("<b>").append(method.getMethodName()).append("</b>");
 
       // Test class
       String testClass = tr.getTestClass().getName();


### PR DESCRIPTION
Hi,

if ITest is implemented in a test class, the test method name is not displayed in the HTML report. 

IMHO the method name should be always displayed in the report. Here is my small fix.

Regards,
José Luis.
