### PR TITLE
FailedReporter does not synchronize iteration on a synchronized map

### DIFF
--- a/src/main/java/org/testng/reporters/FailedReporter.java
+++ b/src/main/java/org/testng/reporters/FailedReporter.java
@@ -60,15 +60,17 @@ public class FailedReporter extends TestListenerAdapter implements IReporter {
 
     Map<String, ISuiteResult> results = suite.getResults();
 
-    for(Map.Entry<String, ISuiteResult> entry : results.entrySet()) {
-      ISuiteResult suiteResult = entry.getValue();
-      ITestContext testContext = suiteResult.getTestContext();
+    synchronized(results) {
+      for(Map.Entry<String, ISuiteResult> entry : results.entrySet()) {
+        ISuiteResult suiteResult = entry.getValue();
+        ITestContext testContext = suiteResult.getTestContext();
 
-      generateXmlTest(suite,
-                      xmlTests.get(testContext.getName()),
-                      testContext,
-                      testContext.getFailedTests().getAllResults(),
-                      testContext.getSkippedTests().getAllResults());
+        generateXmlTest(suite,
+                        xmlTests.get(testContext.getName()),
+                        testContext,
+                        testContext.getFailedTests().getAllResults(),
+                        testContext.getSkippedTests().getAllResults());
+      }
     }
 
     if(null != failedSuite.getTests() && failedSuite.getTests().size() > 0) {


### PR DESCRIPTION
In FailedReporter.java:63, the synchronized map,`results`,
is iterated over in an unsynchronized manner, but according to the [Oracle Java 7 API specification](http://docs.oracle.com/javase/7/docs/api/java/util/Collections.html#synchronizedMap%28java.util.Map%29),
this is not thread-safe and can lead to non-deterministic behavior.
This pull request adds a fix by synchronizing the iteration on results and similar to ones I submitted earlier today. 
