### PR TITLE
(Final) performance improvements for FailedReporter

### DIFF
--- a/src/main/java/org/testng/internal/Graph.java
+++ b/src/main/java/org/testng/internal/Graph.java
@@ -17,7 +17,7 @@ import java.util.Set;
  *
  * @author Cedric Beust, Aug 19, 2004
  */
-public class Graph<T extends Object> {
+public class Graph<T> {
   private static boolean m_verbose = false;
   private Map<T, Node<T>> m_nodes = Maps.newHashMap();
   private List<T> m_strictlySortedNodes = null;
@@ -56,9 +56,7 @@ public class Graph<T extends Object> {
       // Remove these two nodes from the independent list
       if (null == m_independentNodes) {
         m_independentNodes = Maps.newHashMap();
-        for (T k : m_nodes.keySet()) {
-          m_independentNodes.put(k, m_nodes.get(k));
-        }
+        m_independentNodes.putAll(m_nodes);
       }
       m_independentNodes.remove(predecessor);
       m_independentNodes.remove(tm);
@@ -142,7 +140,7 @@ public class Graph<T extends Object> {
       Node<T> node = findNodeWithNoPredecessors(nodes2);
       if (null == node) {
         List<T> cycle = new Tarjan<T>(this, nodes2.get(0).getObject()).getCycle();
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         sb.append("The following methods have cyclic dependencies:\n");
         for (T m : cycle) {
           sb.append(m).append("\n");
@@ -235,7 +233,7 @@ public class Graph<T extends Object> {
 
   @Override
   public String toString() {
-    StringBuffer result = new StringBuffer("[Graph ");
+    StringBuilder result = new StringBuilder("[Graph ");
     for (T node : m_nodes.keySet()) {
       result.append(findNode(node)).append(" ");
     }
@@ -305,10 +303,10 @@ public class Graph<T extends Object> {
 
     @Override
     public String toString() {
-      StringBuffer sb = new StringBuffer("[Node:" + m_object);
+      StringBuilder sb = new StringBuilder("[Node:" + m_object);
       sb.append("  pred:");
       for (T o : m_predecessors.values()) {
-        sb.append(" " + o.toString());
+        sb.append(" ").append(o);
       }
       sb.append("]");
       String result = sb.toString();

--- a/src/main/java/org/testng/internal/MethodHelper.java
+++ b/src/main/java/org/testng/internal/MethodHelper.java
@@ -27,6 +27,8 @@ import java.util.regex.Pattern;
  * @author <a href='mailto:the_mindstorm[at]evolva[dot]ro'>Alexandru Popescu</a>
  */
 public class MethodHelper {
+  private static final Map<ITestNGMethod[], Graph<ITestNGMethod>> GRAPH_CACHE =
+      new ConcurrentHashMap<ITestNGMethod[], Graph<ITestNGMethod>>();
   private static final Map<Method, String> CANONICAL_NAME_CACHE = new ConcurrentHashMap<Method, String>();
   private static final Map<Pair<String, String>, Boolean> MATCH_CACHE =
       new ConcurrentHashMap<Pair<String, String>, Boolean>();
@@ -326,9 +328,13 @@ public class MethodHelper {
    * @return A sorted array containing all the methods 'method' depends on
    */
   public static List<ITestNGMethod> getMethodsDependedUpon(ITestNGMethod method, ITestNGMethod[] methods) {
-    List<ITestNGMethod> parallelList = Lists.newArrayList();
-    List<ITestNGMethod> sequentialList = Lists.newArrayList();
-    Graph<ITestNGMethod> g = topologicalSort(methods, sequentialList, parallelList);
+    Graph<ITestNGMethod> g = GRAPH_CACHE.get(methods);
+    if (g == null) {
+      List<ITestNGMethod> parallelList = Lists.newArrayList();
+      List<ITestNGMethod> sequentialList = Lists.newArrayList();
+      g = topologicalSort(methods, sequentialList, parallelList);
+      GRAPH_CACHE.put(methods, g);
+    }
 
     List<ITestNGMethod> result = g.findPredecessors(method);
     return result;


### PR DESCRIPTION
With a fresh eye on a monday morning, I found the real performance problem: for each failed test method, FailedReporter calls MethodHelper.getMethodsDependedUpon() with the same array (all the test methods), which creates a new Graph solely based on the array. Since the graph is not modified by the findPredecessors() call, it can be reused.

Adding a cache to keep this detail internal, I get the wanted improvement:
- before:
  Tests run: 7900, Failures: 415, Errors: 0, Skipped: 7271, Time elapsed: 232.967 sec <<< FAILURE!
- after:
  Tests run: 7900, Failures: 415, Errors: 0, Skipped: 7271, Time elapsed: 20.884 sec <<< FAILURE!

However, maybe you want to expose the topologicalSort() method instead, so it can be called by FailedReporter once. And of course, the cache only works because the array of methods is never copied.
