### PR TITLE
The result of TrueParallelTest is nondeterministic

### DIFF
--- a/src/test/java/test/thread/TrueParallelSampleTest.java
+++ b/src/test/java/test/thread/TrueParallelSampleTest.java
@@ -2,11 +2,19 @@ package test.thread;
 
 import org.testng.annotations.Test;
 
+import java.util.Random;
+
 @Test
 public class TrueParallelSampleTest extends BaseThreadTest {
+  static Random random = new Random(System.currentTimeMillis());
+
   private void log(String s) {
     logString(s);
-    Thread.yield();
+    try {
+      Thread.sleep(random.nextInt(10));
+    } catch (InterruptedException ex) {
+      Thread.yield();
+    }
     logString(s);
     logCurrentThread();
   }
@@ -14,7 +22,7 @@ public class TrueParallelSampleTest extends BaseThreadTest {
   public void m1() {
     log("m1");
   }
-  
+
   public void m2() {
     log("m2");
   }

--- a/src/test/java/test/thread/TrueParallelTest.java
+++ b/src/test/java/test/thread/TrueParallelTest.java
@@ -20,7 +20,7 @@ public class TrueParallelTest extends SimpleBaseTest {
   @Test
   public void shouldRunInParallel() {
     boolean success = false;
-    for (int i = 0; i < 5; i++) {
+    for (int i = 0, count = Runtime.getRuntime().availableProcessors() * 4; i < count; i++) {
       XmlSuite s = createXmlSuite("TrueParallel");
       createXmlTest(s, "Test", TrueParallelSampleTest.class.getName());
       TestNG tng = create();


### PR DESCRIPTION
The result of TrueParallelTest is inherently nondeterministic, on systems with high number of processors, the default number 5 of concurrent running threads is too low to make the test pass. On my 8 cores system, the test can rarely pass. This patch changes the number of threads to 4 times of available processors to make the test more likely to pass. But still the result of this test is nondeterministic. The patches can make the test less likely to fail.
