### PR TITLE
SuiteHTMLReporter does not synchronize iteration on a synchronized map

### DIFF
--- a/src/main/java/org/testng/reporters/SuiteHTMLReporter.java
+++ b/src/main/java/org/testng/reporters/SuiteHTMLReporter.java
@@ -575,14 +575,16 @@ public class SuiteHTMLReporter implements IReporter {
     Map<String, ISuiteResult> suiteResults = suite.getResults();
     int groupCount = suite.getMethodsByGroups().size();
     int methodCount = 0;
-    for (ISuiteResult sr : suiteResults.values()) {
-      ITestNGMethod[] methods = sr.getTestContext().getAllTestMethods();
-      methodCount += Utils.calculateInvokedMethodCount(methods);
+    synchronized(suiteResults) {
+      for (ISuiteResult sr : suiteResults.values()) {
+        ITestNGMethod[] methods = sr.getTestContext().getAllTestMethods();
+        methodCount += Utils.calculateInvokedMethodCount(methods);
 
-      // Collect testClasses
-      for (ITestNGMethod tm : methods) {
-        ITestClass tc = tm.getTestClass();
-        m_classes.put(tc.getRealClass().getName(), tc);
+        // Collect testClasses
+        for (ITestNGMethod tm : methods) {
+          ITestClass tc = tm.getTestClass();
+          m_classes.put(tc.getRealClass().getName(), tc);
+        }
       }
     }
 


### PR DESCRIPTION
In SuiteHTMLReporter.java:575, the synchronized map, suiteResults,
is iterated over in an unsynchronized manner, but according to the [Oracle Java 7 API specification](http://docs.oracle.com/javase/7/docs/api/java/util/Collections.html#synchronizedMap%28java.util.Map%29),
this is not thread-safe and can lead to non-deterministic behavior.
This pull request adds a fix by synchronizing the iteration on suiteResults.
