### PR TITLE
Fixes issue #116: org.testng.internal.BaseTestMethod does respect genera...

### DIFF
--- a/pom-test.xml
+++ b/pom-test.xml
@@ -65,9 +65,14 @@
       <version>1.27</version>
     </dependency>
     <dependency>
+        <groupId>org.yaml</groupId>
+        <artifactId>snakeyaml</artifactId>
+        <version>1.12</version>
+    </dependency>
+    <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
-      <version>6.8.6-SNAPSHOT</version>
+      <version>6.8.8-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
    </dependencies>

--- a/src/main/java/org/testng/internal/BaseTestMethod.java
+++ b/src/main/java/org/testng/internal/BaseTestMethod.java
@@ -153,7 +153,9 @@ public abstract class BaseTestMethod implements ITestNGMethod {
     int result = -2;
     Class<?> thisClass = getRealClass();
     Class<?> otherClass = ((ITestNGMethod) o).getRealClass();
-    if (thisClass.isAssignableFrom(otherClass)) {
+    if (this == o) {
+      result = 0;
+    } else if (thisClass.isAssignableFrom(otherClass)) {
       result = -1;
     } else if (otherClass.isAssignableFrom(thisClass)) {
       result = 1;


### PR DESCRIPTION
...l contract of Comparable

All tests give the same results now as they did before this change.
Plus a couple changes to the pom-test.xml, so that the tests actually compile.
