### PR TITLE
Suite Listener is registered twice

### DIFF
--- a/src/main/java/org/testng/SuiteRunner.java
+++ b/src/main/java/org/testng/SuiteRunner.java
@@ -334,6 +334,10 @@ public class SuiteRunner implements ISuite, Serializable, IInvokedMethodListener
     m_reporters.add(listener);
   }
 
+  void addConfigurationListener(IConfigurationListener listener) {
+    m_configuration.addConfigurationListener(listener);
+  }
+
   public List<IReporter> getReporters() {
     return m_reporters;
   }
@@ -405,7 +409,7 @@ public class SuiteRunner implements ISuite, Serializable, IInvokedMethodListener
       addReporter((IReporter) listener);
     }
     if (listener instanceof IConfigurationListener) {
-      m_configuration.addConfigurationListener((IConfigurationListener) listener);
+      addConfigurationListener((IConfigurationListener) listener);
     }
   }
 

--- a/src/main/java/org/testng/TestNG.java
+++ b/src/main/java/org/testng/TestNG.java
@@ -1313,7 +1313,7 @@ public class TestNG {
     }
 
     for (IConfigurationListener cl : m_configuration.getConfigurationListeners()) {
-      result.addListener(cl);
+      result.addConfigurationListener(cl);
     }
 
     return result;

--- a/src/test/java/test/listeners/SuiteAndConfigurationListenerTest.java
+++ b/src/test/java/test/listeners/SuiteAndConfigurationListenerTest.java
@@ -1,0 +1,58 @@
+package test.listeners;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.testng.Assert;
+import org.testng.IConfigurationListener;
+import org.testng.ISuite;
+import org.testng.ISuiteListener;
+import org.testng.ITestResult;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import test.listeners.SuiteAndConfigurationListenerTest.MyListener;
+
+/**
+ * Check that if a listener implements IConfigurationListener additionally to
+ * ISuiteListener, ISuiteListener gets invoked exactly once.
+ *
+ * @author Mihails Volkovs
+ */
+@Listeners(MyListener.class)
+public class SuiteAndConfigurationListenerTest {
+  public static class MyListener implements ISuiteListener, IConfigurationListener {
+
+    private static volatile AtomicInteger started = new AtomicInteger(0);
+
+    public MyListener() {
+    }
+
+    @Override
+    public void onStart(ISuite suite) {
+      started.incrementAndGet();
+    }
+
+    @Override
+    public void onFinish(ISuite suite) {
+    }
+
+    @Override
+    public void onConfigurationSuccess(ITestResult itr) {
+    }
+
+    @Override
+    public void onConfigurationFailure(ITestResult itr) {
+    }
+
+    @Override
+    public void onConfigurationSkip(ITestResult itr) {
+    }
+
+  }
+
+  @Test
+  public void bothListenersShouldRun() {
+    Assert.assertEquals(MyListener.started.get(), 1, "ISuiteListener was not invoked exactly once:");
+  }
+
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -143,6 +143,7 @@
       <class name="test.listeners.ResultEndMillisTest" />
       <class name="test.listeners.ListenerTest"/>
       <class name="test.listeners.SuiteAndInvokedMethodListenerTest" />
+      <class name="test.listeners.SuiteAndConfigurationListenerTest" />
       <class name="test.listeners.ListenerInXmlTest" />
       <class name="test.listeners.ExecutionListenerTest" />
       <class name="test.listeners.ConfigurationListenerTest" />


### PR DESCRIPTION
When Suite listener additionally implements configuration listener, suite listener is registered twice. Fix and test inside.
