### PR TITLE
Adding a test for ServiceLoader functionality

### DIFF
--- a/src/test/java/test/serviceloader/ServiceLoaderTest.java
+++ b/src/test/java/test/serviceloader/ServiceLoaderTest.java
@@ -22,4 +22,17 @@ public class ServiceLoaderTest extends SimpleBaseTest {
 
     Assert.assertEquals(1, tng.getServiceLoaderListeners().size());
   }
+
+  @Test
+  public void serviceLoaderWithNoClassLoader() {
+    //Here ServiceLoader is expected to rely on the current context class loader to load the service loader file
+    //Since serviceloader.jar doesn't seem to be visible to the current thread's contextual class loader
+    //resorting to pushing in a class loader into the current thread that can load the resource
+    URL url = getClass().getClassLoader().getResource("serviceloader.jar");
+    URLClassLoader ucl = URLClassLoader.newInstance(new URL[] { url });
+    Thread.currentThread().setContextClassLoader(ucl);
+    TestNG tng = create(ServiceLoaderSampleTest.class);
+    tng.run();
+    Assert.assertEquals(1, tng.getServiceLoaderListeners().size());
+  }
 }


### PR DESCRIPTION
- Added a unit test for service loader functionality
  that basically relies on the current thread’s 
  contextual class loader to load the service loader
  file and help TestNG load listeners via it.
