### PR TITLE
Issue #363 primitive arrays cause ClassCastException in eclipse 6.8.1 plugin

### DIFF
--- a/src/main/java/org/testng/remote/strprotocol/TestResultMessage.java
+++ b/src/main/java/org/testng/remote/strprotocol/TestResultMessage.java
@@ -18,8 +18,6 @@ import java.util.List;
  * @author <a href='mailto:the_mindstorm[at]evolva[dot]ro'>Alexandru Popescu</a>
  */
 public class TestResultMessage implements IStringMessage {
-  private static final Object[] EMPTY_PARAMS= new Object[0];
-  private static final Class[] EMPTY_TYPES= new Class[0];
 
   protected int    m_messageType;
   protected String m_suiteName;
@@ -300,7 +298,7 @@ public class TestResultMessage implements IStringMessage {
     return result;
   }
 
-  private String[] toString(Object[] objects, Class[] objectClasses) {
+  String[] toString(Object[] objects, Class<?>[] objectClasses) {
     if(null == objects) {
       return new String[0];
     }
@@ -310,7 +308,12 @@ public class TestResultMessage implements IStringMessage {
         result.add("null");
       }
       else if (o.getClass().isArray()) {
-        String[] strArray = toString((Object[]) o, null);
+        String[] strArray;
+        if (o.getClass().getComponentType().isPrimitive()){
+          strArray = primitiveArrayToString(o);
+        } else {
+          strArray = toString((Object[]) o, null);
+        }
         StringBuilder sb = new StringBuilder("[");
         for (int i = 0; i < strArray.length; i++)
         {
@@ -337,12 +340,58 @@ public class TestResultMessage implements IStringMessage {
     return result.toArray(new String[result.size()]);
   }
 
-  private String[] toString(Class[] classes) {
+  private String[] primitiveArrayToString(Object o) {
+    List<String> results = Lists.newArrayList();
+    if (o instanceof byte[]) {
+      byte[] array = (byte[]) o;
+      for (int i = 0; i < array.length; i++) {
+        results.add(String.valueOf(array[i]));
+      }
+    } else if (o instanceof boolean[]) {
+      boolean[] array = (boolean[]) o;
+      for (int i = 0; i < array.length; i++) {
+        results.add(String.valueOf(array[i]));
+      }
+    } else if (o instanceof char[]) {
+      char[] array = (char[]) o;
+      for (int i = 0; i < array.length; i++) {
+        results.add(String.valueOf(array[i]));
+      }
+    } else if (o instanceof double[]) {
+      double[] array = (double[]) o;
+      for (int i = 0; i < array.length; i++) {
+        results.add(String.valueOf(array[i]));
+      }
+    } else if (o instanceof float[]) {
+      float[] array = (float[]) o;
+      for (int i = 0; i < array.length; i++) {
+        results.add(String.valueOf(array[i]));
+      }
+    } else if (o instanceof short[]) {
+      short[] array = (short[]) o;
+      for (int i = 0; i < array.length; i++) {
+        results.add(String.valueOf(array[i]));
+      }
+    } else if (o instanceof int[]) {
+      int[] array = (int[]) o;
+      for (int i = 0; i < array.length; i++) {
+        results.add(String.valueOf(array[i]));
+      }
+    } else if (o instanceof long[]) {
+      long[] array = (long[]) o;
+      for (int i = 0; i < array.length; i++) {
+        results.add(String.valueOf(array[i]));
+      }
+    }
+    return results.toArray(new String[results.size()]);
+  }
+
+  private String[] toString(Class<?>[] classes) {
     if(null == classes) {
       return new String[0];
     }
     List<String> result= Lists.newArrayList(classes.length);
-    for(Class cls: classes) {
+    for(Class<?> cls: classes) {
       result.add(cls.getName());
     }
 

--- a/src/test/java/org/testng/remote/strprotocol/TestResultMessageTest.java
+++ b/src/test/java/org/testng/remote/strprotocol/TestResultMessageTest.java
@@ -1,0 +1,54 @@
+package org.testng.remote.strprotocol;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class TestResultMessageTest {
+
+	private TestResultMessage testResultMessage = new TestResultMessage(0,
+			"suiteName", "testName", "className", "methodName",
+			"testDescriptor", "testinstanceName", new String[] {}, 0, 0,
+			"stackTrace", 1, 0);
+
+	@DataProvider(name = "testGen")
+	private Object[][] getP() {
+		return new Object[][] {
+				{ null, new Class[] { null }, Arrays.asList() },
+				{ new Object[] { new byte[] { 1 } },
+						new Class[] { byte[].class }, Arrays.asList("[1]") },
+				{ new Object[] { new short[] { 1 } },
+						new Class[] { short[].class }, Arrays.asList("[1]") },
+				{ new Object[] { new long[] { 1 } },
+						new Class[] { long[].class }, Arrays.asList("[1]") },
+				{ new Object[] { new int[] { 1, 2, 3 } },
+						new Class[] { int[].class }, Arrays.asList("[1,2,3]") },
+				{ new Object[] { new boolean[] { true, false } },
+						new Class[] { boolean[].class },
+						Arrays.asList("[true,false]") },
+				{ new Object[] { new char[] { 'a', 'b', 'c' } },
+						new Class[] { int[].class }, Arrays.asList("[a,b,c]") },
+				{ new Object[] { new float[] { 1.1f, 2.2f, 3.3f } },
+						new Class[] { float[].class },
+						Arrays.asList("[1.1,2.2,3.3]") },
+				{ new Object[] { new double[] { 1.1, 2.2, 3.3 } },
+						new Class[] { double[].class },
+						Arrays.asList("[1.1,2.2,3.3]") },
+				{ new Object[] { new Object[] { "this is a string", false } },
+						new Class[] { String.class, Boolean.class },
+						Arrays.asList("[this is a string,false]") },
+				{ new Object[] { new Object[] { null, "" } },
+						new Class[] { String.class, Boolean.class },
+						Arrays.asList("[null,\"\"]") }, };
+	}
+
+	@Test(dataProvider = "testGen")
+	public void toStringTest(Object[] objects, Class<?>[] objectClasses,
+			List<String> expectedResults) throws Exception {
+		String[] results = testResultMessage.toString(objects, objectClasses);
+		Assert.assertEquals(Arrays.asList(results), expectedResults);
+	}
+}


### PR DESCRIPTION
Issue #363 primitive arrays cause ClassCastException in eclipse 6.8.1 plugin. Added code fix and tests.
