### PR TITLE
Improve the XmlInclude toXml method to keep the back compatible

### DIFF
--- a/src/main/java/org/testng/xml/XmlInclude.java
+++ b/src/main/java/org/testng/xml/XmlInclude.java
@@ -68,9 +68,14 @@ public class XmlInclude implements Serializable {
           XmlClass.listToString(invocationNumbers).toString());
     }
 
-    xsb.push("include", p);
-    XmlUtils.dumpParameters(xsb, m_parameters);
-    xsb.pop("include");
+    if (!m_parameters.isEmpty()){
+        xsb.push("include", p);
+        XmlUtils.dumpParameters(xsb, m_parameters);
+        xsb.pop("include");
+    }else{//Keep the back compatible
+       xsb.addEmptyElement("include", p);
+    }
+
 
     return xsb.toXML();
   }


### PR DESCRIPTION
Hi Cedric,

I updated XmlInclude toXml() method again to keep the back compatible :)

My yesterday pull request will make the output very ugly, even though there are no parameters in the <include> tag, it still output like this: <inlcude name="xx"></include>

If we have lots of method, it looks very ugly, so I pushed again to keep the back compatible for those no parameters include more clear.

Sorry not push them at once.

Br,
Tim
