### PR TITLE
Fix for retryanalyser running in endless loop

### DIFF
--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -1014,6 +1014,7 @@ public class Invoker implements IInvoker {
     final FailureContext failure = new FailureContext();
     failure.count = failureCount;
     do {
+      failure.instances = Lists.newArrayList ();
       Map<String, String> allParameters = Maps.newHashMap();
       /**
        * TODO: This recreates all the parameters every time when we only need


### PR DESCRIPTION
This pull request addresses the problem being discussed
in the below thread : 

https://groups.google.com/forum/#!topic/testng-users/bR2fx8mSyb8
