### PR TITLE
XMLReporter does not synchronize iteration on a synchronized map

### DIFF
--- a/src/main/java/org/testng/reporters/XMLReporter.java
+++ b/src/main/java/org/testng/reporters/XMLReporter.java
@@ -155,18 +155,19 @@ public class XMLReporter implements IReporter {
     Date minStartDate = new Date();
     Date maxEndDate = null;
     // TODO: We could probably optimize this in order not to traverse this twice
-    for (Map.Entry<String, ISuiteResult> result : results.entrySet()) {
-      ITestContext testContext = result.getValue().getTestContext();
-      Date startDate = testContext.getStartDate();
-      Date endDate = testContext.getEndDate();
-      if (minStartDate.after(startDate)) {
-        minStartDate = startDate;
-      }
-      if (maxEndDate == null || maxEndDate.before(endDate)) {
-        maxEndDate = endDate != null ? endDate : startDate;
+    synchronized(results) {
+      for (Map.Entry<String, ISuiteResult> result : results.entrySet()) {
+        ITestContext testContext = result.getValue().getTestContext();
+        Date startDate = testContext.getStartDate();
+        Date endDate = testContext.getEndDate();
+        if (minStartDate.after(startDate)) {
+          minStartDate = startDate;
+        }
+        if (maxEndDate == null || maxEndDate.before(endDate)) {
+          maxEndDate = endDate != null ? endDate : startDate;
+        }
       }
     }
-
     // The suite could be completely empty
     if (maxEndDate == null) {
       maxEndDate = minStartDate;


### PR DESCRIPTION
In XMLReporter.java:158, the synchronized map, `results`,
is iterated over in an unsynchronized manner, but according to the [Oracle Java 7 API specification](http://docs.oracle.com/javase/7/docs/api/java/util/Collections.html#synchronizedMap%28java.util.Map%29),
this is not thread-safe and can lead to non-deterministic behavior.
This pull request adds a fix by synchronizing the iteration on results.
