### PR TITLE
Only deploy when it is not a PR and with Oracle JDK7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ jdk:
 
 #before_install: bash "gradle/uploadSnapshot.sh"
 script: ./gradlew clean test
-after_success: ./gradlew uploadArchives
+after_success: test "${TRAVIS_PULL_REQUEST}" == "false" && test "${TRAVIS_JDK_VERSION}" == "oraclejdk7" && ./gradlew uploadArchives
 


### PR DESCRIPTION
Since SNAPSHOT deployment with Travis, I've seen 2 issues:
- Artifact is deployed 3 times (one for each jvm target)
- Artifact is deployed after every "working" pull-requests

I don't know if there is a better solution but I found this one here: http://bithacker.org/post/120996678805/publishing-artifacts-to-bintray-from-travis-ci
