### PR TITLE
Shutdown ThreadPoolExecutor explicitly.

### DIFF
--- a/src/main/java/org/testng/internal/thread/ThreadUtil.java
+++ b/src/main/java/org/testng/internal/thread/ThreadUtil.java
@@ -76,6 +76,8 @@ public class ThreadUtil {
     } catch (InterruptedException handled) {
       handled.printStackTrace();
       Thread.currentThread().interrupt();
+    } finally {
+      pooledExecutor.shutdown();
     }
   }
 


### PR DESCRIPTION
Per the documented behavior of ThreadPoolExecutor, you must either call shutdown or
configure the executor to time-out the core threads.  If this is not done, the
thread pool persists and the process will not exit cleanly.
