### PR TITLE
JUnitXMLReporter does not synchronize the two synchronized collections when iterating

### DIFF
--- a/src/main/java/org/testng/reporters/JUnitXMLReporter.java
+++ b/src/main/java/org/testng/reporters/JUnitXMLReporter.java
@@ -174,11 +174,15 @@ public class JUnitXMLReporter implements IResultListener2 {
       document.push(XMLConstants.TESTSUITE, attrs);
 //      document.addEmptyElement(XMLConstants.PROPERTIES);
 
-      for(ITestResult tr : m_configIssues) {
-        createElement(document, tr);
+      synchronized(m_configIssues) {
+          for(ITestResult tr : m_configIssues) {
+              createElement(document, tr);
+          }
       }
-      for(ITestResult tr : m_allTests) {
-        createElement(document, tr);
+      synchronized(m_allTests) {
+          for(ITestResult tr : m_allTests) {
+              createElement(document, tr);
+          }
       }
 
       document.pop();

--- a/src/main/java/org/testng/reporters/JUnitXMLReporter.java
+++ b/src/main/java/org/testng/reporters/JUnitXMLReporter.java
@@ -174,19 +174,19 @@ public class JUnitXMLReporter implements IResultListener2 {
       document.push(XMLConstants.TESTSUITE, attrs);
 //      document.addEmptyElement(XMLConstants.PROPERTIES);
 
-      synchronized(m_configIssues) {
-          for(ITestResult tr : m_configIssues) {
-              createElement(document, tr);
-          }
-      }
-      synchronized(m_allTests) {
-          for(ITestResult tr : m_allTests) {
-              createElement(document, tr);
-          }
-      }
+      createElementFromTestResults(document, m_configIssues);
+      createElementFromTestResults(document, m_allTests);
 
       document.pop();
       Utils.writeUtf8File(context.getOutputDirectory(),generateFileName(context) + ".xml", document.toXML());
+  }
+
+  private void createElementFromTestResults(XMLStringBuffer document, List<ITestResult> results) {
+    synchronized(results) {
+      for(ITestResult tr : results) {
+        createElement(document, tr);
+      }
+    }
   }
 
   private Set<String> getPackages(ITestContext context) {


### PR DESCRIPTION
In lines 177 and 180 of JUnitXMLReporter, synchronized collections m_configIssues and m_allTests
are both iterated in an unsynchronized manner, but according to Oracle Java 7 API specification
(http://docs.oracle.com/javase/7/docs/api/java/util/Collections.html#synchronizedList(java.util.List)),
although a synchronizedList is thread-safe for list manipulations like insertion and deletion, 
manual synchronization is required when the collection is iterated. 
Failure to do so might result in non-deterministic behavior.
This pull request adds a fix by synchronizing m_configIssues and m_allTests when iterating.
