### PR TITLE
GITHUB-759 OSGIfy TestNG by Gradle / Fix scope in deployed pom for com.google.inject:guice

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ plugins {
 version = '6.9.7-SNAPSHOT'
 
 apply plugin: 'java'
+apply plugin: 'osgi'
 
 repositories {
     mavenCentral()
@@ -107,6 +108,22 @@ task myDir {
 
 // Include the generated Version.class in the jar
 jar {
+    manifest {
+        instruction 'Bundle-License', 'http://apache.org/licenses/LICENSE-2.0'
+        instruction 'Bundle-Description', 'TestNG is a testing framework.'
+        instruction 'Import-Package',
+            'bsh.*;version="[2.0.0,3.0.0)";resolution:=optional',
+            'com.beust.jcommander.*;version="[1.7.0,3.0.0)";resolution:=optional',
+            'com.google.inject.*;version="[1.2,1.3)";resolution:=optional',
+            'junit.framework;version="[3.8.1, 5.0.0)";resolution:=optional',
+            'org.junit.*;resolution:=optional',
+            'org.apache.tools.ant.*;version="[1.7.0, 2.0.0)";resolution:=optional',
+            'org.yaml.*;version="[1.6,2.0)";resolution:=optional',
+            '!com.beust.testng',
+            '!org.testng.*',
+            '!com.sun.*',
+            '*'
+    }
     from "$buildDir/classes/generated"
 }
 

--- a/gradle/publishing-maven.gradle
+++ b/gradle/publishing-maven.gradle
@@ -75,7 +75,9 @@ uploadArchives {
                     }
                 }
             }
-
+            pom.whenConfigured { pom ->
+                pom.dependencies.findAll { dependency -> dependency.groupId == 'com.google.inject'  && dependency.artifactId == 'guice' }*.scope = 'provided'
+            }
         }
     }
 }


### PR DESCRIPTION
This pull request refers to issue https://github.com/cbeust/testng/issues/759.
It fix an issue were TestNG wasn't build as an OSGI bundle.

During my investigation, I've found another issue in the generated pom that is uploaded on maven central.
The dependency com.google.inject:guice should have the scope provided.
