### PR TITLE
produce testng.jar with required lib(s) only (jcommander) ommitting optional ones

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -48,6 +48,7 @@ testng.nobsh.guice.jar=${testng.fullname}-nobsh-guice.jar
 testng.ibiblio.jar=${testng.fullname}-bundle.jar
 testng.zip=${target}/${testng.fullname}.zip
 testng.maven-bundle=${target}/${testng.fullname}-bundle.jar
+testng.javadoc.zip=${testng.fullname}-javadoc.zip
 
 other.jars.dir=${target}/other-jars
 

--- a/build.properties
+++ b/build.properties
@@ -39,6 +39,7 @@ all.jar.files=${beanshell.jar},${junit.jar},${ant.jar},${jcommander.jar},${yaml.
 # Names of distributions
 #
 testng.jar=${target}/${testng.fullname}.jar
+testng.dist.jar=${testng.fullname}-dist.jar
 sources.testng.jar=${testng.fullname}-sources.jar
 testng.junit.jar=${testng.fullname}-junit.jar
 testng.nobsh.noguice.jar=${testng.fullname}-nobsh-noguice.jar

--- a/build.xml
+++ b/build.xml
@@ -188,7 +188,7 @@
 
   <target name="dist" depends="build,all-jar-flavors,dist-all-zip,eclipse" />
 
-  <target name="all-jar-flavors" depends="dist-junit,dist-nobsh-guice,dist-bsh-noguice,dist-nobsh-noguice" />
+  <target name="all-jar-flavors" depends="dist-junit,dist-nobsh-guice,dist-bsh-noguice,dist-nobsh-noguice,dist-testng-dist" />
 
   <target name="dist-junit">
     <antcall target="create-jar">
@@ -231,6 +231,15 @@
     <jar jarfile="${other.jars.dir}/${testng.bsh.noguice.jar}" update="true">
       <zipfileset src="${lib.dir}/${jcommander.jar}" />
       <zipfileset src="${lib.dir}/${junit.jar}" />
+    </jar>
+  </target>
+
+  <target name="dist-testng-dist">
+    <antcall target="create-jar">
+      <param name="jar.file" value="${other.jars.dir}/${testng.dist.jar}" />
+    </antcall>
+    <jar jarfile="${other.jars.dir}/${testng.dist.jar}" update="true">
+      <zipfileset src="${lib.dir}/${jcommander.jar}" />
     </jar>
   </target>
 

--- a/build.xml
+++ b/build.xml
@@ -188,7 +188,7 @@
 
   <target name="dist" depends="build,all-jar-flavors,dist-all-zip,eclipse" />
 
-  <target name="all-jar-flavors" depends="dist-junit,dist-nobsh-guice,dist-bsh-noguice,dist-nobsh-noguice,dist-testng-dist" />
+  <target name="all-jar-flavors" depends="dist-junit,dist-nobsh-guice,dist-bsh-noguice,dist-nobsh-noguice,dist-testng-dist,dist-testng-javadoc" />
 
   <target name="dist-junit">
     <antcall target="create-jar">
@@ -241,6 +241,12 @@
     <jar jarfile="${other.jars.dir}/${testng.dist.jar}" update="true">
       <zipfileset src="${lib.dir}/${jcommander.jar}" />
     </jar>
+  </target>
+
+  <target name="dist-testng-javadoc" depends="javadocs">
+    <zip destfile="${other.jars.dir}/${testng.javadoc.zip}">
+        <fileset dir="javadocs"/>
+    </zip>
   </target>
 
   <target name="create-jar" description="Create a jar file with the Testng classes and nothing else" >


### PR DESCRIPTION
produce the minimum jar for which 'java -jar testng.jar' doesn't throw ClassNotFoundException 
