### PR TITLE
ensure that taget directory for file report exists before creating a …

### DIFF
--- a/src/main/java/org/testng/internal/Utils.java
+++ b/src/main/java/org/testng/internal/Utils.java
@@ -102,6 +102,10 @@ public final class Utils {
 
   public static void writeUtf8File(String outputDir, String fileName, XMLStringBuffer xsb, String prefix) {
     try {
+      final File outDir = (outputDir != null) ? new File(outputDir) : new File("").getAbsoluteFile();
+      if (!outDir.exists()) {
+        outDir.mkdirs();
+      }
       final File file = new File(outputDir, fileName);
       if (!file.exists()) {
         file.createNewFile();

--- a/src/main/java/org/testng/internal/Utils.java
+++ b/src/main/java/org/testng/internal/Utils.java
@@ -100,7 +100,7 @@ public final class Utils {
     return vResult.toArray(new String[vResult.size()]);
   }
 
-  public static void writeUtf8File(String outputDir, String fileName, XMLStringBuffer xsb, String prefix) {
+  public static void writeUtf8File(@Nullable String outputDir, String fileName, XMLStringBuffer xsb, String prefix) {
     try {
       final File outDir = (outputDir != null) ? new File(outputDir) : new File("").getAbsoluteFile();
       if (!outDir.exists()) {
@@ -794,7 +794,7 @@ public final class Utils {
   /**
    * Returns the string representation of the specified object, transparently
    * handling null references and arrays.
-   * 
+   *
    * @param obj
    *            the object
    * @return the string representation

--- a/src/main/java/org/testng/internal/Utils.java
+++ b/src/main/java/org/testng/internal/Utils.java
@@ -106,7 +106,7 @@ public final class Utils {
       if (!outDir.exists()) {
         outDir.mkdirs();
       }
-      final File file = new File(outputDir, fileName);
+      final File file = new File(outDir, fileName);
       if (!file.exists()) {
         file.createNewFile();
       }


### PR DESCRIPTION
…report file, affects XMLReporter

Unlike `SuiteHTMLReporter`, `JUnitXMLReporter` and other reports the `XMLReporter` uses `writeUtf8File` method from `Utils` class that does not check whether report directory is present or not. This leads to problems described in the issue https://github.com/cbeust/testng/issues/592.

This pull request adds a check and directory creation logic to the method used in the `XMLReport` class and intended to fix such kind of issues.
