### PR TITLE
Fix for the bug #173

### DIFF
--- a/src/main/java/org/testng/DependencyMap.java
+++ b/src/main/java/org/testng/DependencyMap.java
@@ -16,7 +16,7 @@ public class DependencyMap {
 
   public DependencyMap(ITestNGMethod[] methods) {
     for (ITestNGMethod m : methods) {
-      m_dependencies.put(/* m.getTestClass().getName() + "." + */ m.getMethodName(), m);
+    	m_dependencies.put( m.getRealClass().getName() + "." +  m.getMethodName(), m);
       for (String g : m.getGroups()) {
         m_groups.put(g, m);
       }

--- a/src/main/java/org/testng/TestRunner.java
+++ b/src/main/java/org/testng/TestRunner.java
@@ -1066,8 +1066,7 @@ public class TestRunner
         String[] dependentMethods = m.getMethodsDependedUpon();
         if (dependentMethods != null) {
           for (String d : dependentMethods) {
-            String shortMethodName = d.substring(d.lastIndexOf(".") + 1);
-            ITestNGMethod dm = dependencyMap.getMethodDependingOn(shortMethodName, m);
+            ITestNGMethod dm = dependencyMap.getMethodDependingOn(d, m);
             result.addEdge(m, dm);
           }
         }

--- a/src/test/java/test/testng173/ClassA.java
+++ b/src/test/java/test/testng173/ClassA.java
@@ -1,0 +1,15 @@
+package test.testng173;
+
+import org.testng.annotations.Test;
+
+public class ClassA {
+
+	@Test
+	public void test1() {
+	}
+
+	@Test(dependsOnMethods = "test1")
+	public void test2() {
+	}
+
+}

--- a/src/test/java/test/testng173/ClassB.java
+++ b/src/test/java/test/testng173/ClassB.java
@@ -1,0 +1,18 @@
+package test.testng173;
+
+import org.testng.annotations.*;
+
+public class ClassB {
+	@Test
+	public void testX() {
+	}
+
+	@Test(dependsOnMethods = "testX")
+	public void test2() {
+	}
+
+	@Test(dependsOnMethods = "test2")
+	public void test1() {
+	}
+
+}

--- a/src/test/java/test/testng173/TestNG173Test.java
+++ b/src/test/java/test/testng173/TestNG173Test.java
@@ -1,0 +1,65 @@
+package test.testng173;
+
+import java.util.Arrays;
+
+import org.testng.Assert;
+import org.testng.ITestResult;
+import org.testng.TestListenerAdapter;
+import org.testng.TestNG;
+import org.testng.annotations.Test;
+import org.testng.xml.XmlClass;
+import org.testng.xml.XmlSuite;
+import org.testng.xml.XmlTest;
+
+import test.SimpleBaseTest;
+
+public class TestNG173Test extends SimpleBaseTest {
+
+	@Test
+	public void orderShouldBePreservedInMethodsWithSameNameAndInDifferentClasses() {
+		TestNG tng = create();
+		XmlSuite s = createXmlSuite("PreserveOrder");
+		XmlTest t = new XmlTest(s);
+
+		t.getXmlClasses().add(new XmlClass("test.testng173.ClassA"));
+		t.getXmlClasses().add(new XmlClass("test.testng173.ClassB"));
+
+		t.setPreserveOrder("true");
+
+		tng.setXmlSuites(Arrays.asList(s));
+
+		TestListenerAdapter tla = new TestListenerAdapter();
+		tng.addListener(tla);
+		tng.run();
+
+		// bug
+		//verifyPassedTests(tla, "test1", "test2", "testX", "test1", "test2");
+
+		// Proposed fix
+		verifyPassedTests(tla, "test1", "test2", "testX", "test2", "test1");
+	}
+
+	@Test
+	public void orderShouldBePreservedInMethodsWithSameNameAndInDifferentClassesAndDifferentPackage() {
+		TestNG tng = create();
+		XmlSuite s = createXmlSuite("PreserveOrder");
+		XmlTest t = new XmlTest(s);
+
+		t.getXmlClasses().add(new XmlClass("test.testng173.ClassA"));
+		t.getXmlClasses().add(new XmlClass("test.testng173.anotherpackage.ClassC"));
+
+		t.setPreserveOrder("true");
+
+		tng.setXmlSuites(Arrays.asList(s));
+
+		TestListenerAdapter tla = new TestListenerAdapter();
+		tng.addListener(tla);
+		tng.run();
+
+		// bug
+		//verifyPassedTests(tla, "test1", "test2", "testX", "test1", "test2");
+
+		verifyPassedTests(tla, "test1", "test2", "testX", "test2", "test1");
+	}
+
+}

--- a/src/test/java/test/testng173/anotherpackage/ClassC.java
+++ b/src/test/java/test/testng173/anotherpackage/ClassC.java
@@ -1,0 +1,22 @@
+package test.testng173.anotherpackage;
+
+import org.testng.annotations.Test;
+
+public class ClassC {
+
+	@Test
+	public void testX() {
+
+	}
+
+	@Test(dependsOnMethods = "testX")
+	public void test2() {
+
+	}
+
+	@Test(dependsOnMethods = "test2")
+	public void test1() {
+
+	}
+
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -688,6 +688,12 @@
       <class name="test.configuration.BeforeClassWithDisabledTest" />
     </classes>
   </test>
+  
+  <test name="Bug173">
+    <classes>
+      <class name="test.testng173.TestNG173Test" />
+    </classes>
+  </test>
 
   <test name="Mustache">
     <classes>


### PR DESCRIPTION
Hi,

I was reviewing the [issue #173](https://github.com/cbeust/testng/issues/173) and found that the order was not being respected because only the method name was being saved when the dependencies were created.  I made a change in order to consider, besides the method name, also the real name of the class.
