### PR TITLE
org.testng.internal.Version should be up-to-date

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -6,8 +6,16 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry including="**/*.java" kind="src" path="src/main/resources"/>
-	<classpathentry including="**/*.java" kind="src" path="src/test/resources"/>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
 		<attributes>
 			<attribute name="optional" value="true"/>
@@ -19,6 +27,16 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="src" output="target/classes" path="target/generated-sources/version">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/pom-test.xml
+++ b/pom-test.xml
@@ -90,7 +90,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
         <configuration>
-          <source>1.5</source>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
 

--- a/pom-test.xml
+++ b/pom-test.xml
@@ -92,6 +92,7 @@
         <configuration>
           <source>1.7</source>
           <target>1.7</target>
+          <skipMain>true</skipMain> <!-- Sources are already compiled -->
         </configuration>
       </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -131,9 +131,26 @@
       <optional>true</optional>
 	  </dependency>
 
-  </dependencies>    
-    
+  </dependencies>     
+  
+  <properties>
+  	<version.build.directory>${project.build.directory}/generated-sources/version</version.build.directory>
+  </properties>
+  
   <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <includes>
+          <include>**/Version.java</include>
+        </includes>
+        <filtering>true</filtering>
+        <targetPath>${version.build.directory}</targetPath>
+      </resource>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+    </resources>
     <plugins>
 
       <!-- Bundle sources -->
@@ -171,6 +188,28 @@
         <configuration>
           <encoding>UTF-8</encoding>
         </configuration>
+        <executions>
+          <execution>
+            <phase>process-sources</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${version.build.directory}</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
 
       <!-- OSGi manifest creation -->

--- a/pom.xml
+++ b/pom.xml
@@ -197,6 +197,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
+        <version>1.9.1</version>
         <executions>
           <execution>
             <phase>generate-sources</phase>

--- a/src/main/resources/org/testng/internal/Version.java
+++ b/src/main/resources/org/testng/internal/Version.java
@@ -1,7 +1,7 @@
 package org.testng.internal;
 
 public class Version {
-  public static final String VERSION = "6.8.9beta";
+  public static final String VERSION = "${project.version}";
 
   public static void displayBanner() {
     System.out.println("...\n... TestNG " + VERSION + " by Cédric Beust (cedric@beust.com)\n...\n");


### PR DESCRIPTION
`org.testng.internal.Version.VERSION` is **6.8.9beta** since _TestNG 6.8.8 release_ and was **6.8.2beta...** before.

The version value should be updated with TestNG release like it's written in [CHECKLIST](https://github.com/cbeust/testng/blob/master/CHECKLIST).

I propose to make it with maven and its resources filtering feature.
Eclipse will generate the file with the appropriate m2e plugin.
