### PR TITLE
Allowing Suites to have duplicated name so people can configure the s…

### DIFF
--- a/src/main/java/org/testng/TestNG.java
+++ b/src/main/java/org/testng/TestNG.java
@@ -982,9 +982,20 @@ public class TestNG {
   private void checkSuiteNamesInternal(List<XmlSuite> suites, Set<String> names) {
     for (XmlSuite suite : suites) {
       final String name = suite.getName();
-      if (names.contains(name)) {
-        throw new TestNGException("Two suites cannot have the same name: " + name);
+      
+      int count = 0;
+      String tmpName = name;
+      while (names.contains(tmpName)) {
+        tmpName = name + " (" + count++ + ")";
       }
+ 
+      if (count > 0) {
+        suite.setName(tmpName);
+        names.add(tmpName);
+      } else {
+        names.add(name);
+      }
+
       names.add(name);
       checkSuiteNamesInternal(suite.getChildSuites(), names);
     }


### PR DESCRIPTION
…ame suite-file to run multiple times (performance testing, resiliency, memory leak testing, etc). Did this by checking for duplicated names, and if one or more are found instead of throwing an exception we change the name to <suite name> (0), <suite name> (1), etc... This way they will not conflict internally in any way, results are shown properly across the board, and folks can now repeat test suites if they want to which is extremely useful to make sure you don't have timing issues, memory leaks and other problems that arise from continued use.
