### PR TITLE
Fix import

### DIFF
--- a/src/main/java/org/testng/util/Strings.java
+++ b/src/main/java/org/testng/util/Strings.java
@@ -1,8 +1,7 @@
 package org.testng.util;
 
-import com.google.inject.internal.Maps;
-
 import org.testng.collections.Lists;
+import org.testng.collections.Maps;
 
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
Fixes an import statement introduced in dfc1242c66 - the erroneous import causes a failure at runtime for projects that don't use Guice.
