### PR TITLE
Preserve execution order of test results for IReporters

### DIFF
--- a/src/main/java/org/testng/SuiteRunner.java
+++ b/src/main/java/org/testng/SuiteRunner.java
@@ -41,7 +41,7 @@ public class SuiteRunner implements ISuite, Serializable, IInvokedMethodListener
 
   private static final String DEFAULT_OUTPUT_DIR = "test-output";
 
-  private Map<String, ISuiteResult> m_suiteResults = Maps.newHashMap();
+  private Map<String, ISuiteResult> m_suiteResults = new LinkedHashMap<String, ISuiteResult>();
   transient private List<TestRunner> m_testRunners = Lists.newArrayList();
   transient private List<ISuiteListener> m_listeners = Lists.newArrayList();
   transient private TestListenerAdapter m_textReporter = new TestListenerAdapter();


### PR DESCRIPTION
Hi, 

I am using reportng HTMLReporter to generate reports from my tesng tests. I have 1 suite and a few tests in xml. I have preserve-order set to true, so tests run in order as declared in XML file. I was wondering why reportng outputs tests unordered. I found out it does not do anything with ISuite.getResults() map, so it must come from testng unordered.

This may actually fix this issue too http://jira.opensymphony.com/browse/TESTNG-357

I know, we can argue that classes implementing IReporer should be responsible for sorting, but with this one-liner testng behavior would be more consistent = outputs results with same order as the tests were executed.

Thank you for applying!

Libor
