### PR TITLE
Inconsistent arrays equality comparison in assertEquals and assertNotEquals

### DIFF
--- a/src/test/java/org/testng/AssertCollectionsTest.java
+++ b/src/test/java/org/testng/AssertCollectionsTest.java
@@ -1,0 +1,150 @@
+package org.testng;
+
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+
+/**
+ * Tests different equality cases for nested collections
+ * and arrays.
+ */
+public class AssertCollectionsTest {
+    @Test
+    public void arrayInsideListAssertEquals() {
+        List<int[]> list = Arrays.asList(
+            new int[]{ 42 }
+        );
+        List<int[]> listCopy = Arrays.asList(
+            new int[]{ 42 }
+        );
+        assertEquals(list, listCopy,
+                "arrays inside lists are compared by value in assertEquals");
+    }
+
+    @Test
+    public void arrayInsideListAssertNotEquals() {
+        List<int[]> list = Arrays.asList(
+            new int[]{ 42 }
+        );
+        List<int[]> listCopy = Arrays.asList(
+            new int[]{ 42 }
+        );
+        assertNotEquals(list, listCopy,
+                "arrays inside lists aren't compared by value in assertNotEquals");
+    }
+
+    @Test
+    public void arrayInsideMapAssertEquals() {
+        Map<String, int[]> map = new HashMap<>();
+        map.put("array", new int[]{ 42 });
+        Map<String, int[]> mapCopy = new HashMap<>();
+        mapCopy.put("array", new int[]{ 42 });
+
+        // arrays inside maps are compared by value in assertEquals(Map,Map)
+        assertEquals(map, mapCopy);
+    }
+
+    @Test(expectedExceptions = AssertionError.class)
+    public void arrayInsideMapAssertEqualsWithMessage() {
+        Map<String, int[]> map = new HashMap<>();
+        map.put("array", new int[]{ 42 });
+        Map<String, int[]> mapCopy = new HashMap<>();
+        mapCopy.put("array", new int[]{ 42 });
+
+        assertEquals(map, mapCopy,
+                "arrays inside maps aren't compared by value in assertEquals(Map,Map,String)");
+    }
+
+    @Test
+    public void arrayInsideMapAssertNotEquals() {
+        Map<String, int[]> map = new HashMap<>();
+        map.put("array", new int[]{ 42 });
+        Map<String, int[]> mapCopy = new HashMap<>();
+        mapCopy.put("array", new int[]{ 42 });
+
+        assertNotEquals(map, mapCopy,
+                "arrays inside maps aren't compared by value in assertNotEquals");
+    }
+
+    @Test(expectedExceptions = AssertionError.class)
+    public void arrayInsideSetAssertEquals() {
+        Set<int[]> set = new HashSet<>();
+        set.add(new int[]{ 42 });
+        Set<int[]> setCopy = new HashSet<>();
+        setCopy.add(new int[]{ 42 });
+
+        assertEquals(set, setCopy,
+                "arrays inside sets aren't compared by value in assertNotEquals");
+    }
+
+    @Test
+    public void arrayInsideSetAssertNotEquals() {
+        Set<int[]> set = new HashSet<>();
+        set.add(new int[]{ 42 });
+        Set<int[]> setCopy = new HashSet<>();
+        setCopy.add(new int[]{ 42 });
+
+        assertNotEquals(set, setCopy,
+                "arrays inside sets aren't compared by value in assertNotEquals");
+    }
+
+    @Test(expectedExceptions = AssertionError.class)
+    public void arrayDeepInListsAssertEquals() {
+        List<List<int[]>> list = Collections.singletonList(Arrays.asList(new int[]{ 42 }));
+        List<List<int[]>> listCopy = Collections.singletonList(Arrays.asList(new int[]{ 42 }));
+
+        assertEquals(list, listCopy,
+                "arrays inside lists which are inside lists themselves aren't compared by value in assertEquals");
+    }
+
+    @Test(expectedExceptions = AssertionError.class)
+    public void arrayDeepInMapsAssertEquals() {
+        Map<String, Map<String, int[]>> map = new HashMap<>();
+        Map<String, int[]> innerMap = new HashMap<>();
+        innerMap.put("array", new int[]{ 42 });
+        map.put("map", innerMap);
+        Map<String, Map<String, int[]>> mapCopy = new HashMap<>();
+        Map<String, int[]> innerMapCopy = new HashMap<>();
+        innerMapCopy.put("array", new int[]{ 42 });
+        mapCopy.put("map", innerMapCopy);
+
+        assertEquals(map, mapCopy,
+                "arrays inside maps which are inside maps themselves aren't compared by value in assertEquals");
+    }
+
+    @Test(expectedExceptions = AssertionError.class)
+    public void arrayDeepInListAndMapAssertEquals() {
+        List<Map<String, int[]>> list = new ArrayList<>();
+        Map<String, int[]> innerMap = new HashMap<>();
+        innerMap.put("array", new int[]{ 42 });
+        list.add(innerMap);
+        List<Map<String, int[]>> listCopy = new ArrayList<>();
+        Map<String, int[]> innerMapCopy = new HashMap<>();
+        innerMapCopy.put("array", new int[]{ 42 });
+        list.add(innerMapCopy);
+
+        assertEquals(list, listCopy,
+                "arrays inside maps which are inside lists themselves aren't compared by value in assertEquals");
+    }
+
+    @Test(expectedExceptions = AssertionError.class)
+    public void arrayDeepInMapAndListAssertEquals() {
+        Map<String, List<int[]>> map = new HashMap<>();
+        map.put("list", Arrays.asList(new int[]{ 42 }));
+        Map<String, List<int[]>> mapCopy = new HashMap<>();
+        mapCopy.put("list", Arrays.asList(new int[]{ 42 }));
+
+        assertEquals(map, mapCopy,
+                "arrays inside maps which are inside lists themselves aren't compared by value in assertEquals");
+    }
+}

--- a/src/test/java/test/asserttests/ArrayEqualityAssertTest.java
+++ b/src/test/java/test/asserttests/ArrayEqualityAssertTest.java
@@ -148,5 +148,64 @@ public class ArrayEqualityAssertTest {
                 "arrays inside maps which are inside lists themselves aren't compared by value in assertEquals");
     }
 
-    // Test Iterable and assertArrayEquals()
+    @Test
+    public void arrayInsideIterableAssertEquals() {
+        Iterable<int[]> iterable = Arrays.asList(
+            new int[]{ 42 }
+        );
+        Iterable<int[]> iterableCopy = Arrays.asList(
+            new int[]{ 42 }
+        );
+        assertEquals(iterable, iterableCopy,
+                "arrays inside Iterables are compared by value in assertEquals");
+    }
+
+    @Test(expectedExceptions = AssertionError.class)
+    public void arrayDeepInIterablesAssertEquals() {
+        List<List<int[]>> iterable = Collections.singletonList(Arrays.asList(new int[]{ 42 }));
+        List<List<int[]>> iterableCopy = Collections.singletonList(Arrays.asList(new int[]{ 42 }));
+
+        assertEquals(iterable, iterableCopy,
+                "arrays inside Iterables which are inside Iterables themselves aren't compared by value in assertEquals");
+    }
+
+    @Test
+    public void arrayInsideArrayAssertEquals() {
+        int[][] array = new int[][] {
+            new int[]{ 42 }
+        };
+        int[][] arrayCopy = new int[][] {
+            new int[]{ 42 }
+        };
+        assertEquals(array, arrayCopy,
+                "arrays inside arrays are compared by value in assertEquals");
+    }
+
+    @Test
+    public void arrayDeepInArraysAssertEquals() {
+        int[][][] array = new int[][][] {
+            new int[][] { new int[]{ 42 } }
+        };
+        int[][][] arrayCopy = new int[][][] {
+            new int[][] { new int[]{ 42 } }
+        };
+
+        assertEquals(array, arrayCopy,
+                "arrays inside arrays which are inside arrays themselves are compared by value in assertEquals");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test(expectedExceptions = AssertionError.class)
+    public void arrayDeepInArrayAndListAssertEquals() {
+        List<int[]>[] array = new List[] {
+            Arrays.asList(new int[]{ 42 })
+        };
+        List<int[]>[] arrayCopy = new List[] {
+            Arrays.asList(new int[]{ 42 })
+        };
+
+        assertEquals(array, arrayCopy,
+                "arrays inside arrays which are inside arrays themselves aren't compared by value in assertEquals");
+    }
+
 }

--- a/src/test/java/test/asserttests/ArrayEqualityAssertTest.java
+++ b/src/test/java/test/asserttests/ArrayEqualityAssertTest.java
@@ -1,4 +1,4 @@
-package org.testng;
+package test.asserttests;
 
 import org.testng.annotations.Test;
 
@@ -18,7 +18,7 @@ import static org.testng.Assert.assertNotEquals;
  * Tests different equality cases for nested collections
  * and arrays.
  */
-public class AssertCollectionsTest {
+public class ArrayEqualityAssertTest {
     @Test
     public void arrayInsideListAssertEquals() {
         List<int[]> list = Arrays.asList(
@@ -147,4 +147,6 @@ public class AssertCollectionsTest {
         assertEquals(map, mapCopy,
                 "arrays inside maps which are inside lists themselves aren't compared by value in assertEquals");
     }
+
+    // Test Iterable and assertArrayEquals()
 }

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -638,6 +638,7 @@
     <classes>
       <class name="org.testng.AssertTest" />
       <class name="test.asserttests.AssertTest" />
+      <class name="test.asserttests.ArrayEqualityAssertTest" />
     </classes>
   </test>
 


### PR DESCRIPTION
_Maybe I should have opened an issue instead, but I'm willing to fix the problem myself and wanted to provide the tests to illustrate the problem._
## Some background

When I started looking into the issue, my main concern was that arrays in collections where compared by value in some cases and by reference in another. It turned out that arrays stored in collections directly was compared by value and arrays in collections stored in another collections themselves wasn't. The reason is that TestNG performs custom element-by-element equality tests in `assertEquals` for `Collection`s and `Map`s, but the elements in those collections are compared using `equals`. It happens just because how Java's static method dispatch works and because only arrays are threated specially in `assertEquals(Object, Object, String)`. I thought I could easily do a patch to route equality tests to correct methods but it turned out that the problem of arrays equality is much broader.
## Inconsistencies in arrays equality

Arrays are tested by value or by reference (`equals`) in different places depending on incidental implementation details. So arrays in `Map`s and `Collection`s are tested by value if only if they are direct elements of those containers, if they are buried deeper in the object tree of those collections (as elements of nested collections) they are tested by reference. The same applies to `Iterable`s and arrays (stored in collections inside arrays). `assertNotEquals` will always test arrays by reference (by calling equals on a collection). This leads to bizarre cases when two collections with some array elements are considered equal and not equal simultaneously by `assertEquals` and assertNotEquals respectively. Both `assertEquals` and `assertNotEquals` will compare arrays by reference for `Set`s. All the cases described are showcased in `ArrayEqualityAssertTest`.

One more things that could be considered a bug is that `assertEquals` will lead to different results in regards to equality of arrays stored in maps (even at topmost level) depending on presence of an assertion message. That is `assertEquals(Map, Map)` will lead to by value comparison and `assertEquals(Map, Map, String)` will result in call to `Map`'s `equals` via `assertEquals(Object, Object, String)`. Why not every method has corresponding version with message parameter is another question.
## Why is it a problem?

Inconsistent behaviour described in paragraphs above could easily lead to bugs and confusions in tests and I'm pretty sure should be fixed. I personally spend half of a day investigating problem in my own code before discovering such TestNG behaviour. AFAIK, the behaviour aren't described anywhere in the documentation.
## Possible solutions

I suggest to give up considering arrays a special case. That's the easiest solution to ensure consistency within all assertion methods. Also that should be consistent with how `equals` works for arrays. I admit that it will take away some convenience and will not be backward compatible (as any other resolution of the problem as well, as far as I see).

Support arbitrary nested arrays in `assertEquals` will be easy enough (just a few lines in `assertEqulas(Object,Object)` really), if leave comparison of `Set`s as is. To make the behaviour of `assertNotEquals` symmetric is certainly possible with a little bit more work. I don't see a way to reimplement equality comparison for `Set`s efficiently to support comparison of arrays by value (if you do know such a way, please do a favor and share it).
## Commentaries are welcomed

I'd like to hear your opinions on the problem before doing any real work. What way of resolving the issue do you consider the most reasonable? I haven't found any contribution guidelines, so feel free to correct me if I'm doing things wrong. Thank you in advance.
