### PR TITLE
Empty statements should be removed

### DIFF
--- a/src/main/java/org/testng/TestNGAntTask.java
+++ b/src/main/java/org/testng/TestNGAntTask.java
@@ -157,7 +157,7 @@ public class TestNGAntTask extends Task {
 
   public enum Mode {
       //lower-case to better look in build scripts
-      testng, junit, mixed;
+      testng, junit, mixed
   }
   
   /**

--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -540,7 +540,7 @@ public class Invoker implements IInvoker {
 
   private void throwConfigurationFailure(ITestResult testResult, Throwable ex)
   {
-    testResult.setStatus(ITestResult.FAILURE);;
+    testResult.setStatus(ITestResult.FAILURE);
     testResult.setThrowable(ex.getCause() == null ? ex : ex.getCause());
   }
 

--- a/src/main/java/org/testng/internal/PackageUtils.java
+++ b/src/main/java/org/testng/internal/PackageUtils.java
@@ -188,7 +188,7 @@ public class PackageUtils {
       fileName= URLDecoder.decode(url.getFile(), "UTF-8");
     }
     catch(UnsupportedEncodingException ueex) {
-      ; // ignore. should never happen
+      // ignore. should never happen
     }
 
     for(String classpathFrag: classpathFragments) {

--- a/src/main/java/org/testng/internal/ParameterHolder.java
+++ b/src/main/java/org/testng/internal/ParameterHolder.java
@@ -15,7 +15,7 @@ public class ParameterHolder {
   public enum ParameterOrigin {
     ORIGIN_DATA_PROVIDER, // A data provider
     ORIGIN_XML // TestNG XML suite
-  };
+  }
 
   public DataProviderHolder dataProviderHolder;
   public Iterator<Object[]> parameters;

--- a/src/main/java/org/testng/internal/Utils.java
+++ b/src/main/java/org/testng/internal/Utils.java
@@ -208,7 +208,7 @@ public final class Utils {
         }
       }
       catch (IOException e) {
-        ; // ignore
+        // ignore
       }
     }
   }
@@ -642,7 +642,7 @@ public final class Utils {
       }
     }
     catch(IOException ioex) {
-      ; // do nothing
+      // do nothing
     }
 
     return buf.toString();

--- a/src/test/java/org/testng/internal/MethodInstanceTest.java
+++ b/src/test/java/org/testng/internal/MethodInstanceTest.java
@@ -251,7 +251,7 @@ public class MethodInstanceTest {
     @Override
     public ITestNGMethod clone() {
       return (TestNGMethodStub) this;
-    };
+    }
 
     @Override
     public int compareTo(Object o) {

--- a/src/test/java/test/factory/FactoryAndTestMethodTest.java
+++ b/src/test/java/test/factory/FactoryAndTestMethodTest.java
@@ -33,5 +33,5 @@ public class FactoryAndTestMethodTest {
   @DataProvider(name = "data")
   public Object[][] makeData() {
     return new Object[][] { { "foo" } };
-  };
+  }
 }

--- a/src/test/java/test/factory/NestedFactoryTest.java
+++ b/src/test/java/test/factory/NestedFactoryTest.java
@@ -19,7 +19,7 @@ public class NestedFactoryTest {
         new NestedFactoryTest(10, 0.5f),
       };
     }
-  };
+  }
 
   private static int m_instanceCount = 0;
   public NestedFactoryTest() {

--- a/src/test/java/test/factory/NestedStaticFactoryTest.java
+++ b/src/test/java/test/factory/NestedStaticFactoryTest.java
@@ -19,7 +19,7 @@ public class NestedStaticFactoryTest {
         new NestedStaticFactoryTest(10, 0.5f),
       };
     }
-  };
+  }
 
   private static int m_instanceCount = 0;
   public NestedStaticFactoryTest() {

--- a/src/test/java/test/morten/SampleTest.java
+++ b/src/test/java/test/morten/SampleTest.java
@@ -15,7 +15,7 @@ public class SampleTest {
         new SampleTest(10, 0.5f),
       };
       }
-    };
+    }
 
     public SampleTest() {
 

--- a/src/test/java/test/morten/SampleTestFactory.java
+++ b/src/test/java/test/morten/SampleTestFactory.java
@@ -10,4 +10,4 @@ public class SampleTestFactory {
     new SampleTest(10, 0.5f),
   };
   }
-};
+}

--- a/src/test/java/test/parameters/ParameterOverrideTest.java
+++ b/src/test/java/test/parameters/ParameterOverrideTest.java
@@ -18,7 +18,7 @@ public class ParameterOverrideTest extends SimpleBaseTest {
     PASS_TEST,
     PASS_CLASS,
     PASS_INCLUDE,
-  };
+  }
 
   @Test
   public void testOverrideSuite() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:EmptyStatementUsageCheck - Empty statements should be removed
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:EmptyStatementUsageCheck
Please let me know if you have any questions.
Kirill Vlasov
