### PR TITLE
More than one execution even when success.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 Current
 
+Fixed: GITHUB-740: Fix "More than one execution even when success" with DataProvider and IRetryAnalyzer. (Sergio Sacristán)
 Fixed: The ServiceLoaderTest on Windows (Mathieu Sebire)
 Fixed: GITHUB-691: Fix classloading issue when using TestNG 6.9.4 and JMockit. (Mathieu Sebire)
 Fixed: GITHUB-686: IAnnotationTransformer.transform is called for methods with testClass populated. (Łukasz Rekucki & Julien Herr)

--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -1067,7 +1067,7 @@ public class Invoker implements IInvoker {
                                      new RegexpExpectedExceptionsHolder(m_annotationFinder, testMethod));
     final ITestClass testClass= testMethod.getTestClass();
     final List<ITestResult> result = Lists.newArrayList();
-    final FailureContext failure = new FailureContext();
+    FailureContext failure = new FailureContext();
     final ITestNGMethod[] beforeMethods = filterMethods(testClass, testClass.getBeforeTestMethods(), CAN_RUN_FROM_CLASS);
     final ITestNGMethod[] afterMethods = filterMethods(testClass, testClass.getAfterTestMethods(), CAN_RUN_FROM_CLASS);
     while(invocationCount-- > 0) {
@@ -1170,6 +1170,8 @@ public class Invoker implements IInvoker {
                   }
                   break;
                 }
+                // set next param start without failure
+								failure = new FailureContext();
               }// end finally
               parametersIndex++;
             }

--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -1129,7 +1129,7 @@ public class Invoker implements IInvoker {
                   testMethod.getMethod(), testContext, null /* test result */);
 
               List<ITestResult> tmpResults = Lists.newArrayList();
-
+              int tmpResultsIndex = -1;
               try {
                 tmpResults.add(invokeTestMethod(instance,
                     testMethod,
@@ -1141,9 +1141,14 @@ public class Invoker implements IInvoker {
                     beforeMethods,
                     afterMethods,
                     groupMethods, failure));
+                tmpResultsIndex++;
               }
               finally {
-                if (failure.instances.isEmpty()) {
+              	boolean lastSucces = false;
+                if (tmpResultsIndex >= 0) {
+                  lastSucces = (tmpResults.get(tmpResultsIndex).getStatus() == ITestResult.SUCCESS);
+                }
+                if (failure.instances.isEmpty() || lastSucces) {
                   result.addAll(tmpResults);
                 } else {
                   for (Object failedInstance : failure.instances) {
@@ -1170,8 +1175,6 @@ public class Invoker implements IInvoker {
                   }
                   break;
                 }
-                // set next param start without failure
-								failure = new FailureContext();
               }// end finally
               parametersIndex++;
             }

--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -1067,7 +1067,7 @@ public class Invoker implements IInvoker {
                                      new RegexpExpectedExceptionsHolder(m_annotationFinder, testMethod));
     final ITestClass testClass= testMethod.getTestClass();
     final List<ITestResult> result = Lists.newArrayList();
-    FailureContext failure = new FailureContext();
+    final FailureContext failure = new FailureContext();
     final ITestNGMethod[] beforeMethods = filterMethods(testClass, testClass.getBeforeTestMethods(), CAN_RUN_FROM_CLASS);
     final ITestNGMethod[] afterMethods = filterMethods(testClass, testClass.getAfterTestMethods(), CAN_RUN_FROM_CLASS);
     while(invocationCount-- > 0) {

--- a/src/test/java/test/retryAnalyzer/InvocationCountTest.java
+++ b/src/test/java/test/retryAnalyzer/InvocationCountTest.java
@@ -1,0 +1,134 @@
+package test.retryAnalyzer;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.testng.IRetryAnalyzer;
+import org.testng.ITestResult;
+import org.testng.TestNG;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ConcurrentHashMultiset;
+import com.google.common.collect.Multiset;
+
+/**
+ * retryAnalyzer parameter unit tests.
+ * @author tocman@gmail.com (Jeremie Lenfant-Engelmann)
+ *
+ */
+public final class InvocationCountTest implements IRetryAnalyzer {
+  static final Multiset<String> invocations = ConcurrentHashMultiset.create();
+  private static final AtomicInteger retriesRemaining = new AtomicInteger(100);
+
+  private int r1 = 0;
+  private int r2 = 1;
+  private int r3 = 0;
+  private int r7 = 0;
+  private static int value = 42;
+  private int executionNumber = 0;
+
+  @Test(retryAnalyzer = InvocationCountTest.class)
+  public void testAnnotationWithNoRetries() {
+  }
+
+  @Test(retryAnalyzer = InvocationCountTest.class)
+  public void testAnnotationWithOneRetry() {
+    if (r1++ < 1) {
+      fail();
+    }
+  }
+
+  @Test(retryAnalyzer = InvocationCountTest.class)
+  public void testAnnotationWithSevenRetries() {
+    if (r7++ < 7) {
+      fail();
+    }
+  }
+
+  @Test(retryAnalyzer = ThreeRetries.class, successPercentage = 0)
+  public void failAfterThreeRetries() {
+    fail();
+  }
+
+  @Test(dependsOnMethods = {
+      "testAnnotationWithNoRetries",
+      "testAnnotationWithOneRetry",
+      "testAnnotationWithSevenRetries",
+      "failAfterThreeRetries"
+  }, alwaysRun = true)
+  public void checkInvocationCounts() {
+    assertEquals(invocations.count("testAnnotationWithNoRetries"), 0);
+    assertEquals(invocations.count("testAnnotationWithOneRetry"), 1);
+    assertEquals(invocations.count("testAnnotationWithSevenRetries"), 7);
+    assertEquals(invocations.count("failAfterThreeRetries"), 4);
+  }
+
+  @DataProvider(name="dataProvider")
+  private Object[][] dataProvider() {
+    return new Object[][] { { 1, true }, { 2, false }, { 3, true },
+        { 4, false } };
+  }
+
+  @DataProvider(name="dataProvider2")
+  private Object[][] dataProvider2() {
+    value = 42;
+
+    return new Object[][] { { true }, { true } };
+  }
+
+  @Test(retryAnalyzer = InvocationCountTest.class, dataProvider = "dataProvider")
+  public void testAnnotationWithDataProvider(int paf, boolean test) {
+	executionNumber++;
+    if (paf == 2 && test == false) {
+      if (r2 >= 1) {
+        r2--;
+        fail();
+      }
+    }
+    if (paf == 4){
+      assertEquals(executionNumber,5);
+    }
+  }
+
+  @Test(retryAnalyzer = InvocationCountTest.class, dataProvider = "dataProvider2")
+  public void testAnnotationWithDataProviderAndRecreateParameters(boolean dummy) {
+    if (r3 == 1) {
+      this.value = 0;
+      r3--;
+      fail();
+    } else if (r3 == 0) {
+      assertEquals(this.value, 42);
+    }
+  }
+
+  @Test
+  public void withFactory() {
+    TestNG tng = new TestNG();
+    tng.setVerbose(0);
+    tng.setTestClasses(new Class[] { MyFactory.class});
+    FactoryTest.m_count = 0;
+
+    tng.run();
+
+    assertEquals(FactoryTest.m_count, 4);
+  }
+
+  @Override
+  public boolean retry(ITestResult result) {
+    invocations.add(result.getName());
+    return retriesRemaining.getAndDecrement() >= 0;
+  }
+
+  public static class ThreeRetries implements IRetryAnalyzer {
+    private final AtomicInteger remainingRetries = new AtomicInteger(3);
+
+    @Override
+    public boolean retry(ITestResult result) {
+      invocations.add(result.getName());
+      return remainingRetries.getAndDecrement() > 0;
+    }
+  }
+}

--- a/src/test/java/test/retryAnalyzer/RetryAnalyzerTest.java
+++ b/src/test/java/test/retryAnalyzer/RetryAnalyzerTest.java
@@ -64,13 +64,13 @@ public final class RetryAnalyzerTest extends RetryAnalyzerCount {
         Assert.assertTrue(true);
       }
     } else if (paf == 0 && test == true) {
-			Assert.assertTrue(true);
-			Assert.assertEquals(executionNumber, 3);
-		} else if (paf == 1 && test == true) {
-			Assert.assertTrue(true);
-			// Enforce no duplicate correct executions
-			Assert.assertEquals(executionNumber, 4);
-		}
+	Assert.assertTrue(true);
+	Assert.assertEquals(executionNumber, 3);
+    } else if (paf == 1 && test == true) {
+	Assert.assertTrue(true);
+	// Enforce no duplicate correct executions
+	Assert.assertEquals(executionNumber, 4);
+    }
   }
 
   @Test(retryAnalyzer=RetryAnalyzerTest.class, dataProvider="dataProvider2")

--- a/src/test/java/test/retryAnalyzer/RetryAnalyzerTest.java
+++ b/src/test/java/test/retryAnalyzer/RetryAnalyzerTest.java
@@ -18,6 +18,7 @@ public final class RetryAnalyzerTest extends RetryAnalyzerCount {
   private static int r2 = 1;
   private static int r3 = 1;
   private static int value = 42;
+  private int executionNumber = 0;
 
   public RetryAnalyzerTest() {
     setCount(2);
@@ -41,7 +42,7 @@ public final class RetryAnalyzerTest extends RetryAnalyzerCount {
 
   @DataProvider(name="dataProvider")
   private Object[][] dataProvider() {
-    return new Object[][] { { 1, false }, { 0, true }, { 0, true },
+    return new Object[][] { { 1, false }, { 0, true }, { 1, true },
         { 1, false } };
   }
 
@@ -54,6 +55,7 @@ public final class RetryAnalyzerTest extends RetryAnalyzerCount {
 
   @Test(retryAnalyzer=RetryAnalyzerTest.class, dataProvider="dataProvider")
   public void testAnnotationWithDataProvider(int paf, boolean test) {
+    executionNumber++;
     if (paf == 1 && test == false) {
       if (r2 >= 1) {
         r2--;
@@ -61,10 +63,14 @@ public final class RetryAnalyzerTest extends RetryAnalyzerCount {
       } else if (r2 == 0) {
         Assert.assertTrue(true);
       }
-    }
-    else if (paf == 0 || test == true) {
-      Assert.assertTrue(true);
-    }
+    } else if (paf == 0 && test == true) {
+			Assert.assertTrue(true);
+			Assert.assertEquals(executionNumber, 3);
+		} else if (paf == 1 && test == true) {
+			Assert.assertTrue(true);
+			// Enforce no duplicate correct executions
+			Assert.assertEquals(executionNumber, 4);
+		}
   }
 
   @Test(retryAnalyzer=RetryAnalyzerTest.class, dataProvider="dataProvider2")


### PR DESCRIPTION
Exemple of what I saw: for a test method with two params with retry, if  first param fail (and then a retry is done), then the second param will be executed two times even if first time is SUCCES.

``` java
public class WebDriverRetryListenerTest {

    private int count = 0;

    @Test(dataProvider = "getData2")
    public void testParamsAndRFetry(int p1, String row) {
        System.out.println("testParamsAndRFetry -> count" + count++ + " , row:" + row);
        Assert.assertEquals("2on row", row);
    }

    @DataProvider
    public Object[][] getData2() {
        return new Object[][] { { 1, "1on row" }, { 2, "2on row" } };
    }
}
```
