### PR TITLE
Make XmlInclude honour description from suite file

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 ﻿Current
+Fixed: GITHUB-1112 XmlInclude.getDescription returns null always (Krishnan Mahadevan)
 Fixed: GITHUB-1090 Inconsistent handling "preserve-order" on suite/test level (Michal Domagala & Julien Herr)
 Fixed: GITHUB-1085 Remove Guava dependency (Erik C. Thauvin & Julien Herr)
 Fixed: GITHUB-1084 Using deprecated addListener methods should not register many times (Anna Kozlova & Julien Herr)

--- a/src/main/java/org/testng/xml/TestNGContentHandler.java
+++ b/src/main/java/org/testng/xml/TestNGContentHandler.java
@@ -653,6 +653,7 @@ public class TestNGContentHandler extends DefaultHandler {
       m_locations.push(Location.INCLUDE);
       m_currentInclude = new Include(attributes.getValue("name"),
           attributes.getValue("invocation-numbers"));
+      m_currentInclude.description = attributes.getValue("description");
     } else {
       String name = m_currentInclude.name;
       if (null != m_currentIncludedMethods) {

--- a/src/test/java/test/xml/TestNGContentHandlerTest.java
+++ b/src/test/java/test/xml/TestNGContentHandlerTest.java
@@ -1,0 +1,31 @@
+package test.xml;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.testng.xml.SuiteXmlParser;
+import org.testng.xml.TestNGContentHandler;
+import org.testng.xml.XmlInclude;
+import test.SimpleBaseTest;
+
+import java.io.FileInputStream;
+import java.util.List;
+
+public class TestNGContentHandlerTest extends SimpleBaseTest {
+    @Test
+    public void testDescriptionInclusion() throws Exception {
+        final String xml = "src/test/resources/xml/simple-suite-with-method-desc.xml";
+        SuiteXmlParser parser = new SuiteXmlParser();
+        TestNGContentHandler handler = new TestNGContentHandler(xml, false);
+        parser.parse(new FileInputStream(xml), handler);
+        List<XmlInclude> includes = handler.getSuite().getTests().get(0).getXmlClasses().get(0).getIncludedMethods();
+        String desc = includes.get(0).getDescription();
+        Assert.assertEquals("simple-description", desc);
+    }
+
+    public static class LocalTestClass {
+        @Test
+        public void helloWorld() {
+
+        }
+    }
+}

--- a/src/test/java/test/xml/TestNGContentHandlerTest.java
+++ b/src/test/java/test/xml/TestNGContentHandlerTest.java
@@ -13,7 +13,7 @@ import java.util.List;
 public class TestNGContentHandlerTest extends SimpleBaseTest {
     @Test
     public void testDescriptionInclusion() throws Exception {
-        final String xml = "src/test/resources/xml/simple-suite-with-method-desc.xml";
+        final String xml = getPathToResource("xml/simple-suite-with-method-desc.xml");
         SuiteXmlParser parser = new SuiteXmlParser();
         TestNGContentHandler handler = new TestNGContentHandler(xml, false);
         parser.parse(new FileInputStream(xml), handler);

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -447,6 +447,12 @@
     </classes>
   </test>
 
+  <test name="Individual method with description">
+    <classes>
+      <class name="test.xml.TestNGContentHandlerTest"/>
+    </classes>
+  </test>
+
   <test name="Method inheritance">
     <classes>
       <class name="test.inheritance.DChild_2" />

--- a/src/test/resources/xml/simple-suite-with-method-desc.xml
+++ b/src/test/resources/xml/simple-suite-with-method-desc.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<suite name="Sample-suite" verbose="3">
+    <test name="Sample-test">
+        <classes>
+            <class name="test.xml.TestNGContentHandlerTest$LocalTestClass">
+                <methods>
+                    <include name="helloWorld" description="simple-description"/>
+                </methods>
+            </class>
+        </classes>
+    </test>
+</suite>


### PR DESCRIPTION
Fixes #1112

Description provided via the suite xml file for a 
included method was not being retrieved. Fixed this
issue and also added a unit test for the same.
