### PR TITLE
allow '-testnames' option to work with '-xmlpathinjar'

### DIFF
--- a/src/main/java/org/testng/TestNG.java
+++ b/src/main/java/org/testng/TestNG.java
@@ -376,7 +376,16 @@ public class TestNG {
         JarEntry je = entries.nextElement();
         if (je.getName().equals(m_xmlPathInJar)) {
           Parser parser = getParser(jf.getInputStream(je));
-          m_suites.addAll(parser.parse());
+          Collection<XmlSuite> suites = parser.parse();
+          for (XmlSuite suite : suites) {
+            // If test names were specified, only run these test names
+            if (m_testNames != null) {
+              m_suites.add(extractTestNames(suite, m_testNames));
+            } else {
+              m_suites.add(suite);
+            }
+          }
+
           foundTestngXml = true;
           break;
         }


### PR DESCRIPTION
When '-testjar' and '-xmlpathinjar' are used, the '-testnames' option is ignored. This patch will have it work the same as if '-testnames' was used for xml suite files given on the command line. Thanks!
