### PR TITLE
More performance improvements

### DIFF
--- a/src/main/java/org/testng/internal/BaseTestMethod.java
+++ b/src/main/java/org/testng/internal/BaseTestMethod.java
@@ -37,6 +37,7 @@ public abstract class BaseTestMethod implements ITestNGMethod {
 
   protected final transient Class<?> m_methodClass;
   protected final transient ConstructorOrMethod m_method;
+  private final transient String m_signature;
   protected String m_id = "";
   protected long m_date = -1;
   protected final transient IAnnotationFinder m_annotationFinder;
@@ -89,6 +90,7 @@ public abstract class BaseTestMethod implements ITestNGMethod {
     m_methodName = com.getName();
     m_annotationFinder = annotationFinder;
     m_instance = instance;
+    m_signature = computeSignature();
   }
 
   /**
@@ -509,15 +511,10 @@ public abstract class BaseTestMethod implements ITestNGMethod {
     return m_testClass;
   }
 
-  /**
-   * TODO cquezel JavaDoc.
-   *
-   * @return
-   */
-  protected String getSignature() {
+  private String computeSignature() {
     String classLong = m_method.getDeclaringClass().getName();
     String cls = classLong.substring(classLong.lastIndexOf(".") + 1);
-    StringBuffer result = new StringBuffer(cls + "." + m_method.getName() + "(");
+    StringBuilder result = new StringBuilder(cls).append(".").append(m_method.getName()).append("(");
     int i = 0;
     for (Class<?> p : m_method.getParameterTypes()) {
       if (i++ > 0) {
@@ -526,9 +523,18 @@ public abstract class BaseTestMethod implements ITestNGMethod {
       result.append(p.getName());
     }
     result.append(")");
-    result.append("[pri:" + getPriority() + ", instance:" + m_instance + "]");
+    result.append("[pri:").append(getPriority()).append(", instance:").append(m_instance).append("]");
 
     return result.toString();
+  }
+
+  /**
+   * TODO cquezel JavaDoc.
+   *
+   * @return
+   */
+  protected String getSignature() {
+    return m_signature;
   }
 
   /**

--- a/src/main/java/org/testng/internal/BaseTestMethod.java
+++ b/src/main/java/org/testng/internal/BaseTestMethod.java
@@ -23,12 +23,15 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  * Superclass to represent both &#64;Test and &#64;Configuration methods.
  */
 public abstract class BaseTestMethod implements ITestNGMethod {
   private static final long serialVersionUID = -2666032602580652173L;
+  private static final Pattern SPACE_SEPARATOR_PATTERN = Pattern.compile(" +");
+
   /**
    * The test class on which the test method was found. Note that this is not
    * necessarily the declaring class.
@@ -483,7 +486,7 @@ public abstract class BaseTestMethod implements ITestNGMethod {
   }
 
 
-  private Map<String, Set<String>> calculateXmlGroupDependencies(XmlTest xmlTest) {
+  private static Map<String, Set<String>> calculateXmlGroupDependencies(XmlTest xmlTest) {
     Map<String, Set<String>> result = Maps.newHashMap();
     if (xmlTest == null) {
       return result;
@@ -497,7 +500,7 @@ public abstract class BaseTestMethod implements ITestNGMethod {
         set = Sets.newHashSet();
         result.put(name, set);
       }
-      set.addAll(Arrays.asList(dependsOn.split(" +")));
+      set.addAll(Arrays.asList(SPACE_SEPARATOR_PATTERN.split(dependsOn)));
     }
 
     return result;
@@ -590,9 +593,7 @@ public abstract class BaseTestMethod implements ITestNGMethod {
   public void addMethodDependedUpon(String method) {
     String[] newMethods = new String[m_methodsDependedUpon.length + 1];
     newMethods[0] = method;
-    for (int i =1; i < newMethods.length; i++) {
-      newMethods[i] = m_methodsDependedUpon[i - 1];
-    }
+    System.arraycopy(m_methodsDependedUpon, 0, newMethods, 1, m_methodsDependedUpon.length);
     m_methodsDependedUpon = newMethods;
   }
 

--- a/src/main/java/org/testng/internal/MethodGroupsHelper.java
+++ b/src/main/java/org/testng/internal/MethodGroupsHelper.java
@@ -59,8 +59,7 @@ public class MethodGroupsHelper {
       else {
         IConfigurationAnnotation annotation = AnnotationHelper.findConfiguration(finder, m);
         if (annotation.getAlwaysRun()) {
-        	if (!unique || (unique && !MethodGroupsHelper
-    						.isMethodAlreadyPresent(outIncludedMethods, tm))) {
+        	if (!unique || !MethodGroupsHelper.isMethodAlreadyPresent(outIncludedMethods, tm)) {
         		in = true;
         	}
         }

--- a/src/main/java/org/testng/internal/MethodGroupsHelper.java
+++ b/src/main/java/org/testng/internal/MethodGroupsHelper.java
@@ -8,12 +8,14 @@ import org.testng.collections.Lists;
 import org.testng.collections.Maps;
 import org.testng.internal.annotations.AnnotationHelper;
 import org.testng.internal.annotations.IAnnotationFinder;
+import org.testng.internal.collections.Pair;
 
 import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
 /**
@@ -25,7 +27,11 @@ import java.util.regex.Pattern;
  */
 public class MethodGroupsHelper {
 
-  /**
+  private static final Map<String, Pattern> PATTERN_CACHE = new ConcurrentHashMap<String, Pattern>();
+  private static final Map<Pair<String, String>, Boolean> MATCH_CACHE =
+      new ConcurrentHashMap<Pair<String, String>, Boolean>();
+
+    /**
    * Collect all the methods that belong to the included groups and exclude all
    * the methods that belong to an excluded group.
    */
@@ -251,11 +257,21 @@ public class MethodGroupsHelper {
   {
     boolean foundGroup = false;
     List<ITestNGMethod> vResult = Lists.newArrayList();
-    Pattern groupPattern = Pattern.compile(groupRegexp);
+    Pattern groupPattern = PATTERN_CACHE.get(groupRegexp);
+    if (groupPattern == null) {
+      groupPattern = Pattern.compile(groupRegexp);
+      PATTERN_CACHE.put(groupRegexp, groupPattern);
+    }
     for (ITestNGMethod tm : methods) {
       String[] groups = tm.getGroups();
       for (String group : groups) {
-        if (groupPattern.matcher(group).matches()) {
+        Pair<String, String> cacheKey = Pair.create(groupRegexp, group);
+        Boolean match = MATCH_CACHE.get(cacheKey);
+        if (match == null) {
+          match = groupPattern.matcher(group).matches();
+          MATCH_CACHE.put(cacheKey, match);
+        }
+        if (match) {
           vResult.add(tm);
           foundGroup = true;
         }

--- a/src/main/java/org/testng/internal/MethodHelper.java
+++ b/src/main/java/org/testng/internal/MethodHelper.java
@@ -73,7 +73,8 @@ public class MethodHelper {
       boolean foundAtLeastAMethod = false;
 
       if (null != fullyQualifiedRegexp) {
-        regexp = escapeRegexp(fullyQualifiedRegexp);
+        // Escapes $ in regexps as it is not meant for end - line matching, but inner class matches.
+        regexp = fullyQualifiedRegexp.replace("$", "\\$");
         boolean usePackage = regexp.indexOf('.') != -1;
         Pattern pattern = Pattern.compile(regexp);
 
@@ -153,27 +154,6 @@ public class MethodHelper {
   }
 
   /**
-   * Escapes $ in regexps as it is not meant for end-line matching, but inner class matches.
-   * Impl.is weird as the String methods are not available in 1.4
-   */
-  private static String escapeRegexp(String regex) {
-    if (regex.indexOf('$') == -1) {
-      return regex;
-    }
-    String[] fragments = regex.split("\\$");
-    StringBuffer result = new StringBuffer();
-    for (int i = 0; i < fragments.length - 1; i++) {
-      result.append(fragments[i]).append("\\$");
-    }
-    result.append(fragments[fragments.length - 1]);
-    if (regex.endsWith("$")) {
-      result.append("\\$");
-    }
-
-    return result.toString();
-  }
-
-  /**
    * Read the expected exceptions, if any (need to handle both the old and new
    * syntax)
    */
@@ -193,7 +173,7 @@ public class MethodHelper {
         (ITestAnnotation) finder.findAnnotation(method, ITestAnnotation.class);
       if (testAnnotation != null) {
         Class<?>[] ee = testAnnotation.getExpectedExceptions();
-        if (testAnnotation != null && ee.length > 0) {
+        if (ee.length > 0) {
           result = new ExpectedExceptionsHolder(ee,
               testAnnotation.getExpectedExceptionsMessageRegExp());
         }
@@ -220,7 +200,7 @@ public class MethodHelper {
   }
 
   protected static boolean isEnabled(ITestOrConfiguration test) {
-    return null == test || (null != test && test.getEnabled());
+    return null == test || test.getEnabled();
   }
 
   /**

--- a/src/main/java/org/testng/internal/MethodHelper.java
+++ b/src/main/java/org/testng/internal/MethodHelper.java
@@ -9,6 +9,7 @@ import org.testng.collections.Lists;
 import org.testng.internal.annotations.AnnotationHelper;
 import org.testng.internal.annotations.IAnnotationFinder;
 import org.testng.internal.annotations.Sets;
+import org.testng.internal.collections.Pair;
 
 import java.lang.reflect.Method;
 import java.util.Collection;
@@ -27,6 +28,8 @@ import java.util.regex.Pattern;
  */
 public class MethodHelper {
   private static final Map<Method, String> CANONICAL_NAME_CACHE = new ConcurrentHashMap<Method, String>();
+  private static final Map<Pair<String, String>, Boolean> MATCH_CACHE =
+      new ConcurrentHashMap<Pair<String, String>, Boolean>();
 
   /**
    * Collects and orders test or configuration methods
@@ -80,7 +83,13 @@ public class MethodHelper {
           String methodName = usePackage ?
               calculateMethodCanonicalName(thisMethod)
               : thisMethodName;
-          if (pattern.matcher(methodName).matches()) {
+          Pair<String, String> cacheKey = Pair.create(regexp, methodName);
+          Boolean match = MATCH_CACHE.get(cacheKey);
+          if (match == null) {
+              match = pattern.matcher(methodName).matches();
+              MATCH_CACHE.put(cacheKey, match);
+          }
+          if (match) {
             vResult.add(method);
             foundAtLeastAMethod = true;
           }


### PR DESCRIPTION
Following your comment in https://github.com/cbeust/testng/pull/226, and since the testng-failed.xml generation still took more than 7 minutes (way better than the 41 minutes it took with 6.5.2, but still...), I looked deeper into the problem.

With my project, I get a bit more than 23K calls to MethodGroupHelper.findMethodsThatBelongToGroup(), but simply caching the Patterns has a negligible effect. However, caching the matches has much more impact, as does pre-computing the method signatures, as there are lots of calls to BaseTestMethod.toString() during the topological sort.

I now have the following results:
- 6.5.3-SNAPSHOT unmodified:
  Tests run: 7900, Failures: 415, Errors: 0, Skipped: 7271, Time elapsed: 393.218 sec <<< FAILURE!
- 6.5.3-SNAPSHOT with match caches:
  Tests run: 7900, Failures: 415, Errors: 0, Skipped: 7271, Time elapsed: 232.967 sec <<< FAILURE!

With Yourkit, I also have the following results regarding garbage generation:
- 6.5.3-SNAPSHOT unmodified: 3.81 GB of garbage generated by FailedReporter.generateReport()
- 6.5.3-SNAPSHOT with all the modifications: 360 MB of garbage

Most of the garbage was the method signatures and the matchers, and it's a lot more than the Pairs that are now created for the cache lookups.

Of course, the generation still takes almost 4 minutes, but now I think it's essentially due to the topological sort algorithm and the number of dependencies (lots of tests with Spring injection, so a lot of before/after methods).
