### PR TITLE
testng-eclipse issue #76 TestNG view should display the array content with a test accepting an array parameter via a dataProvider.

### DIFF
--- a/src/main/java/org/testng/remote/strprotocol/TestResultMessage.java
+++ b/src/main/java/org/testng/remote/strprotocol/TestResultMessage.java
@@ -309,6 +309,20 @@ public class TestResultMessage implements IStringMessage {
       if(null == o) {
         result.add("null");
       }
+      else if (o.getClass().isArray()) {
+        String[] strArray = toString((Object[]) o, null);
+        StringBuilder sb = new StringBuilder("[");
+        for (int i = 0; i < strArray.length; i++)
+        {
+          sb.append(strArray[i]);
+          if (i + 1 < strArray.length)
+          {
+            sb.append(",");
+          }
+        }
+        sb.append("]");
+        result.add(sb.toString());
+      }
       else {
         String tostring= o.toString();
         if(isStringEmpty(tostring)) {


### PR DESCRIPTION
See testng-eclipse issue #76: https://github.com/cbeust/testng-eclipse/issues/76.
