### PR TITLE
Add suite names sanity check

### DIFF
--- a/src/main/java/org/testng/TestNG.java
+++ b/src/main/java/org/testng/TestNG.java
@@ -982,6 +982,7 @@ public class TestNG {
    */
   private void sanityCheck() {
     checkTestNames(m_suites);
+    checkSuiteNames(m_suites);
   }
 
   /**
@@ -999,6 +1000,26 @@ public class TestNG {
         }
       }
       checkTestNames(suite.getChildSuites());
+    }
+  }
+
+  /**
+   * Ensure that two XmlSuite don't have the same name
+   * Otherwise will be clash in SuiteRunnerMap
+   * See issue #302
+   */
+  private void checkSuiteNames(List<XmlSuite> suites) {
+    checkSuiteNamesInternal(suites, Sets.<String>newHashSet());
+  }
+
+  private void checkSuiteNamesInternal(List<XmlSuite> suites, Set<String> names) {
+    for (XmlSuite suite : suites) {
+      final String name = suite.getName();
+      if (names.contains(name)) {
+        throw new TestNGException("Two suites cannot have the same name: " + name);
+      }
+      names.add(name);
+      checkSuiteNamesInternal(suite.getChildSuites(), names);
     }
   }
 

--- a/src/main/java/org/testng/internal/SuiteRunnerMap.java
+++ b/src/main/java/org/testng/internal/SuiteRunnerMap.java
@@ -1,6 +1,7 @@
 package org.testng.internal;
 
 import org.testng.ISuite;
+import org.testng.TestNGException;
 import org.testng.collections.Maps;
 import org.testng.xml.XmlSuite;
 
@@ -12,7 +13,11 @@ public class SuiteRunnerMap {
   private Map<String, ISuite> m_map = Maps.newHashMap();
 
   public void put(XmlSuite xmlSuite, ISuite suite) {
-    m_map.put(xmlSuite.getName(), suite);
+    final String name = xmlSuite.getName();
+    if (m_map.containsKey(name)) {
+      throw new TestNGException("SuiteRunnerMap already have runner for suite " + name);
+    }
+    m_map.put(name, suite);
   }
 
   public ISuite get(XmlSuite xmlSuite) {

--- a/src/test/java/test/sanitycheck/CheckSuiteNamesTest.java
+++ b/src/test/java/test/sanitycheck/CheckSuiteNamesTest.java
@@ -1,0 +1,65 @@
+package test.sanitycheck;
+
+import org.testng.Assert;
+import org.testng.TestListenerAdapter;
+import org.testng.TestNG;
+import org.testng.TestNGException;
+import org.testng.annotations.Test;
+import org.testng.xml.XmlClass;
+import org.testng.xml.XmlSuite;
+import org.testng.xml.XmlTest;
+import test.SimpleBaseTest;
+
+import java.util.Arrays;
+
+public class CheckSuiteNamesTest extends SimpleBaseTest {
+
+  /**
+   * Child suites have different names
+   */
+  @Test
+  public void checkChildSuites() {
+    TestListenerAdapter tla = new TestListenerAdapter();
+    TestNG tng = create();
+    String testngXmlPath = getPathToResource("sanitycheck/test-s-b.xml");
+    tng.setTestSuites(Arrays.asList(testngXmlPath));
+    tng.addListener(tla);
+    tng.run();
+    Assert.assertEquals(tla.getPassedTests().size(), 4);
+  }
+
+  /**
+   * Child suites have same names
+   */
+  @Test(expectedExceptions = TestNGException.class, expectedExceptionsMessageRegExp = "\\s*Two suites cannot have the same name.*")
+  public void checkChildSuitesFails() {
+    TestNG tng = create();
+    String testngXmlPath = getPathToResource("sanitycheck/test-s-a.xml");
+    tng.setTestSuites(Arrays.asList(testngXmlPath));
+    tng.run();
+  }
+
+  /**
+   * Checks that suites created programmatically also fails as expected
+   */
+  @Test(expectedExceptions = TestNGException.class, expectedExceptionsMessageRegExp = "\\s*Two suites cannot have the same name.*")
+  public void checkProgrammaticSuitesFails() {
+    XmlSuite xmlSuite1 = new XmlSuite();
+    xmlSuite1.setName("SanityCheckSuite");
+    {
+      XmlTest result = new XmlTest(xmlSuite1);
+      result.getXmlClasses().add(new XmlClass(SampleTest1.class.getCanonicalName()));
+    }
+
+    XmlSuite xmlSuite2 = new XmlSuite();
+    xmlSuite2.setName("SanityCheckSuite");
+    {
+      XmlTest result = new XmlTest(xmlSuite2);
+      result.getXmlClasses().add(new XmlClass(SampleTest2.class.getCanonicalName()));
+    }
+
+    TestNG tng = create();
+    tng.setXmlSuites(Arrays.asList(xmlSuite1, xmlSuite2));
+    tng.run();
+  }
+}

--- a/src/test/java/test/sanitycheck/CheckTestNamesTest.java
+++ b/src/test/java/test/sanitycheck/CheckTestNamesTest.java
@@ -74,7 +74,7 @@ public class CheckTestNamesTest extends SimpleBaseTest {
     tng.setTestSuites(Arrays.asList(testngXmlPath));
     tng.addListener(tla);
     tng.run();
-    Assert.assertEquals(tla.getPassedTests().size(), 6);
+    Assert.assertEquals(tla.getPassedTests().size(), 4);
   }
 
   /**

--- a/src/test/resources/sanitycheck/test-s-1.xml
+++ b/src/test/resources/sanitycheck/test-s-1.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suite name="SanityCheck suites">
+  <test name="SanityCheck:Tests" preserve-order="true">
+    <classes>
+      <class name="test.sanitycheck.SampleTest1"/>
+    </classes>
+  </test>
+  <test name="SanityCheck:Tests:Another" preserve-order="true">
+    <classes>
+      <class name="test.sanitycheck.SampleTest3"/>
+    </classes>
+  </test>
+</suite>

--- a/src/test/resources/sanitycheck/test-s-2.xml
+++ b/src/test/resources/sanitycheck/test-s-2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suite name="SanityCheck suites">
+  <test name="SanityCheck:Tests" preserve-order="true">
+    <classes>
+      <class name="test.sanitycheck.SampleTest1"/>
+    </classes>
+  </test>
+  <test name="SanityCheck:Tests:Another" preserve-order="true">
+    <classes>
+      <class name="test.sanitycheck.SampleTest3"/>
+    </classes>
+  </test>
+</suite>

--- a/src/test/resources/sanitycheck/test-s-3.xml
+++ b/src/test/resources/sanitycheck/test-s-3.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suite name="SanityCheck suites 3">
+  <test name="SanityCheck:Tests" preserve-order="true">
+    <classes>
+      <class name="test.sanitycheck.SampleTest1"/>
+    </classes>
+  </test>
+  <test name="SanityCheck:Tests:Another" preserve-order="true">
+    <classes>
+      <class name="test.sanitycheck.SampleTest3"/>
+    </classes>
+  </test>
+</suite>

--- a/src/test/resources/sanitycheck/test-s-a.xml
+++ b/src/test/resources/sanitycheck/test-s-a.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suite name="SanityCheck suites root">
+  <suite-files>
+    <suite-file path="./test-s-1.xml"/>
+    <suite-file path="./test-s-2.xml"/>
+  </suite-files>
+</suite>

--- a/src/test/resources/sanitycheck/test-s-b.xml
+++ b/src/test/resources/sanitycheck/test-s-b.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suite name="SanityCheck suites root">
+  <suite-files>
+    <suite-file path="./test-s-2.xml"/>
+    <suite-file path="./test-s-3.xml"/>
+  </suite-files>
+</suite>


### PR DESCRIPTION
Before running, TestNG will check that there no two or more suites with same names, because two suites with same names may cause invalid behavior (see #302 for sample).

Added new sanity check into `org.testng.TestNG#sanityCheck()` and check for clashing in `org.testng.internal.SuiteRunnerMap#put(XmlSuite xmlSuite, ISuite suite)`

Also some tests added (see `test.sanitycheck.CheckSuiteNamesTest`).

Also `test.sanitycheck.CheckTestNamesTest.checkNoErrorWtihChildSuites` now fails because has two suites with same name. Also without that check it produces 6 test runs instead of 4.
