### PR TITLE
Add the getCount method in RetryAnalyzerCount class to give the testers more flexibility

### DIFF
--- a/src/main/java/org/testng/util/RetryAnalyzerCount.java
+++ b/src/main/java/org/testng/util/RetryAnalyzerCount.java
@@ -25,6 +25,14 @@ public abstract class RetryAnalyzerCount implements IRetryAnalyzer {
   }
 
   /**
+   * Return the current counter value
+   * @return
+   */
+  protected int getCount(){
+      return this.count.get();
+  }
+
+  /**
    * Retries the test if count is not 0.
    * @param result The result of the test.
    */


### PR DESCRIPTION
Hi Cedric,

I add a get method at RetryAnalyzerCount, so that our testers can have more flexibility to control the retry count.
