### PR TITLE
Attempt to fix unnecessary execution of @Factory-ctors

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,5 +1,33 @@
 <project name="testng" default="dev" basedir="." xmlns:ivy="antlib:org.apache.ivy.ant">
-  
+      <property name="ivy.install.version" value="2.1.0-rc2" />
+    <condition property="ivy.home" value="${env.IVY_HOME}">
+      <isset property="env.IVY_HOME" />
+    </condition>
+    <property name="ivy.home" value="${user.home}/.ant" />
+    <property name="ivy.jar.dir" value="${ivy.home}/lib" />
+    <property name="ivy.jar.file" value="${ivy.jar.dir}/ivy.jar" />
+
+    <target name="download-ivy" unless="offline">
+
+        <mkdir dir="${ivy.jar.dir}"/>
+        <!-- download Ivy from web site so that it can be used even without any special installation -->
+        <get src="http://repo2.maven.org/maven2/org/apache/ivy/ivy/${ivy.install.version}/ivy-${ivy.install.version}.jar" 
+             dest="${ivy.jar.file}" usetimestamp="true"/>
+    </target>
+
+    <target name="init-ivy">
+      <!-- try to load ivy here from ivy home, in case the user has not already dropped
+              it into ant's lib dir (note that the latter copy will always take precedence).
+              We will not fail as long as local lib dir exists (it may be empty) and
+              ivy is in at least one of ant's lib dir or the local lib dir. -->
+        <path id="ivy.lib.path">
+            <fileset dir="${ivy.jar.dir}" includes="*.jar"/>
+
+        </path>
+        <taskdef resource="org/apache/ivy/ant/antlib.xml"
+                 uri="antlib:org.apache.ivy.ant" classpathref="ivy.lib.path"/>
+    </target>
+
   <!-- ====================================================================== -->
   <!-- TestNG build file                                                      -->
   <!-- Created cbeust, April 26th, 2004                                       -->
@@ -12,7 +40,7 @@
   <!-- ====================================================================== -->
   <!-- PREPARE                                                                -->
   <!-- ====================================================================== -->
-  <target name="prepare" depends="retrieve-dependencies"
+  <target name="prepare" depends="init-ivy,retrieve-dependencies"
           description="Performs all preparations required to build.">
     <tstamp />
     <mkdir dir="${build.dir}" />

--- a/src/main/java/org/testng/internal/ClassHelper.java
+++ b/src/main/java/org/testng/internal/ClassHelper.java
@@ -136,7 +136,7 @@ public final class ClassHelper {
       IFactoryAnnotation f = (IFactoryAnnotation) finder.findAnnotation(method,
           IFactoryAnnotation.class);
 
-      if (null != f) {
+      if (null != f && f.getEnabled()) {
         if (result != null) {
           throw new TestNGException(cls.getName() + ":  only one @Factory method allowed");
         }
@@ -147,9 +147,9 @@ public final class ClassHelper {
     }
 
     if (result == null) {
-      for (Constructor constructor : cls.getDeclaredConstructors()) {
-        IAnnotation f = finder.findAnnotation(constructor, IFactoryAnnotation.class);
-        if (f != null) {
+      for (Constructor<?> constructor : cls.getDeclaredConstructors()) {
+    	  IFactoryAnnotation f = (IFactoryAnnotation) finder.findAnnotation(constructor, IFactoryAnnotation.class);
+        if (f != null && f.getEnabled()) {
           result = new ConstructorOrMethod(constructor);
         }
       }

--- a/src/test/java/test/factory/ExcludedFactory.java
+++ b/src/test/java/test/factory/ExcludedFactory.java
@@ -1,0 +1,33 @@
+package test.factory;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+
+/**
+ * Dummy class with @Factory ctor that shouldn't run.
+ * @author beverage
+ */
+public class ExcludedFactory {
+
+  private static boolean factoryRan = false;
+
+  @Factory(dataProvider = "empty")
+  public ExcludedFactory(int a) {
+    factoryRan = true;
+  }
+
+  @Test(groups = "excludedCtorFactory")
+  public void emptyTest() {
+  }
+  
+  public static boolean didFactoryRun() {
+    return factoryRan;
+  }
+
+  @SuppressWarnings("unused")
+  @DataProvider(name = "empty")
+  private static Object[][] provider() {
+    return new Object[][] { { 1 } };
+  }
+}

--- a/src/test/java/test/factory/VerifyExcludedFactory.java
+++ b/src/test/java/test/factory/VerifyExcludedFactory.java
@@ -1,0 +1,11 @@
+package test.factory;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class VerifyExcludedFactory {
+  @Test
+  public void verifyExcludedFactory() {
+    Assert.assertFalse(ExcludedFactory.didFactoryRun(), "Excluded ctor-factory ran.");
+  }
+}


### PR DESCRIPTION
(Ignore the build.xml change - it was a fix I had to do to get things working in my local environment that shouldn't of been pushed.)

Here's the change I was suggesting here: https://groups.google.com/forum/?fromgroups=#!topic/testng-dev/3VjYKh6xXZw

I don't think this is an acceptable change now though as it will result in double execution of default constructors.  While I think in a perfect world that would be fine (nobody should be doing anything expensive in default constructors anyways - they should have things like that in TestNG annotated configuration methods) it could possibly have horrible side effects for some users who are doing expensive initialization there.

What are your thoughts on this?  Alternatively, we could maintain a test class cache from which we could pull objects from once they are initialized - something like that would a bit more complicated though.
