### PR TITLE
Bug/testng eclipse #144/#155: Timeout while trying to contact RemoteTestNG.

### DIFF
--- a/src/main/java/org/testng/remote/strprotocol/BaseMessageSender.java
+++ b/src/main/java/org/testng/remote/strprotocol/BaseMessageSender.java
@@ -118,24 +118,33 @@ abstract public class BaseMessageSender implements IMessageSender {
     if (m_inStream != null) {
       p("Receiver already initialized");
     }
-    ServerSocket serverSocket = null;
+    ServerSocket serverSocket;
     try {
       p("initReceiver on port " + m_port);
       serverSocket = new ServerSocket(m_port);
       serverSocket.setSoTimeout(5000);
 
-	  Socket socket = serverSocket.accept();
-	  m_inStream = socket.getInputStream();
-	  m_inReader = new BufferedReader(new InputStreamReader(m_inStream));
-	  m_outStream = socket.getOutputStream();
-	  m_outWriter = new PrintWriter(new OutputStreamWriter(m_outStream));
+      while (true) {
+        try {
+          Socket socket = serverSocket.accept();
+          m_inStream = socket.getInputStream();
+          m_inReader = new BufferedReader(new InputStreamReader(m_inStream));
+          m_outStream = socket.getOutputStream();
+          m_outWriter = new PrintWriter(new OutputStreamWriter(m_outStream));
+
+          break;
+        }
+        catch (IOException ioe) {
+          try {
+            Thread.sleep(100L);
+          }
+          catch (InterruptedException ie) {
+            // Do nothing.
+          }
+        }
+      }
     }
     catch(SocketTimeoutException ste) {
-      try {
-		serverSocket.close();
-	  } catch (IOException e) {
-		  // ignore
-	  }
       throw ste;
     }
     catch (IOException ioe) {

--- a/src/main/java/org/testng/remote/strprotocol/BaseMessageSender.java
+++ b/src/main/java/org/testng/remote/strprotocol/BaseMessageSender.java
@@ -2,6 +2,7 @@ package org.testng.remote.strprotocol;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -15,7 +16,8 @@ import java.net.Socket;
 import java.net.SocketTimeoutException;
 
 import org.testng.TestNGException;
-import org.testng.remote.RemoteTestNG;
+
+import static org.testng.remote.RemoteTestNG.isVerbose;
 
 abstract public class BaseMessageSender implements IMessageSender {
   private boolean m_debug = false;
@@ -24,6 +26,7 @@ abstract public class BaseMessageSender implements IMessageSender {
   private int m_port;
   protected Object m_ackLock = new Object();
 
+  private boolean m_requstStopReceiver;
   /** Outgoing message stream. */
   protected OutputStream m_outStream;
   /** Used to send ACK and STOP */
@@ -118,20 +121,20 @@ abstract public class BaseMessageSender implements IMessageSender {
     if (m_inStream != null) {
       p("Receiver already initialized");
     }
-    ServerSocket serverSocket;
+    ServerSocket serverSocket = null;
     try {
       p("initReceiver on port " + m_port);
       serverSocket = new ServerSocket(m_port);
       serverSocket.setSoTimeout(5000);
 
-      while (true) {
+      Socket socket = null;
+      while (!m_requstStopReceiver) {
         try {
-          Socket socket = serverSocket.accept();
-          m_inStream = socket.getInputStream();
-          m_inReader = new BufferedReader(new InputStreamReader(m_inStream));
-          m_outStream = socket.getOutputStream();
-          m_outWriter = new PrintWriter(new OutputStreamWriter(m_outStream));
-
+          if (m_debug) {
+            p("polling the client connection");
+          }
+          socket = serverSocket.accept();
+          // break the loop once the first client connected
           break;
         }
         catch (IOException ioe) {
@@ -143,51 +146,49 @@ abstract public class BaseMessageSender implements IMessageSender {
           }
         }
       }
+      if (socket != null) {
+        m_inStream = socket.getInputStream();
+        m_inReader = new BufferedReader(new InputStreamReader(m_inStream));
+        m_outStream = socket.getOutputStream();
+        m_outWriter = new PrintWriter(new OutputStreamWriter(m_outStream));
+      }
     }
     catch(SocketTimeoutException ste) {
       throw ste;
     }
     catch (IOException ioe) {
-      // TODO Auto-generated catch block
-      ioe.printStackTrace();
+      closeQuitely(serverSocket);
     }
+  }
+
+  public void stopReceiver() {
+    m_requstStopReceiver = true;
   }
 
   @Override
   public void shutDown() {
-    if(null != m_outStream) {
+    closeQuitely(m_outStream);
+    m_outStream = null;
+
+    if (null != m_readerThread) {
+      m_readerThread.interrupt();
+    }
+
+    closeQuitely(m_inReader);
+    m_inReader = null;
+
+    closeQuitely(m_clientSocket);
+    m_clientSocket = null;
+  }
+
+  private void closeQuitely(Closeable c) {
+    if (c != null) {
       try {
-        m_outStream.close();
-      }
-      catch(IOException ex) {
-        // ignore
-      }
-      m_outStream = null;
-    }
-
-    try {
-      if(null != m_readerThread) {
-        m_readerThread.interrupt();
-      }
-
-      if(null != m_inReader) {
-        m_inReader.close();
-        m_inReader = null;
-      }
-    }
-    catch(IOException e) {
-      e.printStackTrace();
-    }
-
-    try {
-      if(null != m_clientSocket) {
-        m_clientSocket.close();
-        m_clientSocket = null;
-      }
-    }
-    catch(IOException e) {
-      if(m_debug) {
-        e.printStackTrace();
+        c.close();
+      } catch (IOException e) {
+        if (m_debug) {
+          e.printStackTrace();
+        }
       }
     }
   }
@@ -210,7 +211,7 @@ abstract public class BaseMessageSender implements IMessageSender {
   }
 
   private static void p(String msg) {
-    if (RemoteTestNG.isVerbose()) {
+    if (isVerbose()) {
       System.out.println("[BaseMessageSender] " + msg); //$NON-NLS-1$
     }
   }
@@ -269,7 +270,7 @@ abstract public class BaseMessageSender implements IMessageSender {
 //        }
       }
       catch(IOException ioe) {
-        if (RemoteTestNG.isVerbose()) {
+        if (isVerbose()) {
           ioe.printStackTrace();
         }
       }

--- a/src/main/java/org/testng/remote/strprotocol/BaseMessageSender.java
+++ b/src/main/java/org/testng/remote/strprotocol/BaseMessageSender.java
@@ -26,7 +26,7 @@ abstract public class BaseMessageSender implements IMessageSender {
   private int m_port;
   protected Object m_ackLock = new Object();
 
-  private boolean m_requstStopReceiver;
+  private boolean m_requestStopReceiver;
   /** Outgoing message stream. */
   protected OutputStream m_outStream;
   /** Used to send ACK and STOP */
@@ -128,7 +128,7 @@ abstract public class BaseMessageSender implements IMessageSender {
       serverSocket.setSoTimeout(5000);
 
       Socket socket = null;
-      while (!m_requstStopReceiver) {
+      while (!m_requestStopReceiver) {
         try {
           if (m_debug) {
             p("polling the client connection");
@@ -162,7 +162,7 @@ abstract public class BaseMessageSender implements IMessageSender {
   }
 
   public void stopReceiver() {
-    m_requstStopReceiver = true;
+    m_requestStopReceiver = true;
   }
 
   @Override

--- a/src/main/java/org/testng/remote/strprotocol/BaseMessageSender.java
+++ b/src/main/java/org/testng/remote/strprotocol/BaseMessageSender.java
@@ -157,7 +157,7 @@ abstract public class BaseMessageSender implements IMessageSender {
       throw ste;
     }
     catch (IOException ioe) {
-      closeQuitely(serverSocket);
+      closeQuietly(serverSocket);
     }
   }
 
@@ -167,21 +167,21 @@ abstract public class BaseMessageSender implements IMessageSender {
 
   @Override
   public void shutDown() {
-    closeQuitely(m_outStream);
+    closeQuietly(m_outStream);
     m_outStream = null;
 
     if (null != m_readerThread) {
       m_readerThread.interrupt();
     }
 
-    closeQuitely(m_inReader);
+    closeQuietly(m_inReader);
     m_inReader = null;
 
-    closeQuitely(m_clientSocket);
+    closeQuietly(m_clientSocket);
     m_clientSocket = null;
   }
 
-  private void closeQuitely(Closeable c) {
+  private void closeQuietly(Closeable c) {
     if (c != null) {
       try {
         c.close();

--- a/src/main/java/org/testng/remote/strprotocol/IMessageSender.java
+++ b/src/main/java/org/testng/remote/strprotocol/IMessageSender.java
@@ -10,12 +10,20 @@ public interface IMessageSender {
 
   /**
    * Initialize the receiver.
+   * the underlying socket server will be polling until a first client connect.
    *
    * @throws SocketException This exception will be thrown if a connection
    * to the remote TestNG instance could not be established after ten
    * seconds.
    */
   void initReceiver() throws SocketTimeoutException;
+
+  /**
+   * Stop the receiver.
+   * it provides a way that allow the API invoker to stop the receiver,
+   * e.g. break from a dead while loop
+   */
+  void stopReceiver();
 
   void sendMessage(IMessage message) throws Exception;
 


### PR DESCRIPTION
in this PR, i'd like to bring the while loop for socket.accept back.
beside, i added a new interface `stopReceiver()` allow the API invoker to break from the dead loop.

this is really a historical issue, here is the relate git commit history:
1. add while loop for socket.accept to fix issue #102 BaseMessageSender fails to connect if JVM is slow
2. remoe the while loop to fix https://github.com/cbeust/testng-eclipse/issues/48: testng-eclipse will be hang if run RemoteTestNG with error argument

after some investigation, i think we need bring the while loop back so that it can wait until the first client connect request arrive.
the way to fix the eclipse hang was wrong, the correct way to do it is:
1. put the init receiver into thread (this is done by putting it in a eclipse job)
2. hook into the eclipse launch lifecycle to correct stop the init reviever thread to prevent from a dead loop

Along with the PR for eclipse plugin: https://github.com/cbeust/testng-eclipse/pull/166
it fixes https://github.com/cbeust/testng-eclipse/issues/144 and https://github.com/cbeust/testng-eclipse/issues/155
