### PR TITLE
Fixed skipped tests being marked as failures in JUnit-style reports

### DIFF
--- a/src/main/java/org/testng/reporters/XMLUtils.java
+++ b/src/main/java/org/testng/reporters/XMLUtils.java
@@ -4,6 +4,7 @@ import java.text.CharacterIterator;
 import java.text.StringCharacterIterator;
 import java.util.Map.Entry;
 import java.util.Properties;
+import java.util.TreeMap;
 
 /**
  * Static helpers for XML.
@@ -79,7 +80,7 @@ public final class XMLUtils {
    */
   public static void appendAttributes(IBuffer result, Properties attributes) {
     if (null != attributes) {
-      for (Object element : attributes.entrySet()) {
+      for (Object element : new TreeMap(attributes).entrySet()) {
         Entry entry = (Entry) element;
         String key = entry.getKey().toString();
         String value = escape(entry.getValue().toString());


### PR DESCRIPTION
Made JUnitReportReporter detect org.testng.SkipException. Additionally forced XML attributes in test reports to be outputted in alphabetical order instead of a random one.
#  Motivation

I have some tests that I skip conditionally (by checking some condition and throwing org.testng.SkipException). TestNG report correctly marks such tests as "skipped". However, reports from TestNG generated in JUnit format mark such tests as failures (because an exception is thrown). I have my JUnit-style reports parsed by Jenkins continuous integration server, so having a large number of tests marked as 'failed' (when they are actually just skipped) is a problem for me.
# XML attributes order

It seems that using Properties.entrySet() to iterate over XML attributes causes them to appear in a random order in the output files (ordering is by their hashes). My fix is to use a TreeMap for iteration, which will use String's natural ordering. Note that this will cause an exception if you put keys other than strings (and that are comparable) to the properties containing XML attributes.
