### PR TITLE
Two branches in the same conditional structure should not have exactly the same implementation

### DIFF
--- a/src/main/java/org/testng/internal/BaseTestMethod.java
+++ b/src/main/java/org/testng/internal/BaseTestMethod.java
@@ -142,14 +142,12 @@ public abstract class BaseTestMethod implements ITestNGMethod {
     int result = -2;
     Class<?> thisClass = getRealClass();
     Class<?> otherClass = ((ITestNGMethod) o).getRealClass();
-    if (this == o) {
+    if (this == o || equals(o)) {
       result = 0;
     } else if (thisClass.isAssignableFrom(otherClass)) {
       result = -1;
     } else if (otherClass.isAssignableFrom(thisClass)) {
       result = 1;
-    } else if (equals(o)) {
-      result = 0;
     }
 
     return result;

--- a/src/main/java/org/testng/internal/DynamicGraph.java
+++ b/src/main/java/org/testng/internal/DynamicGraph.java
@@ -66,9 +66,7 @@ public class DynamicGraph<T> {
 
       List<T> du = m_dependedUpon.get(m);
       // - no other nodes depend on it
-      if (!m_dependedUpon.containsKey(m)) {
-        result.add(m);
-      } else if (getUnfinishedNodes(du).size() == 0) {
+      if (!m_dependedUpon.containsKey(m) || getUnfinishedNodes(du).size() == 0) {
         result.add(m);
       }
     }

--- a/src/main/java/org/testng/remote/RemoteTestNG.java
+++ b/src/main/java/org/testng/remote/RemoteTestNG.java
@@ -168,14 +168,7 @@ public class RemoteTestNG extends TestNG {
     }
     m_debug = cla.debug;
     m_ack = ra.ack;
-    if (m_debug) {
-//      while (true) {
-        initAndRun(args, cla, ra);
-//      }
-    }
-    else {
-      initAndRun(args, cla, ra);
-    }
+    initAndRun(args, cla, ra);
   }
 
   private static void initAndRun(String[] args, CommandLineArgs cla, RemoteArgs ra) {

--- a/src/main/java/org/testng/xml/TestNGContentHandler.java
+++ b/src/main/java/org/testng/xml/TestNGContentHandler.java
@@ -738,9 +738,6 @@ public class TestNGContentHandler extends DefaultHandler {
     else if ("script".equals(qName)) {
       xmlScript(false, null);
     }
-    else if ("packages".equals(qName)) {
-      xmlPackages(false, null);
-    }
     else if ("include".equals(qName)) {
       xmlInclude(false, null);
     } else if ("exclude".equals(qName)){

--- a/src/main/java/org/testng/xml/XmlClass.java
+++ b/src/main/java/org/testng/xml/XmlClass.java
@@ -253,9 +253,7 @@ public class XmlClass implements Serializable, Cloneable {
     if (getClass() != obj.getClass())
       return XmlSuite.f();
     XmlClass other = (XmlClass) obj;
-    if (other.m_loadClasses != m_loadClasses) {
-      return XmlSuite.f();
-    } else if (!m_excludedMethods.equals(other.m_excludedMethods)) {
+    if (other.m_loadClasses != m_loadClasses || !m_excludedMethods.equals(other.m_excludedMethods)) {
       return XmlSuite.f();
     }
     if (m_includedMethods == null) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1871 - Two branches in the same conditional structure should not have exactly the same implementation
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1871 - Two branches in the same conditional structure should not have exactly the same implementation
Please let me know if you have any questions.
Kirill Vlasov
