### PR TITLE
Classloading issue when using TestNG 6.9.4 and JMockit

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,10 @@
 Current
+
+Fixed: GITHUB-691: Fix classloading issue when using TestNG 6.9.4 and JMockit. (Mathieu Sebire)
+
+6.9.4:
+2015/05/09
+
 Added: GITHUB-631: Avoid the static limitation of external DataProvider. (Julien Herr)
 Added: GITHUB-631: Allow to use Guice injection in DataProvider. (Julien Herr)
 Added: Drop support of Java6 and previous.

--- a/src/main/java/org/testng/TestNG.java
+++ b/src/main/java/org/testng/TestNG.java
@@ -940,8 +940,9 @@ public class TestNG {
    * Using reflection to remain Java 5 compliant.
    */
   private void addServiceLoaderListeners() {
-      Iterable<ITestNGListener> loader =
-          ServiceLoader.load(ITestNGListener.class, m_serviceLoaderClassLoader);
+      Iterable<ITestNGListener> loader = m_serviceLoaderClassLoader != null ?
+          ServiceLoader.load(ITestNGListener.class, m_serviceLoaderClassLoader)
+          : ServiceLoader.load(ITestNGListener.class);
       for (ITestNGListener l : loader) {
         Utils.log("[TestNG]", 2, "Adding ServiceLoader listener:" + l);
         addListener(l);


### PR DESCRIPTION
On a simple project that contains both TestNG 6.9.4 and JMockit 1.17, when running unit tests, the following exception occurs : 

```
java.util.ServiceConfigurationError: org.testng.ITestNGListener: Provider mockit.integration.testng.internal.TestNGRunnerDecorator not found
    at java.util.ServiceLoader.fail(ServiceLoader.java:231)
    at java.util.ServiceLoader.access$300(ServiceLoader.java:181)
    at java.util.ServiceLoader$LazyIterator.next(ServiceLoader.java:365)
    at java.util.ServiceLoader$1.next(ServiceLoader.java:445)
    at org.testng.TestNG.addServiceLoaderListeners(TestNG.java:945)
    at org.testng.TestNG.initializeConfiguration(TestNG.java:895)
    at org.testng.TestNG.run(TestNG.java:1006)
    at org.testng.remote.RemoteTestNG.run(RemoteTestNG.java:111)
    at org.testng.remote.RemoteTestNG.initAndRun(RemoteTestNG.java:204)
    at org.testng.remote.RemoteTestNG.main(RemoteTestNG.java:175)
    at org.testng.RemoteTestNGStarter.main(RemoteTestNGStarter.java:125)
```
