### PR TITLE
Included message for assertTrue

### DIFF
--- a/src/main/java/org/testng/asserts/Assertion.java
+++ b/src/main/java/org/testng/asserts/Assertion.java
@@ -106,7 +106,7 @@ public class Assertion implements IAssertLifecycle {
 
 
   public void assertTrue(final boolean condition, final String message) {
-    doAssert(new SimpleAssert<Boolean>(condition, Boolean.TRUE) {
+    doAssert(new SimpleAssert<Boolean>(condition, Boolean.TRUE, message) {
       @Override
       public void doAssert() {
         org.testng.Assert.assertTrue(condition, message);


### PR DESCRIPTION
Failure messages weren’t getting reported in the case of 
failures in assertTrue. Fixed it by including 
reference to the failure message.
