### PR TITLE
Fix NPE for dependency methods/groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ z_build
 maven-testng-plugin-1.2.jar
 .settings
 src/test/java/test/ignore
-
+.classpath
+.project

--- a/src/main/java/org/testng/DependencyMap.java
+++ b/src/main/java/org/testng/DependencyMap.java
@@ -5,6 +5,7 @@ import org.testng.collections.Lists;
 import org.testng.collections.Maps;
 import org.testng.collections.Sets;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -41,7 +42,7 @@ public class DependencyMap {
       }
     }
 
-    if (result.isEmpty()) {
+    if (result.isEmpty() && !fromMethod.ignoreMissingDependencies()) {
       throw new TestNGException("DependencyMap::Method \"" + fromMethod
           + "\" depends on nonexistent group \"" + group + "\"");
     } else {
@@ -51,6 +52,9 @@ public class DependencyMap {
 
   public ITestNGMethod getMethodDependingOn(String methodName, ITestNGMethod fromMethod) {
     List<ITestNGMethod> l = m_dependencies.get(methodName);
+    if (l == null && fromMethod.ignoreMissingDependencies()){
+    	return fromMethod;
+    }
     for (ITestNGMethod m : l) {
       // If they are in the same class hierarchy, they must belong to the same instance,
       // otherwise, it's a method depending on a method in a different class so we

--- a/src/main/java/org/testng/TestRunner.java
+++ b/src/main/java/org/testng/TestRunner.java
@@ -1059,7 +1059,9 @@ public class TestRunner
         if (dependentMethods != null) {
           for (String d : dependentMethods) {
             ITestNGMethod dm = dependencyMap.getMethodDependingOn(d, m);
-            result.addEdge(m, dm);
+            if (m != dm){
+            	result.addEdge(m, dm);
+            }
           }
         }
       }

--- a/src/test/java/test/dependent/DependencyFixTest.java
+++ b/src/test/java/test/dependent/DependencyFixTest.java
@@ -1,0 +1,24 @@
+package test.dependent;
+
+import static org.testng.Assert.assertTrue;
+
+import org.testng.annotations.Test;
+
+public class DependencyFixTest {
+	@Test(dependsOnMethods = "helloWorld", ignoreMissingDependencies = true)
+	public void dependentOnNonExistingMethod() {
+		assertTrue(true);
+	}
+
+	@Test(dependsOnMethods = "dependentOnNonExistingMethod")
+	public void dependentOnExistingMethod() {
+		assertTrue(true);
+	}
+
+	@Test(groups = "selfSufficient", dependsOnGroups = "nonExistingGroup", ignoreMissingDependencies = true)
+	public void dependentOnNonExistingGroup() {
+		assertTrue(true);
+
+	}
+
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -210,6 +210,7 @@
       <class name="test.dependsongroup.DependsOnGroupsTest" />
       <class name="test.dependent.GroupByInstancesTest" />
       <class name="test.dependent.xml.GroupDependencyTest" />
+      <class name="test.dependent.DependencyFixTest"/>
     </classes>
   </test>
 


### PR DESCRIPTION
When a test method depends on a group/method
which doesn't exist and when a user specifies
[ignoreMissingDependencies=true] instead of running
the test method, TestNG throws a NullPointerException
Fixed this issue.

Also updated the .gitignore file to include 
class path and project eclipse files.
