### PR TITLE
Fix #392 AfterClass method isn't fired when an IMethodInterceptor removes test methods

### DIFF
--- a/src/test/java/test/methodinterceptors/Issue392.java
+++ b/src/test/java/test/methodinterceptors/Issue392.java
@@ -1,0 +1,17 @@
+package test.methodinterceptors;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+public class Issue392 {
+
+  @AfterClass
+  public void afterClass() {}
+
+  @Test
+  public void test1() {}
+
+  @Test
+  public void test2() {}
+
+}

--- a/src/test/java/test/methodinterceptors/Issue392Test.java
+++ b/src/test/java/test/methodinterceptors/Issue392Test.java
@@ -1,0 +1,43 @@
+package test.methodinterceptors;
+
+import org.testng.IMethodInstance;
+import org.testng.IMethodInterceptor;
+import org.testng.ITestContext;
+import org.testng.TestNG;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import test.InvokedMethodNameListener;
+import test.SimpleBaseTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Issue392Test extends SimpleBaseTest {
+
+  @Test(description = "test for https://github.com/cbeust/testng/issues/392")
+  public void AfterClass_method_should_be_fired_when_IMethodInterceptor_removes_test_methods() {
+    TestNG tng = create(Issue392.class);
+    tng.setMethodInterceptor(new IMethodInterceptor() {
+      @Override
+      public List<IMethodInstance> intercept(List<IMethodInstance> methods, ITestContext context) {
+        List<IMethodInstance> instances = new ArrayList<>();
+        for (IMethodInstance instance : methods) {
+          if (!instance.getMethod().getMethodName().equals("test1")) {
+            instances.add(instance);
+          }
+        }
+        return instances;
+      }
+    });
+
+    InvokedMethodNameListener listener = new InvokedMethodNameListener();
+    tng.addListener(listener);
+
+    tng.run();
+
+    assertThat(listener.getInvokedMethodNames()).containsExactly("test2", "afterClass");
+  }
+
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -630,6 +630,7 @@
   <test name="MethodInterceptor">
     <classes>
       <class name="test.methodinterceptors.MethodInterceptorTest" />
+      <class name="test.methodinterceptors.Issue392Test" />
     </classes>
   </test>
 


### PR DESCRIPTION
#392 and #274 should have been fixed by #525
