### PR TITLE
Setting null field m_isMixed allowed?

### DIFF
--- a/src/main/java/org/testng/TestNG.java
+++ b/src/main/java/org/testng/TestNG.java
@@ -1635,6 +1635,9 @@ public class TestNG {
    * Specify if this run should be made in mixed mode
    */
   public void setMixed(Boolean isMixed) {
+      if(isMixed==null){
+          return;
+      }
     m_isMixed = isMixed;
   }
 


### PR DESCRIPTION
Hi, Cedric,

is it intended to set m_isMixed to null? Maven Surefire 2.12 runs against the wall due to setting m_isMixed to null ...

I added a small patch that seems to be a workaround.

Regards,
Dirk
