### PR TITLE
Fix for #545 - TestNG running JUnit tests but not reporting all results for parameterized tests

### DIFF
--- a/src/main/java/org/testng/internal/BaseTestMethod.java
+++ b/src/main/java/org/testng/internal/BaseTestMethod.java
@@ -82,15 +82,15 @@ public abstract class BaseTestMethod implements ITestNGMethod {
    * @param annotationFinder
    * @param instance 
    */
-  public BaseTestMethod(Method method, IAnnotationFinder annotationFinder, Object instance) {
-    this(new ConstructorOrMethod(method), annotationFinder, instance);
+  public BaseTestMethod(String methodName, Method method, IAnnotationFinder annotationFinder, Object instance) {
+    this(methodName, new ConstructorOrMethod(method), annotationFinder, instance);
   }
 
-  public BaseTestMethod(ConstructorOrMethod com, IAnnotationFinder annotationFinder,
+  public BaseTestMethod(String methodName, ConstructorOrMethod com, IAnnotationFinder annotationFinder,
       Object instance) {
     m_methodClass = com.getDeclaringClass();
     m_method = com;
-    m_methodName = com.getName();
+    m_methodName = methodName;
     m_annotationFinder = annotationFinder;
     m_instance = instance;
     m_signature = computeSignature();

--- a/src/main/java/org/testng/internal/ConfigurationMethod.java
+++ b/src/main/java/org/testng/internal/ConfigurationMethod.java
@@ -59,7 +59,7 @@ public class ConfigurationMethod extends BaseTestMethod {
                               boolean initialize,
                               Object instance)
   {
-    super(com, annotationFinder, instance);
+    super(com.getName(), com, annotationFinder, instance);
     if(initialize) {
       init();
     }

--- a/src/main/java/org/testng/internal/FactoryMethod.java
+++ b/src/main/java/org/testng/internal/FactoryMethod.java
@@ -36,7 +36,7 @@ public class FactoryMethod extends BaseTestMethod {
                        IAnnotationFinder annotationFinder,
                        ITestContext testContext)
   {
-    super(com, annotationFinder, instance);
+    super(com.getName(), com, annotationFinder, instance);
 //    Utils.checkInstanceOrStatic(instance, method);
     Class<?> declaringClass = com.getDeclaringClass();
     if (instance != null && ! declaringClass.isAssignableFrom(instance.getClass())) {

--- a/src/main/java/org/testng/internal/TestNGMethod.java
+++ b/src/main/java/org/testng/internal/TestNGMethod.java
@@ -43,7 +43,7 @@ public class TestNGMethod extends BaseTestMethod implements Serializable {
 
   private TestNGMethod(Method method, IAnnotationFinder finder, boolean initialize,
       XmlTest xmlTest, Object instance) {
-    super(method, finder, instance);
+    super(method.getName(), method, finder, instance);
 
     if(initialize) {
       init(xmlTest);

--- a/src/main/java/org/testng/junit/JUnit4TestMethod.java
+++ b/src/main/java/org/testng/junit/JUnit4TestMethod.java
@@ -22,6 +22,7 @@ public class JUnit4TestMethod extends JUnitTestMethod {
     private static Method getMethod(Description desc) {
         Class<?> c = desc.getTestClass();
         String method = desc.getMethodName();
+        // remove [index] from method name in case of parameterized test
         int idx = method.indexOf('[');
         if (idx != -1) {
             method = method.substring(0, idx);

--- a/src/main/java/org/testng/junit/JUnit4TestMethod.java
+++ b/src/main/java/org/testng/junit/JUnit4TestMethod.java
@@ -11,7 +11,7 @@ import org.testng.internal.Utils;
 public class JUnit4TestMethod extends JUnitTestMethod {
 
     public JUnit4TestMethod(JUnitTestClass owner, Description desc) {
-        super(owner, getMethod(desc), desc);
+        super(owner, desc.getMethodName(), getMethod(desc), desc);
     }
 
     @Override
@@ -22,6 +22,10 @@ public class JUnit4TestMethod extends JUnitTestMethod {
     private static Method getMethod(Description desc) {
         Class<?> c = desc.getTestClass();
         String method = desc.getMethodName();
+        int idx = method.indexOf('[');
+        if (idx != -1) {
+            method = method.substring(0, idx);
+        }
         try {
             return c.getMethod(method);
         } catch (Throwable t) {

--- a/src/main/java/org/testng/junit/JUnitTestMethod.java
+++ b/src/main/java/org/testng/junit/JUnitTestMethod.java
@@ -12,7 +12,11 @@ import org.testng.internal.BaseTestMethod;
 public abstract class JUnitTestMethod extends BaseTestMethod {
 
     protected JUnitTestMethod(JUnitTestClass owner, Method method, Object instance) {
-        super(method, null, instance);
+        this(owner, method.getName(), method, instance);
+    }
+
+    protected JUnitTestMethod(JUnitTestClass owner, String methodName, Method method, Object instance) {
+        super(methodName, method, null, instance);
         setTestClass(owner);
         owner.getTestMethodList().add(this);
     }

--- a/src/test/java/test/JUnit4Test.java
+++ b/src/test/java/test/JUnit4Test.java
@@ -3,6 +3,7 @@ package test;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import test.junit4.JUnit4Child;
+import test.junit4.JUnit4ParameterizedTest;
 import test.junit4.JUnit4Sample2;
 import test.junit4.JUnit4SampleSuite;
 
@@ -72,6 +73,21 @@ public class JUnit4Test extends BaseTest {
         String[] passed = {"t1", "t1"};
         String[] failed = {};
         String[] skipped = {};
+
+        verifyTests("Passed", passed, getPassedTests());
+        verifyTests("Failed", failed, getFailedTests());
+        verifyTests("Skipped", skipped, getSkippedTests());
+    }
+
+    @Test
+    public void testTestParameterized() {
+        addClass("test.junit4.JUnit4ParameterizedTest");
+        assert getTest().isJUnit();
+
+        run();
+        String[] passed = JUnit4ParameterizedTest.EXPECTED;
+        String[] failed = JUnit4ParameterizedTest.FAILED;
+        String[] skipped = JUnit4ParameterizedTest.SKIPPED;
 
         verifyTests("Passed", passed, getPassedTests());
         verifyTests("Failed", failed, getFailedTests());

--- a/src/test/java/test/junit4/JUnit4ParameterizedTest.java
+++ b/src/test/java/test/junit4/JUnit4ParameterizedTest.java
@@ -1,0 +1,57 @@
+package test.junit4;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class JUnit4ParameterizedTest {
+
+    public static final String[] EXPECTED = {"t2[0]", "t2[1]", "t4[0]"};
+    public static final String[] SKIPPED = {"t3[0]", "t3[1]", "ta[0]", "ta[1]"};
+    public static final String[] FAILED = {"t4[1]", "tf[0]", "tf[1]"};
+
+    private int param;
+
+    @Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {{1}, {5}});
+    }
+
+    public JUnit4ParameterizedTest(int param) {
+        this.param = param;
+    }
+
+    @Test
+    public void t2() {
+    }
+
+    @Test
+    @Ignore
+    public void t3() {
+    }
+
+    @Test
+    public void t4() {
+        if (param == 5) {
+            Assert.fail("a test");
+        }
+    }
+
+    @Test
+    public void tf() {
+        Assert.fail("a test");
+    }
+
+    @Test
+    public void ta() {
+        Assume.assumeTrue(false);
+    }
+}


### PR DESCRIPTION
TestNG expects the method name for JUnit test cases to be the name attribute of testcase element from the report. However, this is not true for Parameterized tests: in this case, the name attribute is methodName[index].
The consequence is that JUnit parameterized tests are run, but their results are not reported.

In order to address the issue, the change:
- Extracts the actual method name in case there is a [ character in the method name.
- Passes the actual method name, instead just the Method object, so BaseTestMethod is able to get the right method name.
- Adds unit tests to validate the behavior.

All unit tests are passing, including the new ones.
