### PR TITLE
SoftAssert now uses the same auto-generated message used by Assert.

### DIFF
--- a/src/main/java/org/testng/asserts/SoftAssert.java
+++ b/src/main/java/org/testng/asserts/SoftAssert.java
@@ -33,7 +33,7 @@ public class SoftAssert extends Assertion {
         } else {
           sb.append(", ");
         }
-        sb.append(ae.getValue().getMessage());
+        sb.append(ae.getKey().getMessage());
       }
       throw new AssertionError(sb.toString());
     }


### PR DESCRIPTION
The change brings SoftAssert's message semantics in line with those of Assert's as requested in issue #504. 
