### PR TITLE
symmetric equals assertion

### DIFF
--- a/src/main/java/org/testng/Assert.java
+++ b/src/main/java/org/testng/Assert.java
@@ -112,13 +112,15 @@ public class Assert {
     if((expected == null) && (actual == null)) {
       return;
     }
-    if(expected != null) {
-      if (expected.getClass().isArray()) {
-        assertArrayEquals(actual, expected, message);
-        return;
-      } else if (expected.equals(actual)) {
-        return;
-      }
+    if(expected == null ^ actual == null) {
+      failNotEquals(actual, expected, message);
+    }
+    if (expected.getClass().isArray()) {
+       assertArrayEquals(actual, expected, message);
+       return;
+    }
+    if (expected.equals(actual) && actual.equals(expected)) {
+       return;
     }
     failNotEquals(actual, expected, message);
   }

--- a/src/test/java/org/testng/AssertTest.java
+++ b/src/test/java/org/testng/AssertTest.java
@@ -115,4 +115,72 @@ public class AssertTest {
 
     Assert.assertEquals(mapActual, mapExpected);
   }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void assertEqualsSymmetricScalar() {
+    Assert.assertEquals(new Asymmetric(42, 'd'), new Contrived(42));
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void assertEqualsSymmetricArrays() {
+    Object[] actual = {new Integer(1), new Asymmetric(42, 'd'), "inDay"};
+    Object[] expected = {new Integer(1), new Contrived(42), "inDay"};
+    Assert.assertEquals(actual, expected);
+  }
+
+  class Contrived {
+
+    int integer;
+
+    Contrived(int integer){
+      this.integer = integer;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (!(o instanceof Contrived)) return false;
+
+      Contrived contrived = (Contrived) o;
+
+      if (integer != contrived.integer) return false;
+
+      return true;
+    }
+
+    @Override
+    public int hashCode() {
+      return integer;
+    }
+  }
+
+  class Asymmetric extends Contrived {
+
+      char character;
+
+      Asymmetric(int integer, char character) {
+          super(integer);
+          this.character = character;
+      }
+
+      @Override
+      public boolean equals(Object o) {
+          if (this == o) return true;
+          if (!(o instanceof Asymmetric)) return false;
+          if (!super.equals(o)) return false;
+
+          Asymmetric that = (Asymmetric) o;
+
+          if (character != that.character) return false;
+
+          return true;
+      }
+
+      @Override
+      public int hashCode() {
+          int result = super.hashCode();
+          result = 31 * result + (int) character;
+          return result;
+      }
+  }
 }


### PR DESCRIPTION
This pull request modifies the assertEquals logic of the Assert class to test for equality in both directions when neither expected or actual arguments are null. 

Motives:
- If assertEquals(a, b) passes, it is reasonable for a test author to assume that a.equals(b) and b.equals(a) .
- The obvious case - symmetry is a property of Java equality http://docs.oracle.com/javase/7/docs/api/java/lang/Object.html#equals(java.lang.Object)
- Although usage errors are no reason to change the tool, many developers unfortunately confuse the order of the expected and actual arguments, few know that these arguments are treated differently
