### PR TITLE
Enforce proper project name in gradle

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'testng'


### PR DESCRIPTION
Could be useful if directory not named 'testng', e.g when building under TeamCity CI where checkout directory is 'random' hash.
