### PR TITLE
AfterClass does not get executed when MethodInterceptor is involved.

### DIFF
--- a/src/main/java/org/testng/ClassMethodMap.java
+++ b/src/main/java/org/testng/ClassMethodMap.java
@@ -28,7 +28,9 @@ public class ClassMethodMap {
       // Only add to the class map methods that are included in the
       // method selector. We can pass a null context here since the selector
       // should already have been initialized
-      if (! xmlMethodSelector.includeMethod(null, m, true)) continue;
+      if (xmlMethodSelector != null){
+    	  if (! xmlMethodSelector.includeMethod(null, m, true)) continue;
+      }
 
       Object instance = m.getInstance();
       List<ITestNGMethod> l = m_classMap.get(instance);

--- a/src/main/java/org/testng/TestRunner.java
+++ b/src/main/java/org/testng/TestRunner.java
@@ -790,7 +790,10 @@ public class TestRunner
     for (IMethodInstance imi : resultInstances) {
       result.add(imi.getMethod());
     }
-
+    //Since an interceptor is involved, we would need to ensure that the ClassMethodMap object is in sync with the 
+    //output of the interceptor, else @AfterClass doesn't get executed at all when interceptors are involved.
+    //so let's update the current classMethodMap object with the list of methods obtained from the interceptor.
+    this.m_classMethodMap = new ClassMethodMap(result, null);
     return result.toArray(new ITestNGMethod[result.size()]);
   }
 


### PR DESCRIPTION
The logic to invoke AfterClass was ignoring the output
of MethodInterceptor (especially the ones that alter the
size of the total test methods to be executed). This 
led to AfterClass methods not getting executed at all.
Fixed this problem by ensuring that the classMethodMap
object is updated to refer to the output of a method
interceptor in a TestRunner.
