### PR TITLE
Preliminary support for default methods.

### DIFF
--- a/src/main/java/org/testng/internal/annotations/AnnotationHelper.java
+++ b/src/main/java/org/testng/internal/annotations/AnnotationHelper.java
@@ -219,7 +219,7 @@ public class AnnotationHelper {
 //    for (Class<?> cls : classes) {
         while (null != cls) {
           boolean hasClassAnnotation = isAnnotationPresent(annotationFinder, cls, annotationClass);
-          Method[] methods = getDeclaredMethods(cls);
+          Method[] methods = getLocalMethods(cls);
           for (Method m : methods) {
             boolean hasMethodAnnotation = isAnnotationPresent(annotationFinder, m, annotationClass);
             boolean hasTestNGAnnotation =
@@ -320,11 +320,16 @@ public class AnnotationHelper {
     return result.toString();
   }
   
-  private static Method[] getDeclaredMethods(Class<?> clazz) {
+  /**
+   * @return An array of all locally declared methods or equivalent thereof
+   * (such as default methods on Java 8 based interfaces that the given class
+   * implements).
+   */
+  private static Method[] getLocalMethods(Class<?> clazz) {
     Method[] result;
     Method[] declaredMethods = clazz.getDeclaredMethods();
     List<Method> defaultMethods = getDefaultMethods(clazz);
-    if (defaultMethods != null) {
+    if (!defaultMethods.isEmpty()) {
       result = new Method[declaredMethods.length + defaultMethods.size()];
       System.arraycopy(declaredMethods, 0, result, 0, declaredMethods.length);
       int index = declaredMethods.length;
@@ -340,13 +345,10 @@ public class AnnotationHelper {
   }
 
   private static List<Method> getDefaultMethods(Class<?> clazz) {
-    List<Method> result = null;
+    List<Method> result = new LinkedList<Method>();
     for (Class<?> ifc : clazz.getInterfaces()) {
       for (Method ifcMethod : ifc.getMethods()) {
         if (!Modifier.isAbstract(ifcMethod.getModifiers())) {
-          if (result == null) {
-            result = new LinkedList<Method>();
-          }
           result.add(ifcMethod);
         }
       }

--- a/src/main/java/org/testng/internal/annotations/AnnotationHelper.java
+++ b/src/main/java/org/testng/internal/annotations/AnnotationHelper.java
@@ -4,6 +4,8 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 
 import org.testng.ITestNGMethod;
@@ -217,7 +219,7 @@ public class AnnotationHelper {
 //    for (Class<?> cls : classes) {
         while (null != cls) {
           boolean hasClassAnnotation = isAnnotationPresent(annotationFinder, cls, annotationClass);
-          Method[] methods = cls.getDeclaredMethods();
+          Method[] methods = getDeclaredMethods(cls);
           for (Method m : methods) {
             boolean hasMethodAnnotation = isAnnotationPresent(annotationFinder, m, annotationClass);
             boolean hasTestNGAnnotation =
@@ -316,6 +318,40 @@ public class AnnotationHelper {
     }
 
     return result.toString();
+  }
+  
+  private static Method[] getDeclaredMethods(Class<?> clazz) {
+    Method[] result;
+    Method[] declaredMethods = clazz.getDeclaredMethods();
+    List<Method> defaultMethods = getDefaultMethods(clazz);
+    if (defaultMethods != null) {
+      result = new Method[declaredMethods.length + defaultMethods.size()];
+      System.arraycopy(declaredMethods, 0, result, 0, declaredMethods.length);
+      int index = declaredMethods.length;
+      for (Method defaultMethod : defaultMethods) {
+        result[index] = defaultMethod;
+        index++;
+      }
+    }
+    else {
+      result = declaredMethods;
+    }
+    return result;
+  }
+
+  private static List<Method> getDefaultMethods(Class<?> clazz) {
+    List<Method> result = null;
+    for (Class<?> ifc : clazz.getInterfaces()) {
+      for (Method ifcMethod : ifc.getMethods()) {
+        if (!Modifier.isAbstract(ifcMethod.getModifiers())) {
+          if (result == null) {
+            result = new LinkedList<Method>();
+          }
+          result.add(ifcMethod);
+        }
+      }
+    }
+    return result;
   }
 
 }


### PR DESCRIPTION
#966.

I’m using the same method as Spring’s ReflectionUtil to find default methods. 

This should still be backwards compatible. With the changes left in and ran in Java 7 I don't have any problems and it still passes all the current tests that ran for me using the test goal.

As stated in the issue there are still some potential problems that I see such as MethodHelper not being able to find the default methods here:

https://github.com/cbeust/testng/blob/master/src/main/java/org/testng/internal/MethodHelper.java#L143-L150

And perhaps other places, like ClassHelper.
