### PR TITLE
Performance improvements

### DIFF
--- a/pom-test.xml
+++ b/pom-test.xml
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
-      <version>6.5.2-SNAPSHOT</version>
+      <version>6.5.3-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
    </dependencies>

--- a/src/main/java/org/testng/internal/MethodGroupsHelper.java
+++ b/src/main/java/org/testng/internal/MethodGroupsHelper.java
@@ -251,10 +251,11 @@ public class MethodGroupsHelper {
   {
     boolean foundGroup = false;
     List<ITestNGMethod> vResult = Lists.newArrayList();
+    Pattern groupPattern = Pattern.compile(groupRegexp);
     for (ITestNGMethod tm : methods) {
       String[] groups = tm.getGroups();
       for (String group : groups) {
-        if (Pattern.matches(groupRegexp, group)) {
+        if (groupPattern.matcher(group).matches()) {
           vResult.add(tm);
           foundGroup = true;
         }


### PR DESCRIPTION
I have a project with a few thousands tests using heavily dependsOn*. Anytime I have failures, the failed report generation takes a _really_ long time (about half an hour).

I've made some changes that have a dramatic effect on my tests:
- unmodified testng:
  Tests run: 2494, Failures: 57, Errors: 0, Skipped: 1315, Time elapsed: 2,491.572 sec <<< FAILURE!
- compiled patterns:
  Tests run: 2494, Failures: 57, Errors: 0, Skipped: 1315, Time elapsed: 1,326.325 sec <<< FAILURE!
- compiled patterns + canonical name cache:
  Tests run: 2494, Failures: 57, Errors: 0, Skipped: 1315, Time elapsed: 697.847 sec <<< FAILURE!

The Map used for the cache might be replaced by one with weak keys using MapMaker, but I wasn't sure if there are cases with multiple classloaders.
