### PR TITLE
Update Assert.java

### DIFF
--- a/src/main/java/org/testng/Assert.java
+++ b/src/main/java/org/testng/Assert.java
@@ -142,7 +142,7 @@ public class Assert {
                assertEquals(_actual, _expected);
             } catch (AssertionError ae) {
                failNotEquals(actual, expected, message == null ? "" : message
-                        + " (values as index " + i + " are not the same)");
+                        + " (values at index " + i + " are not the same)");
             }
          }
          //array values matched


### PR DESCRIPTION
Tiny typo in the Error message that shows up when arrays are not equal (but have same length)
