### PR TITLE
Changes needed for TestNG to work for OpenJDK tests 

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 ﻿Current
+New: Minimal code changes to allow TestNG to work for OpenJDK tests, which should be run with only the java.base module present.
 Fixed: GITHUB-923 Refactored data provider's parameter values passing to a varargs or non-varargs method with @NoInjection handling (Nitin Verma)
 New: GITHUB-933: Deprecate XmlTest#getTestParameters (Julien Herr)
 Fixed: GITHUB-911: TestListener#onTestStart should be invoked if a suite configuration method fails (Harmin Parra Rueda & Julien Herr)﻿

--- a/src/main/java/org/testng/internal/Utils.java
+++ b/src/main/java/org/testng/internal/Utils.java
@@ -20,9 +20,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
-import java.util.logging.FileHandler;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import org.testng.ITestNGMethod;
 import org.testng.TestNG;
@@ -449,19 +446,6 @@ public final class Utils {
     strings.add(string.substring(start).trim());
 
     return strings.toArray(new String[strings.size()]);
-  }
-
-  public static void initLogger(Logger logger, String outputLogPath) {
-    try {
-      logger.setUseParentHandlers(false);
-      FileHandler fh = new FileHandler(outputLogPath);
-      fh.setFormatter(new TextFormatter());
-      fh.setLevel(Level.INFO);
-      logger.addHandler(fh);
-    }
-    catch (SecurityException | IOException se) {
-      se.printStackTrace();
-    }
   }
 
   public static void logInvocation(String reason, Method thisMethod, Object[] parameters) {

--- a/src/main/java/org/testng/xml/Parser.java
+++ b/src/main/java/org/testng/xml/Parser.java
@@ -132,13 +132,11 @@ public class Parser {
    *
    * @return the parsed TestNG test suite.
    *
-   * @throws ParserConfigurationException
-   * @throws SAXException
    * @throws IOException if an I/O error occurs while parsing the test suite file or
    * if the default testng.xml file is not found.
    */
   public Collection<XmlSuite> parse()
-    throws ParserConfigurationException, SAXException, IOException
+    throws IOException
   {
     // Each suite found is put in this list, using their canonical
     // path to make sure we don't add a same file twice


### PR DESCRIPTION
With Jigsaw, some tests need to be executed with only java.base module present. Some of the OpenJDK tests use TestNG.

This change includes minimal fixes to allow those tests to work.
