### PR TITLE
XMLReporter does not synchronize iteration on a synchronized map

### DIFF
--- a/src/main/java/org/testng/reporters/XMLReporter.java
+++ b/src/main/java/org/testng/reporters/XMLReporter.java
@@ -43,11 +43,14 @@ public class XMLReporter implements IReporter {
     int failed = 0;
     int skipped = 0;
     for (ISuite s : suites) {
-      for (ISuiteResult sr : s.getResults().values()) {
-        ITestContext testContext = sr.getTestContext();
-        passed += testContext.getPassedTests().size();
-        failed += testContext.getFailedTests().size();
-        skipped += testContext.getSkippedTests().size();
+      Map<String, ISuiteResult> suiteResults = s.getResults();
+      synchronized(suiteResults) {
+        for (ISuiteResult sr : suiteResults.values()) {
+          ITestContext testContext = sr.getTestContext();
+          passed += testContext.getPassedTests().size();
+          failed += testContext.getFailedTests().size();
+          skipped += testContext.getSkippedTests().size();
+        }
       }
     }
 


### PR DESCRIPTION
In XMLReporter.java:46, the synchronized map returned by getResults method 
is iterated over in an unsynchronized manner, but according to the [Oracle Java 7 API specification](http://docs.oracle.com/javase/7/docs/api/java/util/Collections.html#synchronizedMap%28java.util.Map%29),
this is not thread-safe and can lead to non-deterministic behavior.
This pull request adds a fix by synchronizing the iteration.
