### PR TITLE
Update CHANGES.txt for 6.9.11 release

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,10 @@
 ﻿Current
 Fixed: GITHUB-1017 Reporter.log is ignored in skipped test listener (Scott Kirkpatrick)
 New: Minimal code changes to allow TestNG to work for OpenJDK tests, which should be run with only the java.base module present.
+
+6.9.11:
+2016/03/26
+
 Fixed: GITHUB-923 Refactored data provider's parameter values passing to a varargs or non-varargs method with @NoInjection handling (Nitin Verma)
 New: GITHUB-933: Deprecate XmlTest#getTestParameters (Julien Herr)
 Fixed: GITHUB-911: TestListener#onTestStart should be invoked if a suite configuration method fails (Harmin Parra Rueda & Julien Herr)﻿


### PR DESCRIPTION
`CHANGES.txt` was never updated to separate the changes included in 6.9.11 from master.
