### PR TITLE
allow using '*' in methods attribute of testng ant task and reflect this...

### DIFF
--- a/src/main/java/org/testng/TestNG.java
+++ b/src/main/java/org/testng/TestNG.java
@@ -502,7 +502,7 @@ public class TestNG {
           + ", expected <class>.<method>");
     }
 
-    return new String[] { m.substring(0, index), m.substring(index + 1) };
+    return new String[] { m.substring(0, index), m.substring(index + 1).replaceAll("\\*", "\\.\\*") };
   }
 
   /**

--- a/src/main/java/org/testng/junit/JUnit4TestRunner.java
+++ b/src/main/java/org/testng/junit/JUnit4TestRunner.java
@@ -1,6 +1,7 @@
 package org.testng.junit;
 
 import java.util.*;
+import java.util.regex.Pattern;
 import org.junit.runner.Description;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Request;
@@ -89,9 +90,8 @@ public class JUnit4TestRunner implements IJUnitTestRunner {
                         return true;
                     }
                     for (String m: methods) {
-                        if (m.equals(description.getMethodName())) {
-                            return true;
-                        }
+                        Pattern p = Pattern.compile(m);
+                        return p.matcher(description.getMethodName()).matches();
                     }
                     return false;
                 }


### PR DESCRIPTION
... also in junit runner

Currently if one passes sth like 'my.pkg.SomeTest.*' to Ant task's methods attribute, testng fails with some regular expression related exception: cannot compile pattern '*' - which is invalid, it should try to compile '.*' pattern instead
