### PR TITLE
 "switch" statements should end with a "default" clause

### DIFF
--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -1668,6 +1668,8 @@ public class Invoker implements IInvoker {
           case ITestResult.SUCCESS:
             icl.onConfigurationSuccess(tr);
             break;
+          default:
+            throw new AssertionError("Unexpected value: " + tr.getStatus());
         }
       }
     }

--- a/src/main/java/org/testng/internal/TestNGMethodFinder.java
+++ b/src/main/java/org/testng/internal/TestNGMethodFinder.java
@@ -165,6 +165,8 @@ public class TestNGMethodFinder implements ITestMethodFinder {
           create = afterGroups.length > 0;
           isBeforeTestMethod = true;
           break;
+        default:
+          throw new AssertionError("Unexpected value: " + configurationType);
       }
 
       if(create) {

--- a/src/main/java/org/testng/reporters/XMLReporter.java
+++ b/src/main/java/org/testng/reporters/XMLReporter.java
@@ -92,6 +92,9 @@ public class XMLReporter implements IReporter {
     case XMLReporterConfig.FF_LEVEL_SUITE_RESULT:
       File suiteFile = referenceSuite(rootBuffer, suite);
       writeSuiteToFile(suiteFile, suite);
+      break;
+    default:
+      throw new AssertionError("Unexpected value: " + config.getFileFragmentationLevel());
     }
   }
 

--- a/src/main/java/org/testng/reporters/XMLSuiteResultWriter.java
+++ b/src/main/java/org/testng/reporters/XMLSuiteResultWriter.java
@@ -170,8 +170,9 @@ public class XMLSuiteResultWriter {
         return "SKIP";
       case ITestResult.SUCCESS_PERCENTAGE_FAILURE:
         return "SUCCESS_PERCENTAGE_FAILURE";
+      default:
+        throw new AssertionError("Unexpected value: " + testResultStatus);
     }
-    return null;
   }
 
   private Properties getTestResultAttributes(ITestResult testResult) {

--- a/src/main/java/org/testng/xml/TestNGContentHandler.java
+++ b/src/main/java/org/testng/xml/TestNGContentHandler.java
@@ -385,7 +385,8 @@ public class TestNGContentHandler extends DefaultHandler {
     }
     else {
       if (null != m_currentPackages) {
-        switch(m_locations.peek()) {
+        Location location = m_locations.peek();
+        switch(location) {
           case TEST:
             m_currentTest.setXmlPackages(m_currentPackages);
             break;
@@ -394,6 +395,8 @@ public class TestNGContentHandler extends DefaultHandler {
             break;
           case CLASS:
             throw new UnsupportedOperationException("CLASS");
+          default:
+            throw new AssertionError("Unexpected value: " + location);
         }
       }
 
@@ -591,7 +594,8 @@ public class TestNGContentHandler extends DefaultHandler {
     }
     else if ("parameter".equals(qName)) {
       String value = expandValue(attributes.getValue("value"));
-      switch(m_locations.peek()) {
+      Location location = m_locations.peek();
+      switch(location) {
         case TEST:
           m_currentTestParameters.put(name, value);
           break;
@@ -604,6 +608,8 @@ public class TestNGContentHandler extends DefaultHandler {
         case INCLUDE:
           m_currentInclude.parameters.put(name, value);
           break;
+        default:
+          throw new AssertionError("Unexpected value: " + location);
       }
     }
   }

--- a/src/test/java/test/InvokedMethodNameListener.java
+++ b/src/test/java/test/InvokedMethodNameListener.java
@@ -33,6 +33,8 @@ public class InvokedMethodNameListener implements IInvokedMethodListener {
       case ITestResult.SUCCESS:
         succeedMethodNames.add(method.getTestMethod().getConstructorOrMethod().getName());
         break;
+      default:
+        throw new AssertionError("Unexpected value: " + testResult.getStatus());
     }
   }
 

--- a/src/test/java/test/annotationtransformer/MyTransformer.java
+++ b/src/test/java/test/annotationtransformer/MyTransformer.java
@@ -27,6 +27,8 @@ public class MyTransformer implements IAnnotationTransformer {
         case "five":
           annotation.setInvocationCount(5);
           break;
+        default:
+          break;
       }
       methodNames.add(testMethod.getName());
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:SwitchLastCaseIsDefaultCheck
Please let me know if you have any questions.
Kirill Vlasov
