### PR TITLE
Speed up suite html reporter

### DIFF
--- a/src/main/java/org/testng/internal/Utils.java
+++ b/src/main/java/org/testng/internal/Utils.java
@@ -150,19 +150,6 @@ public final class Utils {
   }
 
   /**
-   * Appends contents of the string to the specified file. If output directory/file don't
-   * exist, they are created.
-   * @param outputDir output directory. If <tt>null</tt>, then current directory is used
-   * @param fileName file name
-   * @param sb string to be appended to file
-   */
-  public static void appendToFile(@Nullable String outputDir, String fileName, String sb) {
-     String outDirPath= outputDir != null ? outputDir : "";
-     File outDir= new File(outDirPath);
-     writeFile(outDir, fileName, sb, null, true /* append */);
-  }
-
-  /**
    * Writes the content of the sb string to the file named filename in outDir. If
    * outDir does not exist, it is created.
    *

--- a/src/main/java/org/testng/internal/Utils.java
+++ b/src/main/java/org/testng/internal/Utils.java
@@ -200,17 +200,7 @@ public final class Utils {
   private static void writeFile(File outputFile, String sb, @Nullable String encoding, boolean append) {
     BufferedWriter fw = null;
     try {
-      if (!outputFile.exists()) {
-        outputFile.createNewFile();
-      }
-      OutputStreamWriter osw= null;
-      if (null != encoding) {
-        osw = new OutputStreamWriter(new FileOutputStream(outputFile, append), encoding);
-      }
-      else {
-        osw = new OutputStreamWriter(new FileOutputStream(outputFile, append));
-      }
-      fw = new BufferedWriter(osw);
+      fw = openWriter(outputFile, encoding, append);
       fw.write(sb);
 
       Utils.log("", 3, "Creating " + outputFile.getAbsolutePath());
@@ -234,6 +224,40 @@ public final class Utils {
         ; // ignore
       }
     }
+  }
+
+  /**
+   * Open a BufferedWriter for the specified file. If output directory doesn't
+   * exist, it is created. If the output file exists, it is deleted. The output file is
+   * created in any case.
+   * @param outputDir output directory. If <tt>null</tt>, then current directory is used
+   * @param fileName file name
+   * @throws IOException if anything goes wrong while creating files.
+   */
+  public static BufferedWriter openWriter(@Nullable String outputDir, String fileName) throws IOException {
+    String outDirPath= outputDir != null ? outputDir : "";
+    File outDir= new File(outDirPath);
+    if (outDir.exists()) {
+      outDir.mkdirs();
+    }
+    fileName = replaceSpecialCharacters(fileName);
+    File outputFile = new File(outDir, fileName);
+    outputFile.delete();
+    return openWriter(outputFile, null, false);
+  }
+
+  private static BufferedWriter openWriter(File outputFile, @Nullable String encoding, boolean append) throws IOException {
+    if (!outputFile.exists()) {
+      outputFile.createNewFile();
+    }
+    OutputStreamWriter osw= null;
+    if (null != encoding) {
+      osw = new OutputStreamWriter(new FileOutputStream(outputFile, append), encoding);
+    }
+    else {
+      osw = new OutputStreamWriter(new FileOutputStream(outputFile, append));
+    }
+    return new BufferedWriter(osw);
   }
 
   private static void ppp(String s) {

--- a/src/main/java/org/testng/reporters/SuiteHTMLReporter.java
+++ b/src/main/java/org/testng/reporters/SuiteHTMLReporter.java
@@ -347,10 +347,7 @@ public class SuiteHTMLReporter implements IReporter {
   private void generateMethodsChronologically(XmlSuite xmlSuite, ISuite suite,
       String outputFileName, boolean alphabetical)
   {
-    BufferedWriter bw = null;
-    try {
-      bw = Utils.openWriter(getOutputDirectory(xmlSuite), outputFileName);
-
+    try (BufferedWriter bw = Utils.openWriter(getOutputDirectory(xmlSuite), outputFileName)) {
       bw.append("<h2>Methods run, sorted chronologically</h2>");
       bw.append("<h3>" + BEFORE + " means before, " + AFTER + " means after</h3><p/>");
 
@@ -441,15 +438,6 @@ public class SuiteHTMLReporter implements IReporter {
       bw.append("</table>\n");
     } catch (IOException e) {
       Utils.log("[SuiteHTMLReporter]", 1, "Error writing to " + outputFileName + ": " + e.getMessage());
-    } finally {
-      try {
-        if (bw != null) {
-          bw.close();
-        }
-      }
-      catch (IOException e) {
-        ; // ignore
-      }
     }
   }
 

--- a/src/main/java/org/testng/reporters/SuiteHTMLReporter.java
+++ b/src/main/java/org/testng/reporters/SuiteHTMLReporter.java
@@ -14,6 +14,7 @@ import org.testng.collections.Maps;
 import org.testng.internal.Utils;
 import org.testng.xml.XmlSuite;
 
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
@@ -346,101 +347,110 @@ public class SuiteHTMLReporter implements IReporter {
   private void generateMethodsChronologically(XmlSuite xmlSuite, ISuite suite,
       String outputFileName, boolean alphabetical)
   {
-    StringBuffer sb = new StringBuffer();
+    BufferedWriter bw = null;
+    try {
+      bw = Utils.openWriter(getOutputDirectory(xmlSuite), outputFileName);
 
-    sb.append("<h2>Methods run, sorted chronologically</h2>");
-    sb.append("<h3>" + BEFORE + " means before, " + AFTER + " means after</h3><p/>");
+      bw.append("<h2>Methods run, sorted chronologically</h2>");
+      bw.append("<h3>" + BEFORE + " means before, " + AFTER + " means after</h3><p/>");
 
-    long startDate = -1;
-    sb.append("<br/><em>").append(suite.getName()).append("</em><p/>");
-    sb.append("<small><i>(Hover the method name to see the test class name)</i></small><p/>\n");
-    Utils.writeFile(getOutputDirectory(xmlSuite), outputFileName, sb.toString());
-    sb = null; //not needed anymore
+      long startDate = -1;
+      bw.append("<br/><em>").append(suite.getName()).append("</em><p/>");
+      bw.append("<small><i>(Hover the method name to see the test class name)</i></small><p/>\n");
 
-    Collection<IInvokedMethod> invokedMethods = suite.getAllInvokedMethods();
-    if (alphabetical) {
-      @SuppressWarnings({"unchecked"})
-      Comparator<? super ITestNGMethod>  alphabeticalComparator = new Comparator(){
-        @Override
-        public int compare(Object o1, Object o2) {
-          IInvokedMethod m1 = (IInvokedMethod) o1;
-          IInvokedMethod m2 = (IInvokedMethod) o2;
-          return m1.getTestMethod().getMethodName().compareTo(m2.getTestMethod().getMethodName());
+      Collection<IInvokedMethod> invokedMethods = suite.getAllInvokedMethods();
+      if (alphabetical) {
+	@SuppressWarnings({"unchecked"})
+	Comparator<? super ITestNGMethod>  alphabeticalComparator = new Comparator(){
+	  @Override
+	  public int compare(Object o1, Object o2) {
+	    IInvokedMethod m1 = (IInvokedMethod) o1;
+	    IInvokedMethod m2 = (IInvokedMethod) o2;
+	    return m1.getTestMethod().getMethodName().compareTo(m2.getTestMethod().getMethodName());
+	  }
+	};
+	Collections.sort((List) invokedMethods, alphabeticalComparator);
+      }
+
+      SimpleDateFormat format = new SimpleDateFormat("yy/MM/dd HH:mm:ss");
+      boolean addedHeader = false;
+      for (IInvokedMethod iim : invokedMethods) {
+	ITestNGMethod tm = iim.getTestMethod();
+	if (!addedHeader) {
+	  bw.append("<table border=\"1\">\n")
+	    .append("<tr>")
+	    .append("<th>Time</th>")
+	    .append("<th>Delta (ms)</th>")
+	    .append("<th>Suite<br>configuration</th>")
+	    .append("<th>Test<br>configuration</th>")
+	    .append("<th>Class<br>configuration</th>")
+	    .append("<th>Groups<br>configuration</th>")
+	    .append("<th>Method<br>configuration</th>")
+	    .append("<th>Test<br>method</th>")
+	    .append("<th>Thread</th>")
+	    .append("<th>Instances</th>")
+	    .append("</tr>\n");
+	  addedHeader = true;
+	}
+	String methodName = tm.toString();
+	boolean bc = tm.isBeforeClassConfiguration();
+	boolean ac = tm.isAfterClassConfiguration();
+	boolean bt = tm.isBeforeTestConfiguration();
+	boolean at = tm.isAfterTestConfiguration();
+	boolean bs = tm.isBeforeSuiteConfiguration();
+	boolean as = tm.isAfterSuiteConfiguration();
+	boolean bg = tm.isBeforeGroupsConfiguration();
+	boolean ag = tm.isAfterGroupsConfiguration();
+	boolean setUp = tm.isBeforeMethodConfiguration();
+	boolean tearDown = tm.isAfterMethodConfiguration();
+	boolean isClassConfiguration = bc || ac;
+	boolean isGroupsConfiguration = bg || ag;
+	boolean isTestConfiguration = bt || at;
+	boolean isSuiteConfiguration = bs || as;
+	boolean isSetupOrTearDown = setUp || tearDown;
+	String configurationClassMethod = isClassConfiguration ? (bc ? BEFORE : AFTER) + methodName : SP;
+	String configurationTestMethod = isTestConfiguration ? (bt ? BEFORE : AFTER) + methodName : SP;
+	String configurationGroupsMethod = isGroupsConfiguration ? (bg ? BEFORE : AFTER) + methodName : SP;
+	String configurationSuiteMethod = isSuiteConfiguration ? (bs ? BEFORE : AFTER) + methodName : SP;
+	String setUpOrTearDownMethod = isSetupOrTearDown ? (setUp ? BEFORE : AFTER) + methodName : SP;
+	String testMethod = tm.isTest() ? methodName : SP;
+
+	StringBuffer instances = new StringBuffer();
+	for (long o : tm.getInstanceHashCodes()) {
+	  instances.append(o).append(" ");
+	}
+
+	if (startDate == -1) {
+	  startDate = iim.getDate();
+	}
+	String date = format.format(iim.getDate());
+	bw.append("<tr bgcolor=\"" + createColor(tm) + "\">")
+	  .append("  <td>").append(date).append("</td> ")
+	  .append("  <td>").append(Long.toString(iim.getDate() - startDate)).append("</td> ")
+	  .append(td(configurationSuiteMethod))
+	  .append(td(configurationTestMethod))
+	  .append(td(configurationClassMethod))
+	  .append(td(configurationGroupsMethod))
+	  .append(td(setUpOrTearDownMethod))
+	  .append(td(testMethod))
+	  .append("  <td>").append(tm.getId()).append("</td> ")
+	  .append("  <td>").append(instances).append("</td> ")
+	  .append("</tr>\n")
+	  ;
+      }
+      bw.append("</table>\n");
+    } catch (IOException e) {
+      Utils.log("[SuiteHTMLReporter]", 1, "Error writing to " + outputFileName + ": " + e.getMessage());
+    } finally {
+      try {
+        if (bw != null) {
+          bw.close();
         }
-      };
-      Collections.sort((List) invokedMethods, alphabeticalComparator);
+      }
+      catch (IOException e) {
+        ; // ignore
+      }
     }
-
-    SimpleDateFormat format = new SimpleDateFormat("yy/MM/dd HH:mm:ss");
-    StringBuffer table = new StringBuffer();
-    boolean addedHeader = false;
-    for (IInvokedMethod iim : invokedMethods) {
-      ITestNGMethod tm = iim.getTestMethod();
-      table.setLength(0);
-      if (!addedHeader) {
-        table.append("<table border=\"1\">\n")
-          .append("<tr>")
-          .append("<th>Time</th>")
-          .append("<th>Delta (ms)</th>")
-          .append("<th>Suite<br>configuration</th>")
-          .append("<th>Test<br>configuration</th>")
-          .append("<th>Class<br>configuration</th>")
-          .append("<th>Groups<br>configuration</th>")
-          .append("<th>Method<br>configuration</th>")
-          .append("<th>Test<br>method</th>")
-          .append("<th>Thread</th>")
-          .append("<th>Instances</th>")
-          .append("</tr>\n");
-        addedHeader = true;
-      }
-      String methodName = tm.toString();
-      boolean bc = tm.isBeforeClassConfiguration();
-      boolean ac = tm.isAfterClassConfiguration();
-      boolean bt = tm.isBeforeTestConfiguration();
-      boolean at = tm.isAfterTestConfiguration();
-      boolean bs = tm.isBeforeSuiteConfiguration();
-      boolean as = tm.isAfterSuiteConfiguration();
-      boolean bg = tm.isBeforeGroupsConfiguration();
-      boolean ag = tm.isAfterGroupsConfiguration();
-      boolean setUp = tm.isBeforeMethodConfiguration();
-      boolean tearDown = tm.isAfterMethodConfiguration();
-      boolean isClassConfiguration = bc || ac;
-      boolean isGroupsConfiguration = bg || ag;
-      boolean isTestConfiguration = bt || at;
-      boolean isSuiteConfiguration = bs || as;
-      boolean isSetupOrTearDown = setUp || tearDown;
-      String configurationClassMethod = isClassConfiguration ? (bc ? BEFORE : AFTER) + methodName : SP;
-      String configurationTestMethod = isTestConfiguration ? (bt ? BEFORE : AFTER) + methodName : SP;
-      String configurationGroupsMethod = isGroupsConfiguration ? (bg ? BEFORE : AFTER) + methodName : SP;
-      String configurationSuiteMethod = isSuiteConfiguration ? (bs ? BEFORE : AFTER) + methodName : SP;
-      String setUpOrTearDownMethod = isSetupOrTearDown ? (setUp ? BEFORE : AFTER) + methodName : SP;
-      String testMethod = tm.isTest() ? methodName : SP;
-
-      StringBuffer instances = new StringBuffer();
-      for (long o : tm.getInstanceHashCodes()) {
-        instances.append(o).append(" ");
-      }
-
-      if (startDate == -1) {
-        startDate = iim.getDate();
-      }
-      String date = format.format(iim.getDate());
-      table.append("<tr bgcolor=\"" + createColor(tm) + "\">")
-        .append("  <td>").append(date).append("</td> ")
-        .append("  <td>").append(iim.getDate() - startDate).append("</td> ")
-        .append(td(configurationSuiteMethod))
-        .append(td(configurationTestMethod))
-        .append(td(configurationClassMethod))
-        .append(td(configurationGroupsMethod))
-        .append(td(setUpOrTearDownMethod))
-        .append(td(testMethod))
-        .append("  <td>").append(tm.getId()).append("</td> ")
-        .append("  <td>").append(instances).append("</td> ")
-        .append("</tr>\n")
-        ;
-      Utils.appendToFile(getOutputDirectory(xmlSuite), outputFileName, table.toString());
-    }
-    Utils.appendToFile(getOutputDirectory(xmlSuite), outputFileName, "</table>\n");
   }
 
   /**


### PR DESCRIPTION
As the second commit explains, this speeds up a random test suite (the reason that I am working on this at all) from

```
   [testng] [TestNG] Time taken by org.testng.reporters.SuiteHTMLReporter@4f2410ac: 6644 ms
```

to

```
   [testng] [TestNG] Time taken by org.testng.reporters.SuiteHTMLReporter@78e03bb5: 275 ms
```

I tested this with the following patch (note: I did not get an OOM error by just using a `StringBuffer`, as proposed in #567, so this doesn't say much; however, the `StringBuffer` had a size of 42563696 = 40.6 MiB which is a lot, I guess). I watched the test suite's memory usage in `top` and could not see any difference with this PR compared to master or compared to my `StringBuffer` patch (always peaks over 1.5 GiB).

``` diff
diff --git a/src/test/java/test/factory/FactoryTest.java b/src/test/java/test/factory/FactoryTest.java
index f44f3e9..45a4e28 100644
--- a/src/test/java/test/factory/FactoryTest.java
+++ b/src/test/java/test/factory/FactoryTest.java
@@ -6,21 +6,19 @@ import org.testng.Assert;
 import org.testng.annotations.AfterSuite;
 import org.testng.annotations.Factory;
 import org.testng.annotations.Parameters;
+import org.testng.internal.Utils;

 public class FactoryTest {
   static boolean m_invoked = false;

-  @Parameters({ "factory-param" })
   @Factory
-  public Object[] createObjects(String param) {
-    Assert.assertEquals(param, "FactoryParam");
-    assertFalse(m_invoked, "Should only be invoked once");
+  public Object[] createObjects() {
     m_invoked = true;

-    return new Object[] {
-        new FactoryTest2(42),
-        new FactoryTest2(43)
-    };
+    Object[] objs = new Object[2000];
+    for (int i = 0; i < objs.length; i++)
+       objs[i] = new FactoryTest2(i);
+    return objs;
   }

   @AfterSuite
diff --git a/src/test/java/test/factory/VerifyFactoryTest.java b/src/test/java/test/factory/VerifyFactoryTest.java
index 3ec6d56..9e6d244 100644
--- a/src/test/java/test/factory/VerifyFactoryTest.java
+++ b/src/test/java/test/factory/VerifyFactoryTest.java
@@ -12,8 +12,8 @@ public class VerifyFactoryTest {
       : "Didn't find 42";
     assert null != numbers.get(43)
       : "Didn't find 43";
-    assert 2 == numbers.size()
-      : "Expected 2 numbers, found " + (numbers.size());
+    assert 2000 == numbers.size()
+      : "Expected 2000 numbers, found " + (numbers.size());
   }


diff --git a/src/test/java/test/retryAnalyzer/RetryAnalyzerTest.java b/src/test/java/test/retryAnalyzer/RetryAnalyzerTest.java
index ee3fca6..e9c0d98 100644
--- a/src/test/java/test/retryAnalyzer/RetryAnalyzerTest.java
+++ b/src/test/java/test/retryAnalyzer/RetryAnalyzerTest.java
@@ -34,4 +34,12 @@ public class RetryAnalyzerTest extends SimpleBaseTest {
         List<ITestResult> skipped = tla.getSkippedTests();
         assertEquals(skipped.size(), InvocationCountTest.invocations.size() - fsp.size());
     }
+
+    @Test
+    public void foo() {
+       TestNG tng = new TestNG();
+       tng.setTestClasses(new Class[] { test.factory.FactoryTest.class});
+
+       tng.run();
+    }
 }
```
