### PR TITLE
Ensure that HTML escaping behaves consistently across JVMs

### DIFF
--- a/src/main/java/org/testng/util/Strings.java
+++ b/src/main/java/org/testng/util/Strings.java
@@ -12,12 +12,12 @@ public class Strings {
   }
 
   private static List<String> ESCAPE_HTML_LIST = Lists.newArrayList(
+    "&", "&amp;",
     "<", "&lt;",
-    ">", "&gt;",
-    "&", "&amp;"
+    ">", "&gt;"
   );
   
-  private static final Map<String, String> ESCAPE_HTML_MAP = Maps.newHashMap();
+  private static final Map<String, String> ESCAPE_HTML_MAP = Maps.newLinkedHashMap();
 
   static {
     for (int i = 0; i < ESCAPE_HTML_LIST.size(); i += 2) {


### PR DESCRIPTION
The HTML escaping logic in d435608220c657962a7dfc03cfcef19dea0beafd relies on a specific iteration order for a HashMap; when this pre-condition is violated (due to differences in JDK implementation), the output contains over-escaped entities (e.g. `<` becomes `&amp;lt;`).
