### PR TITLE
Add assertThrows(Class, ThrowingRunnable)

### DIFF
--- a/src/main/java/org/testng/Assert.java
+++ b/src/main/java/org/testng/Assert.java
@@ -971,12 +971,27 @@ public class Assert {
    * @param runnable A function that is expected to throw an exception when invoked
    */
   public static void assertThrows(ThrowingRunnable runnable) {
-    expectThrows(Throwable.class, runnable);
+    assertThrows(Throwable.class, runnable);
   }
 
   /**
    * Asserts that {@code runnable} throws an exception of type {@code throwableClass} when
-   * executed. If it does, the exception object is returned. If it does not throw an exception, an
+   * executed. If it does not throw an exception, an {@link AssertionError} is thrown. If it
+   * throws the wrong type of exception, an {@code AssertionError} is thrown describing the
+   * mismatch; the exception that was actually thrown can be obtained by calling {@link
+   * AssertionError#getCause}.
+   *
+   * @param throwableClass the expected type of the exception
+   * @param runnable       A function that is expected to throw an exception when invoked
+   */
+  @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
+  public static <T extends Throwable> void assertThrows(Class<T> throwableClass, ThrowingRunnable runnable) {
+    expectThrows(throwableClass, runnable);
+  }
+
+  /**
+   * Asserts that {@code runnable} throws an exception of type {@code throwableClass} when
+   * executed and returns the exception. If {@code runnable} does not throw an exception, an
    * {@link AssertionError} is thrown. If it throws the wrong type of exception, an {@code
    * AssertionError} is thrown describing the mismatch; the exception that was actually thrown can
    * be obtained by calling {@link AssertionError#getCause}.


### PR DESCRIPTION
This adds a convenience method that simply delegates to expectThrows and
discards its result. There are three reasons for this:

(1) It prevents warnings: discarding a Throwable return value can raise
    red flags
(2) It facilitates convention: "assert" is called solely for its side
    effect, whereas "expect" returns something but first asserts
    something about its return value
(3) It enhances discoverability: most people will look for methods
    prefixed with "assert", and indeed, the return value of expectThrows
    is often unneeded
