### PR TITLE
Fix the interactions between ExitCodeListener and IRetryAnalyzer

### DIFF
--- a/src/main/java/org/testng/TestNG.java
+++ b/src/main/java/org/testng/TestNG.java
@@ -1857,7 +1857,9 @@ public class TestNG {
     @Override
     public void onTestSkipped(ITestResult result) {
       setHasRunTests();
-      m_mainRunner.setStatus(HAS_SKIPPED);
+      if ((m_mainRunner.getStatus() & HAS_FAILURE) != 0) {
+        m_mainRunner.setStatus(HAS_SKIPPED);
+      }
     }
 
     @Override

--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -1432,19 +1432,18 @@ public class Invoker implements IInvoker {
         }
       }
 
-      testResult.setStatus(status);
+      IRetryAnalyzer retryAnalyzer = testMethod.getRetryAnalyzer();
+      boolean willRetry = retryAnalyzer != null && status == ITestResult.FAILURE && failure.instances != null && retryAnalyzer.retry(testResult);
 
-      if (status == ITestResult.FAILURE && !handled) {
-        handleException(ite, testMethod, testResult, failure.count++);
-        status = testResult.getStatus();
-      }
-
-      if (status == ITestResult.FAILURE) {
-        IRetryAnalyzer retryAnalyzer = testMethod.getRetryAnalyzer();
-
-        if (retryAnalyzer != null &&  failure.instances != null && retryAnalyzer.retry(testResult)) {
-          resultsToRetry.add(testResult);
-          failure.instances.add(testResult.getInstance());
+      if (willRetry) {
+        resultsToRetry.add(testResult);
+        failure.instances.add(testResult.getInstance());
+        testResult.setStatus(ITestResult.SKIP);
+      } else {
+        testResult.setStatus(status);
+        if (status == ITestResult.FAILURE && !handled) {
+          handleException(ite, testMethod, testResult, failure.count++);
+          testResult.setStatus(status);
         }
       }
       if (collectResults) {

--- a/src/main/java/org/testng/util/RetryAnalyzerCount.java
+++ b/src/main/java/org/testng/util/RetryAnalyzerCount.java
@@ -38,13 +38,10 @@ public abstract class RetryAnalyzerCount implements IRetryAnalyzer {
    */
   @Override
   public boolean retry(ITestResult result) {
-    boolean retry = false;
-
-    if (count.intValue() > 0) {
-      retry = retryMethod(result);
-      count.decrementAndGet();
+    if (count.getAndDecrement() > 0) {
+      return retryMethod(result);
     }
-    return retry;
+    return false;
   }
 
   /**

--- a/src/test/java/test/retryAnalyzer/EventualSuccess.java
+++ b/src/test/java/test/retryAnalyzer/EventualSuccess.java
@@ -1,0 +1,17 @@
+package test.retryAnalyzer;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class EventualSuccess {
+  private static final AtomicBoolean ranYet = new AtomicBoolean(false);
+
+  @Test(retryAnalyzer = MyRetry.class)
+  public void test() {
+    if (!ranYet.getAndSet(true)) {
+      Assert.fail();
+    }
+  }
+}

--- a/src/test/java/test/retryAnalyzer/ExitCodeTest.java
+++ b/src/test/java/test/retryAnalyzer/ExitCodeTest.java
@@ -1,0 +1,31 @@
+package test.retryAnalyzer;
+
+import org.testng.TestNG;
+import org.testng.annotations.Test;
+import test.SimpleBaseTest;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class ExitCodeTest extends SimpleBaseTest {
+  @Test
+  public void exitsWithZeroOnSuccess() {
+    TestNG tng = create(ImmediateSuccess.class);
+    tng.run();
+    assertEquals(tng.getStatus(), 0);
+  }
+
+  @Test
+  public void exitsWithNonzeroOnFailure() {
+    TestNG tng = create(PersistentFailure.class);
+    tng.run();
+    assertTrue(tng.getStatus() != 0);
+  }
+
+  @Test
+  public void exitsWithZeroAfterSuccessfulRetry() {
+    TestNG tng = create(EventualSuccess.class);
+    tng.run();
+    assertEquals(tng.getStatus(), 0);
+  }
+}

--- a/src/test/java/test/retryAnalyzer/ImmediateSuccess.java
+++ b/src/test/java/test/retryAnalyzer/ImmediateSuccess.java
@@ -1,0 +1,9 @@
+package test.retryAnalyzer;
+
+import org.testng.annotations.Test;
+
+public class ImmediateSuccess {
+  @Test(retryAnalyzer = MyRetry.class)
+  public void test() {
+  }
+}

--- a/src/test/java/test/retryAnalyzer/PersistentFailure.java
+++ b/src/test/java/test/retryAnalyzer/PersistentFailure.java
@@ -1,0 +1,11 @@
+package test.retryAnalyzer;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class PersistentFailure {
+  @Test(retryAnalyzer = MyRetry.class)
+  public void test() {
+    Assert.fail();
+  }
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -619,13 +619,12 @@
     </classes>
   </test>
 
-<!--
   <test name="RetryAnalyzer">
     <classes>
-      <class name="test.retryAnalyzer.RetryAnalyzerTest" />
+      <!-- <class name="test.retryAnalyzer.RetryAnalyzerTest" /> -->
+      <class name="test.retryAnalyzer.ExitCodeTest" />
     </classes>
   </test>
--->
 
   <test name="MethodInterceptor">
     <classes>


### PR DESCRIPTION
The main reason that `IRetryAnalyzer` doesn't actually work (not with the out-of-the-box test runner, anyway) is that transient failures are reported as ordinary test case failures, which causes TestNG to exit with a non-zero status code (which build tools in turn interpret as the failure of the test suite). Without totally redesigning IRetryAnalyzer, I've tried to address this with the following two changes:
- Retriable failures will be reported as `SKIP`, not `FAILURE`
- The `ExitCodeListener` will ignore `SKIP` unless `FAILURE` has already been reported

I also fixed an obvious concurrency bug in `RetryAnalyzerCount`.
