### PR TITLE
Fix issue #1009: Iterator<Object[]> DataProvider: indices not working

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,7 @@ Fixed: GITHUB-1047 IClassListener didn't work (Julien Herr)
 Fixed: GITHUB-1049 IClassListener was called many time (Julien Herr)
 Fixed: GITHUB-1045 TestNG swallows exceptions silently if @ClassRule is used (Gili Tzabari & Julien Herr)
 Fixed: GITHUB-506 TestNG cannot find JUnit method names from Spock (@blackduck-joe & Julien Herr)
+Fixed: GITHUB-1009 Iterator<Object[]> DataProvider: indices not working (Mark Fulton & Julien Herr)
 
 6.9.11:
 2016/03/26

--- a/src/main/java/org/testng/ITestNGMethod.java
+++ b/src/main/java/org/testng/ITestNGMethod.java
@@ -8,6 +8,7 @@ import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
 
 /**
  * Describes a TestNG annotated method and the instance on which it will be invoked.
@@ -214,6 +215,8 @@ public interface ITestNGMethod extends Comparable, Serializable, Cloneable {
   public int getCurrentInvocationCount();
   public void setParameterInvocationCount(int n);
   public int getParameterInvocationCount();
+  void setMoreInvocationChecker(Callable<Boolean> moreInvocationChecker);
+  boolean hasMoreInvocation();
 
   public ITestNGMethod clone();
 

--- a/src/main/java/org/testng/internal/BaseTestMethod.java
+++ b/src/main/java/org/testng/internal/BaseTestMethod.java
@@ -8,6 +8,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
 
@@ -57,6 +58,7 @@ public abstract class BaseTestMethod implements ITestNGMethod {
   private String m_description = null;
   protected AtomicInteger m_currentInvocationCount = new AtomicInteger(0);
   private int m_parameterInvocationCount = 1;
+  private Callable<Boolean> m_moreInvocationChecker;
   private IRetryAnalyzer m_retryAnalyzer = null;
   private boolean m_skipFailedInvocations = true;
   private long m_invocationTimeOut = 0L;
@@ -683,6 +685,24 @@ public abstract class BaseTestMethod implements ITestNGMethod {
   @Override
   public int getParameterInvocationCount() {
     return m_parameterInvocationCount;
+  }
+
+  @Override
+  public void setMoreInvocationChecker(Callable<Boolean> moreInvocationChecker) {
+    m_moreInvocationChecker = moreInvocationChecker;
+  }
+
+  @Override
+  public boolean hasMoreInvocation() {
+    if (m_moreInvocationChecker != null) {
+      try {
+        return m_moreInvocationChecker.call();
+      } catch (Exception e) {
+        // Should never append
+        throw new RuntimeException(e);
+      }
+    }
+    return getCurrentInvocationCount() < getInvocationCount() * getParameterInvocationCount();
   }
 
   @Override

--- a/src/main/java/org/testng/internal/ClonedMethod.java
+++ b/src/main/java/org/testng/internal/ClonedMethod.java
@@ -11,6 +11,7 @@ import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
 
 public class ClonedMethod implements ITestNGMethod {
   private static final long serialVersionUID = 1L;
@@ -142,6 +143,14 @@ public class ClonedMethod implements ITestNGMethod {
   @Override
   public int getParameterInvocationCount() {
     return 1;
+  }
+
+  @Override
+  public void setMoreInvocationChecker(Callable<Boolean> moreInvocationChecker) {}
+
+  @Override
+  public boolean hasMoreInvocation() {
+    return false;
   }
 
   @Override

--- a/src/main/java/org/testng/internal/ConfigurationGroupMethods.java
+++ b/src/main/java/org/testng/internal/ConfigurationGroupMethods.java
@@ -60,8 +60,7 @@ public class ConfigurationGroupMethods implements Serializable {
   public synchronized boolean isLastMethodForGroup(String group, ITestNGMethod method) {
 
     // If we have more invocation to do, this is not the last one yet
-    int invocationCount= method.getCurrentInvocationCount();
-    if(invocationCount < (method.getInvocationCount() * method.getParameterInvocationCount())) {
+    if(method.hasMoreInvocation()) {
       return false;
     }
 

--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -1095,13 +1095,18 @@ public class Invoker implements IInvoker {
         int parametersIndex = 0;
 
         try {
-          List<TestMethodWithDataProviderMethodWorker> workers = Lists.newArrayList();
-
           if (bag.parameterHolder.origin == ParameterOrigin.ORIGIN_DATA_PROVIDER &&
               bag.parameterHolder.dataProviderHolder.annotation.isParallel()) {
+            List<TestMethodWithDataProviderMethodWorker> workers = Lists.newArrayList();
             while (allParameterValues.hasNext()) {
-              Object[] parameterValues = injectParameters(allParameterValues.next(),
+              Object[] next = allParameterValues.next();
+              if (next == null) {
+                // skipped value
+                continue;
+              }
+              Object[] parameterValues = injectParameters(next,
                   testMethod.getMethod(), testContext, null /* test result */);
+
               TestMethodWithDataProviderMethodWorker w =
                 new TestMethodWithDataProviderMethodWorker(this,
                     testMethod, parametersIndex,
@@ -1122,7 +1127,12 @@ public class Invoker implements IInvoker {
 
           } else {
             while (allParameterValues.hasNext()) {
-              Object[] parameterValues = injectParameters(allParameterValues.next(),
+              Object[] next = allParameterValues.next();
+              if (next == null) {
+                // skipped value
+                continue;
+              }
+              Object[] parameterValues = injectParameters(next,
                   testMethod.getMethod(), testContext, null /* test result */);
 
               List<ITestResult> tmpResults = Lists.newArrayList();
@@ -1165,7 +1175,6 @@ public class Invoker implements IInvoker {
                   while (invocationCount-- > 0) {
                     result.add(registerSkippedTestResult(testMethod, instance, System.currentTimeMillis(), null));
                   }
-                  break;
                 }
               }// end finally
               parametersIndex++;
@@ -1251,9 +1260,6 @@ public class Invoker implements IInvoker {
             m_annotationFinder,
             fedInstance));
     }
-//    catch(TestNGException ex) {
-//      throw ex;
-//    }
     catch(Throwable cause) {
       return new ParameterBag(
           new TestResult(

--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -769,19 +769,7 @@ public class Invoker implements IInvoker {
         }
       }
       else {
-        int current = tm.getCurrentInvocationCount();
-        boolean isLast = false;
-        // If we have parameters, set the boolean if we are about to run
-        // the last invocation
-        if (tm.getParameterInvocationCount() > 0) {
-          isLast = current == tm.getParameterInvocationCount() * tm.getTotalInvocationCount();
-        }
-        // If we have invocationCount > 1, set the boolean if we are about to
-        // run the last invocation
-        else if (tm.getTotalInvocationCount() > 1) {
-          isLast = current == tm.getTotalInvocationCount();
-        }
-        if (! cm.isLastTimeOnly() || (cm.isLastTimeOnly() && isLast)) {
+        if (! cm.isLastTimeOnly() || (cm.isLastTimeOnly() && !tm.hasMoreInvocation())) {
           result.add(m);
         }
       }

--- a/src/main/java/org/testng/internal/MethodInvocationHelper.java
+++ b/src/main/java/org/testng/internal/MethodInvocationHelper.java
@@ -107,11 +107,7 @@ public class MethodInvocationHelper {
     Class<?> returnType = dataProvider.getReturnType();
     // If it returns an Object[][], convert it to an Iterable<Object[]>
     if (Object[][].class.isAssignableFrom(returnType)) {
-      Object[][] originalResult = (Object[][]) invokeMethodNoCheckedException(dataProvider, instance, parameters);
-      // If the data provider is restricting the indices to return, filter them out
-      int[] indices = dataProvider.getAnnotation(DataProvider.class).indices();
-      Object[][] result = filterByIndices(originalResult, indices);
-      method.setParameterInvocationCount(result.length);
+      Object[][] result = (Object[][]) invokeMethodNoCheckedException(dataProvider, instance, parameters);
       return new ArrayIterator(result);
     } else if (Iterator.class.isAssignableFrom(returnType)) {
       return (Iterator<Object[]>) invokeMethodNoCheckedException(dataProvider, instance, parameters);
@@ -160,18 +156,6 @@ public class MethodInvocationHelper {
       throw new TestNGException(sb.toString());
     }
     return parameters;
-  }
-
-  private static Object[][] filterByIndices(Object[][] originalResult, int[] indices) {
-    if (indices.length == 0) {
-      return originalResult;
-    }
-    Object[][] result = new Object[indices.length][];
-    for (int j = 0; j < indices.length; j++) {
-      result[j] = originalResult[indices[j]];
-    }
-
-    return result;
   }
 
   /**

--- a/src/main/java/org/testng/xml/XmlInclude.java
+++ b/src/main/java/org/testng/xml/XmlInclude.java
@@ -5,7 +5,6 @@ import org.testng.collections.Maps;
 import org.testng.reporters.XMLStringBuffer;
 
 import java.io.Serializable;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -13,23 +12,20 @@ import java.util.Properties;
 public class XmlInclude implements Serializable {
   private static final long serialVersionUID = 1L;
 
-  private String m_name;
-  private List<Integer> m_invocationNumbers = Lists.newArrayList();
-  private int m_index;
+  private final String m_name;
+  private final List<Integer> m_invocationNumbers;
+  private final int m_index;
   private String m_description;
-  private Map<String, String> m_parameters = Maps.newHashMap();
+  private final Map<String, String> m_parameters = Maps.newHashMap();
 
   private XmlClass m_xmlClass;
 
-  public XmlInclude() {
-  }
-
   public XmlInclude(String n) {
-    this(n, Collections.<Integer> emptyList(), 0);
+    this(n, 0);
   }
 
   public XmlInclude(String n, int index) {
-    this(n, Collections.<Integer> emptyList(), index);
+    this(n, Lists.<Integer>newArrayList(), index);
   }
 
   public XmlInclude(String n, List<Integer> list, int index) {

--- a/src/test/java/org/testng/internal/MethodInstanceTest.java
+++ b/src/test/java/org/testng/internal/MethodInstanceTest.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
 
 import org.testng.Assert;
 import org.testng.IClass;
@@ -412,6 +413,15 @@ public class MethodInstanceTest {
 
     @Override
     public void setInvocationCount(int count) {
+    }
+
+    @Override
+    public void setMoreInvocationChecker(Callable<Boolean> moreInvocationChecker) {
+    }
+
+    @Override
+    public boolean hasMoreInvocation() {
+      return false;
     }
 
     @Override

--- a/src/test/java/test/configuration/ConfigurationGroupIteratorDataProviderSampleTest.java
+++ b/src/test/java/test/configuration/ConfigurationGroupIteratorDataProviderSampleTest.java
@@ -1,0 +1,50 @@
+package test.configuration;
+
+import org.testng.annotations.AfterGroups;
+import org.testng.annotations.BeforeGroups;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+public class ConfigurationGroupIteratorDataProviderSampleTest {
+  static List<Integer> m_list = new ArrayList<>();
+
+  @BeforeGroups(groups={"twice"}, value={"twice"})
+  public void a(){
+    ppp("BEFORE()");
+    m_list.add(1);
+  }
+
+  @Test(groups={"twice"}, dataProvider="MyData")
+  public void b(int a, int b) {
+    m_list.add(2);
+    ppp("B()"  + a + "," + b);
+  }
+
+  @AfterGroups(groups={"twice"}, value={"twice"})
+  public void c(){
+    m_list.add(3);
+    ppp("AFTER()");
+  }
+
+  @DataProvider(name="MyData")
+  public Iterator<Object[]> input() {
+    return Arrays.asList(
+            new Object[]{1, 1},
+            new Object[]{2, 2},
+            new Object[]{3, 3}
+    ).iterator();
+  }
+
+  private void ppp(String string) {
+    if (false) {
+      System.out.println("[A] " + string);
+    }
+  }
+
+
+}

--- a/src/test/java/test/configuration/GroupsTest.java
+++ b/src/test/java/test/configuration/GroupsTest.java
@@ -28,6 +28,15 @@ public class GroupsTest {
   }
 
   @Test
+  public void verifyIteratorDataProviderAfterGroups() {
+    runTest(ConfigurationGroupIteratorDataProviderSampleTest.class,
+        ConfigurationGroupIteratorDataProviderSampleTest.m_list,
+        Arrays.asList(new Integer[] {
+                1, 2, 2, 2, 3
+        }));
+  }
+
+  @Test
   public void verifyParametersAfterGroups() {
     runTest(ConfigurationGroupInvocationCountSampleTest.class,
         ConfigurationGroupInvocationCountSampleTest.m_list,

--- a/src/test/java/test/dataprovider/FailingIterableDataProviderTest.java
+++ b/src/test/java/test/dataprovider/FailingIterableDataProviderTest.java
@@ -1,10 +1,17 @@
 package test.dataprovider;
 
 import org.testng.Assert;
+import org.testng.ITestNGListener;
 import org.testng.TestListenerAdapter;
 import org.testng.TestNG;
 import org.testng.annotations.Test;
+import org.testng.xml.XmlClass;
+import org.testng.xml.XmlInclude;
+import org.testng.xml.XmlSuite;
+import org.testng.xml.XmlTest;
 
+import java.util.Arrays;
+import java.util.Collections;
 
 /**
  * TESTNG-291:
@@ -28,4 +35,31 @@ public class FailingIterableDataProviderTest {
     Assert.assertEquals(tla.getPassedTests().size(), 5,
       "Should have 5 passed test from before the bad data-provider iteration");
     }
+
+  @Test
+  public void failingDataProviderWithInvocationNumber() {
+    XmlSuite suite = new XmlSuite();
+    XmlTest test = new XmlTest(suite);
+    XmlClass clazz = new XmlClass(FailingIterableDataProvider.class);
+    clazz.setXmlTest(test);
+    test.getClasses().add(clazz);
+    XmlInclude include = new XmlInclude("happyTest",  Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 9), 0);
+    include.setXmlClass(clazz);
+    clazz.getIncludedMethods().add(include);
+    TestListenerAdapter tla = new TestListenerAdapter();
+
+    TestNG testng= new TestNG(false);
+    testng.setXmlSuites(Collections.singletonList(suite));
+    testng.addListener((ITestNGListener) tla);
+    testng.setVerbose(0);
+    try {
+      testng.run();
+    } catch (RuntimeException e) {
+      Assert.fail("Exceptions thrown during tests should always be caught!", e);
+    }
+    Assert.assertEquals(tla.getFailedTests().size(), 1,
+            "Should have 1 failure from a bad data-provider iteration");
+    Assert.assertEquals(tla.getPassedTests().size(), 5,
+            "Should have 5 passed test from before the bad data-provider iteration");
+  }
 }

--- a/src/test/java/test/dataprovider/IndicesSample.java
+++ b/src/test/java/test/dataprovider/IndicesSample.java
@@ -1,0 +1,42 @@
+package test.dataprovider;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Iterator;
+
+public class IndicesSample {
+
+  @DataProvider(indices = { 2 })
+  public Object[][] dp1() {
+    return new Object[][] {
+      new Object[] { 1 },  
+      new Object[] { 2 },  
+      new Object[] { 3 },  
+    };
+  }
+
+  @Test(dataProvider = "dp1")
+  public void indicesShouldWork(int n) {
+    if (n == 2) {
+      throw new RuntimeException("This method should not have received a 2");
+    }
+  }
+
+  @DataProvider(indices = { 2 })
+  public Iterator<Object[]> dp2() {
+    return Arrays.asList(
+      new Object[] { 1 },
+      new Object[] { 2 },
+      new Object[] { 3 }
+    ).iterator();
+  }
+
+  @Test(dataProvider = "dp2")
+  public void indicesShouldWorkWithIterator(int n) {
+    if (n == 2) {
+      throw new RuntimeException("This method should not have received a 2");
+    }
+  }
+}

--- a/src/test/java/test/dataprovider/IndicesTest.java
+++ b/src/test/java/test/dataprovider/IndicesTest.java
@@ -1,42 +1,70 @@
 package test.dataprovider;
 
-import org.testng.annotations.DataProvider;
+import org.testng.Assert;
+import org.testng.ITestNGListener;
+import org.testng.TestListenerAdapter;
+import org.testng.TestNG;
 import org.testng.annotations.Test;
+import org.testng.xml.XmlClass;
+import org.testng.xml.XmlInclude;
+import org.testng.xml.XmlSuite;
+import org.testng.xml.XmlTest;
 
 import java.util.Arrays;
-import java.util.Iterator;
+import java.util.Collections;
 
 public class IndicesTest {
 
-  @DataProvider(indices = { 0, 2 })
-  public Object[][] dp1() {
-    return new Object[][] {
-      new Object[] { 1 },  
-      new Object[] { 2 },  
-      new Object[] { 3 },  
-    };
-  }
+    @Test
+    public void test() {
+        TestNG testng = new TestNG(false);
 
-  @Test(dataProvider = "dp1")
-  public void indicesShouldWork(int n) {
-    if (n == 2) {
-      throw new RuntimeException("This method should not have received a 2");
+        testng.setTestClasses(new Class[]{IndicesSample.class});
+
+        TestListenerAdapter tla = new TestListenerAdapter();
+        testng.addListener((ITestNGListener) tla);
+        testng.setVerbose(0);
+        try {
+            testng.run();
+        } catch (RuntimeException e) {
+            Assert.fail("Exceptions thrown during tests should always be caught!", e);
+        }
+
+        Assert.assertTrue(tla.getFailedTests().isEmpty(),
+                "Should have 0 failure: bad data-provider iteration should be ignored");
+        Assert.assertEquals(tla.getPassedTests().size(), 2,
+                "Should have 2 passed test");
     }
-  }
 
-  @DataProvider(indices = { 0, 2 })
-  public Iterator<Object[]> dp2() {
-    return Arrays.asList(
-      new Object[] { 1 },
-      new Object[] { 2 },
-      new Object[] { 3 }
-    ).iterator();
-  }
+    @Test
+    public void test2() {
+        TestNG testng = new TestNG(false);
 
-  @Test(dataProvider = "dp2")
-  public void indicesShouldWorkWithIterator(int n) {
-    if (n == 2) {
-      throw new RuntimeException("This method should not have received a 2");
+        XmlSuite suite = new XmlSuite();
+        XmlTest test = new XmlTest(suite);
+        XmlClass clazz = new XmlClass(IndicesSample.class);
+        clazz.setXmlTest(test);
+        test.getClasses().add(clazz);
+        XmlInclude include = new XmlInclude("indicesShouldWork", Arrays.asList(0), 0);
+        include.setXmlClass(clazz);
+        clazz.getIncludedMethods().add(include);
+        XmlInclude include2 = new XmlInclude("indicesShouldWorkWithIterator", Arrays.asList(0), 0);
+        include2.setXmlClass(clazz);
+        clazz.getIncludedMethods().add(include2);
+        testng.setXmlSuites(Collections.singletonList(suite));
+
+        TestListenerAdapter tla = new TestListenerAdapter();
+        testng.addListener((ITestNGListener) tla);
+        testng.setVerbose(0);
+        try {
+            testng.run();
+        } catch (RuntimeException e) {
+            Assert.fail("Exceptions thrown during tests should always be caught!", e);
+        }
+
+        Assert.assertTrue(tla.getFailedTests().isEmpty(),
+                "Should have 0 failure: bad data-provider iteration should be ignored");
+        Assert.assertEquals(tla.getPassedTests().size(), 4,
+                "Should have 4 passed test");
     }
-  }
 }

--- a/src/test/java/test/dataprovider/IndicesTest.java
+++ b/src/test/java/test/dataprovider/IndicesTest.java
@@ -3,6 +3,9 @@ package test.dataprovider;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.util.Arrays;
+import java.util.Iterator;
+
 public class IndicesTest {
 
   @DataProvider(indices = { 0, 2 })
@@ -16,6 +19,24 @@ public class IndicesTest {
 
   @Test(dataProvider = "dp1")
   public void indicesShouldWork(int n) {
-    if (n == 2) throw new RuntimeException("This method should not have received a 1");
+    if (n == 2) {
+      throw new RuntimeException("This method should not have received a 2");
+    }
+  }
+
+  @DataProvider(indices = { 0, 2 })
+  public Iterator<Object[]> dp2() {
+    return Arrays.asList(
+      new Object[] { 1 },
+      new Object[] { 2 },
+      new Object[] { 3 }
+    ).iterator();
+  }
+
+  @Test(dataProvider = "dp2")
+  public void indicesShouldWorkWithIterator(int n) {
+    if (n == 2) {
+      throw new RuntimeException("This method should not have received a 2");
+    }
   }
 }

--- a/src/test/java/test/invocationcount/DataProviderBase.java
+++ b/src/test/java/test/invocationcount/DataProviderBase.java
@@ -3,6 +3,9 @@ package test.invocationcount;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.util.Arrays;
+import java.util.Iterator;
+
 public class DataProviderBase {
   @Test(dataProvider = "dp")
   public void f(Integer n) {
@@ -13,8 +16,21 @@ public class DataProviderBase {
     return new Integer[][] {
         new Integer[] { 0 },
         new Integer[] { 1 },
-        new Integer[] { 2 },
+        new Integer[] { 2 }
     };
+  }
+
+  @Test(dataProvider = "dp2")
+  public void f2(Integer n) {
+  }
+
+  @DataProvider
+  public Iterator<Object[]> dp2() {
+    return Arrays.asList(
+        new Object[] { 0 },
+        new Object[] { 1 },
+        new Object[] { 2 }
+    ).iterator();
   }
 
 }

--- a/src/test/java/test/invocationcount/FirstAndLastTimeTest.java
+++ b/src/test/java/test/invocationcount/FirstAndLastTimeTest.java
@@ -17,7 +17,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author cbeust@google.com
  *
  */
-// TODO check with iterator data provider
 public class FirstAndLastTimeTest extends SimpleBaseTest {
   @Test
   public void verifyDataProviderFalseFalse() {

--- a/src/test/java/test/invocationcount/FirstAndLastTimeTest.java
+++ b/src/test/java/test/invocationcount/FirstAndLastTimeTest.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author cbeust@google.com
  *
  */
+// TODO check with iterator data provider
 public class FirstAndLastTimeTest extends SimpleBaseTest {
   @Test
   public void verifyDataProviderFalseFalse() {
@@ -25,7 +26,10 @@ public class FirstAndLastTimeTest extends SimpleBaseTest {
     assertThat(invokedMethodNames).containsExactly(
         "beforeMethod", "f", "afterMethod",
         "beforeMethod", "f", "afterMethod",
-        "beforeMethod", "f", "afterMethod"
+        "beforeMethod", "f", "afterMethod",
+        "beforeMethod", "f2", "afterMethod",
+        "beforeMethod", "f2", "afterMethod",
+        "beforeMethod", "f2", "afterMethod"
     );
   }
 
@@ -36,7 +40,10 @@ public class FirstAndLastTimeTest extends SimpleBaseTest {
     assertThat(invokedMethodNames).containsExactly(
         "beforeMethod", "f", "afterMethod",
         "f", "afterMethod",
-        "f", "afterMethod"
+        "f", "afterMethod",
+        "beforeMethod", "f2", "afterMethod",
+        "f2", "afterMethod",
+        "f2", "afterMethod"
     );
   }
 
@@ -47,7 +54,10 @@ public class FirstAndLastTimeTest extends SimpleBaseTest {
     assertThat(invokedMethodNames).containsExactly(
         "beforeMethod", "f",
         "beforeMethod", "f",
-        "beforeMethod", "f", "afterMethod"
+        "beforeMethod", "f", "afterMethod",
+        "beforeMethod", "f2",
+        "beforeMethod", "f2",
+        "beforeMethod", "f2", "afterMethod"
     );
   }
 
@@ -58,7 +68,10 @@ public class FirstAndLastTimeTest extends SimpleBaseTest {
     assertThat(invokedMethodNames).containsExactly(
         "beforeMethod", "f",
         "f",
-        "f", "afterMethod"
+        "f", "afterMethod",
+        "beforeMethod", "f2",
+        "f2",
+        "f2", "afterMethod"
     );
   }
 


### PR DESCRIPTION
The diff is bit more important that what I was expected... because was, in fact, really complicate and highlighted many other issues (which should now be covered by tests).

I think a commit by commit reading will be easier.
