### PR TITLE
When running TestNG programmatically, child xml suites are not run (when added using setSuiteFIles())

### DIFF
--- a/src/main/java/org/testng/TestNG.java
+++ b/src/main/java/org/testng/TestNG.java
@@ -263,6 +263,32 @@ public class TestNG {
     // The Eclipse plug-in (RemoteTestNG) might have invoked this method already
     // so don't initialize suites twice.
     if (m_suites.size() > 0) {
+    	//to parse the suite files (<suite-file>), if any
+    	for (XmlSuite s: m_suites){
+	        List<String> suiteFiles = s.getSuiteFiles();
+			for (int i = 0; i < suiteFiles.size(); i++) {
+				try {
+					Collection<XmlSuite> childSuites = getParser(suiteFiles.get(i)).parse();
+					for (XmlSuite cSuite : childSuites){
+						cSuite.setParentSuite(s);
+						s.getChildSuites().add(cSuite);
+					}
+				}
+				catch(FileNotFoundException e) {
+					e.printStackTrace(System.out);
+				}
+				catch (ParserConfigurationException e) {
+					e.printStackTrace(System.out);
+				} catch (SAXException e) {
+					e.printStackTrace(System.out);
+				} catch (IOException e) {
+					e.printStackTrace(System.out);
+				}
+
+
+			}
+
+    	}
       return;
     }
 


### PR DESCRIPTION
When running TestNG programmatically by creating and adding XmlSuite, if child suites are added using setSuiteFiles(), the child suites are not run.

If the same suite is run using testng.xml file (either directly or programmatically using setTestSuites()), the child suites are run correctly. Below is sample code. Here's the complete code to demonstrate the issue: https://gist.github.com/1629341

```
        // create a suite programmatically
        XmlSuite suite = new XmlSuite();
        suite.setName("Programmatic XmlSuite");

        // create and add a test case for the suite

        // add a suite-file to the suite
        suite.setSuiteFiles(Arrays.asList("./Suite1.xml"));

                    //add suite to testng
        testng.setXmlSuites(Arrays.asList(suite));

        testng.run();
```
