### PR TITLE
Fixed warning string

### DIFF
--- a/src/main/java/org/testng/internal/XmlMethodSelector.java
+++ b/src/main/java/org/testng/internal/XmlMethodSelector.java
@@ -248,7 +248,7 @@ public class XmlMethodSelector implements IMethodSelector {
       throw new TestNGException(e);
     }
 
-    Utils.log("Warning", 2, "The regular exception \"" + methodName + "\" didn't match any" +
+    Utils.log("Warning", 2, "The regular expression \"" + methodName + "\" didn't match any" +
     		" method in class " + className);
   }
 


### PR DESCRIPTION
Just a small fix: it should say "regular expression" instead of "regular exception"
