### PR TITLE
Performance improvement for topological sort

### DIFF
--- a/src/main/java/org/testng/internal/Graph.java
+++ b/src/main/java/org/testng/internal/Graph.java
@@ -54,10 +54,7 @@ public class Graph<T> {
       node.addPredecessor(predecessor);
       addNeighbor(tm, predecessor);
       // Remove these two nodes from the independent list
-      if (null == m_independentNodes) {
-        m_independentNodes = Maps.newHashMap();
-        m_independentNodes.putAll(m_nodes);
-      }
+      initializeIndependentNodes();
       m_independentNodes.remove(predecessor);
       m_independentNodes.remove(tm);
       ppp("  REMOVED " + predecessor + " FROM INDEPENDENT OBJECTS");
@@ -103,9 +100,7 @@ public class Graph<T> {
   public void topologicalSort() {
     ppp("================ SORTING");
     m_strictlySortedNodes = Lists.newArrayList();
-    if (null == m_independentNodes) {
-      m_independentNodes = Maps.newHashMap();
-    }
+    initializeIndependentNodes();
 
     //
     // Clone the list of nodes but only keep those that are
@@ -156,6 +151,20 @@ public class Graph<T> {
     ppp("=============== DONE SORTING");
     if (m_verbose) {
       dumpSortedNodes();
+    }
+  }
+
+  private void initializeIndependentNodes() {
+    if (null == m_independentNodes) {
+      List<Node<T>> list = Lists.newArrayList(m_nodes.values());
+      // Ideally, we should not have to sort this. However, due to a bug where it treats all the methods as
+      // dependent nodes. Therefore, all the nodes were mostly sorted alphabetically. So we need to keep
+      // the behavior for now.
+      Collections.sort(list);
+      m_independentNodes = Maps.newLinkedHashMap();
+      for (Node<T> node : list) {
+        m_independentNodes.put(node.getObject(), node);
+      }
     }
   }
 


### PR DESCRIPTION
- topologicalSort() method has a bug where if there are no dependent nodes, it will treat all the nodes as dependent nodes. By fixing that logic, it will significantly speed up the test case that has a lot of independent nodes. The code in #772 with 6,000 tests now takes 78 seconds vs 98 seconds earlier.
- also provide a shortcut for removeFromNodes where if the node does not have any predecessor, it will not try to perform HashMap.get() which is expensive due to the hashing it has to perform. This change will help the the test case where tests are heavily dependent on each other. It seems to shed off 2-3% off from the start up time.
