### PR TITLE
externally synchronize our use of the static SimpleDateFormat

### DIFF
--- a/src/main/java/org/testng/TimeBombSkipException.java
+++ b/src/main/java/org/testng/TimeBombSkipException.java
@@ -181,7 +181,11 @@ public class TimeBombSkipException extends SkipException {
 
   private void initExpireDate(String date) {
     try {
-      Date d= m_inFormat.parse(date);
+      // SimpleDateFormat is not thread-safe, and m_inFormat 
+      // is, by default, connected to the static SDF variable
+      synchronized( m_inFormat ){
+        Date d= m_inFormat.parse(date);
+      }
       initExpireDate(d);
     }
     catch(ParseException pex) {


### PR DESCRIPTION
When running testng multi-threaded, multiple TimeBombSkipExceptions in different tests will occasionally die with a parsing exception. Given the choice of making SDF not static or adding the synchronized, I just added the synchronized - but I don't have a preference either way.
