### PR TITLE
Fix reporting of retried tests

### DIFF
--- a/src/test/java/test/retryAnalyzer/FactoryTest.java
+++ b/src/test/java/test/retryAnalyzer/FactoryTest.java
@@ -1,41 +1,30 @@
 package test.retryAnalyzer;
 
-import org.testng.Assert;
+import static org.testng.Assert.fail;
+
 import org.testng.ITest;
 import org.testng.annotations.Test;
 
 public class FactoryTest implements ITest {
+    public static int m_count = 0;
 
-  public static int m_count = 0;
+    private String name;
 
-  private String name;
+    public FactoryTest(String name) {
+        this.name = name;
+    }
 
-	@Override
-  public String getTestName() {
-		return  this.name;
-	}
+    @Override
+    public String getTestName() {
+        return name;
+    }
 
-	public FactoryTest(String name){
-
-		this.name = name;
-
-	}
-
-	@Test(retryAnalyzer = MyRetry.class)
-	public void someTest1(){
-		System.out.println("Test Called : "+ this.name);
-		if(this.name.contains("5")){
-//			System.out.println("fail");
-			m_count++;
-			Assert.fail();
-		}else{
-
-		Assert.assertEquals(true, true);
-		}
-	}
-
-
-
-
-
+    @Test(retryAnalyzer = MyRetry.class)
+    public void someTest1() {
+        System.out.println("Test Called : " + this.name);
+        if (name.contains("5")) {
+            m_count++;
+            fail();
+        }
+    }
 }

--- a/src/test/java/test/retryAnalyzer/InvocationCountTest.java
+++ b/src/test/java/test/retryAnalyzer/InvocationCountTest.java
@@ -1,0 +1,129 @@
+package test.retryAnalyzer;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.testng.IRetryAnalyzer;
+import org.testng.ITestResult;
+import org.testng.TestNG;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ConcurrentHashMultiset;
+import com.google.common.collect.Multiset;
+
+/**
+ * retryAnalyzer parameter unit tests.
+ * @author tocman@gmail.com (Jeremie Lenfant-Engelmann)
+ *
+ */
+public final class InvocationCountTest implements IRetryAnalyzer {
+  static final Multiset<String> invocations = ConcurrentHashMultiset.create();
+  private static final AtomicInteger retriesRemaining = new AtomicInteger(100);
+
+  private int r1 = 0;
+  private int r2 = 0;
+  private int r3 = 0;
+  private int r7 = 0;
+  private static int value = 42;
+
+  @Test(retryAnalyzer = InvocationCountTest.class)
+  public void testAnnotationWithNoRetries() {
+  }
+
+  @Test(retryAnalyzer = InvocationCountTest.class)
+  public void testAnnotationWithOneRetry() {
+    if (r1++ < 1) {
+      fail();
+    }
+  }
+
+  @Test(retryAnalyzer = InvocationCountTest.class)
+  public void testAnnotationWithSevenRetries() {
+    if (r7++ < 7) {
+      fail();
+    }
+  }
+
+  @Test(retryAnalyzer = ThreeRetries.class, successPercentage = 0)
+  public void failAfterThreeRetries() {
+    fail();
+  }
+
+  @Test(dependsOnMethods = {
+      "testAnnotationWithNoRetries",
+      "testAnnotationWithOneRetry",
+      "testAnnotationWithSevenRetries",
+      "failAfterThreeRetries"
+  }, alwaysRun = true)
+  public void checkInvocationCounts() {
+    assertEquals(invocations.count("testAnnotationWithNoRetries"), 0);
+    assertEquals(invocations.count("testAnnotationWithOneRetry"), 1);
+    assertEquals(invocations.count("testAnnotationWithSevenRetries"), 7);
+    assertEquals(invocations.count("failAfterThreeRetries"), 4);
+  }
+
+  @DataProvider(name="dataProvider")
+  private Object[][] dataProvider() {
+    return new Object[][] { { 1, false }, { 0, true }, { 0, true },
+        { 1, false } };
+  }
+
+  @DataProvider(name="dataProvider2")
+  private Object[][] dataProvider2() {
+    value = 42;
+
+    return new Object[][] { { true }, { true } };
+  }
+
+  @Test(retryAnalyzer = InvocationCountTest.class, dataProvider = "dataProvider")
+  public void testAnnotationWithDataProvider(int paf, boolean test) {
+    if (paf == 1 && test == false) {
+      if (r2 >= 1) {
+        r2--;
+        fail();
+      }
+    }
+  }
+
+  @Test(retryAnalyzer = InvocationCountTest.class, dataProvider = "dataProvider2")
+  public void testAnnotationWithDataProviderAndRecreateParameters(boolean dummy) {
+    if (r3 == 1) {
+      this.value = 0;
+      r3--;
+      fail();
+    } else if (r3 == 0) {
+      assertEquals(this.value, 42);
+    }
+  }
+
+  @Test
+  public void withFactory() {
+    TestNG tng = new TestNG();
+    tng.setVerbose(0);
+    tng.setTestClasses(new Class[] { MyFactory.class});
+    FactoryTest.m_count = 0;
+
+    tng.run();
+
+    assertEquals(FactoryTest.m_count, 4);
+  }
+
+  @Override
+  public boolean retry(ITestResult result) {
+    invocations.add(result.getName());
+    return retriesRemaining.getAndDecrement() >= 0;
+  }
+
+  public static class ThreeRetries implements IRetryAnalyzer {
+    private final AtomicInteger remainingRetries = new AtomicInteger(3);
+
+    @Override
+    public boolean retry(ITestResult result) {
+      invocations.add(result.getName());
+      return remainingRetries.getAndDecrement() > 0;
+    }
+  }
+}

--- a/src/test/java/test/retryAnalyzer/MyFactory.java
+++ b/src/test/java/test/retryAnalyzer/MyFactory.java
@@ -3,18 +3,14 @@ package test.retryAnalyzer;
 import org.testng.annotations.Factory;
 
 public class MyFactory {
-
-
-	@Factory
-	public Object[] createTests(){
-
-		int num = 10;
-		Object[] result = new Object[num];
-		for(int i=0;i<num;i++){
-			FactoryTest obj  = new FactoryTest("Test" + i);
-			result[i] = obj;
-		}
-		return result;
-	}
-
+    @Factory
+    public Object[] createTests() {
+        int num = 10;
+        Object[] result = new Object[num];
+        for (int i = 0; i < num; i++) {
+            FactoryTest obj = new FactoryTest("Test" + i);
+            result[i] = obj;
+        }
+        return result;
+    }
 }

--- a/src/test/java/test/retryAnalyzer/RetryAnalyzerTest.java
+++ b/src/test/java/test/retryAnalyzer/RetryAnalyzerTest.java
@@ -1,96 +1,37 @@
 package test.retryAnalyzer;
 
-import org.testng.Assert;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import java.util.List;
+
 import org.testng.ITestResult;
+import org.testng.TestListenerAdapter;
 import org.testng.TestNG;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import org.testng.util.RetryAnalyzerCount;
 
-/**
- * retryAnalyzer parameter unit tests.
- * @author tocman@gmail.com (Jeremie Lenfant-Engelmann)
- *
- */
-public final class RetryAnalyzerTest extends RetryAnalyzerCount {
+import test.SimpleBaseTest;
 
-  private static int r = 1;
-  private static int r2 = 1;
-  private static int r3 = 1;
-  private static int value = 42;
+public class RetryAnalyzerTest extends SimpleBaseTest {
+    @Test
+    public void testInvocationCounts() {
+        TestNG tng = create(InvocationCountTest.class);
+        TestListenerAdapter tla = new TestListenerAdapter();
+        tng.addListener(tla);
 
-  public RetryAnalyzerTest() {
-    setCount(2);
-  }
+        tng.run();
 
-  @Test(retryAnalyzer=RetryAnalyzerTest.class)
-  public void testAnnotation() {
-    Assert.assertTrue(true);
-  }
+        assertFalse(tng.hasFailure());
+        assertFalse(tng.hasSkip());
 
-  @Test(retryAnalyzer=RetryAnalyzerTest.class)
-  public void testAnnotationWithOneRetry() {
-    if (r == 1) {
-      r--;
-      Assert.assertTrue(false);
+        assertTrue(tla.getFailedTests().isEmpty());
+
+        List<ITestResult> fsp = tla.getFailedButWithinSuccessPercentageTests();
+        assertEquals(fsp.size(), 1);
+        assertEquals(fsp.get(0).getName(), "failAfterThreeRetries");
+
+        List<ITestResult> skipped = tla.getSkippedTests();
+        assertEquals(skipped.size(), InvocationCountTest.invocations.size() - fsp.size());
     }
-    if (r == 0) {
-      Assert.assertTrue(true);
-    }
-  }
-
-  @DataProvider(name="dataProvider")
-  private Object[][] dataProvider() {
-    return new Object[][] { { 1, false }, { 0, true }, { 0, true },
-        { 1, false } };
-  }
-
-  @DataProvider(name="dataProvider2")
-  private Object[][] dataProvider2() {
-    value = 42;
-
-    return new Object[][] { { true }, { true } };
-  }
-
-  @Test(retryAnalyzer=RetryAnalyzerTest.class, dataProvider="dataProvider")
-  public void testAnnotationWithDataProvider(int paf, boolean test) {
-    if (paf == 1 && test == false) {
-      if (r2 >= 1) {
-        r2--;
-        Assert.assertTrue(false);
-      } else if (r2 == 0) {
-        Assert.assertTrue(true);
-      }
-    }
-    else if (paf == 0 || test == true) {
-      Assert.assertTrue(true);
-    }
-  }
-
-  @Test(retryAnalyzer=RetryAnalyzerTest.class, dataProvider="dataProvider2")
-  public void testAnnotationWithDataProviderAndRecreateParameters(boolean dummy) {
-    if (r3 == 1) {
-      this.value = 0;
-      r3--;
-      Assert.assertTrue(false);
-    } else if (r3 == 0) {
-      Assert.assertEquals(this.value, 42);
-    }
-  }
-
-  @Test
-  public void withFactory() {
-    TestNG tng = new TestNG();
-    tng.setVerbose(0);
-    tng.setTestClasses(new Class[] { MyFactory.class});
-    FactoryTest.m_count = 0;
-    tng.run();
-
-    Assert.assertEquals(FactoryTest.m_count, 4);
-  }
-
-  @Override
-  public boolean retryMethod(ITestResult result) {
-    return true;
-  }
 }

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -623,7 +623,7 @@
 
   <test name="RetryAnalyzer">
     <classes>
-      <!-- <class name="test.retryAnalyzer.RetryAnalyzerTest" /> -->
+      <class name="test.retryAnalyzer.RetryAnalyzerTest" />
       <class name="test.retryAnalyzer.ExitCodeTest" />
     </classes>
   </test>


### PR DESCRIPTION
Despite the recent `ExitCodeListener` fixes, it turns out that the `IRetryAnalyzer` is still buggy:
- Failures are not accounted correctly, resulting in an excessive number of calls to `IRetryAnalyzer#retry` and false positives for tests that never succeed (!)
- The `collectResults` logic is essentially gibberish, and can be greatly simplified because failures pending retry are now reported as `SKIPPED`

This PR fixes all of these issues and improves test coverage for `IRetryAnalyzer`.
