### PR TITLE
ignores synthetic methods as being included as @Test methods

### DIFF
--- a/src/main/java/org/testng/internal/annotations/AnnotationHelper.java
+++ b/src/main/java/org/testng/internal/annotations/AnnotationHelper.java
@@ -219,7 +219,8 @@ public class AnnotationHelper {
               isAnnotationPresent(annotationFinder, m, ITestAnnotation.class) ||
               isAnnotationPresent(annotationFinder, m, CONFIGURATION_CLASSES);
             boolean isPublic = Modifier.isPublic(m.getModifiers());
-            if ((isPublic && hasClassAnnotation && (! hasTestNGAnnotation)) || hasMethodAnnotation) {
+            boolean isSynthetic = m.isSynthetic();            
+            if ((isPublic && hasClassAnnotation && !isSynthetic && (! hasTestNGAnnotation)) || hasMethodAnnotation) {
 
               // Small hack to allow users to specify @Configuration classes even though
               // a class-level @Test annotation is present.  In this case, don't count


### PR DESCRIPTION
This allows someone writing Groovy tests to annotate at the class level
instead of having to annotate each individual method.

This is a fix for issue #84, but I couldn't attach the pull request to that ticket.
