### PR TITLE
Fix empty test name when not specified in @Test

### DIFF
--- a/src/main/java/org/testng/internal/ClassImpl.java
+++ b/src/main/java/org/testng/internal/ClassImpl.java
@@ -65,7 +65,7 @@ public class ClassImpl implements IClass {
     }
     if (m_testName == null) {
       ITestAnnotation annotation = m_annotationFinder.findAnnotation(cls, ITestAnnotation.class);
-      if (annotation != null) {
+      if (annotation != null && !annotation.getTestName().isEmpty()) {
         m_testName = annotation.getTestName();
       }
     }

--- a/src/main/java/org/testng/internal/TestResult.java
+++ b/src/main/java/org/testng/internal/TestResult.java
@@ -87,7 +87,7 @@ public class TestResult implements ITestResult {
       if (m_instance instanceof ITest) {
         m_name = ((ITest) m_instance).getTestName();
       }
-      else if (testClass.getTestName() != null && !testClass.getTestName().isEmpty()) {
+      else if (testClass.getTestName() != null) {
         m_name = testClass.getTestName();
       }
       else {

--- a/src/test/java/test/name/BlankNameSample.java
+++ b/src/test/java/test/name/BlankNameSample.java
@@ -1,0 +1,19 @@
+package test.name;
+
+import org.testng.Assert;
+import org.testng.ITest;
+import org.testng.annotations.Test;
+
+public class BlankNameSample implements ITest {
+	
+	@Test
+	public void test() {
+		Assert.assertTrue(true);
+	}
+
+	@Override
+	public String getTestName() {
+		return "";
+	}
+
+}

--- a/src/test/java/test/name/NameTest.java
+++ b/src/test/java/test/name/NameTest.java
@@ -159,4 +159,38 @@ public class NameTest extends SimpleBaseTest {
     Assert.assertEquals(listener.getTestNames().size(), 1);
     Assert.assertEquals(listener.getTestNames().get(0), null);
   }
+  
+  @Test
+  public void blankNameTest() {
+	    TestNG tng = create(BlankNameSample.class);
+	    TestListenerAdapter adapter = new TestListenerAdapter();
+	    tng.addListener(adapter);
+
+	    tng.run();
+
+	    Assert.assertTrue(adapter.getFailedTests().isEmpty());
+	    Assert.assertTrue(adapter.getSkippedTests().isEmpty());
+	    Assert.assertEquals(adapter.getPassedTests().size(), 1);
+	    ITestResult result = adapter.getPassedTests().get(0);
+	    Assert.assertEquals(result.getMethod().getMethodName(), "test");
+	    Assert.assertEquals(result.getName(), "");
+	    Assert.assertEquals(result.getTestName(), "");
+  }
+  
+  @Test
+  public void blankNameTestWithXml() {
+	    TestNG tng = createTests("suite", BlankNameSample.class);
+	    TestListenerAdapter adapter = new TestListenerAdapter();
+	    tng.addListener(adapter);
+
+	    tng.run();
+
+	    Assert.assertTrue(adapter.getFailedTests().isEmpty());
+	    Assert.assertTrue(adapter.getSkippedTests().isEmpty());
+	    Assert.assertEquals(adapter.getPassedTests().size(), 1);
+	    ITestResult result = adapter.getPassedTests().get(0);
+	    Assert.assertEquals(result.getMethod().getMethodName(), "test");
+	    Assert.assertEquals(result.getName(), "");
+	    Assert.assertEquals(result.getTestName(), "");
+  }
 }

--- a/src/test/java/test/name/NameTest.java
+++ b/src/test/java/test/name/NameTest.java
@@ -1,15 +1,15 @@
 package test.name;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import org.testng.Assert;
 import org.testng.ITestResult;
 import org.testng.TestListenerAdapter;
 import org.testng.TestNG;
 import org.testng.annotations.Test;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 
 import test.SimpleBaseTest;
 
@@ -154,5 +154,9 @@ public class NameTest extends SimpleBaseTest {
 
     Assert.assertEquals(listener.getNames().size(), 1);
     Assert.assertEquals(listener.getNames().get(0), "test");
+    
+    // testName should be ignored if not specified
+    Assert.assertEquals(listener.getTestNames().size(), 1);
+    Assert.assertEquals(listener.getTestNames().get(0), null);
   }
 }

--- a/src/test/java/test/name/TestOnClassListener.java
+++ b/src/test/java/test/name/TestOnClassListener.java
@@ -11,17 +11,23 @@ import java.util.List;
 public class TestOnClassListener implements IReporter {
 
     private final List<String> names = new ArrayList<>();
+    private final List<String> testNames = new ArrayList<>();
 
     @Override
     public void generateReport(List<XmlSuite> xmlSuites, List<ISuite> suites, String outputDirectory) {
         for (ISuite suite : suites) {
             for (IInvokedMethod method : suite.getAllInvokedMethods()) {
                 names.add(method.getTestResult().getName());
+                testNames.add(method.getTestResult().getTestName());
             }
         }
     }
 
     public List<String> getNames() {
         return names;
+    }
+    
+    public List<String> getTestNames() {
+    	return testNames;
     }
 }


### PR DESCRIPTION
06ee812f9dbb2e780083c3909e1618e49431209e introduced a regression where `TestResult#getTestName()` is returning an empty string instead of null if there is a class level `@Test` annotation and `testName` is not specified. According to the Javadoc for that method:

```
If this result's related instance implements ITest or use @Test(testName=...),
returns its test name, otherwise returns null.
```
#922 addressed a similar issue with `TestResult#getName()`, but this fixes the root cause.
