### PR TITLE
Add ability to get ITestContext from ITestResult

### DIFF
--- a/src/main/java/org/testng/ITestResult.java
+++ b/src/main/java/org/testng/ITestResult.java
@@ -89,4 +89,9 @@ public interface ITestResult extends IAttributes, Comparable<ITestResult> {
   public String getTestName();
 
   public String getInstanceName();
+  
+  /**
+   * Get this tests {@link ITestContext}
+   */
+  public ITestContext getContext();
 }

--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -166,7 +166,8 @@ public class Invoker implements IInvoker {
                                              tm,
                                              null,
                                              System.currentTimeMillis(),
-                                             System.currentTimeMillis());
+                                             System.currentTimeMillis(),
+                                             m_testContext);
 
       IConfigurationAnnotation configurationAnnotation= null;
       try {
@@ -643,7 +644,8 @@ public class Invoker implements IInvoker {
                                  tm,
                                  null,
                                  System.currentTimeMillis(),
-                                 0);
+                                 0,
+                                 m_testContext);
       testResult.setParameters(parameterValues);
       testResult.setHost(m_testContext.getHost());
       testResult.setStatus(ITestResult.STARTED);
@@ -1127,7 +1129,8 @@ public class Invoker implements IInvoker {
                                                testMethod,
                                                null /* cause */,
                                                start,
-                                               System.currentTimeMillis());
+                                               System.currentTimeMillis(),
+                                               m_testContext);
         String missingGroup = testMethod.getMissingGroup();
         if (missingGroup != null) {
           testResult.setThrowable(new Throwable("Method " + testMethod
@@ -1263,7 +1266,8 @@ public class Invoker implements IInvoker {
                 testMethod,
                 cause,
                 start,
-                System.currentTimeMillis());
+                System.currentTimeMillis(),
+                m_testContext);
             r.setStatus(TestResult.FAILURE);
             result.add(r);
             runTestListeners(r);
@@ -1284,7 +1288,8 @@ public class Invoker implements IInvoker {
         testMethod,
         throwable,
         start,
-        System.currentTimeMillis());
+        System.currentTimeMillis(),
+        m_testContext);
     result.setStatus(TestResult.SKIP);
     runTestListeners(result);
 
@@ -1380,7 +1385,8 @@ public class Invoker implements IInvoker {
               testMethod,
               cause,
               System.currentTimeMillis(),
-              System.currentTimeMillis()));
+              System.currentTimeMillis(),
+              m_testContext));
     }
   }
 

--- a/src/main/java/org/testng/internal/TestMethodWithDataProviderMethodWorker.java
+++ b/src/main/java/org/testng/internal/TestMethodWithDataProviderMethodWorker.java
@@ -122,7 +122,8 @@ public class TestMethodWithDataProviderMethodWorker implements Callable<List<ITe
               m_testMethod,
               null,
               start,
-              System.currentTimeMillis());
+              System.currentTimeMillis(),
+              m_testContext);
           r.setStatus(TestResult.SKIP);
           m_testResults.add(r);
           m_invoker.runTestListeners(r);

--- a/src/main/java/org/testng/internal/TestResult.java
+++ b/src/main/java/org/testng/internal/TestResult.java
@@ -3,6 +3,7 @@ package org.testng.internal;
 import org.testng.IAttributes;
 import org.testng.IClass;
 import org.testng.ITest;
+import org.testng.ITestContext;
 import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
 import org.testng.Reporter;
@@ -30,6 +31,7 @@ public class TestResult implements ITestResult {
   transient private Object[] m_parameters = {};
   transient private Object m_instance;
   private String m_instanceName;
+  private ITestContext m_context;
 
   public TestResult() {
 
@@ -40,9 +42,10 @@ public class TestResult implements ITestResult {
       ITestNGMethod method,
       Throwable throwable,
       long start,
-      long end)
+      long end,
+      ITestContext context)
   {
-    init(testClass, instance, method, throwable, start, end);
+    init(testClass, instance, method, throwable, start, end, context);
   }
 
   /**
@@ -59,7 +62,8 @@ public class TestResult implements ITestResult {
       ITestNGMethod method,
       Throwable throwable,
       long start,
-      long end)
+      long end,
+      ITestContext context)
   {
     m_testClass = testClass;
     m_throwable = throwable;
@@ -70,6 +74,7 @@ public class TestResult implements ITestResult {
     m_startMillis = start;
     m_endMillis = end;
     m_method = method;
+    m_context = context;
 
     m_instance = instance;
 
@@ -281,6 +286,14 @@ public class TestResult implements ITestResult {
   @Override
   public Object removeAttribute(String name) {
     return m_attributes.removeAttribute(name);
+  }
+  
+  public ITestContext getContext() {
+	  return m_context;
+  }
+  
+  public void setContext(ITestContext context) {
+	  m_context = context;
   }
 
   @Override

--- a/src/main/java/org/testng/junit/JUnitTestRunner.java
+++ b/src/main/java/org/testng/junit/JUnitTestRunner.java
@@ -114,7 +114,8 @@ public class JUnitTestRunner implements TestListener, IJUnitTestRunner {
                                                                           tm,
                                                                           tri.m_failure,
                                                                           tri.m_start,
-                                                                          Calendar.getInstance().getTimeInMillis());
+                                                                          Calendar.getInstance().getTimeInMillis(),
+                                                                          null);
 
     if(tri.isFailure()) {
       tr.setStatus(ITestResult.FAILURE);

--- a/src/test/java/test/listeners/ResultContextListener.java
+++ b/src/test/java/test/listeners/ResultContextListener.java
@@ -1,0 +1,36 @@
+package test.listeners;
+
+import org.testng.ITestContext;
+import org.testng.ITestListener;
+import org.testng.ITestResult;
+
+public class ResultContextListener implements ITestListener {
+	
+	public static boolean contextProvided = false;
+	
+	public void onTestStart(ITestResult result) {
+		ITestContext context = result.getContext();
+		if (context != null) {
+			contextProvided = true;
+		}
+	}
+
+	public void onTestSuccess(ITestResult result) {
+	}
+
+	public void onTestFailure(ITestResult result) {
+	}
+
+	public void onTestSkipped(ITestResult result) {
+	}
+
+	public void onTestFailedButWithinSuccessPercentage(ITestResult result) {
+	}
+
+	public void onStart(ITestContext context) {
+	}
+
+	public void onFinish(ITestContext context) {
+	}
+
+}

--- a/src/test/java/test/listeners/ResultContextListenerSample.java
+++ b/src/test/java/test/listeners/ResultContextListenerSample.java
@@ -1,0 +1,13 @@
+package test.listeners;
+
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+@Listeners(ResultContextListener.class)
+public class ResultContextListenerSample {
+	
+	@Test
+	public void f() {
+	}
+	
+}

--- a/src/test/java/test/listeners/ResultContextTest.java
+++ b/src/test/java/test/listeners/ResultContextTest.java
@@ -1,0 +1,19 @@
+package test.listeners;
+
+import org.testng.Assert;
+import org.testng.TestNG;
+import org.testng.annotations.Test;
+
+import test.SimpleBaseTest;
+
+public class ResultContextTest extends SimpleBaseTest {
+	
+	@Test
+	public void testResultContext() {
+		TestNG tng = create(ResultContextListenerSample.class);
+	    tng.run();
+	    Assert.assertTrue(ResultContextListener.contextProvided, 
+	    		"Test context was not provided to the listener");
+	}
+	
+}


### PR DESCRIPTION
I needed to have the ability to get the test context from a test result in one of my ITestListener listeners. There didn't seem to be a reliable way to do that so I added the ability to get the test context from the test result. Would love to see this added, for now I will have to use my own build.
