### PR TITLE
fix the bug that xml report, testng-results.xml, doesn't have field 'test-instance-name' populated by any value of test result.

### DIFF
--- a/src/main/java/org/testng/reporters/XMLSuiteResultWriter.java
+++ b/src/main/java/org/testng/reporters/XMLSuiteResultWriter.java
@@ -150,6 +150,7 @@ public class XMLSuiteResultWriter {
   private void addTestResult(XMLStringBuffer xmlBuffer, ITestResult testResult) {
     Properties attribs = getTestResultAttributes(testResult);
     attribs.setProperty(XMLReporterConfig.ATTR_STATUS, getStatusString(testResult.getStatus()));
+    attribs.setProperty(XMLReporterConfig.ATTR_TEST_INSTANCE_NAME, testResult.getName());
     xmlBuffer.push(XMLReporterConfig.TAG_TEST_METHOD, attribs);
     addTestMethodParams(xmlBuffer, testResult);
     addTestResultException(xmlBuffer, testResult);

--- a/src/main/java/org/testng/reporters/XMLSuiteResultWriter.java
+++ b/src/main/java/org/testng/reporters/XMLSuiteResultWriter.java
@@ -150,7 +150,13 @@ public class XMLSuiteResultWriter {
   private void addTestResult(XMLStringBuffer xmlBuffer, ITestResult testResult) {
     Properties attribs = getTestResultAttributes(testResult);
     attribs.setProperty(XMLReporterConfig.ATTR_STATUS, getStatusString(testResult.getStatus()));
-    attribs.setProperty(XMLReporterConfig.ATTR_TEST_INSTANCE_NAME, testResult.getName());
+    String test_instance_name;
+    if (testResult.getName()==null) {
+    	test_instance_name = "";
+    } else {
+    	test_instance_name = testResult.getName();
+    }
+    attribs.setProperty(XMLReporterConfig.ATTR_TEST_INSTANCE_NAME, test_instance_name);
     xmlBuffer.push(XMLReporterConfig.TAG_TEST_METHOD, attribs);
     addTestMethodParams(xmlBuffer, testResult);
     addTestResultException(xmlBuffer, testResult);


### PR DESCRIPTION
The current version of xml report leaves value of test-instance-name empty. this fix will fill the correct value for it.

I found this bug when learning this project, https://github.com/djangofan/testng-dynamic-testname
