### PR TITLE
Java 9 fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.10.3</version>
+        <version>2.10.4-SNAPSHOT</version>
         <configuration>
           <failOnError>false</failOnError>
           <excludePackageNames>*internal</excludePackageNames>
@@ -265,7 +265,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>2.3.1</version>
+        <version>3.0.0-SNAPSHOT</version>
         <configuration>
           <archive>
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
@@ -337,7 +337,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>2.10.3</version>
+            <version>2.10.4-SNAPSHOT</version>
             <configuration>
               <failOnError>false</failOnError>
               <excludePackageNames>*internal</excludePackageNames>


### PR DESCRIPTION
Linked to https://github.com/cbeust/testng/issues/938

Two maven plugins, maven-jar-plugin and maven-javadoc-plugin also have issues with Java 9.

Once https://github.com/apache/maven-plugins/pull/76 is merged it will depending on a fixed version of plexus-archiver (see https://github.com/codehaus-plexus/plexus-archiver/pull/12).
