### PR TITLE
Remove redundant cleanTest; use gradle daemon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ jdk:
   - oraclejdk7
   - openjdk7
 
-script: ./gradlew clean cleanTest test
+script: ./gradlew clean test

--- a/build-with-gradle
+++ b/build-with-gradle
@@ -1,1 +1,1 @@
-./gradlew --stacktrace clean build cleanTest test
+./gradlew --daemon --stacktrace clean build test


### PR DESCRIPTION
Since `gradle clean` deletes the entire build directory, it is a superset of `cleanTest`, which just deletes the output of the tests. In addition, I have added the `--daemon` flag to `build-with-gradle`, since it will speed up iteration for people who use that script.
