### PR TITLE
Fix encoding issue in XMLReporter

### DIFF
--- a/src/main/java/org/testng/reporters/XMLReporter.java
+++ b/src/main/java/org/testng/reporters/XMLReporter.java
@@ -104,7 +104,7 @@ public class XMLReporter implements IReporter {
     File parentDir = suiteFile.getParentFile();
     suiteFile.getParentFile().mkdirs();
     if (parentDir.exists() || suiteFile.getParentFile().exists()) {
-      Utils.writeFile(parentDir.getAbsolutePath(), FILE_NAME, xmlBuffer.toXML());
+      Utils.writeUtf8File(parentDir.getAbsolutePath(), FILE_NAME, xmlBuffer.toXML());
     }
   }
 


### PR DESCRIPTION
The writeSuiteToFile method currently uses the writeFile method instead of writeUtf8File, resulting in encoding issues in the generated file for certain characters (for example, "en-dash", "em-dash", and the "section sign" character).

Refer to line 69 for an example of where writeUtf8File is already being used.
