### PR TITLE
Extend Guice support

### DIFF
--- a/doc/documentation-main.html
+++ b/doc/documentation-main.html
@@ -2226,7 +2226,7 @@ public interface IModuleFactory {
 
 Your factory will be passed an instance of the test context and the test class that TestNG needs to instantiate. Your <tt>createModule</tt> method should return a Guice Module that will know how to instantiate this test class. You can use the test context to find out more information about your environment, such as parameters specified in <tt>testng.xml</tt>, etc...
 
-You will get even more flexibility and Guice power with parent-module siute parameter. Here is how you can define parent-module in your test.xml file:
+You will get even more flexibility and Guice power with parent-module suite parameter. Here is how you can define parent-module in your test.xml file:
 
 <pre class="brush: xml">
 <suite parent-module="com.example.SuiteParenModule">
@@ -2235,7 +2235,64 @@ You will get even more flexibility and Guice power with parent-module siute para
 
 TestNG will create this module only once for given suite. Will also use this module for obtaining instances of test specific Guice modules and module factories, then will create child injector for each test class.
 
-With such approach you can declare all common bindings in parent-module also you can inject binding declared in parent-module in module and module factory.
+With such approach you can declare all common bindings in parent-module also you can inject binding declared in parent-module in module and module factory. Here is an example of this functionality:
+
+<pre class="brush: java">
+package com.example;
+
+public class ParentModule extends AbstractModule {
+  @Override
+  protected void conigure() {
+    bind(MyService.class).toProvider(MyServiceProvider.class);
+    bind(MyContext.class).to(MyContextImpl.class).in(Singleton.class);
+  }
+}
+</pre>
+
+<pre class="brush: java">
+package com.example;
+
+public class TestModule extends AbstractModule {
+  private final MyContext myContext;
+
+  @Inject
+  TestModule(MyContext myContext) {
+    this.myContext = myContext
+  }
+  
+  @Override
+  protected void configure() {
+    bind(MySession.class).toInstance(myContext.getSession());
+  }
+}
+</pre>
+
+<pre class="brush: xml">
+<suite parent-module="com.example.ParentModule">
+</suite>
+</pre>
+
+<pre class="brush: java">
+package com.example;
+
+@Test
+@Guice(modules = TestModule.class)
+public class TestClass {
+  @Inject
+  MyService myService;
+  @Inject
+  MySession mySession;
+  
+  public void testServiceWithSession() {
+    myService.serve(mySession);
+  }
+}
+</pre>
+
+As you see ParentModule declares binding for MyService and MyContext classes. Then MyContext is injected using constructor injection into TestModule class, which also declare binding for MySession. Then parent-module in test XML file is set to ParentModule class, this enables injection in TestModule. Later in TestClass you see two injections:
+ * MyService - binding taken from ParentModule
+ * MySession - binding taken from TestModule
+This configuration ensures you that all tests in this suite will be run with same session instance, the MyContextImpl object is only created once per suite, this give you possibility to configure common environment state for all tests in suite. 
 
 <!-------------------------------------
   INVOKED METHOD LISTENERS

--- a/doc/documentation-main.html
+++ b/doc/documentation-main.html
@@ -2226,7 +2226,16 @@ public interface IModuleFactory {
 
 Your factory will be passed an instance of the test context and the test class that TestNG needs to instantiate. Your <tt>createModule</tt> method should return a Guice Module that will know how to instantiate this test class. You can use the test context to find out more information about your environment, such as parameters specified in <tt>testng.xml</tt>, etc...
 
+You will get even more flexibility and Guice power with parent-module siute parameter. Here is how you can define parent-module in your test.xml file:
 
+<pre class="brush: xml">
+<suite parent-module="com.example.SuiteParenModule">
+</suite>
+</pre>
+
+TestNG will create this module only once for given suite. Will also use this module for obtaining instances of test specific Guice modules and module factories, then will create child injector for each test class.
+
+With such approach you can declare all common bindings in parent-module also you can inject binding declared in parent-module in module and module factory.
 
 <!-------------------------------------
   INVOKED METHOD LISTENERS

--- a/doc/download.html
+++ b/doc/download.html
@@ -39,8 +39,7 @@
 <pre class="brush: plain">
 $ git clone git://github.com/cbeust/testng.git
 $ cd testng
-$ cp ivy-2.1.0.jar ~/.ant/lib
-$ ant
+$ mvn package
 </pre>
 
 <p>You will then find the jar file in the <tt>target</tt> directory</p>

--- a/src/main/java/org/testng/ISuite.java
+++ b/src/main/java/org/testng/ISuite.java
@@ -1,12 +1,14 @@
 package org.testng;
 
 
-import org.testng.internal.annotations.IAnnotationFinder;
-import org.testng.xml.XmlSuite;
-
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+
+import org.testng.internal.annotations.IAnnotationFinder;
+import org.testng.xml.XmlSuite;
+
+import com.google.inject.Injector;
 
 /**
  * Interface defining a Test Suite.
@@ -41,6 +43,8 @@ public interface ISuite extends IAttributes {
    * @return true if the tests must be run in parallel.
    */
   public String getParallel();
+
+  public String getParentModule();
 
   /**
    * @return The value of this parameter, or null if none was specified.
@@ -102,6 +106,10 @@ public interface ISuite extends IAttributes {
   public XmlSuite getXmlSuite();
 
   public void addListener(ITestNGListener listener);
+
+  public Injector getParentInjector();
+
+  public void setParentInjector(Injector injector);
 
   /**
    * @return the total number of methods found in this suite. The presence of

--- a/src/main/java/org/testng/SuiteRunner.java
+++ b/src/main/java/org/testng/SuiteRunner.java
@@ -27,6 +27,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import com.google.inject.Injector;
 
 /**
  * <CODE>SuiteRunner</CODE> is responsible for running all the tests included in one
@@ -48,6 +49,7 @@ public class SuiteRunner implements ISuite, Serializable, IInvokedMethodListener
 
   private String m_outputDir; // DEFAULT_OUTPUT_DIR;
   private XmlSuite m_suite;
+  private Injector m_parentInjector;
 
   transient private List<ITestListener> m_testListeners = Lists.newArrayList();
   transient private ITestRunnerFactory m_tmpRunnerFactory;
@@ -231,6 +233,18 @@ public class SuiteRunner implements ISuite, Serializable, IInvokedMethodListener
   @Override
   public String getParallel() {
     return m_suite.getParallel();
+  }
+
+  public String getParentModule() {
+    return m_suite.getParentModule();
+  }
+
+  public Injector getParentInjector() {
+    return m_parentInjector;
+  }
+
+  public void setParentInjector(Injector injector) {
+    m_parentInjector = injector;
   }
 
   @Override

--- a/src/main/java/org/testng/remote/SuiteDispatcher.java
+++ b/src/main/java/org/testng/remote/SuiteDispatcher.java
@@ -114,6 +114,7 @@ public class SuiteDispatcher
             tmpSuite.setSkipFailedInvocationCounts(suite.skipFailedInvocationCounts());
 						tmpSuite.setName("Temporary suite for " + test.getName());
 						tmpSuite.setParallel(suite.getParallel());
+						tmpSuite.setParentModule(suite.getParentModule());
 						tmpSuite.setParameters(suite.getParameters());
 						tmpSuite.setThreadCount(suite.getThreadCount());
             tmpSuite.setDataProviderThreadCount(suite.getDataProviderThreadCount());

--- a/src/main/java/org/testng/xml/TestNGContentHandler.java
+++ b/src/main/java/org/testng/xml/TestNGContentHandler.java
@@ -163,6 +163,10 @@ public class TestNGContentHandler extends DefaultHandler {
           Utils.log("Parser", 1, "[WARN] Unknown value of attribute 'parallel' at suite level: '" + parallel + "'.");
         }
       }
+      String parentModule = attributes.getValue("parent-module");
+      if (parentModule != null) {
+        m_currentSuite.setParentModule(parentModule);
+      }
       String configFailurePolicy = attributes.getValue("configfailurepolicy");
       if (null != configFailurePolicy) {
         if (XmlSuite.SKIP.equals(configFailurePolicy) || XmlSuite.CONTINUE.equals(configFailurePolicy)) {

--- a/src/main/java/org/testng/xml/XmlSuite.java
+++ b/src/main/java/org/testng/xml/XmlSuite.java
@@ -62,6 +62,8 @@ public class XmlSuite implements Serializable, Cloneable {
   public static String DEFAULT_PARALLEL = "false";
   private String m_parallel = DEFAULT_PARALLEL;
 
+  private String m_parentModule = "";
+
   /** Whether to SKIP or CONTINUE to re-attempt failed configuration methods. */
   public static String DEFAULT_CONFIG_FAILURE_POLICY = SKIP;
   private String m_configFailurePolicy = DEFAULT_CONFIG_FAILURE_POLICY;
@@ -156,6 +158,11 @@ public class XmlSuite implements Serializable, Cloneable {
     return m_parallel;
   }
 
+
+  public String getParentModule() {
+    return m_parentModule;
+  }
+
   public ITestObjectFactory getObjectFactory() {
     return m_objectFactory;
   }
@@ -170,6 +177,10 @@ public class XmlSuite implements Serializable, Cloneable {
    */
   public void setParallel(String parallel) {
     m_parallel = parallel;
+  }
+
+  public void setParentModule(String parentModule) {
+    m_parentModule = parentModule;
   }
 
   /**
@@ -442,6 +453,9 @@ public class XmlSuite implements Serializable, Cloneable {
     if(null != m_objectFactory) {
       p.setProperty("object-factory", m_objectFactory.getClass().getName());
     }
+    if (isStringNotEmpty(m_parentModule)) {
+      p.setProperty("parent-module", getParentModule());
+    }
     XmlUtils.setProperty(p, "allow-return-values", String.valueOf(getAllowReturnValues()),
         DEFAULT_ALLOW_RETURN_VALUES.toString());
     xsb.push("suite", p);
@@ -570,6 +584,7 @@ public class XmlSuite implements Serializable, Cloneable {
     result.setName(getName());
     result.setListeners(getListeners());
     result.setParallel(getParallel());
+    result.setParentModule(getParentModule());
     result.setConfigFailurePolicy(getConfigFailurePolicy());
     result.setThreadCount(getThreadCount());
     result.setDataProviderThreadCount(getDataProviderThreadCount());

--- a/src/main/resources/testng-1.0.dtd
+++ b/src/main/resources/testng-1.0.dtd
@@ -61,6 +61,7 @@ Cedric Beust & Alexandru Popescu
     junit (true | false) "false"
     verbose CDATA #IMPLIED
     parallel (false | methods | tests | classes | instances) "false"
+    parent-module CDATA #IMPLIED
     configfailurepolicy (skip | continue) "skip"
     thread-count CDATA "5"
     annotations CDATA #IMPLIED

--- a/src/test/java/test/guice/GuiceParentModule.java
+++ b/src/test/java/test/guice/GuiceParentModule.java
@@ -1,0 +1,13 @@
+package test.guice;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Singleton;
+
+public class GuiceParentModule extends AbstractModule {
+
+  @Override
+  protected void configure() {
+    bind(MyService.class).toProvider(MyServiceProvider.class);
+    bind(MyContext.class).to(MyContextImpl.class).in(Singleton.class);
+  }
+}

--- a/src/test/java/test/guice/GuiceParentModuleTest.java
+++ b/src/test/java/test/guice/GuiceParentModuleTest.java
@@ -1,0 +1,22 @@
+package test.guice;
+
+import org.testng.Assert;
+import org.testng.annotations.Guice;
+import org.testng.annotations.Test;
+
+import com.google.inject.Inject;
+
+@Test
+@Guice(modules = GuiceTestModule.class)
+public class GuiceParentModuleTest {
+  @Inject
+  MySession mySession;
+  @Inject
+  MyService myService;
+
+  public void testService() {
+    Assert.assertNotNull(myService);
+    Assert.assertNotNull(mySession);
+    myService.serve(mySession);
+  }
+}

--- a/src/test/java/test/guice/GuiceTestModule.java
+++ b/src/test/java/test/guice/GuiceTestModule.java
@@ -1,0 +1,18 @@
+package test.guice;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Inject;
+
+public class GuiceTestModule extends AbstractModule {
+  private final MyContext myContext;
+
+  @Inject
+  GuiceTestModule(MyContext myContext) {
+    this.myContext = myContext;
+  }
+
+  @Override
+  protected void configure() {
+    bind(MySession.class).toInstance(myContext.getSession());
+  }
+}

--- a/src/test/java/test/guice/MyContext.java
+++ b/src/test/java/test/guice/MyContext.java
@@ -1,0 +1,6 @@
+package test.guice;
+
+public interface MyContext {
+
+  MySession getSession();
+}

--- a/src/test/java/test/guice/MyContextImpl.java
+++ b/src/test/java/test/guice/MyContextImpl.java
@@ -1,0 +1,11 @@
+package test.guice;
+
+
+public class MyContextImpl implements MyContext {
+  private final MySession mySession = new MySession();
+
+  @Override
+  public MySession getSession() {
+    return mySession;
+  }
+}

--- a/src/test/java/test/guice/MyService.java
+++ b/src/test/java/test/guice/MyService.java
@@ -1,0 +1,6 @@
+package test.guice;
+
+public interface MyService {
+
+  void serve(MySession mySession);
+}

--- a/src/test/java/test/guice/MyServiceProvider.java
+++ b/src/test/java/test/guice/MyServiceProvider.java
@@ -1,0 +1,15 @@
+package test.guice;
+
+import com.google.inject.Provider;
+
+public class MyServiceProvider implements Provider<MyService> {
+
+  @Override
+  public MyService get() {
+    return new MyService() {
+      @Override
+      public void serve(MySession mySession) {
+      }
+    };
+  }
+}

--- a/src/test/java/test/guice/MySession.java
+++ b/src/test/java/test/guice/MySession.java
@@ -1,0 +1,5 @@
+package test.guice;
+
+public class MySession {
+
+}

--- a/src/test/resources/parent-module-suite.xml
+++ b/src/test/resources/parent-module-suite.xml
@@ -1,0 +1,9 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="parent-module-suite" parent-module="test.guice.GuiceParentModule">
+  <test name="Guice">
+    <classes>
+      <class name="test.guice.GuiceParentModuleTest" />
+    </classes>
+  </test>
+</suite>

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -5,6 +5,7 @@
 
   <suite-files>
     <suite-file path="./junit-suite.xml" />
+    <suite-file path="./parent-module-suite.xml" />
   </suite-files>
 
   <test name="Nopackage">
@@ -731,3 +732,4 @@
   </test>
 
 </suite>
+


### PR DESCRIPTION
This patch adds new 'parent-module' property to 'siute' tag. Users should provide full class name of class that extends Guice's Abstract Module. Then users can inject dependences into all modules and module factories in given suite. All injectors in this siute would be created as child injectors. This gives more flexibility in test module configuration
