### PR TITLE
Remove reference to subversion

### DIFF
--- a/README.template
+++ b/README.template
@@ -4,8 +4,7 @@ Please note that even though the .zip distribution contains the TestNG sources,
 you will not be able to build the software with them because we decided
 not to include the external jar files in order to keep the size down.
 
-If you want to build TestNG, please sync to the Subversion depot (the exact information
-can be found at http://testng.org).
+If you want to build TestNG, please sync to the GitHub repository at https://github.com/cbeust/testng.
 
--- 
+--
 The TestNG team


### PR DESCRIPTION
README file references svn, changed it to specify github and point to the right address
