### PR TITLE
Always use the ResourceCollection iterator when building file list from ant

### DIFF
--- a/src/main/java/org/testng/TestNGAntTask.java
+++ b/src/main/java/org/testng/TestNGAntTask.java
@@ -993,9 +993,6 @@ public class TestNGAntTask extends Task {
   private List<String> getFiles(List<ResourceCollection> resources) throws BuildException {
     List<String> files= Lists.newArrayList();
     for (ResourceCollection rc : resources) {
-      if (rc instanceof FileSet) {
-          files.addAll(fileset((FileSet) rc));
-      } else {
         for (Iterator i = rc.iterator(); i.hasNext();) {
           Object o = i.next();
           if (o instanceof FileResource) {
@@ -1011,7 +1008,6 @@ public class TestNGAntTask extends Task {
               log("Unsupported Resource type: " + o.toString(), Project.MSG_VERBOSE);
           }
         }
-      }
     }
     return files;
   }


### PR DESCRIPTION
Hi Cedric
I've been investigating using test-load-balancer(http://test-load-balancer.github.com/) to run my testng tests across multiple machines. They have their own ant FileSet type (LoadBalancedFileSet) which takes the full list of tests and carves it up before sending it over to Junit. I found that it doesn't work with TestNG because TestNG uses the directoryScanner on the fileset, instead of just using the iterator (which is what they override). 

This patch simply always uses the iterator on the ResourceCollection to get the fileset list when invoked in ant. 

This seems to work just fine for regular ant filesets, and has the benefit of enabling TLB for TestNG executions.

Thanks
Chris
