### PR TITLE
Fix OSGI Import-Package to make jUnit4 dependency optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,7 @@
                   com.beust.jcommander.*;version="[1.7.0,3.0.0)";resolution:=optional,
                   com.google.inject.*;version="[1.2,1.3)";resolution:=optional,
                   junit.framework;version="[3.8.1, 5.0.0)";resolution:=optional,
-                  org.junit;resolution:=optional,
+                  org.junit.*;resolution:=optional,
                   org.apache.tools.ant.*;version="[1.7.0, 2.0.0)";resolution:=optional,
                   org.yaml.*;version="[1.6,2.0)";resolution:=optional,
                   !com.beust.testng,


### PR DESCRIPTION
1d168507576d56dc8eba665794168da7a50a9b7d miss wildcard in order to make the jUnit dependency optional
