### PR TITLE
Change the constructor modifier from protected to public for SkipException

### DIFF
--- a/src/main/java/org/testng/SkipException.java
+++ b/src/main/java/org/testng/SkipException.java
@@ -18,7 +18,7 @@ public class SkipException extends RuntimeException {
     super(skipMessage);
   }
 
-  protected SkipException(String skipMessage, Throwable cause) {
+  public SkipException(String skipMessage, Throwable cause) {
     super(skipMessage, cause);
   }
 


### PR DESCRIPTION
Hi,

Currently, in SkipException, there are two constuctor, one of them is public access, another is protected.

Could we change both as public?

Br,
Tim
