### PR TITLE
Make addFailedInvocationNumber thread-safe

### DIFF
--- a/src/main/java/org/testng/internal/BaseTestMethod.java
+++ b/src/main/java/org/testng/internal/BaseTestMethod.java
@@ -63,7 +63,7 @@ public abstract class BaseTestMethod implements ITestNGMethod {
   private long m_invocationTimeOut = 0L;
 
   private List<Integer> m_invocationNumbers = Lists.newArrayList();
-  private List<Integer> m_failedInvocationNumbers = Lists.newArrayList();
+  private final List<Integer> m_failedInvocationNumbers = Collections.synchronizedList(Lists.<Integer>newArrayList());
   /**
    * {@inheritDoc}
    */

--- a/src/test/java/test/testng387/FailedDPTest.java
+++ b/src/test/java/test/testng387/FailedDPTest.java
@@ -1,6 +1,7 @@
 package test.testng387;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
@@ -16,16 +17,7 @@ import org.testng.annotations.Test;
  * @author freynaud
  */
 public class FailedDPTest {
-
-	// prime numbers < 10
-	static List<Integer> primes = new ArrayList<Integer>();
-	public FailedDPTest(){
-		primes.add(2);
-		primes.add(3);
-		primes.add(5);
-		primes.add(7);
-	}
-
+	static final List<Integer> primes = Arrays.asList(2, 3, 5, 7);
 
 	/**
 	 * DP generating all number from 0 to 9.

--- a/src/test/java/test/testng387/TestNG387.java
+++ b/src/test/java/test/testng387/TestNG387.java
@@ -1,18 +1,15 @@
 package test.testng387;
 
-import java.util.Collections;
-import java.util.List;
-
-import org.testng.Assert;
-import org.testng.ITestContext;
-import org.testng.ITestNGMethod;
-import org.testng.TestListenerAdapter;
-import org.testng.TestNG;
+import org.testng.*;
 import org.testng.annotations.Test;
 import test.SimpleBaseTest;
 
+import java.util.List;
+
+import static org.testng.Assert.assertEqualsNoOrder;
+
 public class TestNG387 extends SimpleBaseTest {
-  @Test
+  @Test(invocationCount = 500)
   public void testInvocationCounterIsCorrectForMethodWithDataProvider() throws Exception {
     final TestNG tng = create(FailedDPTest.class);
     tng.setThreadCount(1);
@@ -22,17 +19,9 @@ public class TestNG387 extends SimpleBaseTest {
     tng.addListener(tla);
     tng.run();
 
-    final List<ITestContext> contexts = tla.getTestContexts();
-    Assert.assertNotNull(contexts);
-    Assert.assertEquals(contexts.size(), 1);
-    final ITestContext context = contexts.iterator().next();
-    Assert.assertNotNull(context);
-    final ITestNGMethod[] methods = context.getAllTestMethods();
-    Assert.assertNotNull(methods.length);
-    Assert.assertEquals(methods.length, 1);
+    ITestNGMethod method = tla.getTestContexts().get(0).getAllTestMethods()[0];
 
-    List<Integer> failed = methods[0].getFailedInvocationNumbers();
-    Collections.sort(failed); // Is that correct? Shouldn't be already sorted by Invoker (like DataProvider parameters)
-    Assert.assertEquals(failed, FailedDPTest.primes, "FailedInvocationNumbers mismatch");
+    List<Integer> failed = method.getFailedInvocationNumbers();
+    assertEqualsNoOrder(failed.toArray(), FailedDPTest.primes.toArray());
   }
 }


### PR DESCRIPTION
TestNG387 doesn't actually work as written; because the underlying concurrency bug is inherently non-deterministic, a much higher invocation count is necessary in order to reliably reproduce the issue when running the test suite.
