### PR TITLE
VerboseReporter.log(): make protected

### DIFF
--- a/src/main/java/org/testng/reporters/VerboseReporter.java
+++ b/src/main/java/org/testng/reporters/VerboseReporter.java
@@ -250,7 +250,7 @@ public class VerboseReporter extends TestListenerAdapter {
         log(sb.toString());
     }
 
-    private void log(String message) {
+    protected void log(String message) {
         //prefix all output lines
         System.out.println(message.replaceAll("(?m)^", prefix));
     }


### PR DESCRIPTION
Allows sub-classes to redirect logging to favourite log framework.
