### PR TITLE
Model does not synchronize iteration on a synchronized map

### DIFF
--- a/src/main/java/org/testng/reporters/jq/Model.java
+++ b/src/main/java/org/testng/reporters/jq/Model.java
@@ -46,20 +46,23 @@ public class Model {
       List<ITestResult> passed = Lists.newArrayList();
       List<ITestResult> failed = Lists.newArrayList();
       List<ITestResult> skipped = Lists.newArrayList();
-      for (ISuiteResult sr : suite.getResults().values()) {
-        ITestContext context = sr.getTestContext();
-        m_testTags.put(context.getName(), "test-" + testCounter++);
-        failed.addAll(context.getFailedTests().getAllResults());
-        skipped.addAll(context.getSkippedTests().getAllResults());
-        passed.addAll(context.getPassedTests().getAllResults());
-        IResultMap[] map = new IResultMap[] {
-            context.getFailedTests(),
-            context.getSkippedTests(),
-            context.getPassedTests()
-        };
-        for (IResultMap m : map) {
-          for (ITestResult tr : m.getAllResults()) {
-            m_testResultMap.put(tr, getTestResultName(tr));
+      Map<String, ISuiteResult> suiteResults = suite.getResults();
+      synchronized(suiteResults) {
+        for (ISuiteResult sr : suiteResults.values()) {
+          ITestContext context = sr.getTestContext();
+          m_testTags.put(context.getName(), "test-" + testCounter++);
+          failed.addAll(context.getFailedTests().getAllResults());
+          skipped.addAll(context.getSkippedTests().getAllResults());
+          passed.addAll(context.getPassedTests().getAllResults());
+          IResultMap[] map = new IResultMap[] {
+              context.getFailedTests(),
+              context.getSkippedTests(),
+              context.getPassedTests()
+          };
+          for (IResultMap m : map) {
+            for (ITestResult tr : m.getAllResults()) {
+              m_testResultMap.put(tr, getTestResultName(tr));
+            }
           }
         }
       }


### PR DESCRIPTION
In Model.java:49, the synchronized map returned by suite.getResults()
is iterated over in an unsynchronized manner, but according to the [Oracle Java 7 API specification](http://docs.oracle.com/javase/7/docs/api/java/util/Collections.html#synchronizedMap%28java.util.Map%29),
this is not thread-safe and can lead to non-deterministic behavior.
This pull request adds a fix by synchronizing the iteration.
