### PR TITLE
SuiteHTMLReporter does not synchronize iteration on a synchronized map

### DIFF
--- a/src/main/java/org/testng/reporters/SuiteHTMLReporter.java
+++ b/src/main/java/org/testng/reporters/SuiteHTMLReporter.java
@@ -631,25 +631,27 @@ public class SuiteHTMLReporter implements IReporter {
       Map<String, ISuiteResult> yellowResults = Maps.newHashMap();
       Map<String, ISuiteResult> greenResults = Maps.newHashMap();
 
-      for (Map.Entry<String, ISuiteResult> entry : suiteResults.entrySet()) {
-        String suiteName = entry.getKey();
-        ISuiteResult sr = entry.getValue();
-        ITestContext tc = sr.getTestContext();
-        int failed = tc.getFailedTests().size();
-        int skipped = tc.getSkippedTests().size();
-        int passed = tc.getPassedTests().size();
+      synchronized(suiteResults) {
+        for (Map.Entry<String, ISuiteResult> entry : suiteResults.entrySet()) {
+          String suiteName = entry.getKey();
+          ISuiteResult sr = entry.getValue();
+          ITestContext tc = sr.getTestContext();
+          int failed = tc.getFailedTests().size();
+          int skipped = tc.getSkippedTests().size();
+          int passed = tc.getPassedTests().size();
 
-        if (failed > 0) {
-          redResults.put(suiteName, sr);
-        }
-        else if (skipped > 0) {
-          yellowResults.put(suiteName, sr);
-        }
-        else if (passed > 0) {
-          greenResults.put(suiteName, sr);
-        }
-        else {
-          redResults.put(suiteName, sr);
+          if (failed > 0) {
+            redResults.put(suiteName, sr);
+          }
+          else if (skipped > 0) {
+            yellowResults.put(suiteName, sr);
+          }
+          else if (passed > 0) {
+            greenResults.put(suiteName, sr);
+          }
+          else {
+            redResults.put(suiteName, sr);
+          }
         }
       }
 


### PR DESCRIPTION
In SuiteHTMLReporter.java:575, the synchronized map, suiteResults,
is iterated over in an unsynchronized manner, but according to the [Oracle Java 7 API specification](http://docs.oracle.com/javase/7/docs/api/java/util/Collections.html#synchronizedMap%28java.util.Map%29),
this is not thread-safe and can lead to non-deterministic behavior.
This pull request adds a fix by synchronizing the iteration on suiteResults.
