### PR TITLE
Improve the XmlInclude toXml method.

### DIFF
--- a/src/main/java/org/testng/xml/XmlInclude.java
+++ b/src/main/java/org/testng/xml/XmlInclude.java
@@ -67,9 +67,10 @@ public class XmlInclude implements Serializable {
       p.setProperty("invocation-numbers",
           XmlClass.listToString(invocationNumbers).toString());
     }
-    xsb.addEmptyElement("include", p);
 
+    xsb.push("include", p);
     XmlUtils.dumpParameters(xsb, m_parameters);
+    xsb.pop("include");
 
     return xsb.toXML();
   }


### PR DESCRIPTION
Hi Cedric,

Currently, when you run the XmlSuite.toXml(), the generate result is not the same with originally.

The method level parameters will move from <include> tag to <methods> tag.

Pls help me review this patch.

Br,
Tim
