### PR TITLE
Fix for issue #960

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,7 @@ Fixed: GITHUB-793: Test suite with tests using dependency and priority has wrong
 Fixed: GITHUB-922: ITestResult doesn't contain name if a class has @Test (@dr29bart & Julien Herr)
 Fixed: GITHUB-419: parallel mode was ignored with command line (@khospodarysko & Julien Herr)
 New: GITHUB-932: Deprecate true/false parallel values. none is the new default value. (Julien Herr)
+Fixed: GITHUB-960: testng-failed.xml gets generated even when there are no failures. (Krishnan Mahadevan)
 ﻿
 6.9.10:
 2015/12/15

--- a/src/main/java/org/testng/reporters/FailedReporter.java
+++ b/src/main/java/org/testng/reporters/FailedReporter.java
@@ -49,7 +49,7 @@ public class FailedReporter extends TestListenerAdapter implements IReporter {
   }
 
   protected void generateFailureSuite(XmlSuite xmlSuite, ISuite suite, String outputDir) {
-    XmlSuite failedSuite = (XmlSuite) xmlSuite.clone();
+    XmlSuite failedSuite = xmlSuite.shallowCopy();
     failedSuite.setName("Failed suite [" + xmlSuite.getName() + "]");
     m_xmlSuite= failedSuite;
 

--- a/src/main/java/org/testng/xml/XmlSuite.java
+++ b/src/main/java/org/testng/xml/XmlSuite.java
@@ -644,8 +644,7 @@ public class XmlSuite implements Serializable, Cloneable {
    */
   @Override
   public Object clone() {
-    XmlSuite result = new XmlSuite();
-    
+    XmlSuite result = shallowCopy();
     result.setExcludedGroups(getExcludedGroups());
     result.setIncludedGroups(getIncludedGroups());
     result.setGroupByInstances(getGroupByInstances());
@@ -657,6 +656,15 @@ public class XmlSuite implements Serializable, Cloneable {
     result.setSuiteFiles(getSuiteFiles());
     result.setTests(getTests());
     result.setXmlMethodSelectors(getXmlMethodSelectors());
+    return result;
+  }
+
+  /**
+   * This method returns a shallow cloned version. {@link XmlTest} are not copied by this method.
+   * @return - A Shallow copied version of {@link XmlSuite}.
+     */
+  public XmlSuite shallowCopy() {
+    XmlSuite result = new XmlSuite();
     result.setName(getName());
     result.setFileName(getFileName());
     result.setListeners(getListeners());

--- a/src/test/java/test/failedreporter/FailedReporterLocalTestClass.java
+++ b/src/test/java/test/failedreporter/FailedReporterLocalTestClass.java
@@ -1,0 +1,27 @@
+package test.failedreporter;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * A simple test class that is used by {@link FailedReporterScenariosTest} class to test out the presence/absence
+ * of testng-failed.xml file when there are failures/no failures scenarios.
+ */
+public class FailedReporterLocalTestClass {
+
+    public static class WithFailure {
+        @Test
+        public void testMethodWithFailure() {
+            Assert.fail();
+        }
+
+    }
+
+    public static class WithoutFailure {
+        @Test
+        public void testMethodWithoutFailure() {
+            Assert.assertTrue(true);
+        }
+
+    }
+}

--- a/src/test/java/test/failedreporter/FailedReporterScenariosTest.java
+++ b/src/test/java/test/failedreporter/FailedReporterScenariosTest.java
@@ -1,0 +1,108 @@
+package test.failedreporter;
+
+import org.testng.Assert;
+import org.testng.TestNG;
+import org.testng.annotations.Test;
+import org.testng.reporters.FailedReporter;
+import test.BaseTest;
+
+import java.io.File;
+import java.util.UUID;
+
+import static test.failedreporter.FailedReporterLocalTestClass.WithFailure;
+import static test.failedreporter.FailedReporterLocalTestClass.WithoutFailure;
+
+public class FailedReporterScenariosTest extends BaseTest {
+    private File tempDir = new File(System.getProperty("java.io.tmpdir"));
+
+    @Test
+    public void testFileCreationSkipWhenNoFailuresExist() {
+        File fileLocation = runTests(RUN_TYPES.WITHOUT_FAILURES);
+        try {
+            Assert.assertFalse(getLocation(fileLocation).exists());
+        } finally {
+            if (fileLocation.exists()) {
+                deleteRecursive(fileLocation);
+            }
+        }
+    }
+
+    @Test
+    public void testFileCreationInMixedMode() {
+        File fileLocation = runTests(RUN_TYPES.MIXED_MODE);
+        runAssertions(fileLocation);
+    }
+
+    @Test
+    public void testFileCreationWhenFailuresExist() {
+        File fileLocation = runTests(RUN_TYPES.WITH_FAILURES);
+        runAssertions(fileLocation);
+    }
+
+    private void runAssertions(File fileLocation) {
+        try {
+            FailedReporterTest.runAssertions(fileLocation, new String[] {"testMethodWithFailure"},
+                "<include name=\"%s\"" + "\"/>");
+            Assert.assertTrue(getLocation(fileLocation).exists());
+        } finally {
+            if (fileLocation.exists()) {
+                deleteRecursive(fileLocation);
+            }
+        }
+    }
+
+    private File getLocation(File fileLocation) {
+        String name = fileLocation.getAbsolutePath() + File.separator + FailedReporter.TESTNG_FAILED_XML;
+        return new File(name);
+    }
+
+    private File runTests(RUN_TYPES runType) {
+        String suiteName = UUID.randomUUID().toString();
+        File fileLocation = new File(tempDir, suiteName);
+        if (! fileLocation.exists()) {
+            fileLocation.mkdirs();
+        }
+        TestNG testNG = new TestNG();
+        Class[] classes = {};
+        switch (runType) {
+            case WITH_FAILURES:
+                classes = new Class[] {WithFailure.class};
+                break;
+            case WITHOUT_FAILURES:
+                classes = new Class[] {WithoutFailure.class};
+                break;
+            case MIXED_MODE:
+                classes = new Class[] {WithFailure.class, WithoutFailure.class};
+        }
+        testNG.setTestClasses(classes);
+        testNG.setOutputDirectory(fileLocation.getAbsolutePath());
+        try {
+            testNG.run();
+        } catch (AssertionError e) {
+            //catch all assertion failures. Our intent is not assertions of the test class.
+        }
+        return fileLocation;
+    }
+
+    private static void deleteRecursive(File path) {
+        if (! path.exists()) {
+            return;
+        }
+        if (path.isDirectory()) {
+            File[] files = path.listFiles();
+            if (null != files) {
+                for (File f : files) {
+                    deleteRecursive(f);
+                }
+            }
+        }
+        path.delete();
+    }
+
+    enum RUN_TYPES {
+        WITH_FAILURES,
+        WITHOUT_FAILURES,
+        MIXED_MODE
+    }
+
+}

--- a/src/test/java/test/failedreporter/FailedReporterTest.java
+++ b/src/test/java/test/failedreporter/FailedReporterTest.java
@@ -46,13 +46,15 @@ public class FailedReporterTest extends BaseTest {
     tng.setTestClasses(new Class[] { cls });
     tng.setOutputDirectory(mTempDirectory.getAbsolutePath());
     tng.run();
+    runAssertions(mTempDirectory,expectedMethods,expectedLine);
+  }
 
-    File failed = new File(mTempDirectory, "testng-failed.xml");
+  public static void runAssertions(File outputDir, String[] expectedMethods, String expectedLine) {
+    File failed = new File(outputDir, "testng-failed.xml");
     for (String s : expectedMethods) {
       List<String> resultLines = Lists.newArrayList();
       grep(failed, expectedLine.format(s), resultLines);
       Assert.assertEquals(1, resultLines.size());
     }
-
   }
 }

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -115,6 +115,7 @@
       <class name="test.parameters.ShadowTest" />
       <class name="test.parameters.ParameterOverrideTest" />
       <class name="test.reports.FailedReporterTest" />
+      <class name="test.failedreporter.FailedReporterScenariosTest"/>
       <class name="test.reports.ReporterLogTest" />
       <class name="test.testng387.TestNG387"/>
     </classes>


### PR DESCRIPTION
TestNG created the testng-failed.xml all the time 
whereas it should have created this file only when
there are no failures.

Fixed this problem by adding a flag which indicates
that there were actual test failures in a suite.
This flag would now control the testng-failed.xml 
file generation.
