### PR TITLE
Support dependency map with custom ITestNGMethod implementation

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,6 @@
 ﻿Current
 Fixed: GITHUB-1105: Test skipped instead failed if incorrect enum value (Liza Ivanova & Julien Herr)﻿
 Fixed: GITHUB-1111: XMLReporter crashes if a test parameter is exactly "]]>" (Łukasz Rekucki & Julien Herr)
-New: code improvement in order to calculate key for dependency map. Dependency map will use methodQualifiedName as key provided by ITestNGMethod (Chirag Jayswal)
 Fixed: GITHUB-1108 @BeforeGroups called twice (Krishnan Mahadevan)
 Fixed: GITHUB-1112 XmlInclude.getDescription returns null always (Krishnan Mahadevan)
 Fixed: GITHUB-1090 Inconsistent handling "preserve-order" on suite/test level (Michal Domagala & Julien Herr)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 ﻿Current
 Fixed: GITHUB-1105: Test skipped instead failed if incorrect enum value (Liza Ivanova & Julien Herr)﻿
 Fixed: GITHUB-1111: XMLReporter crashes if a test parameter is exactly "]]>" (Łukasz Rekucki & Julien Herr)
+New: code improvement in order to calculate key for dependency map. Dependency map will use methodQualifiedName as key provided by ITestNGMethod (Chirag Jayswal)
 Fixed: GITHUB-1108 @BeforeGroups called twice (Krishnan Mahadevan)
 Fixed: GITHUB-1112 XmlInclude.getDescription returns null always (Krishnan Mahadevan)
 Fixed: GITHUB-1090 Inconsistent handling "preserve-order" on suite/test level (Michal Domagala & Julien Herr)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 ﻿Current
+New: code improvement in order to calculate key for dependency map. Dependency map will use methodQualifiedName as key provided by ITestNGMethod (Chirag Jayswal)
 Fixed: GITHUB-1108 @BeforeGroups called twice (Krishnan Mahadevan)
 Fixed: GITHUB-1112 XmlInclude.getDescription returns null always (Krishnan Mahadevan)
 Fixed: GITHUB-1090 Inconsistent handling "preserve-order" on suite/test level (Michal Domagala & Julien Herr)

--- a/src/main/java/org/testng/DependencyMap.java
+++ b/src/main/java/org/testng/DependencyMap.java
@@ -21,7 +21,7 @@ public class DependencyMap {
 
   public DependencyMap(ITestNGMethod[] methods) {
     for (ITestNGMethod m : methods) {
-    	m_dependencies.put( m.getQualifiedName(), m);
+    	m_dependencies.put( m.getRealClass().getName() + "." +  m.getMethodName(), m);
       for (String g : m.getGroups()) {
         m_groups.put(g, m);
       }

--- a/src/main/java/org/testng/DependencyMap.java
+++ b/src/main/java/org/testng/DependencyMap.java
@@ -21,7 +21,7 @@ public class DependencyMap {
 
   public DependencyMap(ITestNGMethod[] methods) {
     for (ITestNGMethod m : methods) {
-    	m_dependencies.put( m.getRealClass().getName() + "." +  m.getMethodName(), m);
+    	m_dependencies.put( m.getQualifiedName(), m);
       for (String g : m.getGroups()) {
         m_groups.put(g, m);
       }

--- a/src/main/java/org/testng/ITestNGMethod.java
+++ b/src/main/java/org/testng/ITestNGMethod.java
@@ -268,4 +268,10 @@ public interface ITestNGMethod extends Comparable, Serializable, Cloneable {
    * @param test
    */
   Map<String, String> findMethodParameters(XmlTest test);
+  
+  /**
+   * getRealClass().getName() + "." +  getMethodName()
+   * @return qualified name for this method
+   */
+  public String getQualifiedName();
 }

--- a/src/main/java/org/testng/ITestNGMethod.java
+++ b/src/main/java/org/testng/ITestNGMethod.java
@@ -268,10 +268,4 @@ public interface ITestNGMethod extends Comparable, Serializable, Cloneable {
    * @param test
    */
   Map<String, String> findMethodParameters(XmlTest test);
-  
-  /**
-   * getRealClass().getName() + "." +  getMethodName()
-   * @return qualified name for this method
-   */
-  public String getQualifiedName();
 }

--- a/src/main/java/org/testng/internal/BaseTestMethod.java
+++ b/src/main/java/org/testng/internal/BaseTestMethod.java
@@ -809,9 +809,4 @@ public abstract class BaseTestMethod implements ITestNGMethod {
 
     return result;
   }
-  
-  @Override
-  public String getQualifiedName() {
-	return getRealClass().getName() + "." + getMethodName();
-  }
 }

--- a/src/main/java/org/testng/internal/BaseTestMethod.java
+++ b/src/main/java/org/testng/internal/BaseTestMethod.java
@@ -809,4 +809,9 @@ public abstract class BaseTestMethod implements ITestNGMethod {
 
     return result;
   }
+  
+  @Override
+  public String getQualifiedName() {
+	return getRealClass().getName() + "." + getMethodName();
+  }
 }

--- a/src/main/java/org/testng/internal/ClonedMethod.java
+++ b/src/main/java/org/testng/internal/ClonedMethod.java
@@ -387,4 +387,9 @@ public class ClonedMethod implements ITestNGMethod {
   public Map<String, String> findMethodParameters(XmlTest test) {
     return Collections.emptyMap();
   }
+  
+  @Override
+  public String getQualifiedName() {
+	return getRealClass().getName() + "." + getMethodName();
+  }
 }

--- a/src/main/java/org/testng/internal/ClonedMethod.java
+++ b/src/main/java/org/testng/internal/ClonedMethod.java
@@ -387,9 +387,4 @@ public class ClonedMethod implements ITestNGMethod {
   public Map<String, String> findMethodParameters(XmlTest test) {
     return Collections.emptyMap();
   }
-  
-  @Override
-  public String getQualifiedName() {
-	return getRealClass().getName() + "." + getMethodName();
-  }
 }

--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -299,7 +299,7 @@ public class Invoker implements IInvoker {
       return;
     }
     Utils.log("", 3, "Failed to invoke configuration method "
-        + tm.getRealClass().getName() + "." + tm.getMethodName() + ":" + cause.getMessage());
+        + tm.getQualifiedName() + ":" + cause.getMessage());
     handleException(cause, tm, testResult, 1);
     runConfigurationListeners(testResult, false /* after */);
 
@@ -630,7 +630,7 @@ public class Invoker implements IInvoker {
       Method thisMethod = tm.getConstructorOrMethod().getMethod();
 
       if(confInvocationPassed(tm, tm, testClass, instance)) {
-        log(3, "Invoking " + tm.getRealClass().getName() + "." + tm.getMethodName());
+        log(3, "Invoking " + tm.getQualifiedName());
 
         // If this method is a IHookable, invoke its run() method
         IHookable hookableInstance =

--- a/src/main/java/org/testng/internal/MethodGroupsHelper.java
+++ b/src/main/java/org/testng/internal/MethodGroupsHelper.java
@@ -225,8 +225,7 @@ public class MethodGroupsHelper {
   private static ITestNGMethod findMethodNamed(String tm, List<ITestNGMethod> allMethods) {
     for (ITestNGMethod m : allMethods) {
       // TODO(cbeust):  account for package
-      String methodName =
-        m.getMethod().getDeclaringClass().getName() + "." + m.getMethodName();
+      String methodName = m.getQualifiedName();
       if (methodName.equals(tm)) {
         return m;
       }

--- a/src/main/java/org/testng/internal/MethodInvocationHelper.java
+++ b/src/main/java/org/testng/internal/MethodInvocationHelper.java
@@ -254,7 +254,7 @@ public class MethodInvocationHelper {
     if (!finished) {
       exec.stopNow();
       ThreadTimeoutException exception = new ThreadTimeoutException("Method "
-          + tm.getClass().getName() + "." + tm.getMethodName() + "()"
+          + tm.getQualifiedName() + "()"
           + " didn't finish within the time-out " + realTimeOut);
       exception.setStackTrace(exec.getStackTraces()[0]);
       testResult.setThrowable(exception);

--- a/src/main/java/org/testng/internal/XmlMethodSelector.java
+++ b/src/main/java/org/testng/internal/XmlMethodSelector.java
@@ -372,8 +372,7 @@ public class XmlMethodSelector implements IMethodSelector {
 
       // Make the transitive closure our new included methods
       for (ITestNGMethod m : methodClosure) {
-        String methodName =
-         m.getMethod().getDeclaringClass().getName() + "." + m.getMethodName();
+        String methodName = m.getQualifiedName();
 //        m_includedMethods.add(methodName);
         List<XmlInclude> includeList = m_includedMethods.get(methodName);
         XmlInclude xi = new XmlInclude(methodName);

--- a/src/test/java/org/testng/internal/MethodInstanceTest.java
+++ b/src/test/java/org/testng/internal/MethodInstanceTest.java
@@ -572,6 +572,11 @@ public class MethodInstanceTest {
     public Map<String, String> findMethodParameters(XmlTest test) {
       return null;
     }
+
+    @Override
+    public String getQualifiedName() {
+  	  return getRealClass().getName() + "." + getMethodName();
+    }
   }
 
 }

--- a/src/test/java/org/testng/internal/MethodInstanceTest.java
+++ b/src/test/java/org/testng/internal/MethodInstanceTest.java
@@ -572,11 +572,6 @@ public class MethodInstanceTest {
     public Map<String, String> findMethodParameters(XmlTest test) {
       return null;
     }
-
-    @Override
-    public String getQualifiedName() {
-  	  return getRealClass().getName() + "." + getMethodName();
-    }
   }
 
 }


### PR DESCRIPTION
In order to support dependency map with custom ITestNGMethod implementation, Added method to get qualified name in ITestNGMethod and used in Dependency map to proved key.
