### PR TITLE
Honor excludeGroups on testng tests when run in mixed mode

### DIFF
--- a/src/main/java/org/testng/TestNG.java
+++ b/src/main/java/org/testng/TestNG.java
@@ -845,11 +845,14 @@ public class TestNG {
     List<XmlSuite> suites = m_cmdlineSuites != null ? m_cmdlineSuites : m_suites;
     if (hasIncludedGroups || hasExcludedGroups) {
       for (XmlSuite s : suites) {
-        if(hasIncludedGroups) {
-          s.getTests().get(0).setIncludedGroups(Arrays.asList(m_includedGroups));
-        }
-        if(hasExcludedGroups) {
-          s.getTests().get(0).setExcludedGroups(Arrays.asList(m_excludedGroups));
+        //set on each test, instead of just the first one of the suite
+        for (XmlTest t : s.getTests()) {
+          if(hasIncludedGroups) {
+            t.setIncludedGroups(Arrays.asList(m_includedGroups));
+          }
+          if(hasExcludedGroups) {
+            t.setExcludedGroups(Arrays.asList(m_excludedGroups));
+          }
         }
       }
     }

--- a/src/test/java/test/mixed/MixedTest.java
+++ b/src/test/java/test/mixed/MixedTest.java
@@ -12,6 +12,23 @@ import testhelper.OutputDirectoryPatch;
  * @author lukas
  */
 public class MixedTest extends BaseTest {
+    @Test
+    public void mixedWithExcludedGroups() {
+        String[] argv = {
+                "-d", OutputDirectoryPatch.getOutputDirectory(),
+                "-log", "0",
+                "-mixed",
+                "-groups", "unit",
+                "-excludegroups", "ignore",
+                "-testclass", "test.mixed.JUnit3Test1,test.mixed.JUnit4Test1,test.mixed.TestNGTest1,test.mixed.TestNGGroups"
+        };
+        TestListenerAdapter tla = new TestListenerAdapter();
+        TestNG.privateMain(argv, tla);
+
+        Assert.assertEquals(tla.getPassedTests().size(), 5); //2 from junit3test1, 2 from junit4test1, 0 from testngtest1 (no groups), 1 from testnggroups (1 is included, 1 is excluded)
+        Assert.assertEquals(tla.getFailedTests().size(), 0);
+
+    }
 
     @Test
     public void mixedClasses() {

--- a/src/test/java/test/mixed/TestNGGroups.java
+++ b/src/test/java/test/mixed/TestNGGroups.java
@@ -1,0 +1,17 @@
+package test.mixed;
+
+import org.testng.annotations.Test;
+
+@Test(groups = {"unit"})
+public class TestNGGroups {
+    @Test
+    public void tngTest1() {
+
+    }
+
+    @Test(groups = {"ignore"})
+    public void tngShouldBeIgnored() {
+
+    }
+
+}


### PR DESCRIPTION
Hi Cedric,

Here's a new pull for the fix for Issue 221 - excludeGroups setting ignored in Mixed Mode.

The test added for this fix is another method on an existing test, so an update to testng.xml wasn't needed.

thanks
Chris
