### PR TITLE
Updated version to be tested to 6.8.9-SNAPSHOT, in pom-test.xml.

### DIFF
--- a/pom-test.xml
+++ b/pom-test.xml
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
-      <version>6.8.8-SNAPSHOT</version>
+      <version>6.8.9-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
    </dependencies>


### PR DESCRIPTION
I'm following the instructions in "build-with-maven" file, to build testng and run the test, which gives me the below error. Am I right thinking that the version to be tested should be updated in pom-test.xml to 6.8.9-SNAPSHOT? If so, here is a pull request to fix it.

If I'm wrong please let me know where to find information on how to build and run the unit tests for testng?

[ERROR] Failed to execute goal on project testng-test: Could not resolve dependencies for project org.testng:testng-test:jar:1.0-SNAPSHOT: Failure to find org.testng:testng:jar:6.8.8-SNAPSHOT in http://oss.sonatype.org/content/repositories/snapshots was cached in the local repository, resolution will not be reattempted until the update interval of sonatype-nexus-snapshots has elapsed or updates are forced -> [Help 1]
