### PR TITLE
Fixed typo in EmailableReporter2 it was using EmailableReport

### DIFF
--- a/src/main/java/org/testng/reporters/EmailableReporter2.java
+++ b/src/main/java/org/testng/reporters/EmailableReporter2.java
@@ -32,7 +32,7 @@ import org.testng.xml.XmlSuite;
  * @author Abraham Lin
  */
 public class EmailableReporter2 implements IReporter {
-    private static final Logger LOG = Logger.getLogger(EmailableReporter.class);
+    private static final Logger LOG = Logger.getLogger(EmailableReporter2.class);
 
     protected PrintWriter writer;
 


### PR DESCRIPTION
Just a small typo in the initialisation of the Logger. It was using a different EmailableReport instead of EmailableReport2
