### PR TITLE
Suggested fix for issue 214

### DIFF
--- a/src/main/java/org/testng/TestNG.java
+++ b/src/main/java/org/testng/TestNG.java
@@ -358,10 +358,7 @@ public class TestNG {
     File jarFile = new File(m_jarPath);
 
     try {
-      URL jarfileUrl = jarFile.getCanonicalFile().toURI().toURL();
-      URLClassLoader jarLoader = new URLClassLoader(new URL[] { jarfileUrl });
-      Thread.currentThread().setContextClassLoader(jarLoader);
-
+ 
       Utils.log("TestNG", 2, "Trying to open jar file:" + jarFile);
 
       JarFile jf = new JarFile(jarFile);


### PR DESCRIPTION
Hi,

This is a simple change request so I didn't bother with a topic branch. The intent is to avoid unhappy side effects in a servlet container. A consequence of this change is that a command-line invocation will require the test jar to be explicitly added to the classpath.
