### PR TITLE
Fix for #496

### DIFF
--- a/src/test/java/test/JUnit4Test.java
+++ b/src/test/java/test/JUnit4Test.java
@@ -39,7 +39,7 @@ public class JUnit4Test extends BaseTest {
 
         run();
         String[] passed = JUnit4SampleSuite.EXPECTED;
-        String[] failed = JUnit4Sample2.FAILED;
+        String[] failed = JUnit4SampleSuite.FAILED;
         String[] skipped = JUnit4SampleSuite.SKIPPED;
 
         verifyTests("Passed", passed, getPassedTests());

--- a/src/test/java/test/junit4/JUnit4Sample2.java
+++ b/src/test/java/test/junit4/JUnit4Sample2.java
@@ -1,6 +1,7 @@
 package test.junit4;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -11,7 +12,7 @@ import org.junit.Test;
 public class JUnit4Sample2 {
 
     public static final String[] EXPECTED = {"t2", "t4"};
-    public static final String[] SKIPPED = {"t3"};
+    public static final String[] SKIPPED = {"t3", "ta"};
     public static final String[] FAILED = {"tf"};
 
     @Test
@@ -30,5 +31,10 @@ public class JUnit4Sample2 {
     @Test
     public void tf() {
         Assert.fail("a test");
+    }
+
+    @Test
+    public void ta() {
+        Assume.assumeTrue(false);
     }
 }

--- a/src/test/java/test/junit4/JUnit4SampleSuite.java
+++ b/src/test/java/test/junit4/JUnit4SampleSuite.java
@@ -15,6 +15,6 @@ import org.junit.runners.Suite;
 public class JUnit4SampleSuite {
 
     public static final String[] EXPECTED = {"t1", "t2", "t4"};
-    public static final String[] SKIPPED = {"t3"};
+    public static final String[] SKIPPED = {"t3", "ta"};
     public static final String[] FAILED = {"tf"};
 }


### PR DESCRIPTION
Report test as skip.
Also report as skip from #testFailure with AssumptionViolatedException as failure exception
Remove unnecessary super calls. (RunListener is special not-implementation class)
Fix bug when test with assumption failure reported also as passed.
Add test for this case.
