### PR TITLE
Implemented tracking for thread counts. Added a test case for multipl…

### DIFF
--- a/src/test/java/test/thread/parallelization/BaseParallelizationTest.java
+++ b/src/test/java/test/thread/parallelization/BaseParallelizationTest.java
@@ -1,0 +1,30 @@
+package test.thread.parallelization;
+
+import com.google.common.collect.Multimap;
+import org.testng.xml.XmlSuite;
+import org.testng.xml.XmlTest;
+import test.SimpleBaseTest;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+
+import test.thread.parallelization.TestNgRunStateTracker.EventLog;
+
+import static org.testng.Assert.assertEquals;
+import static test.thread.parallelization.TestNgRunStateTracker.getTestMethodEventLogsForMethod;
+
+public class BaseParallelizationTest extends SimpleBaseTest {
+    public static void addParams(XmlSuite suite, String suiteName, String testName, String sleepFor) {
+        Map<String,String> parameters = new HashMap<>();
+        parameters.put("suiteName", suiteName);
+        parameters.put("testName", testName);
+        parameters.put("sleepFor", sleepFor);
+
+        for(XmlTest test : suite.getTests()) {
+            if(test.getName().equals(testName)) {
+                test.setParameters(parameters);
+            }
+        }
+    }
+}

--- a/src/test/java/test/thread/parallelization/ParallelByMethodsMultipleSuitesTestsClassesTest.java
+++ b/src/test/java/test/thread/parallelization/ParallelByMethodsMultipleSuitesTestsClassesTest.java
@@ -1,0 +1,1387 @@
+package test.thread.parallelization;
+
+import com.google.common.collect.Multimap;
+import org.testng.ITestNGListener;
+import org.testng.TestNG;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.testng.xml.XmlSuite;
+import org.testng.xml.XmlTest;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+import test.thread.parallelization.TestNgRunStateTracker.EventLog;
+import test.thread.parallelization.TestNgRunStateTracker.TestNgRunEvent;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import static org.testng.Assert.fail;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHOD_NAME;
+import static test.thread.parallelization.TestNgRunStateTracker.getAllEventLogsForSuite;
+import static test.thread.parallelization.TestNgRunStateTracker.getAllEventLogsForTest;
+
+import static test.thread.parallelization.TestNgRunStateTracker.getSuiteListenerFinishActiveThreadCount;
+import static test.thread.parallelization.TestNgRunStateTracker.getSuiteListenerFinishThreadId;
+import static test.thread.parallelization.TestNgRunStateTracker.getSuiteListenerFinishTimestamp;
+import static test.thread.parallelization.TestNgRunStateTracker.getSuiteListenerStartEventLogs;
+import static test.thread.parallelization.TestNgRunStateTracker.getSuiteListenerStartActiveThreadCount;
+import static test.thread.parallelization.TestNgRunStateTracker.getSuiteListenerStartThreadId;
+import static test.thread.parallelization.TestNgRunStateTracker.getSuiteListenerStartTimestamp;
+
+import static test.thread.parallelization.TestNgRunStateTracker.getTestListenerFinishActiveThreadCount;
+import static test.thread.parallelization.TestNgRunStateTracker.getTestListenerFinishThreadId;
+import static test.thread.parallelization.TestNgRunStateTracker.getTestListenerFinishTimestamp;
+import static test.thread.parallelization.TestNgRunStateTracker.getTestListenerStartEventLogsForSuite;
+import static test.thread.parallelization.TestNgRunStateTracker.getTestListenerStartActiveThreadCount;
+import static test.thread.parallelization.TestNgRunStateTracker.getTestListenerStartThreadId;
+import static test.thread.parallelization.TestNgRunStateTracker.getTestListenerStartTimestamp;
+
+import static test.thread.parallelization.TestNgRunStateTracker.getTestMethodEventLogsForMethod;
+import static test.thread.parallelization.TestNgRunStateTracker.getTestMethodLevelEventLogsForTest;
+import static test.thread.parallelization.TestNgRunStateTracker.getTestMethodExecutionEventLogsForTest;
+import static test.thread.parallelization.TestNgRunStateTracker.getTestMethodListenerPassEventLogsForTest;
+import static test.thread.parallelization.TestNgRunStateTracker.getTestMethodListenerStartEventLogsForTest;
+import static test.thread.parallelization.TestNgRunStateTracker.getTestMethodEventLogsForClass;
+
+import static test.thread.parallelization.TestNgRunStateTracker.reset;
+
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_NAME;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.SUITE_NAME;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.TEST_NAME;
+
+import static test.thread.parallelization.TestNgRunStateTracker.TestNgRunEvent.LISTENER_TEST_METHOD_START;
+import static test.thread.parallelization.TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION;
+import static test.thread.parallelization.TestNgRunStateTracker.TestNgRunEvent.LISTENER_TEST_METHOD_PASS;
+
+//Verify complex test run with multiple suites, tests and test classes and a thread count which is less than the number
+//of test methods to be executed.
+public class ParallelByMethodsMultipleSuitesTestsClassesTest extends BaseParallelizationTest {
+    private static final String SUITE_A = "TestSuiteA";
+    private static final String SUITE_B = "TestSuiteB";
+    private static final String SUITE_C = "TestSuiteC";
+    
+    private static final String SUITE_A_TEST_A = "TestSuiteA-TwoTestClassTest";
+
+    private static final String SUITE_B_TEST_A = "TestSuiteB-SingleTestClassTest";
+    private static final String SUITE_B_TEST_B = "TestSuiteB-ThreeTestClassTest";
+    
+    private static final String SUITE_C_TEST_A = "TestSuiteC-ThreeTestClassTest";
+    private static final String SUITE_C_TEST_B = "TestSuiteC-TwoTestClassTest";
+    private static final String SUITE_C_TEST_C = "TestSuiteC-FourTestClassTest";
+    
+    private List<EventLog> suiteOneEventLogs;
+    private List<EventLog> suiteTwoEventLogs;
+    private List<EventLog> suiteThreeEventLogs;
+
+    private List<EventLog> suiteTwoTestOneEventLogs;
+    private List<EventLog> suiteTwoTestTwoEventLogs;
+
+    private List<EventLog> suiteThreeTestOneEventLogs;
+    private List<EventLog> suiteThreeTestTwoEventLogs;
+    private List<EventLog> suiteThreeTestThreeEventLogs;
+
+    private Long suiteOneListenerStartTimestamp;
+    private Long suiteTwoListenerStartTimestamp;
+    private Long suiteThreeListenerStartTimestamp;
+
+    private Long suiteOneListenerFinishTimestamp;
+    private Long suiteTwoListenerFinishTimestamp;
+    private Long suiteThreeListenerFinishTimestamp;
+
+    private Long suiteOneListenerStartThreadId;
+    private Long suiteTwoListenerStartThreadId;
+    private Long suiteThreeListenerStartThreadId;
+
+    private Long suiteOneListenerFinishThreadId;
+    private Long suiteTwoListenerFinishThreadId;
+    private Long suiteThreeListenerFinishThreadId;
+
+    private Integer suiteOneListenerStartThreadCount;
+    private Integer suiteTwoListenerStartThreadCount;
+    private Integer suiteThreeListenerStartThreadCount;
+
+    private Integer suiteOneListenerFinishThreadCount;
+    private Integer suiteTwoListenerFinishThreadCount;
+    private Integer suiteThreeListenerFinishThreadCount;
+
+    private Long suiteOneTestOneListenerStartTimestamp;
+    private Long suiteOneTestOneListenerFinishTimestamp;
+    
+    private Long suiteOneTestOneListenerStartThreadId;
+    private Long suiteOneTestOneListenerFinishThreadId;
+
+    private Integer suiteOneTestOneListenerStartThreadCount;
+    private Integer suiteOneTestOneListenerFinishThreadCount;
+
+    private Long suiteTwoTestOneListenerStartTimestamp;
+    private Long suiteTwoTestTwoListenerStartTimestamp;
+    private Long suiteTwoTestOneListenerFinishTimestamp;
+    private Long suiteTwoTestTwoListenerFinishTimestamp;
+
+    private Long suiteTwoTestOneListenerStartThreadId;
+    private Long suiteTwoTestTwoListenerStartThreadId;
+    private Long suiteTwoTestOneListenerFinishThreadId;
+    private Long suiteTwoTestTwoListenerFinishThreadId;
+
+    private Integer suiteTwoTestOneListenerStartThreadCount;
+    private Integer suiteTwoTestTwoListenerStartThreadCount;
+    private Integer suiteTwoTestOneListenerFinishThreadCount;
+    private Integer suiteTwoTestTwoListenerFinishThreadCount;
+    
+    private Long suiteThreeTestOneListenerStartTimestamp;
+    private Long suiteThreeTestTwoListenerStartTimestamp;
+    private Long suiteThreeTestThreeListenerStartTimestamp;
+    private Long suiteThreeTestOneListenerFinishTimestamp;
+    private Long suiteThreeTestTwoListenerFinishTimestamp;
+    private Long suiteThreeTestThreeListenerFinishTimestamp;
+
+    private Long suiteThreeTestOneListenerStartThreadId;
+    private Long suiteThreeTestTwoListenerStartThreadId;
+    private Long suiteThreeTestThreeListenerStartThreadId;
+    private Long suiteThreeTestOneListenerFinishThreadId;
+    private Long suiteThreeTestTwoListenerFinishThreadId;
+    private Long suiteThreeTestThreeListenerFinishThreadId;
+
+    private Integer suiteThreeTestOneListenerStartThreadCount;
+    private Integer suiteThreeTestTwoListenerStartThreadCount;
+    private Integer suiteThreeTestThreeListenerStartThreadCount;
+    private Integer suiteThreeTestOneListenerFinishThreadCount;
+    private Integer suiteThreeTestTwoListenerFinishThreadCount;
+    private Integer suiteThreeTestThreeListenerFinishThreadCount;
+
+    private Multimap<Object,EventLog> suiteOneTestOneFiveMethodsClassEventLogMap;
+    private Multimap<Object,EventLog> suiteOneTestOneSixMethodsClassEventLogMap;
+
+    private Multimap<Object,EventLog> suiteTwoTestOneFiveMethodsClassEventLogMap;
+    private Multimap<Object,EventLog> suiteTwoTestTwoThreeMethodsClassEventLogMap;
+    private Multimap<Object,EventLog> suiteTwoTestTwoFourMethodsClassEventLogMap;
+    private Multimap<Object,EventLog> suiteTwoTestTwoSixMethodsClassEventLogMap;
+
+    private Multimap<Object,EventLog> suiteThreeTestOneThreeMethodsClassEventLogMap;
+    private Multimap<Object,EventLog> suiteThreeTestOneFourMethodsClassEventLogMap;
+    private Multimap<Object,EventLog> suiteThreeTestOneFiveMethodsClassEventLogMap;
+
+    private Multimap<Object,EventLog> suiteThreeTestTwoFourMethodsClassEventLogMap;
+    private Multimap<Object,EventLog> suiteThreeTestTwoFiveMethodsClassEventLogMap;
+
+    private Multimap<Object,EventLog> suiteThreeTestThreeThreeMethodsClassEventLogMap;
+    private Multimap<Object,EventLog> suiteThreeTestThreeFourMethodsClassEventLogMap;
+    private Multimap<Object,EventLog> suiteThreeTestThreeFiveMethodsClassEventLogMap;
+    private Multimap<Object,EventLog> suiteThreeTestThreeSixMethodsClassEventLogMap;
+
+    private List<EventLog> suiteOneTestOneTestMethodListenerStartEventLogs;
+    private List<EventLog> suiteOneTestOneTestMethodListenerPassEventLogs;
+    private List<EventLog> suiteOneTestOneTestMethodExecutionEventLogs;
+
+    private List<EventLog> suiteTwoTestOneTestMethodListenerStartEventLogs;
+    private List<EventLog> suiteTwoTestTwoTestMethodListenerStartEventLogs;
+    private List<EventLog> suiteTwoTestOneTestMethodListenerPassEventLogs;
+    private List<EventLog> suiteTwoTestTwoTestMethodListenerPassEventLogs;
+    private List<EventLog> suiteTwoTestOneTestMethodExecutionEventLogs;
+    private List<EventLog> suiteTwoTestTwoTestMethodExecutionEventLogs;
+
+    private List<EventLog> suiteThreeTestOneTestMethodListenerStartEventLogs;
+    private List<EventLog> suiteThreeTestTwoTestMethodListenerStartEventLogs;
+    private List<EventLog> suiteThreeTestThreeTestMethodListenerStartEventLogs;
+    private List<EventLog> suiteThreeTestOneTestMethodListenerPassEventLogs;
+    private List<EventLog> suiteThreeTestTwoTestMethodListenerPassEventLogs;
+    private List<EventLog> suiteThreeTestThreeTestMethodListenerPassEventLogs;
+    private List<EventLog> suiteThreeTestOneTestMethodExecutionEventLogs;
+    private List<EventLog> suiteThreeTestTwoTestMethodExecutionEventLogs;
+    private List<EventLog> suiteThreeTestThreeTestMethodExecutionEventLogs;
+
+    @BeforeClass
+    public void complexMultipleSuites() {
+        reset();
+
+        XmlSuite suiteOne = createXmlSuite(SUITE_A);
+        XmlSuite suiteTwo = createXmlSuite(SUITE_B);
+        XmlSuite suiteThree = createXmlSuite(SUITE_C);
+
+        suiteOne.setParallel(XmlSuite.ParallelMode.METHODS);
+        suiteOne.setThreadCount(3);
+
+        createXmlTest(suiteOne, SUITE_A_TEST_A, TestClassAWithNoDepsSample.class, TestClassCWithNoDepsSample.class);
+        createXmlTest(suiteTwo, SUITE_B_TEST_A, TestClassEWithNoDepsSample.class);
+        createXmlTest(suiteTwo, SUITE_B_TEST_B, TestClassDWithNoDepsSample.class, TestClassBWithNoDepsSample.class,
+                TestClassFWithNoDepsSample.class);
+
+        suiteTwo.setParallel(XmlSuite.ParallelMode.METHODS);
+
+        for(XmlTest test : suiteTwo.getTests()) {
+            if(test.getName().equals(SUITE_B_TEST_A)) {
+                test.setThreadCount(6);
+            } else {
+                test.setThreadCount(20);
+            }
+        }
+
+        createXmlTest(suiteThree, SUITE_C_TEST_A, TestClassGWithNoDepsSample.class, TestClassHWithNoDepsSample.class,
+                TestClassIWithNoDepsSample.class);
+        createXmlTest(suiteThree, SUITE_C_TEST_B, TestClassJWithNoDepsSample.class, TestClassKWithNoDepsSample.class);
+        createXmlTest(suiteThree, SUITE_C_TEST_C, TestClassLWithNoDepsSample.class, TestClassMWithNoDepsSample.class,
+                TestClassNWithNoDepsSample.class, TestClassOWithNoDepsSample.class);
+
+        for(XmlTest test : suiteThree.getTests()) {
+            test.setParallel(XmlSuite.ParallelMode.METHODS);
+
+            switch(test.getName()) {
+                case SUITE_C_TEST_A:
+                    test.setThreadCount(10);
+                    break;
+                case SUITE_C_TEST_B:
+                    test.setThreadCount(5);
+                    break;
+                default:
+                    test.setThreadCount(12);
+                    break;
+            }
+        }
+
+        addParams(suiteOne, SUITE_A, SUITE_A_TEST_A, "5");
+
+        addParams(suiteTwo, SUITE_B, SUITE_B_TEST_A, "5");
+        addParams(suiteTwo, SUITE_B, SUITE_B_TEST_B, "5");
+
+        addParams(suiteThree, SUITE_C, SUITE_C_TEST_A, "5");
+        addParams(suiteThree, SUITE_C, SUITE_C_TEST_B, "5");
+        addParams(suiteThree, SUITE_C, SUITE_C_TEST_C, "5");
+
+        TestNG tng = create(suiteOne, suiteTwo, suiteThree);
+        tng.addListener((ITestNGListener) new TestNgRunStateListener());
+
+        tng.run();
+
+        suiteOneEventLogs = getAllEventLogsForSuite(SUITE_A);
+        suiteTwoEventLogs = getAllEventLogsForSuite(SUITE_B);
+        suiteThreeEventLogs = getAllEventLogsForSuite(SUITE_C);
+
+        suiteTwoTestOneEventLogs = getAllEventLogsForTest(SUITE_B, SUITE_B_TEST_A);
+        suiteTwoTestTwoEventLogs = getAllEventLogsForTest(SUITE_B, SUITE_B_TEST_B);
+
+        suiteThreeTestOneEventLogs = getAllEventLogsForTest(SUITE_C, SUITE_C_TEST_A);
+        suiteThreeTestTwoEventLogs = getAllEventLogsForTest(SUITE_C, SUITE_C_TEST_B);
+        suiteThreeTestThreeEventLogs = getAllEventLogsForTest(SUITE_C, SUITE_C_TEST_C);
+
+        suiteOneListenerStartTimestamp = getSuiteListenerStartTimestamp(SUITE_A);
+        suiteTwoListenerStartTimestamp = getSuiteListenerStartTimestamp(SUITE_B);
+        suiteThreeListenerStartTimestamp = getSuiteListenerStartTimestamp(SUITE_C);
+
+        suiteOneListenerFinishTimestamp = getSuiteListenerFinishTimestamp(SUITE_A);
+        suiteTwoListenerFinishTimestamp = getSuiteListenerFinishTimestamp(SUITE_B);
+        suiteThreeListenerFinishTimestamp = getSuiteListenerFinishTimestamp(SUITE_C);
+
+        suiteOneListenerStartThreadId = getSuiteListenerStartThreadId(SUITE_A);
+        suiteTwoListenerStartThreadId = getSuiteListenerStartThreadId(SUITE_B);
+        suiteThreeListenerStartThreadId = getSuiteListenerStartThreadId(SUITE_C);
+
+        suiteOneListenerFinishThreadId = getSuiteListenerFinishThreadId(SUITE_A);
+        suiteTwoListenerFinishThreadId = getSuiteListenerFinishThreadId(SUITE_B);
+        suiteThreeListenerFinishThreadId= getSuiteListenerFinishThreadId(SUITE_C);
+
+        suiteOneListenerStartThreadCount = getSuiteListenerStartActiveThreadCount(SUITE_A);
+        suiteTwoListenerStartThreadCount = getSuiteListenerStartActiveThreadCount(SUITE_B);
+        suiteThreeListenerStartThreadCount = getSuiteListenerStartActiveThreadCount(SUITE_C);
+
+        suiteOneListenerFinishThreadCount = getSuiteListenerFinishActiveThreadCount(SUITE_A);
+        suiteTwoListenerFinishThreadCount = getSuiteListenerFinishActiveThreadCount(SUITE_B);
+        suiteThreeListenerFinishThreadCount = getSuiteListenerFinishActiveThreadCount(SUITE_C);
+
+        suiteOneTestOneListenerStartTimestamp = getTestListenerStartTimestamp(SUITE_A, SUITE_A_TEST_A);
+        suiteOneTestOneListenerFinishTimestamp = getTestListenerFinishTimestamp(SUITE_A, SUITE_A_TEST_A);
+
+        suiteOneTestOneListenerStartThreadId = getTestListenerStartThreadId(SUITE_A, SUITE_A_TEST_A);
+        suiteOneTestOneListenerFinishThreadId = getTestListenerFinishThreadId(SUITE_A, SUITE_A_TEST_A);
+
+        suiteOneTestOneListenerStartThreadCount = getTestListenerStartActiveThreadCount(SUITE_A, SUITE_A_TEST_A);
+        suiteOneTestOneListenerFinishThreadCount = getTestListenerFinishActiveThreadCount(SUITE_A, SUITE_A_TEST_A);
+
+        suiteTwoTestOneListenerStartTimestamp = getTestListenerStartTimestamp(SUITE_B, SUITE_B_TEST_A);
+        suiteTwoTestTwoListenerStartTimestamp = getTestListenerStartTimestamp(SUITE_B, SUITE_B_TEST_B);
+        suiteTwoTestOneListenerFinishTimestamp = getTestListenerFinishTimestamp(SUITE_B, SUITE_B_TEST_A);
+        suiteTwoTestTwoListenerFinishTimestamp = getTestListenerFinishTimestamp(SUITE_B, SUITE_B_TEST_B);
+
+        suiteTwoTestOneListenerStartThreadId = getTestListenerStartThreadId(SUITE_B, SUITE_B_TEST_A);
+        suiteTwoTestTwoListenerStartThreadId = getTestListenerStartThreadId(SUITE_B, SUITE_B_TEST_B);
+        suiteTwoTestOneListenerFinishThreadId = getTestListenerFinishThreadId(SUITE_B, SUITE_B_TEST_A);
+        suiteTwoTestTwoListenerFinishThreadId = getTestListenerFinishThreadId(SUITE_B, SUITE_B_TEST_B);
+
+        suiteTwoTestOneListenerStartThreadCount = getTestListenerStartActiveThreadCount(SUITE_B, SUITE_B_TEST_A);
+        suiteTwoTestTwoListenerStartThreadCount = getTestListenerStartActiveThreadCount(SUITE_B, SUITE_B_TEST_B);
+        suiteTwoTestOneListenerFinishThreadCount = getTestListenerFinishActiveThreadCount(SUITE_B, SUITE_B_TEST_A);
+        suiteTwoTestTwoListenerFinishThreadCount = getTestListenerFinishActiveThreadCount(SUITE_B, SUITE_B_TEST_B);
+
+        suiteThreeTestOneListenerStartTimestamp = getTestListenerStartTimestamp(SUITE_C, SUITE_C_TEST_A);
+        suiteThreeTestTwoListenerStartTimestamp = getTestListenerStartTimestamp(SUITE_C, SUITE_C_TEST_B);
+        suiteThreeTestThreeListenerStartTimestamp = getTestListenerStartTimestamp(SUITE_C, SUITE_C_TEST_C);
+
+        suiteThreeTestOneListenerFinishTimestamp = getTestListenerFinishTimestamp(SUITE_C, SUITE_C_TEST_A);
+        suiteThreeTestTwoListenerFinishTimestamp = getTestListenerFinishTimestamp(SUITE_C, SUITE_C_TEST_B);
+        suiteThreeTestThreeListenerFinishTimestamp = getTestListenerFinishTimestamp(SUITE_C, SUITE_C_TEST_C);
+
+        suiteThreeTestOneListenerStartThreadId = getTestListenerStartThreadId(SUITE_C, SUITE_C_TEST_A);
+        suiteThreeTestTwoListenerStartThreadId = getTestListenerStartThreadId(SUITE_C, SUITE_C_TEST_B);
+        suiteThreeTestThreeListenerStartThreadId = getTestListenerStartThreadId(SUITE_C, SUITE_C_TEST_C);
+        suiteThreeTestOneListenerFinishThreadId = getTestListenerFinishThreadId(SUITE_C, SUITE_C_TEST_A);
+        suiteThreeTestTwoListenerFinishThreadId = getTestListenerFinishThreadId(SUITE_C, SUITE_C_TEST_B);
+        suiteThreeTestThreeListenerFinishThreadId = getTestListenerFinishThreadId(SUITE_C, SUITE_C_TEST_C);
+
+        suiteThreeTestOneListenerStartThreadCount = getTestListenerStartActiveThreadCount(SUITE_C, SUITE_C_TEST_A);
+        suiteThreeTestTwoListenerStartThreadCount = getTestListenerStartActiveThreadCount(SUITE_C, SUITE_C_TEST_B);
+        suiteThreeTestThreeListenerStartThreadCount = getTestListenerStartActiveThreadCount(SUITE_C, SUITE_C_TEST_C);
+        suiteThreeTestOneListenerFinishThreadCount = getTestListenerFinishActiveThreadCount(SUITE_C, SUITE_C_TEST_A);
+        suiteThreeTestTwoListenerFinishThreadCount = getTestListenerFinishActiveThreadCount(SUITE_C, SUITE_C_TEST_B);
+        suiteThreeTestThreeListenerFinishThreadCount = getTestListenerFinishActiveThreadCount(SUITE_C, SUITE_C_TEST_C);
+
+        suiteOneTestOneFiveMethodsClassEventLogMap = getTestMethodEventLogsForClass(SUITE_A, SUITE_A_TEST_A,
+                TestClassAWithNoDepsSample.class.getCanonicalName());
+        suiteOneTestOneSixMethodsClassEventLogMap = getTestMethodEventLogsForClass(SUITE_A, SUITE_A_TEST_A,
+                TestClassCWithNoDepsSample.class.getCanonicalName());
+
+        suiteTwoTestOneFiveMethodsClassEventLogMap = getTestMethodEventLogsForClass(SUITE_B, SUITE_B_TEST_A,
+                TestClassEWithNoDepsSample.class.getCanonicalName());
+
+        suiteTwoTestTwoThreeMethodsClassEventLogMap = getTestMethodEventLogsForClass(SUITE_B, SUITE_B_TEST_B,
+                TestClassDWithNoDepsSample.class.getCanonicalName());
+        suiteTwoTestTwoFourMethodsClassEventLogMap = getTestMethodEventLogsForClass(SUITE_B, SUITE_B_TEST_B,
+                TestClassBWithNoDepsSample.class.getCanonicalName());
+        suiteTwoTestTwoSixMethodsClassEventLogMap = getTestMethodEventLogsForClass(SUITE_B, SUITE_B_TEST_B,
+                TestClassFWithNoDepsSample.class.getCanonicalName());
+
+        suiteThreeTestOneThreeMethodsClassEventLogMap = getTestMethodEventLogsForClass(SUITE_C, SUITE_C_TEST_A,
+                TestClassGWithNoDepsSample.class.getCanonicalName());
+        suiteThreeTestOneFourMethodsClassEventLogMap = getTestMethodEventLogsForClass(SUITE_C, SUITE_C_TEST_A,
+                TestClassHWithNoDepsSample.class.getCanonicalName());
+        suiteThreeTestOneFiveMethodsClassEventLogMap = getTestMethodEventLogsForClass(SUITE_C, SUITE_C_TEST_A,
+                TestClassIWithNoDepsSample.class.getCanonicalName());
+
+        suiteThreeTestTwoFourMethodsClassEventLogMap = getTestMethodEventLogsForClass(SUITE_C, SUITE_C_TEST_B,
+                TestClassJWithNoDepsSample.class.getCanonicalName());
+        suiteThreeTestTwoFiveMethodsClassEventLogMap = getTestMethodEventLogsForClass(SUITE_C, SUITE_C_TEST_B,
+                TestClassKWithNoDepsSample.class.getCanonicalName());
+
+        suiteThreeTestThreeThreeMethodsClassEventLogMap = getTestMethodEventLogsForClass(SUITE_C, SUITE_C_TEST_C,
+                TestClassLWithNoDepsSample.class.getCanonicalName());
+        suiteThreeTestThreeFourMethodsClassEventLogMap = getTestMethodEventLogsForClass(SUITE_C, SUITE_C_TEST_C,
+                TestClassMWithNoDepsSample.class.getCanonicalName());
+        suiteThreeTestThreeFiveMethodsClassEventLogMap = getTestMethodEventLogsForClass(SUITE_C, SUITE_C_TEST_C,
+                TestClassNWithNoDepsSample.class.getCanonicalName());
+        suiteThreeTestThreeSixMethodsClassEventLogMap = getTestMethodEventLogsForClass(SUITE_C, SUITE_C_TEST_C,
+                TestClassOWithNoDepsSample.class.getCanonicalName());
+
+        suiteOneTestOneTestMethodListenerStartEventLogs = getTestMethodListenerStartEventLogsForTest(SUITE_A,
+                SUITE_A_TEST_A);
+        suiteOneTestOneTestMethodListenerPassEventLogs = getTestMethodListenerPassEventLogsForTest(SUITE_A,
+                SUITE_A_TEST_A);
+
+        suiteTwoTestOneTestMethodListenerStartEventLogs = getTestMethodListenerStartEventLogsForTest(SUITE_B,
+                SUITE_B_TEST_A);
+        suiteTwoTestTwoTestMethodListenerStartEventLogs = getTestMethodListenerStartEventLogsForTest(SUITE_B,
+                SUITE_B_TEST_B);
+        suiteTwoTestOneTestMethodListenerPassEventLogs = getTestMethodListenerPassEventLogsForTest(SUITE_B,
+                SUITE_B_TEST_A);
+        suiteTwoTestTwoTestMethodListenerPassEventLogs = getTestMethodListenerPassEventLogsForTest(SUITE_B,
+                SUITE_B_TEST_B);
+
+        suiteThreeTestOneTestMethodListenerStartEventLogs = getTestMethodListenerStartEventLogsForTest(SUITE_C,
+                SUITE_C_TEST_A);
+        suiteThreeTestTwoTestMethodListenerStartEventLogs = getTestMethodListenerStartEventLogsForTest(SUITE_C,
+                SUITE_C_TEST_B);
+        suiteThreeTestThreeTestMethodListenerStartEventLogs = getTestMethodListenerStartEventLogsForTest(SUITE_C,
+                SUITE_C_TEST_C);
+        suiteThreeTestOneTestMethodListenerPassEventLogs = getTestMethodListenerPassEventLogsForTest(SUITE_C,
+                SUITE_C_TEST_A);
+        suiteThreeTestTwoTestMethodListenerPassEventLogs = getTestMethodListenerPassEventLogsForTest(SUITE_C,
+                SUITE_C_TEST_B);
+        suiteThreeTestThreeTestMethodListenerPassEventLogs = getTestMethodListenerPassEventLogsForTest(SUITE_C,
+                SUITE_C_TEST_C);
+
+        suiteOneTestOneTestMethodExecutionEventLogs = getTestMethodExecutionEventLogsForTest(SUITE_A, SUITE_A_TEST_A);
+        suiteTwoTestOneTestMethodExecutionEventLogs = getTestMethodExecutionEventLogsForTest(SUITE_B, SUITE_B_TEST_A);
+        suiteTwoTestTwoTestMethodExecutionEventLogs = getTestMethodExecutionEventLogsForTest(SUITE_B, SUITE_B_TEST_B);
+        suiteThreeTestOneTestMethodExecutionEventLogs = getTestMethodExecutionEventLogsForTest(SUITE_C, SUITE_C_TEST_A);
+        suiteThreeTestTwoTestMethodExecutionEventLogs = getTestMethodExecutionEventLogsForTest(SUITE_C, SUITE_C_TEST_B);
+        suiteThreeTestThreeTestMethodExecutionEventLogs = getTestMethodExecutionEventLogsForTest(SUITE_C,
+                SUITE_C_TEST_C);
+    }
+
+    //Verify that all the events in the second suite and third suites run have timestamps later than the suite
+    //listener's onFinish event for the first suite run. Verify that all the events in the third suite run have
+    //timestamps later than the suite listener's onFinish event for the second suite run.
+    @Test
+    public void verifySuitesRunSequentially() {
+        List<EventLog> suiteListenerStartEventLogs = getSuiteListenerStartEventLogs();
+
+        assertEquals(suiteListenerStartEventLogs.size(),  3, "There should be three suite listener onStart events " +
+                "logged");
+
+        String firstSuite = (String)suiteListenerStartEventLogs.get(0).getData(SUITE_NAME);
+        String secondSuite = (String)suiteListenerStartEventLogs.get(1).getData(SUITE_NAME);
+        String thirdSuite = (String)suiteListenerStartEventLogs.get(2).getData(SUITE_NAME);
+
+        List<String> suitesRun = new ArrayList<>();
+        suitesRun.add(firstSuite);
+        suitesRun.add(secondSuite);
+        suitesRun.add(thirdSuite);
+
+        assertTrue(suitesRun.contains(SUITE_A), "There should be an event log for the suite listener onStart event " +
+                "for " + SUITE_A);
+        assertTrue(suitesRun.contains(SUITE_B), "There should be an event log for the suite listener onStart event " +
+                "for " + SUITE_B);
+        assertTrue(suitesRun.contains(SUITE_C), "There should be an event log for the suite listener onStart event " +
+                "for " + SUITE_C);
+
+        switch(firstSuite) {
+            case SUITE_A:
+                for(EventLog eventLog : suiteTwoEventLogs) {
+                    assertTrue(eventLog.getTimeOfEvent() > suiteOneListenerFinishTimestamp, "If " + SUITE_A + " is " +
+                            "the first test suite that is executed, all events logged for " + SUITE_B + " should" +
+                            "have a timestamp later the suite listener's onFinish event log for " + SUITE_A);
+                }
+
+                for(EventLog eventLog : suiteThreeEventLogs) {
+                    assertTrue(eventLog.getTimeOfEvent() > suiteOneListenerFinishTimestamp, "If " + SUITE_A + " is " +
+                            "the first test suite that is executed, all events logged for " + SUITE_C + " should" +
+                            "have a timestamp later the suite listener's onFinish event log for " + SUITE_A);
+                }
+                break;
+            case SUITE_B:
+                for(EventLog eventLog : suiteOneEventLogs) {
+                    assertTrue(eventLog.getTimeOfEvent() > suiteTwoListenerFinishTimestamp, "If " + SUITE_B + " is " +
+                            "the first test suite that is executed, all events logged for " + SUITE_A + " should" +
+                            "have a timestamp later the suite listener's onFinish event log for " + SUITE_B);
+                }
+
+                for(EventLog eventLog : suiteThreeEventLogs) {
+                    assertTrue(eventLog.getTimeOfEvent() > suiteTwoListenerFinishTimestamp, "If " + SUITE_B + " is " +
+                            "the first test suite that is executed, all events logged for " + SUITE_C + " should" +
+                            "have a timestamp later the suite listener's onFinish event log for " + SUITE_B);
+                }
+                break;
+            default:
+                for(EventLog eventLog : suiteOneEventLogs) {
+                    assertTrue(eventLog.getTimeOfEvent() > suiteThreeListenerFinishTimestamp, "If " + SUITE_C +
+                            " is the first test suite that is executed, all events logged for " + SUITE_A + " should" +
+                            " have a timestamp later the suite listener's onFinish event log for " + SUITE_C);
+                }
+
+                for(EventLog eventLog : suiteTwoEventLogs) {
+                    assertTrue(eventLog.getTimeOfEvent() > suiteThreeListenerFinishTimestamp, "If " + SUITE_C +
+                            " is the first test suite that is executed, all events logged for " + SUITE_B + " should" +
+                            " have a timestamp later the suite listener's onFinish event log for " + SUITE_C);
+                }
+                break;
+        }
+
+        switch(secondSuite) {
+            case SUITE_A:
+                if(firstSuite.equals(SUITE_B)) {
+                    for(EventLog eventLog : suiteThreeEventLogs) {
+                        assertTrue(eventLog.getTimeOfEvent() > suiteOneListenerFinishTimestamp, "If " + SUITE_B +
+                                " is the first suite run and " + SUITE_A + " is the second suite run, all events " +
+                                "logged for " + SUITE_C + " should have a timestamp later than the suite listener's " +
+                                "onFinish event for " + SUITE_A);
+                    }
+                } else if(firstSuite.equals(SUITE_C)) {
+                    for(EventLog eventLog : suiteTwoEventLogs) {
+                        assertTrue(eventLog.getTimeOfEvent() > suiteOneListenerFinishTimestamp, "If " + SUITE_C +
+                                " is the first suite run and " + SUITE_A + " is the second suite run, all events " +
+                                "logged for " + SUITE_B + " should have a timestamp later than the suite listener's " +
+                                "onFinish event for " + SUITE_A);
+                    }
+                }
+                break;
+            case SUITE_B:
+                if(firstSuite.equals(SUITE_A)) {
+                    for(EventLog eventLog : suiteThreeEventLogs) {
+                        assertTrue(eventLog.getTimeOfEvent() > suiteTwoListenerFinishTimestamp, "If " + SUITE_A +
+                                " is the first suite run and " + SUITE_B + " is the second suite run, all events " +
+                                "logged for " + SUITE_C + " should have a timestamp later than the suite listener's " +
+                                "onFinish event for " + SUITE_B);
+                    }
+                } else if(firstSuite.equals(SUITE_C)) {
+                    for(EventLog eventLog : suiteOneEventLogs) {
+                        assertTrue(eventLog.getTimeOfEvent() > suiteTwoListenerFinishTimestamp, "If " + SUITE_C +
+                                " is the first suite run and " + SUITE_B + " is the second suite run, all events " +
+                                "logged for " + SUITE_A + " should have a timestamp later than the suite listener's " +
+                                "onFinish event for " + SUITE_B);
+                    }
+                }
+                break;
+            default:
+                if(firstSuite.equals(SUITE_A)) {
+                    for(EventLog eventLog : suiteTwoEventLogs) {
+                        assertTrue(eventLog.getTimeOfEvent() > suiteThreeListenerFinishTimestamp, "If " + SUITE_A +
+                                " is the first suite run and " + SUITE_C + "  is the second suite run, all events " +
+                                "logged for " + SUITE_B + " should have a timestamp later than the suite listener's " +
+                                "onFinish event for " + SUITE_C);
+                    }
+                } else if(firstSuite.equals(SUITE_B)) {
+                    for(EventLog eventLog : suiteOneEventLogs) {
+                        assertTrue(eventLog.getTimeOfEvent() > suiteThreeListenerFinishTimestamp, "If " + SUITE_B +
+                                " is the first suite run and " + SUITE_C + " is the second suite run, all events " +
+                                "logged for " + SUITE_A + " should have a timestamp later than the suite listener's " +
+                                "onFinish event for " + SUITE_C);
+                    }
+                }
+                break;
+        }
+    }
+
+    //For all suites, verify that the suite listener and test listener events have timestamps in the following order:
+    //suite start, then for each test in the suite, test start and test finish, followed by suite finish. For all
+    //suites, verify that all of these events run in the same thread because the parallelization mode is by methods
+    //only.
+    @Test
+    public void verifySuiteAndTestLevelEventsRunInSequentialOrderInSameThreadForAllSuites() {
+        assertTrue(suiteOneListenerStartTimestamp < suiteOneTestOneListenerStartTimestamp, "The timestamp for the " +
+                "suite listener's onStart method for " + SUITE_A + " should be before the timestamp for the test " +
+                "listener's onStart method for " + SUITE_A_TEST_A);
+        assertTrue(suiteOneListenerFinishTimestamp > suiteOneTestOneListenerFinishTimestamp, "The timestamp for the " +
+                "onFinish method for the suite listener's onFinish method for " + SUITE_A + " should be after the " +
+                "timestamp for the test listener's onFinish method for " + SUITE_A_TEST_A);
+
+        assertTrue(suiteTwoListenerStartTimestamp < suiteTwoTestOneListenerStartTimestamp, "The timestamp for the " +
+                "suite listener's onStart method for " + SUITE_B + " should be before the timestamp for the test " +
+                "listener's onStart method for " + SUITE_B_TEST_A);
+        assertTrue(suiteTwoListenerStartTimestamp < suiteTwoTestTwoListenerStartTimestamp, "The timestamp for the " +
+                "suite listener's onStart method for " + SUITE_B + " should be before the timestamp for the test " +
+                "listener's onStart method for " + SUITE_B_TEST_B);
+        assertTrue(suiteTwoListenerFinishTimestamp > suiteTwoTestOneListenerFinishTimestamp, "The timestamp for the " +
+                "onFinish method for the suite listener's onFinish method for " + SUITE_B + " should be after the " +
+                "timestamp for the test listener's onFinish method for " + SUITE_B_TEST_A);
+        assertTrue(suiteTwoListenerFinishTimestamp > suiteTwoTestTwoListenerFinishTimestamp, "The timestamp for the " +
+                "onFinish method for the suite listener's onFinish method for " + SUITE_B + " should be after the " +
+                "timestamp for the test listener's onFinish method for " + SUITE_B_TEST_B);
+        
+        assertTrue(suiteThreeListenerStartTimestamp < suiteThreeTestOneListenerStartTimestamp, "The timestamp for " +
+                "the suite listener's onStart method for " + SUITE_C + " should be before the timestamp for the test " +
+                "listener's onStart method for " + SUITE_C_TEST_A);
+        assertTrue(suiteThreeListenerStartTimestamp < suiteThreeTestTwoListenerStartTimestamp, "The timestamp for " +
+                "the suite listener's onStart method for " + SUITE_C + " should be before the timestamp for the test " +
+                "listener's onStart method for " + SUITE_C_TEST_B);
+        assertTrue(suiteThreeListenerStartTimestamp < suiteThreeTestThreeListenerStartTimestamp, "The timestamp for " +
+                "the suite listener's onStart method for " + SUITE_C + " should be before the timestamp for the test " +
+                "listener's onStart method for " + SUITE_C_TEST_C);
+        assertTrue(suiteThreeListenerFinishTimestamp > suiteThreeTestOneListenerFinishTimestamp, "The timestamp for " +
+                "the onFinish method for the suite listener's onFinish method for " + SUITE_C + " should be after " +
+                "the timestamp for the test listener's onFinish method for " + SUITE_C_TEST_A);
+        assertTrue(suiteThreeListenerFinishTimestamp > suiteThreeTestTwoListenerFinishTimestamp, "The timestamp for " +
+                "the onFinish method for the suite listener's onFinish method for " + SUITE_C + " should be after " +
+                "the timestamp for the test listener's onFinish method for " + SUITE_C_TEST_B);
+        assertTrue(suiteThreeListenerFinishTimestamp > suiteThreeTestThreeListenerFinishTimestamp, "The timestamp " +
+                "for the onFinish method for the suite listener's onFinish method for " + SUITE_C + " should be " +
+                "after the timestamp for the test listener's onFinish method for " + SUITE_C_TEST_C);
+        
+
+        List<EventLog> testListenerStartEventLogs = getTestListenerStartEventLogsForSuite(SUITE_B);
+
+        assertEquals(testListenerStartEventLogs.size(),  2, "There should be two test listener onStart events " +
+                "logged for " + SUITE_B);
+
+        String firstTest = (String)testListenerStartEventLogs.get(0).getData(TEST_NAME);
+        String secondTest = (String)testListenerStartEventLogs.get(1).getData(TEST_NAME);
+
+        List<String> testsRun = new ArrayList<>();
+        testsRun.add(firstTest);
+        testsRun.add(secondTest);
+
+        assertTrue(testsRun.contains(SUITE_B_TEST_A), "There should be an event log for the test listener onStart " +
+                "event for " + SUITE_B_TEST_A);
+        assertTrue(testsRun.contains(SUITE_B_TEST_B), "There should be an event log for the test listener onStart " +
+                "event for " + SUITE_B_TEST_B);
+
+        if(firstTest.equals(SUITE_B_TEST_A)) {
+            for(EventLog eventLog : suiteTwoTestTwoEventLogs) {
+                assertTrue(eventLog.getTimeOfEvent() > suiteTwoTestOneListenerFinishTimestamp, "If " + SUITE_B_TEST_A +
+                        " is the first test run in " + SUITE_B + ", then all the events logged for " + SUITE_B_TEST_B +
+                        " should have a timestamp after the test listener's onFinish event for " + SUITE_B_TEST_A);
+            }
+        } else {
+            for(EventLog eventLog : suiteTwoTestOneEventLogs) {
+                assertTrue(eventLog.getTimeOfEvent() > suiteTwoTestTwoListenerFinishTimestamp, "If " + SUITE_B_TEST_B +
+                        " is the first test run in " + SUITE_C + ", then all the events logged for " + SUITE_B_TEST_A +
+                        " should have a timestamp after the test listener's onFinish event for " + SUITE_B_TEST_A);
+            }
+        }
+
+        testListenerStartEventLogs = getTestListenerStartEventLogsForSuite(SUITE_C);
+
+        assertEquals(testListenerStartEventLogs.size(),  3, "There should be two test listener onStart events logged " +
+                "for " + SUITE_C);
+
+        firstTest = (String)testListenerStartEventLogs.get(0).getData(TEST_NAME);
+        secondTest = (String)testListenerStartEventLogs.get(1).getData(TEST_NAME);
+        String thirdTest =  (String)testListenerStartEventLogs.get(2).getData(TEST_NAME);
+
+        testsRun = new ArrayList<>();
+        testsRun.add(firstTest);
+        testsRun.add(secondTest);
+        testsRun.add(thirdTest);
+
+        assertTrue(testsRun.contains(SUITE_C_TEST_A), "There should be an event log for the test listener onStart " +
+                "event for " + SUITE_C_TEST_A);
+        assertTrue(testsRun.contains(SUITE_C_TEST_B), "There should be an event log for the test listener onStart " +
+                "event for " + SUITE_C_TEST_B);
+        assertTrue(testsRun.contains(SUITE_C_TEST_C), "There should be an event log for the test listener onStart " +
+                "event for " + SUITE_C_TEST_C);
+
+        switch (firstTest) {
+            case SUITE_C_TEST_A:
+                for (EventLog eventLog : suiteThreeTestTwoEventLogs) {
+                    assertTrue(eventLog.getTimeOfEvent() > suiteThreeTestOneListenerFinishTimestamp, "If " +
+                            SUITE_C_TEST_A + " is the first test run in " + SUITE_B + " , then all the events logged " +
+                            "for " + SUITE_C_TEST_B + "  should have a timestamp after the test listener's onFinish " +
+                            "event for " + SUITE_C_TEST_A);
+                }
+
+                for (EventLog eventLog : suiteThreeTestThreeEventLogs) {
+                    assertTrue(eventLog.getTimeOfEvent() > suiteThreeTestOneListenerFinishTimestamp, "If " +
+                            SUITE_C_TEST_A + " is the first test run in " + SUITE_B + ", then all the events logged " +
+                            "for " + SUITE_C_TEST_C + " should have a timestamp after the test listener's onFinish " +
+                            "event for " + SUITE_C_TEST_A);
+                }
+                break;
+            case SUITE_C_TEST_B:
+                for (EventLog eventLog : suiteThreeTestOneEventLogs) {
+                    assertTrue(eventLog.getTimeOfEvent() > suiteThreeTestTwoListenerFinishTimestamp, "If " +
+                            SUITE_C_TEST_B + " is the first test run in " + SUITE_B + ", then all the events logged " +
+                            "for " + SUITE_C_TEST_A + " should have a timestamp after the test listener's onFinish " +
+                            "event for " + SUITE_C_TEST_B);
+                }
+
+                for (EventLog eventLog : suiteThreeTestThreeEventLogs) {
+                    assertTrue(eventLog.getTimeOfEvent() > suiteThreeTestTwoListenerFinishTimestamp, "If " +
+                            SUITE_C_TEST_A + " is the first test run in " + SUITE_B + ", then all the events logged " +
+                            "for " + SUITE_C_TEST_C + " should have a timestamp after the test listener's onFinish " +
+                            "event for " + SUITE_C_TEST_A);
+                }
+                break;
+            default:
+                for (EventLog eventLog : suiteThreeTestOneEventLogs) {
+                    assertTrue(eventLog.getTimeOfEvent() > suiteThreeTestThreeListenerFinishTimestamp, "If " +
+                            SUITE_C_TEST_C + " is the first test run in " + SUITE_B + ", then all the events logged " +
+                            "for " + SUITE_C_TEST_A + " should have a timestamp after the test listener's onFinish " +
+                            "event for " + SUITE_C_TEST_C);
+                }
+
+                for (EventLog eventLog : suiteThreeTestTwoEventLogs) {
+                    assertTrue(eventLog.getTimeOfEvent() > suiteThreeTestThreeListenerFinishTimestamp, "If " +
+                            SUITE_C_TEST_C + " is the first test run in " + SUITE_B + ", then all the events logged " +
+                            "for " + SUITE_C_TEST_B + " should have a timestamp after the test listener's onFinish " +
+                            "event for " + SUITE_C_TEST_C);
+                }
+                break;
+        }
+
+        switch(secondTest) {
+            case SUITE_C_TEST_A:
+                if(firstTest.equals(SUITE_C_TEST_B)) {
+                    for(EventLog eventLog : suiteThreeTestThreeEventLogs) {
+                        assertTrue(eventLog.getTimeOfEvent() > suiteThreeTestOneListenerFinishTimestamp, "If " +
+                                SUITE_C_TEST_B + " is the first test run in " + SUITE_C + " and " + SUITE_C_TEST_A +
+                                " is the second test run, all events logged for " + SUITE_C_TEST_C + " should have a " +
+                                "timestamp after the test listener's onFinish event for " + SUITE_C_TEST_A);
+                    }
+                } else if(firstTest.equals(SUITE_C_TEST_C)) {
+                    for(EventLog eventLog : suiteThreeTestTwoEventLogs) {
+                        assertTrue(eventLog.getTimeOfEvent() > suiteThreeTestOneListenerFinishTimestamp, "If " +
+                                SUITE_C_TEST_C + " is the first test run in " + SUITE_C + " and " + SUITE_C_TEST_A +
+                                " is the second test run, all events logged for " + SUITE_C_TEST_B + " should have a " +
+                                "timestamp after the test listener's onFinish event for " + SUITE_C_TEST_A);
+                    }
+                }
+                break;
+            case SUITE_C_TEST_B:
+                if(firstTest.equals(SUITE_C_TEST_A)) {
+                    for(EventLog eventLog : suiteThreeTestThreeEventLogs) {
+                        assertTrue(eventLog.getTimeOfEvent() > suiteThreeTestTwoListenerFinishTimestamp, "If " +
+                                SUITE_C_TEST_A + " is the first test run in " + SUITE_C + " and " + SUITE_C_TEST_B +
+                                " is the second test run, all events logged for " + SUITE_C_TEST_C + " should have a " +
+                                "timestamp after the test listener's onFinish event for " + SUITE_C_TEST_B);
+                    }
+                } else if(firstTest.equals(SUITE_C_TEST_C)) {
+                    for(EventLog eventLog : suiteThreeTestOneEventLogs) {
+                        assertTrue(eventLog.getTimeOfEvent() > suiteThreeTestTwoListenerFinishTimestamp, "If " +
+                                SUITE_C_TEST_C + " is the first test run in " + SUITE_C + " and " + SUITE_C_TEST_B +
+                                " is the second test run, all events logged for " + SUITE_C_TEST_A + " should have a " +
+                                "timestamp after the test listener's onFinish event for " + SUITE_C_TEST_B);
+                    }
+                }
+                break;
+            default:
+                if(firstTest.equals(SUITE_C_TEST_A)) {
+                    for(EventLog eventLog : suiteThreeTestTwoEventLogs) {
+                        assertTrue(eventLog.getTimeOfEvent() > suiteThreeTestThreeListenerFinishTimestamp, "If " +
+                                SUITE_C_TEST_A + " is the first test run in " + SUITE_C + " and " + SUITE_C_TEST_C +
+                                " is the second test run, all events logged for " + SUITE_C_TEST_B + " should have a " +
+                                "timestamp after the test listener's onFinish event for " + SUITE_C_TEST_C);
+                    }
+                } else if(firstTest.equals(SUITE_C_TEST_B)) {
+                    for(EventLog eventLog : suiteThreeTestOneEventLogs) {
+                        assertTrue(eventLog.getTimeOfEvent() > suiteThreeTestThreeListenerFinishTimestamp, "If " +
+                                SUITE_C_TEST_B + " is the first test run in " + SUITE_C + " and " + SUITE_C_TEST_C +
+                                " is the second test run, all events logged for " + SUITE_C_TEST_A + " should have a " +
+                                "timestamp after the test listener's onFinish event for " + SUITE_C_TEST_C);
+                    }
+                }
+                break;
+        }
+
+        assertEquals(suiteOneListenerStartThreadId, suiteOneListenerFinishThreadId, "The thread ID for the suite " + 
+                "listener's onStart method should be the same as the thread ID for the suite listener's onFinish " + 
+                "method for " + SUITE_A);
+        assertEquals(suiteOneTestOneListenerStartThreadId, suiteOneTestOneListenerFinishThreadId, "The thread ID for " +
+                "the test listener's onStart method should be the same as the thread ID for the test listener's " +
+                "onFinish method for " + SUITE_A_TEST_A);
+
+
+        assertEquals(suiteTwoListenerStartThreadId, suiteTwoListenerFinishThreadId, "The thread ID for the suite " +
+                "listener's onStart method should be the same as the thread ID for the suite listener's onFinish " +
+                "method for " + SUITE_B);
+        assertEquals(suiteTwoTestOneListenerStartThreadId, suiteTwoTestOneListenerFinishThreadId, "The thread ID for " +
+                "the test listener's onStart method should be the same as the thread ID for the test listener's " +
+                "onFinish method for " + SUITE_B_TEST_A);
+        assertEquals(suiteTwoTestTwoListenerStartThreadId, suiteTwoTestTwoListenerFinishThreadId, "The thread ID for " +
+                "the test listener's onStart method should be the same as the thread ID for the test listener's " +
+                "onFinish method for " + SUITE_B_TEST_B);
+
+        assertEquals(suiteThreeListenerStartThreadId, suiteThreeListenerFinishThreadId, "The thread ID for the suite " +
+                "listener's onStart method should be the same as the thread ID for the suite listener's onFinish " +
+                "method for " + SUITE_C);
+        assertEquals(suiteThreeTestOneListenerStartThreadId, suiteThreeTestOneListenerFinishThreadId, "The thread ID " +
+                "for the test listener's onStart method should be the same as the thread ID for the test listener's " +
+                "onFinish method for " + SUITE_C_TEST_A);
+        assertEquals(suiteThreeTestTwoListenerStartThreadId, suiteThreeTestTwoListenerFinishThreadId, "The thread ID " +
+                "for the test listener's onStart method should be the same as the thread ID for the test listener's " +
+                "onFinish method for " + SUITE_C_TEST_B);
+        assertEquals(suiteThreeTestThreeListenerStartThreadId, suiteThreeTestThreeListenerFinishThreadId, "The " +
+                "thread ID for the test listener's onStart method should be the same as the thread ID for the test " +
+                "listener's onFinish method for " + SUITE_C_TEST_C);
+
+        assertEquals(suiteOneListenerStartThreadId, suiteTwoListenerStartThreadId, "The thread IDs for the " + 
+                "suite level events for all the test suites should be the same");
+        assertEquals(suiteOneListenerStartThreadId, suiteThreeListenerStartThreadId, "The thread IDs for the " +
+                "suite level events for all the test suites should be the same");
+
+        assertEquals(suiteOneListenerStartThreadId, suiteOneTestOneListenerStartThreadId, "The thread IDs for the " +
+                "suite level and the test level events for all the test suites should be the same");
+        assertEquals(suiteOneListenerStartThreadId, suiteTwoTestOneListenerStartThreadId, "The thread IDs for the " +
+                "suite level and the test level events for all the test suites should be the same");
+        assertEquals(suiteOneListenerStartThreadId, suiteTwoTestTwoListenerStartThreadId, "The thread IDs for the " +
+                "suite level and the test level events for all the test suites should be the same");
+        assertEquals(suiteOneListenerStartThreadId, suiteThreeTestOneListenerStartThreadId, "The thread IDs for the " +
+                "suite level and the test level events for all the test suites should be the same");
+        assertEquals(suiteOneListenerStartThreadId, suiteThreeTestTwoListenerStartThreadId, "The thread IDs for the " +
+                "suite level and the test level events for all the test suites should be the same");
+        assertEquals(suiteOneListenerStartThreadId, suiteThreeTestThreeListenerStartThreadId, "The thread IDs for " +
+                "the suite level and the test level events for all the test suites should be the same");
+    }
+
+    @Test
+    public void verifyThreadCountsForSuiteAndTestLevelEvents() {
+        assertEquals(suiteOneListenerStartThreadCount, suiteOneListenerFinishThreadCount, "The number of active " +
+                "threads when the suite listener's onStart event for " + SUITE_A + " was logged should be the same " +
+                "as the number of active threads when the suite listener's onFinish event for " + SUITE_A + " was " +
+                "logged");
+        assertEquals(suiteOneTestOneListenerStartThreadCount, suiteOneTestOneListenerFinishThreadCount, "The number " +
+                "of active threads when the test listener's onStart event for " + SUITE_A_TEST_A + " was logged " +
+                "should be the same as the number of active threads when the test listener's onFinish event for " +
+                SUITE_A_TEST_A + " was logged");
+
+        assertEquals(suiteTwoListenerStartThreadCount, suiteTwoListenerFinishThreadCount, "The number of active " +
+                "threads when the suite listener's onStart event for " + SUITE_B + " was logged should be the same " +
+                "as the number of active threads when the suite listener's onFinish event for " + SUITE_B + " was " +
+                "logged");
+        assertEquals(suiteTwoTestOneListenerStartThreadCount, suiteTwoTestOneListenerFinishThreadCount, "The number " +
+                "of active threads when the test listener's onStart event for " + SUITE_B_TEST_A + " was logged " +
+                "should be the same as the number of active threads when the test listener's onFinish event for " +
+                SUITE_B_TEST_A + " was logged");
+        assertEquals(suiteTwoTestTwoListenerStartThreadCount, suiteTwoTestTwoListenerFinishThreadCount, "The number " +
+                "of active threads when the test listener's onStart event for " + SUITE_B_TEST_B + " was logged " +
+                "should be the same as the number of active threads when the test listener's onFinish event for " +
+                SUITE_B_TEST_B + " was logged");
+
+        assertEquals(suiteThreeListenerStartThreadCount, suiteThreeListenerFinishThreadCount, "The number of active " +
+                "threads when the suite listener's onStart event for " + SUITE_C + " was logged should be the same " +
+                "as the number of active threads when the suite listener's onFinish event for " + SUITE_C + " was " +
+                "logged");
+        assertEquals(suiteThreeTestOneListenerStartThreadCount, suiteThreeTestOneListenerFinishThreadCount, "The " +
+                "number of active threads when the test listener's onStart event for " + SUITE_C_TEST_A + " was " +
+                "logged should be the same as the number of active threads when the test listener's onFinish event " +
+                "for " + SUITE_C_TEST_A + " was logged");
+        assertEquals(suiteThreeTestTwoListenerStartThreadCount, suiteThreeTestTwoListenerFinishThreadCount, "The " +
+                "number of active threads when the test listener's onStart event for " + SUITE_C_TEST_B + " was " +
+                "logged should be the same as the number of active threads when the test listener's onFinish event " +
+                "for " + SUITE_C_TEST_B + " was logged");
+        assertEquals(suiteThreeTestThreeListenerStartThreadCount, suiteThreeTestThreeListenerFinishThreadCount, "The " +
+                "number of active threads when the test listener's onStart event for " + SUITE_C_TEST_C + " was " +
+                "logged should be the same as the number of active threads when the test listener's onFinish event " +
+                "for " + SUITE_C_TEST_C + " was logged");
+
+        assertEquals(suiteOneListenerStartThreadCount, suiteTwoListenerStartThreadCount, "The number of active " +
+                "threads when the suite listener's onStart method for " + SUITE_A + " was logged should be the same " +
+                "as the number of active threads when the suite listener's onStart method for " + SUITE_B + " was " +
+                "logged");
+        assertEquals(suiteOneListenerStartThreadCount, suiteThreeListenerStartThreadCount, "The number of active " +
+                "threads when the suite listener's onStart method for " + SUITE_A + " was logged should be the same " +
+                "as the number of active threads when the suite listener's onStart method for " + SUITE_C + " was " +
+                "logged");
+
+        assertEquals(suiteOneListenerStartThreadCount, suiteOneTestOneListenerStartThreadCount, "The active thread " +
+                "count when all the suite level and the test level events for all the test suites were logged should " +
+                "be the same");
+        assertEquals(suiteOneListenerStartThreadCount, suiteTwoTestOneListenerStartThreadCount, "The active thread " +
+                "count when all the suite level and the test level events for all the test suites were logged should " +
+                "be the same");
+        assertEquals(suiteOneListenerStartThreadCount, suiteTwoTestTwoListenerStartThreadCount, "The active thread " +
+                "count when all the suite level and the test level events for all the test suites were logged should " +
+                "be the same");
+        assertEquals(suiteOneListenerStartThreadCount, suiteThreeTestOneListenerStartThreadCount, "The active thread " +
+                "count when all the suite level and the test level events for all the test suites were logged should " +
+                "be the same");
+        assertEquals(suiteOneListenerStartThreadCount, suiteThreeTestTwoListenerStartThreadCount, "The active thread " +
+                "count when all the suite level and the test level events for all the test suites were logged should " +
+                "be the same");
+        assertEquals(suiteOneListenerStartThreadCount, suiteThreeTestThreeListenerStartThreadCount, "The active " +
+                "thread count when all the suite level and the test level events for all the test suites were logged " +
+                "should be the same");
+    }
+
+    //Verify that there is only a single test class instance associated with each of the test methods from the sample
+    //classes for every test in all the suites. Verify that instances are unique and separate if the same test class
+    //is included in different tests in different suites or in different tests within the same suite
+    @Test
+    public void verifyOnlyOneInstanceOfTestClassForAllTestMethodsForAllSuites() {
+
+        assertEquals(suiteOneTestOneFiveMethodsClassEventLogMap.keySet().size(), 1, "There should be only one test " +
+                "class instance associated with " + TestClassAWithNoDepsSample.class.getCanonicalName() +
+                " for " + SUITE_A_TEST_A);
+
+
+
+        assertEquals(suiteOneTestOneSixMethodsClassEventLogMap.keySet().size(), 1, "There should be only one test " +
+                "class instance associated with " + TestClassCWithNoDepsSample.class.getCanonicalName() +
+                " for " + SUITE_A_TEST_A);
+
+
+        assertEquals(suiteTwoTestOneFiveMethodsClassEventLogMap.keySet().size(), 1, "There should be only one test " +
+                "class instance associated with " + TestClassEWithNoDepsSample.class.getCanonicalName() +
+                " for " + SUITE_B_TEST_A);
+
+        assertEquals(suiteTwoTestTwoThreeMethodsClassEventLogMap.keySet().size(), 1, "There should be only one test " +
+                "class instance associated with " + TestClassDWithNoDepsSample.class.getCanonicalName() +
+                " for " + SUITE_B_TEST_B);
+        assertEquals(suiteTwoTestTwoFourMethodsClassEventLogMap.keySet().size(), 1, "There should be only one test " +
+                "class instance associated with " + TestClassBWithNoDepsSample.class.getCanonicalName() +
+                " for " + SUITE_B_TEST_B);
+        assertEquals(suiteTwoTestTwoSixMethodsClassEventLogMap.keySet().size(), 1, "There should be only one test " +
+                "class instance associated with " + TestClassFWithNoDepsSample.class.getCanonicalName() +
+                " for " + SUITE_B_TEST_B);
+
+        assertEquals(suiteThreeTestOneThreeMethodsClassEventLogMap.keySet().size(), 1, "There should be only one " +
+                "test class instance associated with " + TestClassGWithNoDepsSample.class.getCanonicalName() +
+                " for " + SUITE_C_TEST_A);
+        assertEquals(suiteThreeTestOneFourMethodsClassEventLogMap.keySet().size(), 1, "There should be only one " +
+                "test class instance associated with " + TestClassHWithNoDepsSample.class.getCanonicalName() +
+                " for " + SUITE_C_TEST_A);
+        assertEquals(suiteThreeTestOneFiveMethodsClassEventLogMap.keySet().size(), 1, "There should be only one " +
+                "test class instance associated with " + TestClassIWithNoDepsSample.class.getCanonicalName() +
+                " for " + SUITE_C_TEST_A);
+
+        assertEquals(suiteThreeTestTwoFourMethodsClassEventLogMap.keySet().size(), 1, "There should be only one " +
+                "test class instance associated with " + TestClassJWithNoDepsSample.class.getCanonicalName() +
+                " for " + SUITE_C_TEST_B);
+        assertEquals(suiteThreeTestTwoFiveMethodsClassEventLogMap.keySet().size(), 1, "There should be only one " +
+                "test class instance associated with " + TestClassKWithNoDepsSample.class.getCanonicalName() +
+                " for " + SUITE_C_TEST_B);
+
+        assertEquals(suiteThreeTestThreeThreeMethodsClassEventLogMap.keySet().size(), 1, "There should be only one " +
+                "test class instance associated with " + TestClassLWithNoDepsSample.class.getCanonicalName() +
+                " for " + SUITE_C_TEST_C);
+        assertEquals(suiteThreeTestThreeFourMethodsClassEventLogMap.keySet().size(), 1, "There should be only one " +
+                "test class instance associated with " + TestClassMWithNoDepsSample.class.getCanonicalName() +
+                " for " + SUITE_C_TEST_C);
+        assertEquals(suiteThreeTestThreeFiveMethodsClassEventLogMap.keySet().size(), 1, "There should be only one " +
+                "test class instance associated with " + TestClassNWithNoDepsSample.class.getCanonicalName() +
+                " for " + SUITE_C_TEST_C);
+        assertEquals(suiteThreeTestThreeSixMethodsClassEventLogMap.keySet().size(), 1, "There should be only one " +
+                "test class instance associated with " + TestClassOWithNoDepsSample.class.getCanonicalName() +
+                " for " + SUITE_C_TEST_C);
+    }
+
+    //Verify that the test method listener's onTestStart method runs after the test listener's onStart method for
+    //all the test methods in all tests and suites.
+    @Test
+    public void verifyTestMethodLevelListenerOnStartOccursAfterTestListenerStart() {
+
+        for(EventLog eventLog : suiteOneTestOneTestMethodListenerStartEventLogs) {
+            assertTrue(eventLog.getTimeOfEvent() > suiteOneTestOneListenerStartTimestamp, "The timestamps for all " +
+                    "the test method listener's onTestStart methods for test methods associated with " +
+                    SUITE_A_TEST_A + " should be later than the test listener's onStart method for " + SUITE_A_TEST_A);
+        }
+
+
+        for(EventLog eventLog : suiteTwoTestOneTestMethodListenerStartEventLogs) {
+            assertTrue(eventLog.getTimeOfEvent() > suiteTwoTestOneListenerStartTimestamp, "The timestamps for all " +
+                    "the test method listener's onTestStart methods for test methods associated with " +
+                    SUITE_B_TEST_A + " should be later than the test listener's onStart method for " + SUITE_B_TEST_A);
+        }
+
+        for(EventLog eventLog : suiteTwoTestTwoTestMethodListenerStartEventLogs) {
+            assertTrue(eventLog.getTimeOfEvent() > suiteTwoTestTwoListenerStartTimestamp, "The timestamps for all " +
+                    "the test method listener's onTestStart methods for test methods associated with " +
+                    SUITE_B_TEST_B + " should be later than the test listener's onStart method for " + SUITE_B_TEST_B);
+        }
+
+
+        for(EventLog eventLog : suiteThreeTestOneTestMethodListenerStartEventLogs) {
+            assertTrue(eventLog.getTimeOfEvent() > suiteThreeTestOneListenerStartTimestamp, "The timestamps for all " +
+                    "the test method listener's onTestStart methods for test methods associated with " +
+                    SUITE_C_TEST_A + " should be later than the test listener's onStart method for " + SUITE_C_TEST_A);
+        }
+
+        for(EventLog eventLog : suiteThreeTestTwoTestMethodListenerStartEventLogs) {
+            assertTrue(eventLog.getTimeOfEvent() > suiteThreeTestTwoListenerStartTimestamp, "The timestamps for all " +
+                    "the test method listener's onTestStart methods for test methods associated with " +
+                    SUITE_C_TEST_B + " should be later than the test listener's onStart method for " + SUITE_C_TEST_B);
+        }
+
+        for(EventLog eventLog : suiteThreeTestThreeTestMethodListenerStartEventLogs) {
+            assertTrue(eventLog.getTimeOfEvent() > suiteThreeTestThreeListenerStartTimestamp, "The timestamps for " +
+                    "all the test method listener's onTestStart methods for test methods associated with " +
+                    SUITE_C_TEST_C + " should be later than the test listener's onStart method for " + SUITE_C_TEST_C);
+        }
+
+    }
+
+    //Verify that the test method listener's onTestSuccess method runs before the test listener's onFinish method
+    //for all the test methods in all tests and suites.
+    @Test
+    public void verifyTestMethodLevelListenerOnSuccessRunsBeforeTestListenerOnFinish() {
+        for(EventLog eventLog : suiteOneTestOneTestMethodListenerPassEventLogs) {
+            assertTrue(eventLog.getTimeOfEvent() < suiteOneTestOneListenerFinishTimestamp, "The timestamps for all " +
+                    "the test method listener's onTestSuccess methods for test methods associated with " +
+                    SUITE_A_TEST_A + " should be earlier than the test listener's onFinish method for " +
+                    SUITE_A_TEST_A);
+        }
+
+
+        for(EventLog eventLog : suiteTwoTestOneTestMethodListenerPassEventLogs) {
+            assertTrue(eventLog.getTimeOfEvent() < suiteTwoTestOneListenerFinishTimestamp, "The timestamps for all " +
+                    "the test method listener's onTestSuccess methods for test methods associated with " +
+                    SUITE_B_TEST_A + " should be earlier than the test listener's onFinish method for " +
+                    SUITE_B_TEST_A);
+        }
+
+        for(EventLog eventLog : suiteTwoTestTwoTestMethodListenerPassEventLogs) {
+            assertTrue(eventLog.getTimeOfEvent() < suiteTwoTestTwoListenerFinishTimestamp, "The timestamps for all " +
+                    "the test method listener's onTestSuccess methods for test methods associated with " +
+                    SUITE_B_TEST_B + " should be earlier than the test listener's onFinish method for " +
+                    SUITE_B_TEST_B);
+        }
+
+
+        for(EventLog eventLog : suiteThreeTestOneTestMethodListenerPassEventLogs) {
+            assertTrue(eventLog.getTimeOfEvent() < suiteThreeTestOneListenerFinishTimestamp, "The timestamps for all " +
+                    "the test method listener's onTestSuccess methods for test methods associated with " +
+                    SUITE_C_TEST_A + " should be earlier than the test listener's onFinish method for " +
+                    SUITE_C_TEST_A);
+        }
+
+        for(EventLog eventLog : suiteThreeTestTwoTestMethodListenerPassEventLogs) {
+            assertTrue(eventLog.getTimeOfEvent() < suiteThreeTestTwoListenerFinishTimestamp, "The timestamps for all " +
+                    "the test method listener's onTestSuccess methods for test methods associated with " +
+                    SUITE_C_TEST_B + " should be earlier than the test listener's onFinish method for " +
+                    SUITE_C_TEST_B);
+        }
+
+        for(EventLog eventLog : suiteThreeTestThreeTestMethodListenerPassEventLogs) {
+            assertTrue(eventLog.getTimeOfEvent() < suiteThreeTestThreeListenerFinishTimestamp,"The timestamps for all " +
+                    "the test method listener's onTestSuccess methods for test methods associated with " +
+                    SUITE_C_TEST_C + " should be earlier than the test listener's onFinish method for " +
+                    SUITE_C_TEST_C);
+        }
+    }
+
+    //Verify that the test method listener's onTestStart method runs before the test method begins execution
+    //Verify that the test method listener's onTestSuccess method runs after the test method executes and passes
+    @Test
+    public void verifyTestExecutionTimestampIsAfterTestListenerOnStartAndBeforeTestListenerOnTestSuccess() {
+        for(EventLog eventLog : suiteOneTestOneTestMethodExecutionEventLogs) {
+            assertTrue(eventLog.getTimeOfEvent() > suiteOneTestOneListenerStartTimestamp, "All test method level " +
+                    "events should have timestamps between the timestamps for the test listener's onStart event and " +
+                    "the test listener's onFinish event");
+            assertTrue(eventLog.getTimeOfEvent() < suiteOneTestOneListenerFinishTimestamp, "All test method level " +
+                    "events should have timestamps between the timestamps for the test listener's onStart event and " +
+                    "the test listener's onFinish event");
+        }
+
+
+        for(EventLog eventLog : suiteTwoTestOneTestMethodExecutionEventLogs) {
+            assertTrue(eventLog.getTimeOfEvent() > suiteTwoTestOneListenerStartTimestamp, "All test method level " +
+                    "events should have timestamps between the timestamps for the test listener's onStart event and " +
+                    "the test listener's onFinish event");
+            assertTrue(eventLog.getTimeOfEvent() < suiteTwoTestOneListenerFinishTimestamp, "All test method level " +
+                    "events should have timestamps between the timestamps for the test listener's onStart event and " +
+                    "the test listener's onFinish event");
+        }
+
+        for(EventLog eventLog : suiteTwoTestTwoTestMethodExecutionEventLogs) {
+            assertTrue(eventLog.getTimeOfEvent() > suiteTwoTestTwoListenerStartTimestamp, "All test method level " +
+                    "events should have timestamps between the timestamps for the test listener's onStart event and " +
+                    "the test listener's onFinish event");
+            assertTrue(eventLog.getTimeOfEvent() < suiteTwoTestTwoListenerFinishTimestamp, "All test method level " +
+                    "events should have timestamps between the timestamps for the test listener's onStart event and " +
+                    "the test listener's onFinish event");
+        }
+
+        for(EventLog eventLog : suiteThreeTestOneTestMethodExecutionEventLogs) {
+            assertTrue(eventLog.getTimeOfEvent() > suiteThreeTestOneListenerStartTimestamp, "All test method level " +
+                    "events should have timestamps between the timestamps for the test listener's onStart event and " +
+                    "the test listener's onFinish event");
+            assertTrue(eventLog.getTimeOfEvent() < suiteThreeTestOneListenerFinishTimestamp, "All test method level " +
+                    "events should have timestamps between the timestamps for the test listener's onStart event and " +
+                    "the test listener's onFinish event");
+        }
+
+        for(EventLog eventLog : suiteThreeTestTwoTestMethodExecutionEventLogs) {
+            assertTrue(eventLog.getTimeOfEvent() > suiteThreeTestTwoListenerStartTimestamp, "All test method level " +
+                    "events should have timestamps between the timestamps for the test listener's onStart event and " +
+                    "the test listener's onFinish event");
+            assertTrue(eventLog.getTimeOfEvent() < suiteThreeTestTwoListenerFinishTimestamp, "All test method level " +
+                    "events should have timestamps between the timestamps for the test listener's onStart event and " +
+                    "the test listener's onFinish event");
+        }
+
+        for(EventLog eventLog : suiteThreeTestThreeTestMethodExecutionEventLogs) {
+            assertTrue(eventLog.getTimeOfEvent() > suiteThreeTestThreeListenerStartTimestamp, "All test method level " +
+                    "events should have timestamps between the timestamps for the test listener's onStart event and " +
+                    "the test listener's onFinish event");
+            assertTrue(eventLog.getTimeOfEvent() < suiteThreeTestThreeListenerFinishTimestamp, "All test method " +
+                    "level events should have timestamps between the timestamps for the test listener's onStart " +
+                    "event and the test listener's onFinish event");
+        }
+    }
+
+    //Verifies that the method level events all run in different threads from the test and suite level events.
+    //Verifies that the test method listener and execution events for a given test method all run in the same thread.
+    @Test
+    public void verifyThatMethodLevelEventsRunInDifferentThreadsFromSuiteAndTestLevelEvents() {
+        for(EventLog eventLog : suiteOneTestOneTestMethodExecutionEventLogs) {
+            assertTrue(eventLog.getThreadId() > suiteOneTestOneListenerStartThreadId, "The threads in which the test " +
+                    "method level events for " + SUITE_A_TEST_A + " run should be spawned after the thread in which " +
+                    "the suite and test level events listener events run");
+        }
+
+        for(EventLog eventLog : suiteTwoTestOneTestMethodExecutionEventLogs) {
+            assertTrue(eventLog.getThreadId() > suiteTwoTestOneListenerStartThreadId, "The threads in which the test " +
+                    "method level events for " + SUITE_B_TEST_A + " run should be spawned after the thread in which " +
+                    "the suite and test level events listener events run");
+        }
+
+        for(EventLog eventLog : suiteTwoTestTwoTestMethodExecutionEventLogs) {
+            assertTrue(eventLog.getThreadId() > suiteTwoTestTwoListenerStartThreadId, "The threads in which the test " +
+                    "method level events for " + SUITE_B_TEST_B + " run should be spawned after the thread in which " +
+                    "the suite and test level events listener events run");
+        }
+
+        for(EventLog eventLog : suiteThreeTestOneTestMethodExecutionEventLogs) {
+            assertTrue(eventLog.getThreadId() > suiteThreeTestOneListenerStartThreadId, "The threads in which the " +
+                    "test method level events for " + SUITE_C_TEST_A + " run should be spawned after the thread in " +
+                    "which the suite and test level events listener events run");
+        }
+
+        for(EventLog eventLog : suiteThreeTestTwoTestMethodExecutionEventLogs) {
+            assertTrue(eventLog.getThreadId() > suiteThreeTestTwoListenerStartThreadId, "The threads in which the " +
+                    "test method level events for " + SUITE_C_TEST_B + " run should be spawned after the thread in " +
+                    "which the suite and test level events listener events run");
+        }
+
+        for(EventLog eventLog : suiteThreeTestThreeTestMethodExecutionEventLogs) {
+            assertTrue(eventLog.getThreadId() > suiteThreeTestThreeListenerStartThreadId, "The threads in which the " +
+                    "test method level events for " + SUITE_C_TEST_C + " run should be spawned after the thread in " +
+                    "which the suite and test level events listener events run");
+        }
+
+        verifyEventsForTestMethodRunInSameThread(TestClassAWithNoDepsSample.class, SUITE_A, SUITE_A_TEST_A);
+        verifyEventsForTestMethodRunInSameThread(TestClassCWithNoDepsSample.class, SUITE_A, SUITE_A_TEST_A);
+
+        verifyEventsForTestMethodRunInSameThread(TestClassEWithNoDepsSample.class, SUITE_B, SUITE_B_TEST_A);
+
+        verifyEventsForTestMethodRunInSameThread(TestClassDWithNoDepsSample.class, SUITE_B, SUITE_B_TEST_B);
+        verifyEventsForTestMethodRunInSameThread(TestClassBWithNoDepsSample.class, SUITE_B, SUITE_B_TEST_B);
+        verifyEventsForTestMethodRunInSameThread(TestClassFWithNoDepsSample.class, SUITE_B, SUITE_B_TEST_B);
+
+        verifyEventsForTestMethodRunInSameThread(TestClassGWithNoDepsSample.class, SUITE_C, SUITE_C_TEST_A);
+        verifyEventsForTestMethodRunInSameThread(TestClassHWithNoDepsSample.class, SUITE_C, SUITE_C_TEST_A);
+        verifyEventsForTestMethodRunInSameThread(TestClassIWithNoDepsSample.class, SUITE_C, SUITE_C_TEST_A);
+
+        verifyEventsForTestMethodRunInSameThread(TestClassJWithNoDepsSample.class, SUITE_C, SUITE_C_TEST_B);
+        verifyEventsForTestMethodRunInSameThread(TestClassKWithNoDepsSample.class, SUITE_C, SUITE_C_TEST_B);
+
+        verifyEventsForTestMethodRunInSameThread(TestClassLWithNoDepsSample.class, SUITE_C, SUITE_C_TEST_C);
+        verifyEventsForTestMethodRunInSameThread(TestClassMWithNoDepsSample.class, SUITE_C, SUITE_C_TEST_C);
+        verifyEventsForTestMethodRunInSameThread(TestClassNWithNoDepsSample.class, SUITE_C, SUITE_C_TEST_C);
+        verifyEventsForTestMethodRunInSameThread(TestClassOWithNoDepsSample.class, SUITE_C, SUITE_C_TEST_C);
+    }
+
+    //Verify that the methods are run in separate threads in true parallel fashion by checking that the start and run
+    //times of events that should be run simultaneously start basically at the same time using the timestamps and the
+    //known values of the wait time specified for the event. Verify that the thread IDs of parallel events are
+    //different.
+    @Test
+    public void verifyThatTestMethodsRunInParallelThreads() {
+        verifyParallelismForTestMethodEvents(SUITE_A, SUITE_A_TEST_A, 3);
+        verifyParallelismForTestMethodEvents(SUITE_B, SUITE_B_TEST_A, 6);
+        verifyParallelismForTestMethodEvents(SUITE_B, SUITE_B_TEST_B, 20);
+        verifyParallelismForTestMethodEvents(SUITE_C, SUITE_C_TEST_A, 10);
+        verifyParallelismForTestMethodEvents(SUITE_C, SUITE_C_TEST_B, 5);
+        verifyParallelismForTestMethodEvents(SUITE_C, SUITE_C_TEST_C, 12);
+    }
+
+    @Test
+    public void verifyThreadCountsForTestMethodLevelEvents() {
+        verifyThreadCounts(SUITE_A, SUITE_A_TEST_A, 3);
+        verifyThreadCounts(SUITE_B, SUITE_B_TEST_A, 6);
+        verifyThreadCounts(SUITE_B, SUITE_B_TEST_B, 20);
+        verifyThreadCounts(SUITE_C, SUITE_C_TEST_A, 10);
+        verifyThreadCounts(SUITE_C, SUITE_C_TEST_B, 5);
+        verifyThreadCounts(SUITE_C, SUITE_C_TEST_C, 12);
+    }
+
+    private static void verifyEventsForTestMethodRunInSameThread(Class<?> testClass, String suiteName, String
+            testName) {
+
+        for(Method method : testClass.getDeclaredMethods()) {
+            Multimap<Object, EventLog> testMethodEventLogs = getTestMethodEventLogsForMethod(suiteName, testName,
+                    testClass.getCanonicalName(), method.getName());
+
+            long threadId = -1;
+
+            for(EventLog eventLog : testMethodEventLogs.get(testMethodEventLogs.keySet().toArray()[0])) {
+                if (threadId == -1) {
+                    threadId = eventLog.getThreadId();
+                } else {
+                    assertEquals(eventLog.getThreadId(), threadId, "All of the method level events for the test " +
+                            "method " + method.getName() + " in the test class " + testClass.getCanonicalName() +
+                            " for the test " + suiteName + " should be run in the same thread");
+                }
+            }
+        }
+    }
+
+    private static void verifyParallelismForTestMethodEvents(String suiteName, String testName, int
+            threadCount) {
+        List<EventLog> testMethodEventLogs = getTestMethodLevelEventLogsForTest(suiteName, testName);
+
+        List<String> methodsAlreadyExecuted = new ArrayList<>();
+        List<Long> activeMethodEventThreadIds = new ArrayList<>();
+
+        for(int i = 1; i < testMethodEventLogs.size(); i = i + threadCount * 3) {
+            List<EventLog> eventLogListenerStartSublist;
+
+            if(testMethodEventLogs.size() - i < threadCount * 3) {
+
+                int remainder = testMethodEventLogs.size() % (threadCount * 3);
+                int blockSize = remainder / 3;
+
+                eventLogListenerStartSublist = testMethodEventLogs.subList(testMethodEventLogs.size() - remainder,
+                        testMethodEventLogs.size() - remainder + blockSize);
+
+            } else {
+                eventLogListenerStartSublist = testMethodEventLogs.subList(i - 1, i + threadCount - 1);
+            }
+
+
+            if(!methodsAlreadyExecuted.isEmpty()) {
+                verifyTestMethodListenerStartEventLogBlock(eventLogListenerStartSublist, testName, threadCount,
+                        methodsAlreadyExecuted, activeMethodEventThreadIds);
+            } else {
+                verifyTestMethodListenerStartEventLogBlock(eventLogListenerStartSublist, testName, threadCount);
+
+                for(EventLog eventLog : eventLogListenerStartSublist) {
+                    activeMethodEventThreadIds.add(eventLog.getThreadId());
+                }
+
+            }
+
+            List<String> methodsExecuting = new ArrayList<>();
+
+            for(EventLog eventLog : eventLogListenerStartSublist) {
+                methodsExecuting.add(eventLog.getData(CLASS_NAME) + (String) eventLog.getData(METHOD_NAME));
+            }
+
+            List<EventLog> eventLogMethodExecuteSublist;
+
+            if(testMethodEventLogs.size() - i < threadCount * 3) {
+                int remainder = testMethodEventLogs.size() % (threadCount * 3);
+                int blockSize = remainder / 3;
+
+                eventLogMethodExecuteSublist = testMethodEventLogs.subList(testMethodEventLogs.size() - remainder +
+                                blockSize, testMethodEventLogs.size() - remainder + 2 * blockSize);
+            }
+            else {
+                eventLogMethodExecuteSublist = testMethodEventLogs.subList(i + threadCount - 1,
+                        i + 2 * threadCount - 1);
+            }
+
+            verifyTestMethodExecutionEventLogBlock(eventLogMethodExecuteSublist, testName, threadCount,
+                    methodsExecuting, activeMethodEventThreadIds);
+            verifyTimingOfEvents(eventLogListenerStartSublist, eventLogMethodExecuteSublist, 1050, "The test method " +
+                    "execution events for a block of simultaneously executing methods should be within 1050 " +
+                    "milliseconds of their test method listener's onTestStart events");
+
+            List<EventLog> eventLogMethodListenerPassSublist;
+
+            if(testMethodEventLogs.size() - i < threadCount * 3) {
+                int remainder = testMethodEventLogs.size() % (threadCount * 3);
+                int blockSize = remainder / 3;
+
+                eventLogMethodListenerPassSublist = testMethodEventLogs.subList(testMethodEventLogs.size() - remainder +
+                        2 * blockSize, testMethodEventLogs.size() - remainder + 3 * blockSize );
+            } else {
+                eventLogMethodListenerPassSublist = testMethodEventLogs.subList(i + 2 * threadCount - 1,
+                        i + 3 * threadCount - 1);
+            }
+
+            verifyTestMethodListenerPassEventLogBlock(eventLogMethodListenerPassSublist, testName, threadCount,
+                    methodsExecuting, activeMethodEventThreadIds);
+            verifyTimingOfEvents(eventLogMethodExecuteSublist, eventLogMethodListenerPassSublist, 5050, "The test " +
+                    "method listener's onTestSuccess events for a block of simultaneously executing methods should " +
+                    "be within 5050 milliseconds of their execution events");
+
+            methodsAlreadyExecuted.addAll(methodsExecuting);
+        }
+    }
+
+    private static void verifyTestMethodListenerStartEventLogBlock(List<EventLog> listenerStartEventLogs, String
+            testName, int threadCount) {
+
+        verifyEventTypeForMethodLevelEvents(listenerStartEventLogs, LISTENER_TEST_METHOD_START, "The thread count is " +
+                threadCount + " for " + testName + " so more more than " + threadCount + " methods should start " +
+                "running at the same time if there are more than " + threadCount + " methods remaining to execute.");
+        verifyDifferentThreadIdsForEvents(listenerStartEventLogs, "The thread count is " + threadCount + " for " +
+                testName + " so the thread IDs for all the test method listener's onTestStart method " + "the " +
+                threadCount + "currently executing test methods should be different");
+        verifyTimingOfEvents(listenerStartEventLogs, 50,  "The test method listener's onTestStart method " +
+                "for a block of simultaneously executing methods should be within 50 milliseconds of each other");
+    }
+
+    private static void verifyTestMethodListenerStartEventLogBlock(List<EventLog> listenerStartEventLogs, String
+            testName, int threadCount, List<String> methodsAlreadyExecuted, List<Long> activeThreadIds) {
+
+        for(EventLog eventLog : listenerStartEventLogs) {
+            assertTrue(activeThreadIds.contains(eventLog.getThreadId()), "The thread count is " + threadCount +
+                    " for " + testName + " so the thread IDs should be recycled when a brand new block of methods " +
+                    "begins to execute");
+            assertFalse(methodsAlreadyExecuted.contains(eventLog.getData(CLASS_NAME) +
+                    (String)eventLog.getData(METHOD_NAME)), "After the test method listener's onTestSuccess event " +
+                    "is logged for a test method, no subsequent test method level event should belong to that method");
+        }
+
+        verifyTestMethodListenerStartEventLogBlock(listenerStartEventLogs, testName, threadCount);
+    }
+
+    private static void verifyTestMethodExecutionEventLogBlock(List<EventLog> testMethodExecutionEventLogs, String
+            testName, int threadCount, List<String> methodsExecuting, List<Long> activeThreadIds) {
+        verifyEventTypeForMethodLevelEvents(testMethodExecutionEventLogs, TEST_METHOD_EXECUTION, "The thread count " +
+                "is " + threadCount + " for " + testName + " so no more than " + threadCount + " methods should be " +
+                "executing at the same time.");
+        verifyDifferentThreadIdsForEvents(testMethodExecutionEventLogs, "The thread count is " + threadCount + " for " +
+                testName + " so the thread IDs for the test method execution events for the " + threadCount +
+                "currently executing test methods should be different");
+
+        for(EventLog eventLog : testMethodExecutionEventLogs) {
+            assertTrue(activeThreadIds.contains(eventLog.getThreadId()), "The thread count is " + threadCount +
+                    " for " + testName + " so the thread IDs for the " + threadCount + " methods' execution events " +
+                    "should be the same as the thread IDs for their test method listener's onTestStart events");
+            assertTrue(methodsExecuting.contains(eventLog.getData(CLASS_NAME) + (String)eventLog.getData(METHOD_NAME)),
+                    "The thread count is " + threadCount + " for " + testName + " so " + threadCount + " methods " +
+                            "should be running at the same time. The test execution events following the test method " +
+                            "listener's onTestStart events for a block of simultaneously running test methods should " +
+                            "all belong to the same " + threadCount + " methods");
+        }
+
+        verifyTimingOfEvents(testMethodExecutionEventLogs, 50, "The test method execution events for a block of " +
+                "simultaneously executing methods should be within 50 milliseconds of each other");
+    }
+
+    private static void verifyTestMethodListenerPassEventLogBlock(List<EventLog> testMethodListenerPassEventLogs,
+            String testName, int threadCount, List<String> methodsExecuting, List<Long> activeThreadIds) {
+        verifyEventTypeForMethodLevelEvents(testMethodListenerPassEventLogs,  LISTENER_TEST_METHOD_PASS, "The thread " +
+                "count is " + threadCount + " for " + testName + " so no more than " + threadCount + " test listener " +
+                "onTestSuccess methods should be executing at the same time.");
+        verifyDifferentThreadIdsForEvents(testMethodListenerPassEventLogs, "The thread count is " + threadCount +
+                " for " + testName + " so the thread IDs for the test method listener onTestSuccess events for the " +
+                threadCount + "currently executing test methods should be different");
+
+
+        for(EventLog eventLog : testMethodListenerPassEventLogs) {
+            assertTrue(activeThreadIds.contains(eventLog.getThreadId()), "The thread count is " + threadCount +
+                    " for " + testName + " so the thread IDs for the " + threadCount + " methods' test listener " +
+                    "onTestSuccess events should be the same as the thread IDs for their execution events");
+            assertTrue(methodsExecuting.contains(eventLog.getData(CLASS_NAME) + (String)eventLog.getData(METHOD_NAME)),
+                    "The thread count is " + threadCount + " for " + testName + " so no more than " + threadCount +
+                            " methods should be running at the same time. The test method listener's onTestSuccess " +
+                            "events following the execution events for a block of simultaneously running test " +
+                            "methods should all belong to the same " + threadCount + " methods");
+        }
+
+        verifyTimingOfEvents(testMethodListenerPassEventLogs, 50, "The test method listener's onTestSuccess events " +
+                "for a block of simultaneously executing methods should be within 50 milliseconds of each other");
+    }
+
+    private static void verifyEventTypeForMethodLevelEvents(List<EventLog> eventLogs, TestNgRunEvent event, String
+            failMessage) {
+        for(EventLog eventLog : eventLogs) {
+            assertTrue(eventLog.getEvent() == event, failMessage);
+        }
+    }
+
+    private static void verifyDifferentThreadIdsForEvents(List<EventLog> eventLogs, String failMessage) {
+        List<Long> threadIds = new ArrayList<>();
+
+        for(EventLog eventLog : eventLogs) {
+            if(threadIds.contains(eventLog.getThreadId())) {
+                fail(failMessage);
+            }
+
+            threadIds.add(eventLog.getThreadId());
+        }
+    }
+
+    private static void verifyTimingOfEvents(List<EventLog> eventLogs, int timingRange, String failMessage) {
+        for(int i = 0; i < eventLogs.size() - 1; i++) {
+            for(int j = i + 1; j < eventLogs.size(); j++) {
+                assertTrue(Math.abs(eventLogs.get(i).getTimeOfEvent() - eventLogs.get(j).getTimeOfEvent()) <=
+                        timingRange, failMessage);
+            }
+        }
+    }
+
+    private static void verifyTimingOfEvents(List<EventLog> firstEventLogBlock, List<EventLog> secondEventLogBlock,
+            int timingRange, String failMessage) {
+        for(int i = 0; i < firstEventLogBlock.size() - 1; i++) {
+            for(int j = 0; j < secondEventLogBlock.size() - 1; j++) {
+                assertTrue(Math.abs(firstEventLogBlock.get(i).getTimeOfEvent() -
+                        secondEventLogBlock.get(j).getTimeOfEvent()) <= timingRange, failMessage);
+            }
+        }
+    }
+
+    private static void verifyThreadCounts(String suiteName, String testName, int threadCount) {
+        for(EventLog eventLog : getTestMethodLevelEventLogsForTest(suiteName, testName)) {
+
+            assertTrue(eventLog.getActiveThreadCount() <= threadCount + 1 && eventLog.getActiveThreadCount() >= 2,
+                    "The thread count when the test method level events are logged should be at least two: the " +
+                            "methods should have a thread and the suite and test level events should have a thread. " +
+                            "Moreover, the thread count when the test level events are logged should be no more than " +
+                            threadCount + 1 + " because the thread count is " + threadCount);
+        }
+    }
+}

--- a/src/test/java/test/thread/parallelization/ParallelByMethodsMultipleSuitesTestsClassesTest.java
+++ b/src/test/java/test/thread/parallelization/ParallelByMethodsMultipleSuitesTestsClassesTest.java
@@ -24,19 +24,15 @@ import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHOD
 import static test.thread.parallelization.TestNgRunStateTracker.getAllEventLogsForSuite;
 import static test.thread.parallelization.TestNgRunStateTracker.getAllEventLogsForTest;
 
-import static test.thread.parallelization.TestNgRunStateTracker.getSuiteListenerFinishActiveThreadCount;
 import static test.thread.parallelization.TestNgRunStateTracker.getSuiteListenerFinishThreadId;
 import static test.thread.parallelization.TestNgRunStateTracker.getSuiteListenerFinishTimestamp;
 import static test.thread.parallelization.TestNgRunStateTracker.getSuiteListenerStartEventLogs;
-import static test.thread.parallelization.TestNgRunStateTracker.getSuiteListenerStartActiveThreadCount;
 import static test.thread.parallelization.TestNgRunStateTracker.getSuiteListenerStartThreadId;
 import static test.thread.parallelization.TestNgRunStateTracker.getSuiteListenerStartTimestamp;
 
-import static test.thread.parallelization.TestNgRunStateTracker.getTestListenerFinishActiveThreadCount;
 import static test.thread.parallelization.TestNgRunStateTracker.getTestListenerFinishThreadId;
 import static test.thread.parallelization.TestNgRunStateTracker.getTestListenerFinishTimestamp;
 import static test.thread.parallelization.TestNgRunStateTracker.getTestListenerStartEventLogsForSuite;
-import static test.thread.parallelization.TestNgRunStateTracker.getTestListenerStartActiveThreadCount;
 import static test.thread.parallelization.TestNgRunStateTracker.getTestListenerStartThreadId;
 import static test.thread.parallelization.TestNgRunStateTracker.getTestListenerStartTimestamp;
 
@@ -100,22 +96,11 @@ public class ParallelByMethodsMultipleSuitesTestsClassesTest extends BaseParalle
     private Long suiteTwoListenerFinishThreadId;
     private Long suiteThreeListenerFinishThreadId;
 
-    private Integer suiteOneListenerStartThreadCount;
-    private Integer suiteTwoListenerStartThreadCount;
-    private Integer suiteThreeListenerStartThreadCount;
-
-    private Integer suiteOneListenerFinishThreadCount;
-    private Integer suiteTwoListenerFinishThreadCount;
-    private Integer suiteThreeListenerFinishThreadCount;
-
     private Long suiteOneTestOneListenerStartTimestamp;
     private Long suiteOneTestOneListenerFinishTimestamp;
     
     private Long suiteOneTestOneListenerStartThreadId;
     private Long suiteOneTestOneListenerFinishThreadId;
-
-    private Integer suiteOneTestOneListenerStartThreadCount;
-    private Integer suiteOneTestOneListenerFinishThreadCount;
 
     private Long suiteTwoTestOneListenerStartTimestamp;
     private Long suiteTwoTestTwoListenerStartTimestamp;
@@ -126,11 +111,6 @@ public class ParallelByMethodsMultipleSuitesTestsClassesTest extends BaseParalle
     private Long suiteTwoTestTwoListenerStartThreadId;
     private Long suiteTwoTestOneListenerFinishThreadId;
     private Long suiteTwoTestTwoListenerFinishThreadId;
-
-    private Integer suiteTwoTestOneListenerStartThreadCount;
-    private Integer suiteTwoTestTwoListenerStartThreadCount;
-    private Integer suiteTwoTestOneListenerFinishThreadCount;
-    private Integer suiteTwoTestTwoListenerFinishThreadCount;
     
     private Long suiteThreeTestOneListenerStartTimestamp;
     private Long suiteThreeTestTwoListenerStartTimestamp;
@@ -145,13 +125,6 @@ public class ParallelByMethodsMultipleSuitesTestsClassesTest extends BaseParalle
     private Long suiteThreeTestOneListenerFinishThreadId;
     private Long suiteThreeTestTwoListenerFinishThreadId;
     private Long suiteThreeTestThreeListenerFinishThreadId;
-
-    private Integer suiteThreeTestOneListenerStartThreadCount;
-    private Integer suiteThreeTestTwoListenerStartThreadCount;
-    private Integer suiteThreeTestThreeListenerStartThreadCount;
-    private Integer suiteThreeTestOneListenerFinishThreadCount;
-    private Integer suiteThreeTestTwoListenerFinishThreadCount;
-    private Integer suiteThreeTestThreeListenerFinishThreadCount;
 
     private Multimap<Object,EventLog> suiteOneTestOneFiveMethodsClassEventLogMap;
     private Multimap<Object,EventLog> suiteOneTestOneSixMethodsClassEventLogMap;
@@ -283,22 +256,11 @@ public class ParallelByMethodsMultipleSuitesTestsClassesTest extends BaseParalle
         suiteTwoListenerFinishThreadId = getSuiteListenerFinishThreadId(SUITE_B);
         suiteThreeListenerFinishThreadId= getSuiteListenerFinishThreadId(SUITE_C);
 
-        suiteOneListenerStartThreadCount = getSuiteListenerStartActiveThreadCount(SUITE_A);
-        suiteTwoListenerStartThreadCount = getSuiteListenerStartActiveThreadCount(SUITE_B);
-        suiteThreeListenerStartThreadCount = getSuiteListenerStartActiveThreadCount(SUITE_C);
-
-        suiteOneListenerFinishThreadCount = getSuiteListenerFinishActiveThreadCount(SUITE_A);
-        suiteTwoListenerFinishThreadCount = getSuiteListenerFinishActiveThreadCount(SUITE_B);
-        suiteThreeListenerFinishThreadCount = getSuiteListenerFinishActiveThreadCount(SUITE_C);
-
         suiteOneTestOneListenerStartTimestamp = getTestListenerStartTimestamp(SUITE_A, SUITE_A_TEST_A);
         suiteOneTestOneListenerFinishTimestamp = getTestListenerFinishTimestamp(SUITE_A, SUITE_A_TEST_A);
 
         suiteOneTestOneListenerStartThreadId = getTestListenerStartThreadId(SUITE_A, SUITE_A_TEST_A);
         suiteOneTestOneListenerFinishThreadId = getTestListenerFinishThreadId(SUITE_A, SUITE_A_TEST_A);
-
-        suiteOneTestOneListenerStartThreadCount = getTestListenerStartActiveThreadCount(SUITE_A, SUITE_A_TEST_A);
-        suiteOneTestOneListenerFinishThreadCount = getTestListenerFinishActiveThreadCount(SUITE_A, SUITE_A_TEST_A);
 
         suiteTwoTestOneListenerStartTimestamp = getTestListenerStartTimestamp(SUITE_B, SUITE_B_TEST_A);
         suiteTwoTestTwoListenerStartTimestamp = getTestListenerStartTimestamp(SUITE_B, SUITE_B_TEST_B);
@@ -309,11 +271,6 @@ public class ParallelByMethodsMultipleSuitesTestsClassesTest extends BaseParalle
         suiteTwoTestTwoListenerStartThreadId = getTestListenerStartThreadId(SUITE_B, SUITE_B_TEST_B);
         suiteTwoTestOneListenerFinishThreadId = getTestListenerFinishThreadId(SUITE_B, SUITE_B_TEST_A);
         suiteTwoTestTwoListenerFinishThreadId = getTestListenerFinishThreadId(SUITE_B, SUITE_B_TEST_B);
-
-        suiteTwoTestOneListenerStartThreadCount = getTestListenerStartActiveThreadCount(SUITE_B, SUITE_B_TEST_A);
-        suiteTwoTestTwoListenerStartThreadCount = getTestListenerStartActiveThreadCount(SUITE_B, SUITE_B_TEST_B);
-        suiteTwoTestOneListenerFinishThreadCount = getTestListenerFinishActiveThreadCount(SUITE_B, SUITE_B_TEST_A);
-        suiteTwoTestTwoListenerFinishThreadCount = getTestListenerFinishActiveThreadCount(SUITE_B, SUITE_B_TEST_B);
 
         suiteThreeTestOneListenerStartTimestamp = getTestListenerStartTimestamp(SUITE_C, SUITE_C_TEST_A);
         suiteThreeTestTwoListenerStartTimestamp = getTestListenerStartTimestamp(SUITE_C, SUITE_C_TEST_B);
@@ -329,13 +286,6 @@ public class ParallelByMethodsMultipleSuitesTestsClassesTest extends BaseParalle
         suiteThreeTestOneListenerFinishThreadId = getTestListenerFinishThreadId(SUITE_C, SUITE_C_TEST_A);
         suiteThreeTestTwoListenerFinishThreadId = getTestListenerFinishThreadId(SUITE_C, SUITE_C_TEST_B);
         suiteThreeTestThreeListenerFinishThreadId = getTestListenerFinishThreadId(SUITE_C, SUITE_C_TEST_C);
-
-        suiteThreeTestOneListenerStartThreadCount = getTestListenerStartActiveThreadCount(SUITE_C, SUITE_C_TEST_A);
-        suiteThreeTestTwoListenerStartThreadCount = getTestListenerStartActiveThreadCount(SUITE_C, SUITE_C_TEST_B);
-        suiteThreeTestThreeListenerStartThreadCount = getTestListenerStartActiveThreadCount(SUITE_C, SUITE_C_TEST_C);
-        suiteThreeTestOneListenerFinishThreadCount = getTestListenerFinishActiveThreadCount(SUITE_C, SUITE_C_TEST_A);
-        suiteThreeTestTwoListenerFinishThreadCount = getTestListenerFinishActiveThreadCount(SUITE_C, SUITE_C_TEST_B);
-        suiteThreeTestThreeListenerFinishThreadCount = getTestListenerFinishActiveThreadCount(SUITE_C, SUITE_C_TEST_C);
 
         suiteOneTestOneFiveMethodsClassEventLogMap = getTestMethodEventLogsForClass(SUITE_A, SUITE_A_TEST_A,
                 TestClassAWithNoDepsSample.class.getCanonicalName());
@@ -782,76 +732,6 @@ public class ParallelByMethodsMultipleSuitesTestsClassesTest extends BaseParalle
                 "the suite level and the test level events for all the test suites should be the same");
     }
 
-    @Test
-    public void verifyThreadCountsForSuiteAndTestLevelEvents() {
-        assertEquals(suiteOneListenerStartThreadCount, suiteOneListenerFinishThreadCount, "The number of active " +
-                "threads when the suite listener's onStart event for " + SUITE_A + " was logged should be the same " +
-                "as the number of active threads when the suite listener's onFinish event for " + SUITE_A + " was " +
-                "logged");
-        assertEquals(suiteOneTestOneListenerStartThreadCount, suiteOneTestOneListenerFinishThreadCount, "The number " +
-                "of active threads when the test listener's onStart event for " + SUITE_A_TEST_A + " was logged " +
-                "should be the same as the number of active threads when the test listener's onFinish event for " +
-                SUITE_A_TEST_A + " was logged");
-
-        assertEquals(suiteTwoListenerStartThreadCount, suiteTwoListenerFinishThreadCount, "The number of active " +
-                "threads when the suite listener's onStart event for " + SUITE_B + " was logged should be the same " +
-                "as the number of active threads when the suite listener's onFinish event for " + SUITE_B + " was " +
-                "logged");
-        assertEquals(suiteTwoTestOneListenerStartThreadCount, suiteTwoTestOneListenerFinishThreadCount, "The number " +
-                "of active threads when the test listener's onStart event for " + SUITE_B_TEST_A + " was logged " +
-                "should be the same as the number of active threads when the test listener's onFinish event for " +
-                SUITE_B_TEST_A + " was logged");
-        assertEquals(suiteTwoTestTwoListenerStartThreadCount, suiteTwoTestTwoListenerFinishThreadCount, "The number " +
-                "of active threads when the test listener's onStart event for " + SUITE_B_TEST_B + " was logged " +
-                "should be the same as the number of active threads when the test listener's onFinish event for " +
-                SUITE_B_TEST_B + " was logged");
-
-        assertEquals(suiteThreeListenerStartThreadCount, suiteThreeListenerFinishThreadCount, "The number of active " +
-                "threads when the suite listener's onStart event for " + SUITE_C + " was logged should be the same " +
-                "as the number of active threads when the suite listener's onFinish event for " + SUITE_C + " was " +
-                "logged");
-        assertEquals(suiteThreeTestOneListenerStartThreadCount, suiteThreeTestOneListenerFinishThreadCount, "The " +
-                "number of active threads when the test listener's onStart event for " + SUITE_C_TEST_A + " was " +
-                "logged should be the same as the number of active threads when the test listener's onFinish event " +
-                "for " + SUITE_C_TEST_A + " was logged");
-        assertEquals(suiteThreeTestTwoListenerStartThreadCount, suiteThreeTestTwoListenerFinishThreadCount, "The " +
-                "number of active threads when the test listener's onStart event for " + SUITE_C_TEST_B + " was " +
-                "logged should be the same as the number of active threads when the test listener's onFinish event " +
-                "for " + SUITE_C_TEST_B + " was logged");
-        assertEquals(suiteThreeTestThreeListenerStartThreadCount, suiteThreeTestThreeListenerFinishThreadCount, "The " +
-                "number of active threads when the test listener's onStart event for " + SUITE_C_TEST_C + " was " +
-                "logged should be the same as the number of active threads when the test listener's onFinish event " +
-                "for " + SUITE_C_TEST_C + " was logged");
-
-        assertEquals(suiteOneListenerStartThreadCount, suiteTwoListenerStartThreadCount, "The number of active " +
-                "threads when the suite listener's onStart method for " + SUITE_A + " was logged should be the same " +
-                "as the number of active threads when the suite listener's onStart method for " + SUITE_B + " was " +
-                "logged");
-        assertEquals(suiteOneListenerStartThreadCount, suiteThreeListenerStartThreadCount, "The number of active " +
-                "threads when the suite listener's onStart method for " + SUITE_A + " was logged should be the same " +
-                "as the number of active threads when the suite listener's onStart method for " + SUITE_C + " was " +
-                "logged");
-
-        assertEquals(suiteOneListenerStartThreadCount, suiteOneTestOneListenerStartThreadCount, "The active thread " +
-                "count when all the suite level and the test level events for all the test suites were logged should " +
-                "be the same");
-        assertEquals(suiteOneListenerStartThreadCount, suiteTwoTestOneListenerStartThreadCount, "The active thread " +
-                "count when all the suite level and the test level events for all the test suites were logged should " +
-                "be the same");
-        assertEquals(suiteOneListenerStartThreadCount, suiteTwoTestTwoListenerStartThreadCount, "The active thread " +
-                "count when all the suite level and the test level events for all the test suites were logged should " +
-                "be the same");
-        assertEquals(suiteOneListenerStartThreadCount, suiteThreeTestOneListenerStartThreadCount, "The active thread " +
-                "count when all the suite level and the test level events for all the test suites were logged should " +
-                "be the same");
-        assertEquals(suiteOneListenerStartThreadCount, suiteThreeTestTwoListenerStartThreadCount, "The active thread " +
-                "count when all the suite level and the test level events for all the test suites were logged should " +
-                "be the same");
-        assertEquals(suiteOneListenerStartThreadCount, suiteThreeTestThreeListenerStartThreadCount, "The active " +
-                "thread count when all the suite level and the test level events for all the test suites were logged " +
-                "should be the same");
-    }
-
     //Verify that there is only a single test class instance associated with each of the test methods from the sample
     //classes for every test in all the suites. Verify that instances are unique and separate if the same test class
     //is included in different tests in different suites or in different tests within the same suite
@@ -1144,16 +1024,6 @@ public class ParallelByMethodsMultipleSuitesTestsClassesTest extends BaseParalle
         verifyParallelismForTestMethodEvents(SUITE_C, SUITE_C_TEST_C, 12);
     }
 
-    @Test
-    public void verifyThreadCountsForTestMethodLevelEvents() {
-        verifyThreadCounts(SUITE_A, SUITE_A_TEST_A, 3);
-        verifyThreadCounts(SUITE_B, SUITE_B_TEST_A, 6);
-        verifyThreadCounts(SUITE_B, SUITE_B_TEST_B, 20);
-        verifyThreadCounts(SUITE_C, SUITE_C_TEST_A, 10);
-        verifyThreadCounts(SUITE_C, SUITE_C_TEST_B, 5);
-        verifyThreadCounts(SUITE_C, SUITE_C_TEST_C, 12);
-    }
-
     private static void verifyEventsForTestMethodRunInSameThread(Class<?> testClass, String suiteName, String
             testName) {
 
@@ -1377,17 +1247,6 @@ public class ParallelByMethodsMultipleSuitesTestsClassesTest extends BaseParalle
                 assertTrue(Math.abs(firstEventLogBlock.get(i).getTimeOfEvent() -
                         secondEventLogBlock.get(j).getTimeOfEvent()) <= timingRange, failMessage);
             }
-        }
-    }
-
-    private static void verifyThreadCounts(String suiteName, String testName, int threadCount) {
-        for(EventLog eventLog : getTestMethodLevelEventLogsForTest(suiteName, testName)) {
-
-            assertTrue(eventLog.getActiveThreadCount() <= threadCount + 1 && eventLog.getActiveThreadCount() >= 2,
-                    "The thread count when the test method level events are logged should be at least two: the " +
-                            "methods should have a thread and the suite and test level events should have a thread. " +
-                            "Moreover, the thread count when the test level events are logged should be no more than " +
-                            threadCount + 1 + " because the thread count is " + threadCount);
         }
     }
 }

--- a/src/test/java/test/thread/parallelization/ParallelByMethodsMultipleSuitesTestsClassesTest.java
+++ b/src/test/java/test/thread/parallelization/ParallelByMethodsMultipleSuitesTestsClassesTest.java
@@ -1157,19 +1157,25 @@ public class ParallelByMethodsMultipleSuitesTestsClassesTest extends BaseParalle
     private static void verifyEventsForTestMethodRunInSameThread(Class<?> testClass, String suiteName, String
             testName) {
 
-        for(Method method : testClass.getDeclaredMethods()) {
-            Multimap<Object, EventLog> testMethodEventLogs = getTestMethodEventLogsForMethod(suiteName, testName,
-                    testClass.getCanonicalName(), method.getName());
+        for(Method method : testClass.getMethods()) {
+            if (method.getDeclaringClass().equals(testClass)) {
+                Multimap<Object, EventLog> testMethodEventLogs = getTestMethodEventLogsForMethod(suiteName, testName,
+                        testClass.getCanonicalName(), method.getName());
 
-            long threadId = -1;
+                assertTrue(testMethodEventLogs.keySet().size() > 0, "There should be event logs for the method " +
+                        method.getName() + " in an instance of " + testClass.getCanonicalName() + " for test " +
+                        testName + " in suite " + suiteName);
 
-            for(EventLog eventLog : testMethodEventLogs.get(testMethodEventLogs.keySet().toArray()[0])) {
-                if (threadId == -1) {
-                    threadId = eventLog.getThreadId();
-                } else {
-                    assertEquals(eventLog.getThreadId(), threadId, "All of the method level events for the test " +
-                            "method " + method.getName() + " in the test class " + testClass.getCanonicalName() +
-                            " for the test " + suiteName + " should be run in the same thread");
+                long threadId = -1;
+
+                for (EventLog eventLog : testMethodEventLogs.get(testMethodEventLogs.keySet().toArray()[0])) {
+                    if (threadId == -1) {
+                        threadId = eventLog.getThreadId();
+                    } else {
+                        assertEquals(eventLog.getThreadId(), threadId, "All of the method level events for the test " +
+                                "method " + method.getName() + " in the test class " + testClass.getCanonicalName() +
+                                " for the test " + suiteName + " should be run in the same thread");
+                    }
                 }
             }
         }

--- a/src/test/java/test/thread/parallelization/ParallelByMethodsSingleSuiteSingleTestSingleClassTest.java
+++ b/src/test/java/test/thread/parallelization/ParallelByMethodsSingleSuiteSingleTestSingleClassTest.java
@@ -9,22 +9,16 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.testng.xml.XmlSuite;
 
-import test.thread.parallelization.TestNgRunStateTracker.EventLog;
-
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
-import static test.thread.parallelization.TestNgRunStateTracker.getSuiteListenerFinishActiveThreadCount;
 import static test.thread.parallelization.TestNgRunStateTracker.getSuiteListenerFinishThreadId;
 import static test.thread.parallelization.TestNgRunStateTracker.getSuiteListenerFinishTimestamp;
-import static test.thread.parallelization.TestNgRunStateTracker.getSuiteListenerStartActiveThreadCount;
 import static test.thread.parallelization.TestNgRunStateTracker.getSuiteListenerStartThreadId;
 import static test.thread.parallelization.TestNgRunStateTracker.getSuiteListenerStartTimestamp;
 import static test.thread.parallelization.TestNgRunStateTracker.getTestListenerFinishThreadId;
-import static test.thread.parallelization.TestNgRunStateTracker.getTestListenerFinishActiveThreadCount;
 import static test.thread.parallelization.TestNgRunStateTracker.getTestListenerFinishTimestamp;
 import static test.thread.parallelization.TestNgRunStateTracker.getTestListenerStartThreadId;
-import static test.thread.parallelization.TestNgRunStateTracker.getTestListenerStartActiveThreadCount;
 import static test.thread.parallelization.TestNgRunStateTracker.getTestListenerStartTimestamp;
 import static test.thread.parallelization.TestNgRunStateTracker.getTestMethodEventLogsForMethod;
 import static test.thread.parallelization.TestNgRunStateTracker.getTestMethodExecutionTimestamps;
@@ -33,7 +27,6 @@ import static test.thread.parallelization.TestNgRunStateTracker.getTestMethodLis
 import static test.thread.parallelization.TestNgRunStateTracker.getTestMethodListenerPassTimestamps;
 import static test.thread.parallelization.TestNgRunStateTracker.getTestMethodListenerStartThreadIds;
 import static test.thread.parallelization.TestNgRunStateTracker.getTestMethodListenerStartTimestamps;
-import static test.thread.parallelization.TestNgRunStateTracker.getAllTestMethodLevelEventLogs;
 
 import static test.thread.parallelization.TestNgRunStateTracker.reset;
 
@@ -44,8 +37,6 @@ public class ParallelByMethodsSingleSuiteSingleTestSingleClassTest extends BaseP
     private Long testListenerOnStartTimestamp;
     private Long testListenerOnFinishTimestamp;
     private Long testListenerOnStartThreadId;
-
-    private Integer suiteListenerOnStartThreadCount;
 
     private Long testMethodAListenerOnStartTimestamp;
     private Long testMethodBListenerOnStartTimestamp;
@@ -100,7 +91,6 @@ public class ParallelByMethodsSingleSuiteSingleTestSingleClassTest extends BaseP
 
         tng.run();
 
-        suiteListenerOnStartThreadCount = getSuiteListenerStartActiveThreadCount("SingleTestSuite");
         testListenerOnStartTimestamp = getTestListenerStartTimestamp("SingleTestSuite", "SingleTestClassTest");
         testListenerOnFinishTimestamp = getTestListenerFinishTimestamp("SingleTestSuite", "SingleTestClassTest");
         testListenerOnStartThreadId = getTestListenerStartThreadId("SingleTestSuite", "SingleTestClassTest");
@@ -225,21 +215,6 @@ public class ParallelByMethodsSingleSuiteSingleTestSingleClassTest extends BaseP
         assertEquals(testListenerOnStartThreadId, getTestListenerFinishThreadId("SingleTestSuite",
                 "SingleTestClassTest"), "The thread ID for the onFinish methods for the suite and test listeners " +
                 "should be the same as the thread ID for their onStart methods");
-    }
-
-    @Test
-    public void verifyThreadCountsForSuiteAndTestLevelEvents() {
-        assertEquals(suiteListenerOnStartThreadCount, getTestListenerStartActiveThreadCount("SingleTestSuite",
-                "SingleTestClassTest"), "The number of active threads when the test listener's onStart event was " +
-                "logged should be the same as the number of active threads when the suite listener's onStart " +
-                "event was logged");
-        assertEquals(suiteListenerOnStartThreadCount, getSuiteListenerFinishActiveThreadCount("SingleTestSuite"),
-                "The number of active threads when the suite listener's onFinish event was logged should be the same " +
-                        "as the number of active threads when the suite listener's onStart event was logged");
-        assertEquals(suiteListenerOnStartThreadCount, getTestListenerFinishActiveThreadCount("SingleTestSuite",
-                "SingleTestClassTest"), "The number of active threads when the test listener's onFinish event was " +
-                "logged should be the same as the number of active threads when the suite listener's onStart event " +
-                "was logged");
     }
 
     //Verify that there is only a single test class instance associated with each of the test methods from the
@@ -479,16 +454,5 @@ public class ParallelByMethodsSingleSuiteSingleTestSingleClassTest extends BaseP
                         "other methods."
         );
 
-    }
-
-    @Test
-    public void verifyThreadCountsForTestMethodLevelEvents() {
-        for(EventLog eventLog : getAllTestMethodLevelEventLogs()) {
-            assertTrue(eventLog.getActiveThreadCount() <= 6 && eventLog.getActiveThreadCount() >= 2, "The thread " +
-                    "count when the test method level events are logged should be at least two: the methods should " +
-                    "have a thread and the suite and test level events should have a thread. Moreover, the thread " +
-                    "count when the test level events are logged should be no more than six because the thread count " +
-                    "is set to 5.");
-        }
     }
 }

--- a/src/test/java/test/thread/parallelization/ParallelByMethodsSingleSuiteSingleTestSingleClassTest.java
+++ b/src/test/java/test/thread/parallelization/ParallelByMethodsSingleSuiteSingleTestSingleClassTest.java
@@ -1,41 +1,51 @@
 package test.thread.parallelization;
 
+
 import com.google.common.collect.Multimap;
+
 import org.testng.ITestNGListener;
 import org.testng.TestNG;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.testng.xml.XmlSuite;
-import org.testng.xml.XmlTest;
-import test.SimpleBaseTest;
 
-import java.util.HashMap;
-import java.util.Map;
+import test.thread.parallelization.TestNgRunStateTracker.EventLog;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
+
+import static test.thread.parallelization.TestNgRunStateTracker.getSuiteListenerFinishActiveThreadCount;
 import static test.thread.parallelization.TestNgRunStateTracker.getSuiteListenerFinishThreadId;
 import static test.thread.parallelization.TestNgRunStateTracker.getSuiteListenerFinishTimestamp;
+import static test.thread.parallelization.TestNgRunStateTracker.getSuiteListenerStartActiveThreadCount;
 import static test.thread.parallelization.TestNgRunStateTracker.getSuiteListenerStartThreadId;
 import static test.thread.parallelization.TestNgRunStateTracker.getSuiteListenerStartTimestamp;
 import static test.thread.parallelization.TestNgRunStateTracker.getTestListenerFinishThreadId;
+import static test.thread.parallelization.TestNgRunStateTracker.getTestListenerFinishActiveThreadCount;
 import static test.thread.parallelization.TestNgRunStateTracker.getTestListenerFinishTimestamp;
 import static test.thread.parallelization.TestNgRunStateTracker.getTestListenerStartThreadId;
+import static test.thread.parallelization.TestNgRunStateTracker.getTestListenerStartActiveThreadCount;
 import static test.thread.parallelization.TestNgRunStateTracker.getTestListenerStartTimestamp;
 import static test.thread.parallelization.TestNgRunStateTracker.getTestMethodEventLogsForMethod;
 import static test.thread.parallelization.TestNgRunStateTracker.getTestMethodExecutionTimestamps;
-import static test.thread.parallelization.TestNgRunStateTracker.getTestMethodExeuctionThreadIds;
+import static test.thread.parallelization.TestNgRunStateTracker.getTestMethodExecutionThreadIds;
 import static test.thread.parallelization.TestNgRunStateTracker.getTestMethodListenerPassThreadIds;
 import static test.thread.parallelization.TestNgRunStateTracker.getTestMethodListenerPassTimestamps;
 import static test.thread.parallelization.TestNgRunStateTracker.getTestMethodListenerStartThreadIds;
 import static test.thread.parallelization.TestNgRunStateTracker.getTestMethodListenerStartTimestamps;
+import static test.thread.parallelization.TestNgRunStateTracker.getAllTestMethodLevelEventLogs;
+
 import static test.thread.parallelization.TestNgRunStateTracker.reset;
 
-public class ParallelByMethodsSingleSuiteSingleTestSingleClassTest extends SimpleBaseTest {
+//Verify simple test run with a single suite which consists of a single test with a single test class. The thread count
+//is sufficient to run all methods in parallel at once, so no methods should be queued.
+public class ParallelByMethodsSingleSuiteSingleTestSingleClassTest extends BaseParallelizationTest {
 
     private Long testListenerOnStartTimestamp;
     private Long testListenerOnFinishTimestamp;
     private Long testListenerOnStartThreadId;
+
+    private Integer suiteListenerOnStartThreadCount;
 
     private Long testMethodAListenerOnStartTimestamp;
     private Long testMethodBListenerOnStartTimestamp;
@@ -73,97 +83,126 @@ public class ParallelByMethodsSingleSuiteSingleTestSingleClassTest extends Simpl
     private Long testMethodDListenerOnPassThreadId;
     private Long testMethodEListenerOnPassThreadId;
 
-    //Verify simple class with a single suite which consists of a single test with a single test class. The thread count
-    //is sufficient to run all methods in parallel at once, so no methods should be queued.
     @BeforeClass
-    public void singleSuiteSingleTestSingleTestClassNoMethodQueueing() {
+    public void singleSuiteSingleTestSingleTestClass() {
         reset();
 
-        XmlSuite suiteOne = createXmlSuite("SingleTestSuite");
-        suiteOne.setParallel(XmlSuite.ParallelMode.METHODS);
-        suiteOne.setThreadCount(5);
+        XmlSuite suite = createXmlSuite("SingleTestSuite");
+        suite.setParallel(XmlSuite.ParallelMode.METHODS);
+        suite.setThreadCount(5);
 
-        createXmlTest(suiteOne, "SingleTestClassTest", TestClassNoDepsSample.class);
+        createXmlTest(suite, "SingleTestClassTest", TestClassAWithNoDepsSample.class);
 
-        addParams(suiteOne, "SingleTestSuite", "SingleTestClassTest", "5");
+        addParams(suite, "SingleTestSuite", "SingleTestClassTest", "5");
 
-        TestNG tng = create(suiteOne);
+        TestNG tng = create(suite);
         tng.addListener((ITestNGListener)new TestNgRunStateListener());
 
         tng.run();
 
+        suiteListenerOnStartThreadCount = getSuiteListenerStartActiveThreadCount("SingleTestSuite");
         testListenerOnStartTimestamp = getTestListenerStartTimestamp("SingleTestSuite", "SingleTestClassTest");
         testListenerOnFinishTimestamp = getTestListenerFinishTimestamp("SingleTestSuite", "SingleTestClassTest");
         testListenerOnStartThreadId = getTestListenerStartThreadId("SingleTestSuite", "SingleTestClassTest");
 
         Object instanceKey = getTestMethodEventLogsForMethod("SingleTestSuite", "SingleTestClassTest",
-                TestClassNoDepsSample.class.getCanonicalName(), "testMethodA").keySet().toArray()[0];
+                TestClassAWithNoDepsSample.class.getCanonicalName(), "testMethodA").keySet().toArray()[0];
 
         testMethodAListenerOnStartTimestamp = getTestMethodListenerStartTimestamps("SingleTestSuite",
-                "SingleTestClassTest", TestClassNoDepsSample.class.getCanonicalName(), "testMethodA").get(instanceKey);
+                "SingleTestClassTest", TestClassAWithNoDepsSample.class.getCanonicalName(), "testMethodA")
+                .get(instanceKey);
         testMethodBListenerOnStartTimestamp = getTestMethodListenerStartTimestamps("SingleTestSuite",
-                "SingleTestClassTest", TestClassNoDepsSample.class.getCanonicalName(), "testMethodB").get(instanceKey);
+                "SingleTestClassTest", TestClassAWithNoDepsSample.class.getCanonicalName(), "testMethodB")
+                .get(instanceKey);
         testMethodCListenerOnStartTimestamp = getTestMethodListenerStartTimestamps("SingleTestSuite",
-                "SingleTestClassTest", TestClassNoDepsSample.class.getCanonicalName(), "testMethodC").get(instanceKey);
+                "SingleTestClassTest", TestClassAWithNoDepsSample.class.getCanonicalName(), "testMethodC")
+                .get(instanceKey);
         testMethodDListenerOnStartTimestamp = getTestMethodListenerStartTimestamps("SingleTestSuite",
-                "SingleTestClassTest", TestClassNoDepsSample.class.getCanonicalName(), "testMethodD").get(instanceKey);
+                "SingleTestClassTest", TestClassAWithNoDepsSample.class.getCanonicalName(), "testMethodD")
+                .get(instanceKey);
         testMethodEListenerOnStartTimestamp = getTestMethodListenerStartTimestamps("SingleTestSuite",
-                "SingleTestClassTest", TestClassNoDepsSample.class.getCanonicalName(), "testMethodE").get(instanceKey);
+                "SingleTestClassTest", TestClassAWithNoDepsSample.class.getCanonicalName(), "testMethodE")
+                .get(instanceKey);
 
         testMethodAListenerExecutionTimestamp = getTestMethodExecutionTimestamps("SingleTestSuite",
-                "SingleTestClassTest", TestClassNoDepsSample.class.getCanonicalName(), "testMethodA").get(instanceKey);
+                "SingleTestClassTest", TestClassAWithNoDepsSample.class.getCanonicalName(), "testMethodA")
+                .get(instanceKey);
         testMethodBListenerExecutionTimestamp = getTestMethodExecutionTimestamps("SingleTestSuite",
-                "SingleTestClassTest", TestClassNoDepsSample.class.getCanonicalName(), "testMethodB").get(instanceKey);
+                "SingleTestClassTest", TestClassAWithNoDepsSample.class.getCanonicalName(), "testMethodB")
+                .get(instanceKey);
         testMethodCListenerExecutionTimestamp = getTestMethodExecutionTimestamps("SingleTestSuite",
-                "SingleTestClassTest", TestClassNoDepsSample.class.getCanonicalName(), "testMethodC").get(instanceKey);
+                "SingleTestClassTest", TestClassAWithNoDepsSample.class.getCanonicalName(), "testMethodC")
+                .get(instanceKey);
         testMethodDListenerExecutionTimestamp = getTestMethodExecutionTimestamps("SingleTestSuite",
-                "SingleTestClassTest", TestClassNoDepsSample.class.getCanonicalName(), "testMethodD").get(instanceKey);
+                "SingleTestClassTest", TestClassAWithNoDepsSample.class.getCanonicalName(), "testMethodD")
+                .get(instanceKey);
         testMethodEListenerExecutionTimestamp = getTestMethodExecutionTimestamps("SingleTestSuite",
-                "SingleTestClassTest", TestClassNoDepsSample.class.getCanonicalName(), "testMethodE").get(instanceKey);
+                "SingleTestClassTest", TestClassAWithNoDepsSample.class.getCanonicalName(), "testMethodE")
+                .get(instanceKey);
 
         testMethodAListenerOnPassTimestamp = getTestMethodListenerPassTimestamps("SingleTestSuite",
-                "SingleTestClassTest", TestClassNoDepsSample.class.getCanonicalName(), "testMethodA").get(instanceKey);
+                "SingleTestClassTest", TestClassAWithNoDepsSample.class.getCanonicalName(), "testMethodA")
+                .get(instanceKey);
         testMethodBListenerOnPassTimestamp = getTestMethodListenerPassTimestamps("SingleTestSuite",
-                "SingleTestClassTest", TestClassNoDepsSample.class.getCanonicalName(), "testMethodB").get(instanceKey);
+                "SingleTestClassTest", TestClassAWithNoDepsSample.class.getCanonicalName(), "testMethodB")
+                .get(instanceKey);
         testMethodCListenerOnPassTimestamp = getTestMethodListenerPassTimestamps("SingleTestSuite",
-                "SingleTestClassTest", TestClassNoDepsSample.class.getCanonicalName(), "testMethodC").get(instanceKey);
+                "SingleTestClassTest", TestClassAWithNoDepsSample.class.getCanonicalName(), "testMethodC")
+                .get(instanceKey);
         testMethodDListenerOnPassTimestamp = getTestMethodListenerPassTimestamps("SingleTestSuite",
-                "SingleTestClassTest", TestClassNoDepsSample.class.getCanonicalName(), "testMethodD").get(instanceKey);
+                "SingleTestClassTest", TestClassAWithNoDepsSample.class.getCanonicalName(), "testMethodD")
+                .get(instanceKey);
         testMethodEListenerOnPassTimestamp = getTestMethodListenerPassTimestamps("SingleTestSuite",
-                "SingleTestClassTest", TestClassNoDepsSample.class.getCanonicalName(), "testMethodE").get(instanceKey);
+                "SingleTestClassTest", TestClassAWithNoDepsSample.class.getCanonicalName(), "testMethodE")
+                .get(instanceKey);
 
         testMethodAListenerOnStartThreadId = getTestMethodListenerStartThreadIds("SingleTestSuite",
-                "SingleTestClassTest", TestClassNoDepsSample.class.getCanonicalName(), "testMethodA").get(instanceKey);
+                "SingleTestClassTest", TestClassAWithNoDepsSample.class.getCanonicalName(), "testMethodA")
+                .get(instanceKey);
         testMethodBListenerOnStartThreadId = getTestMethodListenerStartThreadIds("SingleTestSuite",
-                "SingleTestClassTest", TestClassNoDepsSample.class.getCanonicalName(), "testMethodB").get(instanceKey);
+                "SingleTestClassTest", TestClassAWithNoDepsSample.class.getCanonicalName(), "testMethodB")
+                .get(instanceKey);
         testMethodCListenerOnStartThreadId = getTestMethodListenerStartThreadIds("SingleTestSuite",
-                "SingleTestClassTest", TestClassNoDepsSample.class.getCanonicalName(), "testMethodC").get(instanceKey);
+                "SingleTestClassTest", TestClassAWithNoDepsSample.class.getCanonicalName(), "testMethodC")
+                .get(instanceKey);
         testMethodDListenerOnStartThreadId = getTestMethodListenerStartThreadIds("SingleTestSuite",
-                "SingleTestClassTest", TestClassNoDepsSample.class.getCanonicalName(), "testMethodD").get(instanceKey);
+                "SingleTestClassTest", TestClassAWithNoDepsSample.class.getCanonicalName(), "testMethodD")
+                .get(instanceKey);
         testMethodEListenerOnStartThreadId = getTestMethodListenerStartThreadIds("SingleTestSuite",
-                "SingleTestClassTest", TestClassNoDepsSample.class.getCanonicalName(), "testMethodE").get(instanceKey);
+                "SingleTestClassTest", TestClassAWithNoDepsSample.class.getCanonicalName(), "testMethodE")
+                .get(instanceKey);
 
-        testMethodAExecutionThreadId = getTestMethodExeuctionThreadIds("SingleTestSuite",
-                "SingleTestClassTest", TestClassNoDepsSample.class.getCanonicalName(), "testMethodA").get(instanceKey);
-        testMethodBExecutionThreadId  = getTestMethodExeuctionThreadIds("SingleTestSuite",
-                "SingleTestClassTest", TestClassNoDepsSample.class.getCanonicalName(), "testMethodB").get(instanceKey);
-        testMethodCExecutionThreadId  = getTestMethodExeuctionThreadIds("SingleTestSuite",
-                "SingleTestClassTest", TestClassNoDepsSample.class.getCanonicalName(), "testMethodC").get(instanceKey);
-        testMethodDExecutionThreadId  = getTestMethodExeuctionThreadIds("SingleTestSuite",
-                "SingleTestClassTest", TestClassNoDepsSample.class.getCanonicalName(), "testMethodD").get(instanceKey);
-        testMethodEExecutionThreadId  = getTestMethodExeuctionThreadIds("SingleTestSuite",
-                "SingleTestClassTest", TestClassNoDepsSample.class.getCanonicalName(), "testMethodE").get(instanceKey);
+        testMethodAExecutionThreadId = getTestMethodExecutionThreadIds("SingleTestSuite",
+                "SingleTestClassTest", TestClassAWithNoDepsSample.class.getCanonicalName(), "testMethodA")
+                .get(instanceKey);
+        testMethodBExecutionThreadId  = getTestMethodExecutionThreadIds("SingleTestSuite",
+                "SingleTestClassTest", TestClassAWithNoDepsSample.class.getCanonicalName(), "testMethodB")
+                .get(instanceKey);
+        testMethodCExecutionThreadId  = getTestMethodExecutionThreadIds("SingleTestSuite",
+                "SingleTestClassTest", TestClassAWithNoDepsSample.class.getCanonicalName(), "testMethodC")
+                .get(instanceKey);
+        testMethodDExecutionThreadId  = getTestMethodExecutionThreadIds("SingleTestSuite",
+                "SingleTestClassTest", TestClassAWithNoDepsSample.class.getCanonicalName(), "testMethodD")
+                .get(instanceKey);
+        testMethodEExecutionThreadId  = getTestMethodExecutionThreadIds("SingleTestSuite",
+                "SingleTestClassTest", TestClassAWithNoDepsSample.class.getCanonicalName(), "testMethodE")
+                .get(instanceKey);
 
         testMethodAListenerOnPassThreadId = getTestMethodListenerPassThreadIds("SingleTestSuite",
-                "SingleTestClassTest", TestClassNoDepsSample.class.getCanonicalName(), "testMethodA").get(instanceKey);
+                "SingleTestClassTest", TestClassAWithNoDepsSample.class.getCanonicalName(), "testMethodA")
+                .get(instanceKey);
         testMethodBListenerOnPassThreadId = getTestMethodListenerPassThreadIds("SingleTestSuite",
-                "SingleTestClassTest", TestClassNoDepsSample.class.getCanonicalName(), "testMethodB").get(instanceKey);
+                "SingleTestClassTest", TestClassAWithNoDepsSample.class.getCanonicalName(), "testMethodB")
+                .get(instanceKey);
         testMethodCListenerOnPassThreadId = getTestMethodListenerPassThreadIds("SingleTestSuite",
-                "SingleTestClassTest", TestClassNoDepsSample.class.getCanonicalName(), "testMethodC").get(instanceKey);
+                "SingleTestClassTest", TestClassAWithNoDepsSample.class.getCanonicalName(), "testMethodC")
+                .get(instanceKey);
         testMethodDListenerOnPassThreadId = getTestMethodListenerPassThreadIds("SingleTestSuite",
-                "SingleTestClassTest", TestClassNoDepsSample.class.getCanonicalName(), "testMethodD").get(instanceKey);
+                "SingleTestClassTest", TestClassAWithNoDepsSample.class.getCanonicalName(), "testMethodD")
+                .get(instanceKey);
         testMethodEListenerOnPassThreadId = getTestMethodListenerPassThreadIds("SingleTestSuite",
-                "SingleTestClassTest", TestClassNoDepsSample.class.getCanonicalName(), "testMethodE").get(instanceKey);
+                "SingleTestClassTest", TestClassAWithNoDepsSample.class.getCanonicalName(), "testMethodE")
+                .get(instanceKey);
     }
 
     //Verify that the suite listener and test listener events have timestamps in the following order: suite start,
@@ -188,51 +227,61 @@ public class ParallelByMethodsSingleSuiteSingleTestSingleClassTest extends Simpl
                 "should be the same as the thread ID for their onStart methods");
     }
 
+    @Test
+    public void verifyThreadCountsForSuiteAndTestLevelEvents() {
+        assertEquals(suiteListenerOnStartThreadCount, getTestListenerStartActiveThreadCount("SingleTestSuite",
+                "SingleTestClassTest"), "The number of active threads when the test listener's onStart event was " +
+                "logged should be the same as the number of active threads when the suite listener's onStart " +
+                "event was logged");
+        assertEquals(suiteListenerOnStartThreadCount, getSuiteListenerFinishActiveThreadCount("SingleTestSuite"),
+                "The number of active threads when the suite listener's onFinish event was logged should be the same " +
+                        "as the number of active threads when the suite listener's onStart event was logged");
+        assertEquals(suiteListenerOnStartThreadCount, getTestListenerFinishActiveThreadCount("SingleTestSuite",
+                "SingleTestClassTest"), "The number of active threads when the test listener's onFinish event was " +
+                "logged should be the same as the number of active threads when the suite listener's onStart event " +
+                "was logged");
+    }
+
     //Verify that there is only a single test class instance associated with each of the test methods from the
     //sample test class
     @Test
     public void verifyOnlyOneInstanceOfTestClassForAllTestMethods() {
         Multimap<Object,TestNgRunStateTracker.EventLog> testMethodAEventLogMap =
-                getTestMethodEventLogsForMethod("SingleTestSuite", "SingleTestClassTest", TestClassNoDepsSample.class
-                        .getCanonicalName(), "testMethodA");
+                getTestMethodEventLogsForMethod("SingleTestSuite", "SingleTestClassTest",
+                        TestClassAWithNoDepsSample.class.getCanonicalName(), "testMethodA");
 
         Multimap<Object,TestNgRunStateTracker.EventLog> testMethodBEventLogMap =
-                getTestMethodEventLogsForMethod("SingleTestSuite", "SingleTestClassTest", TestClassNoDepsSample.class
-                        .getCanonicalName(), "testMethodB");
+                getTestMethodEventLogsForMethod("SingleTestSuite", "SingleTestClassTest",
+                        TestClassAWithNoDepsSample.class.getCanonicalName(), "testMethodB");
 
         Multimap<Object,TestNgRunStateTracker.EventLog> testMethodCEventLogMap =
-                getTestMethodEventLogsForMethod("SingleTestSuite", "SingleTestClassTest", TestClassNoDepsSample.class
-                        .getCanonicalName(), "testMethodC");
+                getTestMethodEventLogsForMethod("SingleTestSuite", "SingleTestClassTest",
+                        TestClassAWithNoDepsSample.class.getCanonicalName(), "testMethodC");
 
         Multimap<Object,TestNgRunStateTracker.EventLog> testMethodDEventLogMap =
-                getTestMethodEventLogsForMethod("SingleTestSuite", "SingleTestClassTest", TestClassNoDepsSample.class
-                        .getCanonicalName(), "testMethodD");
+                getTestMethodEventLogsForMethod("SingleTestSuite", "SingleTestClassTest",
+                        TestClassAWithNoDepsSample.class.getCanonicalName(), "testMethodD");
 
         Multimap<Object,TestNgRunStateTracker.EventLog> testMethodEEventLogMap =
-                getTestMethodEventLogsForMethod("SingleTestSuite", "SingleTestClassTest", TestClassNoDepsSample.class
-                        .getCanonicalName(), "testMethodE");
+                getTestMethodEventLogsForMethod("SingleTestSuite", "SingleTestClassTest",
+                        TestClassAWithNoDepsSample.class.getCanonicalName(), "testMethodE");
 
         assertEquals(testMethodAEventLogMap.keySet().size(), 1, "There should be only one test class instance " +
-                "associated with testMethodA from " + TestClassNoDepsSample.class.getCanonicalName());
+                "associated with testMethodA from " + TestClassAWithNoDepsSample.class.getCanonicalName());
         assertEquals(testMethodBEventLogMap.keySet().size(), 1, "There should be only one test class instance " +
-                "associated with testMethodB from " + TestClassNoDepsSample.class.getCanonicalName());
+                "associated with testMethodB from " + TestClassAWithNoDepsSample.class.getCanonicalName());
         assertEquals(testMethodCEventLogMap.keySet().size(), 1, "There should be only one test class instance " +
-                "associated with testMethodC from " + TestClassNoDepsSample.class.getCanonicalName());
+                "associated with testMethodC from " + TestClassAWithNoDepsSample.class.getCanonicalName());
         assertEquals(testMethodDEventLogMap.keySet().size(), 1, "There should be only one test class instance " +
-                "associated with testMethodD from " + TestClassNoDepsSample.class.getCanonicalName());
+                "associated with testMethodD from " + TestClassAWithNoDepsSample.class.getCanonicalName());
         assertEquals(testMethodEEventLogMap.keySet().size(), 1, "There should be only one test class instance " +
-                "associated with testMethodE from " + TestClassNoDepsSample.class.getCanonicalName());
+                "associated with testMethodE from " + TestClassAWithNoDepsSample.class.getCanonicalName());
 
-        Object methodAInstanceKey = getTestMethodEventLogsForMethod("SingleTestSuite", "SingleTestClassTest",
-                TestClassNoDepsSample.class.getCanonicalName(), "testMethodA").keySet().toArray()[0];
-        Object methodBInstanceKey = getTestMethodEventLogsForMethod("SingleTestSuite", "SingleTestClassTest",
-                TestClassNoDepsSample.class.getCanonicalName(), "testMethodB").keySet().toArray()[0];
-        Object methodCInstanceKey = getTestMethodEventLogsForMethod("SingleTestSuite", "SingleTestClassTest",
-                TestClassNoDepsSample.class.getCanonicalName(), "testMethodC").keySet().toArray()[0];
-        Object methodDInstanceKey = getTestMethodEventLogsForMethod("SingleTestSuite", "SingleTestClassTest",
-                TestClassNoDepsSample.class.getCanonicalName(), "testMethodD").keySet().toArray()[0];
-        Object methodEInstanceKey = getTestMethodEventLogsForMethod("SingleTestSuite", "SingleTestClassTest",
-                TestClassNoDepsSample.class.getCanonicalName(), "testMethodE").keySet().toArray()[0];
+        Object methodAInstanceKey = testMethodAEventLogMap.keySet().toArray()[0];
+        Object methodBInstanceKey = testMethodBEventLogMap.keySet().toArray()[0];
+        Object methodCInstanceKey = testMethodCEventLogMap.keySet().toArray()[0];
+        Object methodDInstanceKey = testMethodDEventLogMap.keySet().toArray()[0];
+        Object methodEInstanceKey = testMethodEEventLogMap.keySet().toArray()[0];
 
         assertTrue(
                 methodAInstanceKey == methodBInstanceKey &&
@@ -432,16 +481,14 @@ public class ParallelByMethodsSingleSuiteSingleTestSingleClassTest extends Simpl
 
     }
 
-    private static void addParams(XmlSuite suite, String suiteName, String testName, String sleepFor) {
-        Map<String,String> parameters = new HashMap<>();
-        parameters.put("suiteName", suiteName);
-        parameters.put("testName", testName);
-        parameters.put("sleepFor", sleepFor);
-
-        for(XmlTest test : suite.getTests()) {
-            if(test.getName().equals(testName)) {
-                test.setParameters(parameters);
-            }
+    @Test
+    public void verifyThreadCountsForTestMethodLevelEvents() {
+        for(EventLog eventLog : getAllTestMethodLevelEventLogs()) {
+            assertTrue(eventLog.getActiveThreadCount() <= 6 && eventLog.getActiveThreadCount() >= 2, "The thread " +
+                    "count when the test method level events are logged should be at least two: the methods should " +
+                    "have a thread and the suite and test level events should have a thread. Moreover, the thread " +
+                    "count when the test level events are logged should be no more than six because the thread count " +
+                    "is set to 5.");
         }
     }
 }

--- a/src/test/java/test/thread/parallelization/TestClassAWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/TestClassAWithNoDepsSample.java
@@ -1,0 +1,114 @@
+package test.thread.parallelization;
+
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.TimeUnit;
+
+public class TestClassAWithNoDepsSample {
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodA(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodA")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodB(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodB")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodC(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodC")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodD(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodD")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodE(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodE")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+}

--- a/src/test/java/test/thread/parallelization/TestClassAWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/TestClassAWithNoDepsSample.java
@@ -16,13 +16,13 @@ public class TestClassAWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodA")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -37,13 +37,13 @@ public class TestClassAWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodB")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -58,13 +58,13 @@ public class TestClassAWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodC")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -79,13 +79,13 @@ public class TestClassAWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodD")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -100,13 +100,13 @@ public class TestClassAWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodE")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));

--- a/src/test/java/test/thread/parallelization/TestClassBWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/TestClassBWithNoDepsSample.java
@@ -5,8 +5,7 @@ import org.testng.annotations.Test;
 
 import java.util.concurrent.TimeUnit;
 
-public class TestClassNoDepsSample {
-
+public class TestClassBWithNoDepsSample {
     @Parameters({ "suiteName", "testName", "sleepFor" })
     @Test
     public void testMethodA(String suiteName, String testName, String sleepFor) throws InterruptedException {
@@ -18,12 +17,11 @@ public class TestClassNoDepsSample {
                         .setTimeOfEvent(time)
                         .setThreadId(Thread.currentThread().getId())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodA")
-                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, TestClassNoDepsSample.class
-                                .getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build()
+                        .build(), Thread.currentThread()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -40,12 +38,11 @@ public class TestClassNoDepsSample {
                         .setTimeOfEvent(time)
                         .setThreadId(Thread.currentThread().getId())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodB")
-                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, TestClassNoDepsSample.class
-                                .getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build()
+                        .build(), Thread.currentThread()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -62,12 +59,11 @@ public class TestClassNoDepsSample {
                         .setTimeOfEvent(time)
                         .setThreadId(Thread.currentThread().getId())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodC")
-                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, TestClassNoDepsSample.class
-                                .getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build()
+                        .build(), Thread.currentThread()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -84,34 +80,11 @@ public class TestClassNoDepsSample {
                         .setTimeOfEvent(time)
                         .setThreadId(Thread.currentThread().getId())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodD")
-                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, TestClassNoDepsSample.class
-                                .getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build()
-        );
-
-        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
-    }
-
-    @Parameters({ "suiteName", "testName", "sleepFor" })
-    @Test
-    public void testMethodE(String suiteName, String testName, String sleepFor) throws InterruptedException {
-        long time = System.currentTimeMillis();
-
-        TestNgRunStateTracker.logEvent(
-                TestNgRunStateTracker.EventLog.builder()
-                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
-                        .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
-                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodE")
-                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, TestClassNoDepsSample.class
-                                .getCanonicalName())
-                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
-                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
-                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build()
+                        .build(), Thread.currentThread()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));

--- a/src/test/java/test/thread/parallelization/TestClassBWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/TestClassBWithNoDepsSample.java
@@ -15,13 +15,13 @@ public class TestClassBWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodA")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -36,13 +36,13 @@ public class TestClassBWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodB")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -57,13 +57,13 @@ public class TestClassBWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodC")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -78,13 +78,13 @@ public class TestClassBWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodD")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));

--- a/src/test/java/test/thread/parallelization/TestClassCWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/TestClassCWithNoDepsSample.java
@@ -15,13 +15,13 @@ public class TestClassCWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodA")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -36,13 +36,13 @@ public class TestClassCWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodB")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -57,13 +57,13 @@ public class TestClassCWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodC")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -78,13 +78,13 @@ public class TestClassCWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodD")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -99,13 +99,13 @@ public class TestClassCWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodE")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -120,13 +120,13 @@ public class TestClassCWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodF")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));

--- a/src/test/java/test/thread/parallelization/TestClassCWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/TestClassCWithNoDepsSample.java
@@ -1,0 +1,134 @@
+package test.thread.parallelization;
+
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.TimeUnit;
+
+public class TestClassCWithNoDepsSample {
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodA(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodA")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodB(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodB")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodC(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodC")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodD(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodD")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodE(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodE")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodF(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodF")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+}

--- a/src/test/java/test/thread/parallelization/TestClassDWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/TestClassDWithNoDepsSample.java
@@ -16,13 +16,13 @@ public class TestClassDWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodA")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -37,13 +37,13 @@ public class TestClassDWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodB")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -58,13 +58,13 @@ public class TestClassDWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodC")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));

--- a/src/test/java/test/thread/parallelization/TestClassDWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/TestClassDWithNoDepsSample.java
@@ -1,0 +1,72 @@
+package test.thread.parallelization;
+
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.TimeUnit;
+
+public class TestClassDWithNoDepsSample {
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodA(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodA")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodB(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodB")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodC(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodC")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+}

--- a/src/test/java/test/thread/parallelization/TestClassEWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/TestClassEWithNoDepsSample.java
@@ -1,0 +1,114 @@
+package test.thread.parallelization;
+
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.TimeUnit;
+
+public class TestClassEWithNoDepsSample {
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodA(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodA")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodB(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodB")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodC(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodC")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodD(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodD")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodE(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodE")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+}

--- a/src/test/java/test/thread/parallelization/TestClassEWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/TestClassEWithNoDepsSample.java
@@ -16,13 +16,13 @@ public class TestClassEWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodA")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -37,13 +37,13 @@ public class TestClassEWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodB")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -58,13 +58,13 @@ public class TestClassEWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodC")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -79,13 +79,13 @@ public class TestClassEWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodD")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -100,13 +100,13 @@ public class TestClassEWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodE")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));

--- a/src/test/java/test/thread/parallelization/TestClassFWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/TestClassFWithNoDepsSample.java
@@ -15,13 +15,13 @@ public class TestClassFWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodA")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -36,13 +36,13 @@ public class TestClassFWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodB")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -57,13 +57,13 @@ public class TestClassFWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodC")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -78,13 +78,13 @@ public class TestClassFWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodD")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -99,13 +99,13 @@ public class TestClassFWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodE")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -120,13 +120,13 @@ public class TestClassFWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodF")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));

--- a/src/test/java/test/thread/parallelization/TestClassFWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/TestClassFWithNoDepsSample.java
@@ -1,0 +1,134 @@
+package test.thread.parallelization;
+
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.TimeUnit;
+
+public class TestClassFWithNoDepsSample {
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodA(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodA")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodB(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodB")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodC(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodC")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodD(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodD")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodE(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodE")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodF(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodF")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+}

--- a/src/test/java/test/thread/parallelization/TestClassGWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/TestClassGWithNoDepsSample.java
@@ -1,0 +1,72 @@
+package test.thread.parallelization;
+
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.TimeUnit;
+
+public class TestClassGWithNoDepsSample {
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodA(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodA")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodB(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodB")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodC(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodC")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+}

--- a/src/test/java/test/thread/parallelization/TestClassGWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/TestClassGWithNoDepsSample.java
@@ -16,13 +16,13 @@ public class TestClassGWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodA")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -37,13 +37,13 @@ public class TestClassGWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodB")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -58,13 +58,13 @@ public class TestClassGWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodC")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));

--- a/src/test/java/test/thread/parallelization/TestClassHWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/TestClassHWithNoDepsSample.java
@@ -15,13 +15,13 @@ public class TestClassHWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodA")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -36,13 +36,13 @@ public class TestClassHWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodB")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -57,13 +57,13 @@ public class TestClassHWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodC")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -78,13 +78,13 @@ public class TestClassHWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodD")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));

--- a/src/test/java/test/thread/parallelization/TestClassHWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/TestClassHWithNoDepsSample.java
@@ -1,0 +1,92 @@
+package test.thread.parallelization;
+
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.TimeUnit;
+
+public class TestClassHWithNoDepsSample {
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodA(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodA")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodB(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodB")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodC(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodC")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodD(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodD")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+}

--- a/src/test/java/test/thread/parallelization/TestClassIWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/TestClassIWithNoDepsSample.java
@@ -1,0 +1,114 @@
+package test.thread.parallelization;
+
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.TimeUnit;
+
+public class TestClassIWithNoDepsSample {
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodA(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodA")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodB(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodB")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodC(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodC")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodD(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodD")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodE(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodE")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+}

--- a/src/test/java/test/thread/parallelization/TestClassIWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/TestClassIWithNoDepsSample.java
@@ -16,13 +16,13 @@ public class TestClassIWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodA")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -37,13 +37,13 @@ public class TestClassIWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodB")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -58,13 +58,13 @@ public class TestClassIWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodC")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -79,13 +79,13 @@ public class TestClassIWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodD")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -100,13 +100,13 @@ public class TestClassIWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodE")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));

--- a/src/test/java/test/thread/parallelization/TestClassJWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/TestClassJWithNoDepsSample.java
@@ -15,13 +15,13 @@ public class TestClassJWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodA")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -36,13 +36,13 @@ public class TestClassJWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodB")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -57,13 +57,13 @@ public class TestClassJWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodC")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -78,13 +78,13 @@ public class TestClassJWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodD")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));

--- a/src/test/java/test/thread/parallelization/TestClassJWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/TestClassJWithNoDepsSample.java
@@ -1,0 +1,92 @@
+package test.thread.parallelization;
+
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.TimeUnit;
+
+public class TestClassJWithNoDepsSample {
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodA(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodA")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodB(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodB")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodC(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodC")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodD(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodD")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+}

--- a/src/test/java/test/thread/parallelization/TestClassKWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/TestClassKWithNoDepsSample.java
@@ -16,13 +16,13 @@ public class TestClassKWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodA")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -37,13 +37,13 @@ public class TestClassKWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodB")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -58,13 +58,13 @@ public class TestClassKWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodC")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -79,13 +79,13 @@ public class TestClassKWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodD")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -100,13 +100,13 @@ public class TestClassKWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodE")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));

--- a/src/test/java/test/thread/parallelization/TestClassKWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/TestClassKWithNoDepsSample.java
@@ -1,0 +1,114 @@
+package test.thread.parallelization;
+
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.TimeUnit;
+
+public class TestClassKWithNoDepsSample {
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodA(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodA")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodB(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodB")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodC(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodC")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodD(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodD")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodE(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodE")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+}

--- a/src/test/java/test/thread/parallelization/TestClassLWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/TestClassLWithNoDepsSample.java
@@ -16,13 +16,13 @@ public class TestClassLWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodA")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -37,13 +37,13 @@ public class TestClassLWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodB")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -58,13 +58,13 @@ public class TestClassLWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodC")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));

--- a/src/test/java/test/thread/parallelization/TestClassLWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/TestClassLWithNoDepsSample.java
@@ -1,0 +1,72 @@
+package test.thread.parallelization;
+
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.TimeUnit;
+
+public class TestClassLWithNoDepsSample {
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodA(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodA")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodB(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodB")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodC(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodC")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+}

--- a/src/test/java/test/thread/parallelization/TestClassMWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/TestClassMWithNoDepsSample.java
@@ -15,13 +15,13 @@ public class TestClassMWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodA")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -36,13 +36,13 @@ public class TestClassMWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodB")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -57,13 +57,13 @@ public class TestClassMWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodC")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -78,13 +78,13 @@ public class TestClassMWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodD")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));

--- a/src/test/java/test/thread/parallelization/TestClassMWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/TestClassMWithNoDepsSample.java
@@ -1,0 +1,92 @@
+package test.thread.parallelization;
+
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.TimeUnit;
+
+public class TestClassMWithNoDepsSample {
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodA(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodA")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodB(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodB")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodC(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodC")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodD(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodD")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+}

--- a/src/test/java/test/thread/parallelization/TestClassNWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/TestClassNWithNoDepsSample.java
@@ -16,13 +16,13 @@ public class TestClassNWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodA")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -37,13 +37,13 @@ public class TestClassNWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodB")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -58,13 +58,13 @@ public class TestClassNWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodC")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -79,13 +79,13 @@ public class TestClassNWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodD")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -100,13 +100,13 @@ public class TestClassNWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodE")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));

--- a/src/test/java/test/thread/parallelization/TestClassNWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/TestClassNWithNoDepsSample.java
@@ -1,0 +1,114 @@
+package test.thread.parallelization;
+
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.TimeUnit;
+
+public class TestClassNWithNoDepsSample {
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodA(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodA")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodB(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodB")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodC(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodC")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodD(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodD")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodE(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodE")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+}

--- a/src/test/java/test/thread/parallelization/TestClassOWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/TestClassOWithNoDepsSample.java
@@ -15,13 +15,13 @@ public class TestClassOWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodA")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -36,13 +36,13 @@ public class TestClassOWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodB")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -57,13 +57,13 @@ public class TestClassOWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodC")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -78,13 +78,13 @@ public class TestClassOWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodD")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -99,13 +99,13 @@ public class TestClassOWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodE")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
@@ -120,13 +120,13 @@ public class TestClassOWithNoDepsSample {
                 TestNgRunStateTracker.EventLog.builder()
                         .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
                         .setTimeOfEvent(time)
-                        .setThreadId(Thread.currentThread().getId())
+                        .setThread(Thread.currentThread())
                         .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodF")
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
                         .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
                         .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
                         .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
-                        .build(), Thread.currentThread()
+                        .build()
         );
 
         TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));

--- a/src/test/java/test/thread/parallelization/TestClassOWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/TestClassOWithNoDepsSample.java
@@ -1,0 +1,134 @@
+package test.thread.parallelization;
+
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.TimeUnit;
+
+public class TestClassOWithNoDepsSample {
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodA(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodA")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodB(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodB")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodC(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodC")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodD(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodD")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodE(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodE")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Parameters({ "suiteName", "testName", "sleepFor" })
+    @Test
+    public void testMethodF(String suiteName, String testName, String sleepFor) throws InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThreadId(Thread.currentThread().getId())
+                        .addData(TestNgRunStateTracker.EventInfo.METHOD_NAME, "testMethodF")
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_NAME, getClass().getCanonicalName())
+                        .addData(TestNgRunStateTracker.EventInfo.CLASS_INSTANCE, this)
+                        .addData(TestNgRunStateTracker.EventInfo.TEST_NAME, testName)
+                        .addData(TestNgRunStateTracker.EventInfo.SUITE_NAME, suiteName)
+                        .build(), Thread.currentThread()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+}

--- a/src/test/java/test/thread/parallelization/TestNgRunStateListener.java
+++ b/src/test/java/test/thread/parallelization/TestNgRunStateListener.java
@@ -34,56 +34,56 @@ import static test.thread.parallelization.TestNgRunStateTracker.logEvent;
 public class TestNgRunStateListener implements ISuiteListener, ITestListener {
     @Override
     public void onStart(ISuite suite) {
-        logEvent(buildEventLog(suite, LISTENER_SUITE_START).build(), Thread.currentThread());
+        logEvent(buildEventLog(suite, LISTENER_SUITE_START).build());
         delayAfterEvent(LISTENER_SUITE_START);
     }
 
     @Override
     public void onFinish(ISuite suite) {
-        logEvent(buildEventLog(suite, LISTENER_SUITE_FINISH).build(), Thread.currentThread());
+        logEvent(buildEventLog(suite, LISTENER_SUITE_FINISH).build());
         delayAfterEvent(LISTENER_SUITE_FINISH);
     }
 
     @Override
     public void onStart(ITestContext context) {
-        logEvent(buildEventLog(context, LISTENER_TEST_START).build(), Thread.currentThread());
+        logEvent(buildEventLog(context, LISTENER_TEST_START).build());
         delayAfterEvent(LISTENER_TEST_START);
     }
 
     @Override
     public void onFinish(ITestContext context) {
-        logEvent(buildEventLog(context, LISTENER_TEST_FINISH).build(), Thread.currentThread());
+        logEvent(buildEventLog(context, LISTENER_TEST_FINISH).build());
         delayAfterEvent(LISTENER_TEST_FINISH);
     }
 
     @Override
     public void onTestStart(ITestResult result) {
-        logEvent(buildEventLog(result, LISTENER_TEST_METHOD_START).build(), Thread.currentThread());
+        logEvent(buildEventLog(result, LISTENER_TEST_METHOD_START).build());
         delayAfterEvent(LISTENER_TEST_METHOD_START);
     }
 
     @Override
     public void onTestSuccess(ITestResult result) {
-        logEvent(buildEventLog(result, LISTENER_TEST_METHOD_PASS).build(), Thread.currentThread());
+        logEvent(buildEventLog(result, LISTENER_TEST_METHOD_PASS).build());
         delayAfterEvent(LISTENER_TEST_METHOD_PASS);
     }
 
 
     @Override
     public void onTestFailure(ITestResult result) {
-        logEvent(buildEventLog(result, LISTENER_TEST_METHOD_FAIL).build(), Thread.currentThread());
+        logEvent(buildEventLog(result, LISTENER_TEST_METHOD_FAIL).build());
         delayAfterEvent(LISTENER_TEST_METHOD_FAIL);
     }
 
     @Override
     public void onTestSkipped(ITestResult result) {
-        logEvent(buildEventLog(result, LISTENER_TEST_METHOD_SKIPPED).build(), Thread.currentThread());
+        logEvent(buildEventLog(result, LISTENER_TEST_METHOD_SKIPPED).build());
         delayAfterEvent(LISTENER_TEST_METHOD_SKIPPED);
     }
 
     @Override
     public void onTestFailedButWithinSuccessPercentage(ITestResult result) {
-        logEvent(buildEventLog(result, LISTENER_TEST_METHOD_FAIL_PERCENTAGE).build(), Thread.currentThread());
+        logEvent(buildEventLog(result, LISTENER_TEST_METHOD_FAIL_PERCENTAGE).build());
         delayAfterEvent(LISTENER_TEST_METHOD_FAIL_PERCENTAGE);
     }
 
@@ -93,7 +93,7 @@ public class TestNgRunStateListener implements ISuiteListener, ITestListener {
         return EventLog.builder()
                 .setEvent(event)
                 .setTimeOfEvent(time)
-                .setThreadId(Thread.currentThread().getId())
+                .setThread(Thread.currentThread())
                 .addData(SUITE_NAME, suite.getName());
     }
 

--- a/src/test/java/test/thread/parallelization/TestNgRunStateListener.java
+++ b/src/test/java/test/thread/parallelization/TestNgRunStateListener.java
@@ -34,56 +34,56 @@ import static test.thread.parallelization.TestNgRunStateTracker.logEvent;
 public class TestNgRunStateListener implements ISuiteListener, ITestListener {
     @Override
     public void onStart(ISuite suite) {
-        logEvent(buildEventLog(suite, LISTENER_SUITE_START).build());
+        logEvent(buildEventLog(suite, LISTENER_SUITE_START).build(), Thread.currentThread());
         delayAfterEvent(LISTENER_SUITE_START);
     }
 
     @Override
     public void onFinish(ISuite suite) {
-        logEvent(buildEventLog(suite, LISTENER_SUITE_FINISH).build());
+        logEvent(buildEventLog(suite, LISTENER_SUITE_FINISH).build(), Thread.currentThread());
         delayAfterEvent(LISTENER_SUITE_FINISH);
     }
 
     @Override
     public void onStart(ITestContext context) {
-        logEvent(buildEventLog(context, LISTENER_TEST_START).build());
+        logEvent(buildEventLog(context, LISTENER_TEST_START).build(), Thread.currentThread());
         delayAfterEvent(LISTENER_TEST_START);
     }
 
     @Override
     public void onFinish(ITestContext context) {
-        logEvent(buildEventLog(context, LISTENER_TEST_FINISH).build());
+        logEvent(buildEventLog(context, LISTENER_TEST_FINISH).build(), Thread.currentThread());
         delayAfterEvent(LISTENER_TEST_FINISH);
     }
 
     @Override
     public void onTestStart(ITestResult result) {
-        logEvent(buildEventLog(result, LISTENER_TEST_METHOD_START).build());
+        logEvent(buildEventLog(result, LISTENER_TEST_METHOD_START).build(), Thread.currentThread());
         delayAfterEvent(LISTENER_TEST_METHOD_START);
     }
 
     @Override
     public void onTestSuccess(ITestResult result) {
-        logEvent(buildEventLog(result, LISTENER_TEST_METHOD_PASS).build());
+        logEvent(buildEventLog(result, LISTENER_TEST_METHOD_PASS).build(), Thread.currentThread());
         delayAfterEvent(LISTENER_TEST_METHOD_PASS);
     }
 
 
     @Override
     public void onTestFailure(ITestResult result) {
-        logEvent(buildEventLog(result, LISTENER_TEST_METHOD_FAIL).build());
+        logEvent(buildEventLog(result, LISTENER_TEST_METHOD_FAIL).build(), Thread.currentThread());
         delayAfterEvent(LISTENER_TEST_METHOD_FAIL);
     }
 
     @Override
     public void onTestSkipped(ITestResult result) {
-        logEvent(buildEventLog(result, LISTENER_TEST_METHOD_SKIPPED).build());
+        logEvent(buildEventLog(result, LISTENER_TEST_METHOD_SKIPPED).build(), Thread.currentThread());
         delayAfterEvent(LISTENER_TEST_METHOD_SKIPPED);
     }
 
     @Override
     public void onTestFailedButWithinSuccessPercentage(ITestResult result) {
-        logEvent(buildEventLog(result, LISTENER_TEST_METHOD_FAIL_PERCENTAGE).build());
+        logEvent(buildEventLog(result, LISTENER_TEST_METHOD_FAIL_PERCENTAGE).build(), Thread.currentThread());
         delayAfterEvent(LISTENER_TEST_METHOD_FAIL_PERCENTAGE);
     }
 

--- a/src/test/java/test/thread/parallelization/TestNgRunStateTracker.java
+++ b/src/test/java/test/thread/parallelization/TestNgRunStateTracker.java
@@ -24,23 +24,6 @@ public class TestNgRunStateTracker {
 
     public static void logEvent(EventLog eventLog) {
         synchronized(eventLogs) {
-            Set<Thread> uniqueThreads = new HashSet<>();
-
-            for(EventLog eL : eventLogs) {
-                uniqueThreads.add(eL.getThread());
-            }
-
-            uniqueThreads.add(eventLog.getThread());
-
-            int count = 0;
-
-            for(Thread t : uniqueThreads) {
-                if(t.getState() != TERMINATED) {
-                    count++;
-                }
-            }
-
-            eventLog.setActiveThreadCount(count);
             eventLogs.add(eventLog);
         }
     }
@@ -171,18 +154,6 @@ public class TestNgRunStateTracker {
         EventLog eventLog = getSuiteListenerFinishEventLog(suiteName);
 
         return eventLog == null ? null : eventLog.getThreadId();
-    }
-
-    public static Integer getSuiteListenerStartActiveThreadCount(String suiteName) {
-        EventLog eventLog = getSuiteListenerStartEventLog(suiteName);
-
-        return eventLog == null ? null : eventLog.getActiveThreadCount();
-    }
-
-    public static Integer getSuiteListenerFinishActiveThreadCount(String suiteName) {
-        EventLog eventLog = getSuiteListenerFinishEventLog(suiteName);
-
-        return eventLog == null ? null : eventLog.getActiveThreadCount();
     }
 
     //Get all test level event logs
@@ -323,18 +294,6 @@ public class TestNgRunStateTracker {
         EventLog eventLog = getTestListenerFinishEventLog(suiteName, testName);
 
         return eventLog == null ? null : eventLog.getThreadId();
-    }
-
-    public static Integer getTestListenerStartActiveThreadCount(String suiteName, String testName) {
-        EventLog eventLog = getTestListenerStartEventLog(suiteName, testName);
-
-        return eventLog == null ? null : eventLog.getActiveThreadCount();
-    }
-
-    public static Integer getTestListenerFinishActiveThreadCount(String suiteName, String testName) {
-        EventLog eventLog = getTestListenerFinishEventLog(suiteName, testName);
-
-        return eventLog == null ? null : eventLog.getActiveThreadCount();
     }
 
     //Get all test method level event logs
@@ -858,8 +817,6 @@ public class TestNgRunStateTracker {
             this.thread = thread;
         }
 
-        public int getActiveThreadCount() { return activeThreadCount; }
-
         public long getThreadId() {
             return thread.getId();
         }
@@ -870,10 +827,6 @@ public class TestNgRunStateTracker {
 
         public Object getData(EventInfo key) {
             return data.get(key);
-        }
-
-        private void setActiveThreadCount(int count) {
-            this.activeThreadCount = count;
         }
 
         private Thread getThread() {

--- a/src/test/java/test/thread/parallelization/TestNgRunStateTracker.java
+++ b/src/test/java/test/thread/parallelization/TestNgRunStateTracker.java
@@ -21,28 +21,21 @@ import static java.lang.Thread.State.TERMINATED;
 public class TestNgRunStateTracker {
 
     private static List<EventLog> eventLogs = new ArrayList<>();
-    private static Set<Thread> threads = new HashSet<Thread>();
 
-    public static void logEvent(EventLog eventLog, Thread thread) {
+    public static void logEvent(EventLog eventLog) {
         synchronized(eventLogs) {
+            Set<Thread> uniqueThreads = new HashSet<>();
+
+            for(EventLog eL : eventLogs) {
+                uniqueThreads.add(eL.getThread());
+            }
+
+            uniqueThreads.add(eventLog.getThread());
+
             int count = 0;
 
-            synchronized (threads) {
-                List<Thread> deadThreads = new ArrayList<>();
-
-                for(Thread t : threads) {
-                    if(t.getState() == TERMINATED) {
-                        deadThreads.add(t);
-                    }
-                }
-
-                for(Thread t : deadThreads) {
-                    threads.remove(t);
-                }
-
-                threads.add(thread);
-
-                for (Thread t : threads) {
+            for(Thread t : uniqueThreads) {
+                if(t.getState() != TERMINATED) {
                     count++;
                 }
             }
@@ -841,6 +834,7 @@ public class TestNgRunStateTracker {
         private long timeOfEvent;
         private long threadId;
         private int activeThreadCount;
+        private Thread thread;
 
         private Map<EventInfo, Object> data = new HashMap<>();
 
@@ -860,14 +854,14 @@ public class TestNgRunStateTracker {
             return timeOfEvent;
         }
 
-        public void setThreadId(long threadId) {
-            this.threadId = threadId;
+        public void setThread(Thread thread) {
+            this.thread = thread;
         }
 
         public int getActiveThreadCount() { return activeThreadCount; }
 
         public long getThreadId() {
-            return threadId;
+            return thread.getId();
         }
 
         public void addData(EventInfo key, Object value) {
@@ -880,6 +874,10 @@ public class TestNgRunStateTracker {
 
         private void setActiveThreadCount(int count) {
             this.activeThreadCount = count;
+        }
+
+        private Thread getThread() {
+            return thread;
         }
 
         public static EventLogBuilder builder() {
@@ -911,8 +909,8 @@ public class TestNgRunStateTracker {
             return this;
         }
 
-        EventLogBuilder setThreadId(long threadId) {
-            eventLog.setThreadId(threadId);
+        EventLogBuilder setThread(Thread thread) {
+            eventLog.setThread(thread);
             return this;
         }
 

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -772,6 +772,7 @@
   <test name = "Parallelization">
     <classes>
       <class name="test.thread.parallelization.ParallelByMethodsSingleSuiteSingleTestSingleClassTest"/>
+      <class name="test.thread.parallelization.ParallelByMethodsMultipleSuitesTestsClassesTest"/>
     </classes>
   </test>
 </suite>


### PR DESCRIPTION
1> Added a bunch of new sample classes.
2> Added some new accessor methods to the execution state tracker.
3> Implemented thread count bookkeeping and updated the listener class and the sample classes accordingly. 
4> Added thread count tests to the existing test class in the new parallelization test suite.

Added a test class for Scenario #2 for PTP-TC-1: Parallel by methods mode with sequential test suites, no dependencies and no factories or data providers.

Test scenario:  

Three suites with 1, 2 and 3 tests respectively. One test for a suite shall consist of a single test class while the rest shall consist of more than one test class.

```
* For one of the suites, the thread count and parallel mode are specified at the suite level
* For one of the suites, the thread count and parallel mode are specified at the test level
* For one of the suites, the parallel mode is specified at the suite level, and the thread counts are specified at the test level (thread counts for each test differ)
* The thread count is less than the number of test methods for the tests in two of the suites, so some methods will have to wait the active thread count to drop below the maximum thread count before they can begin execution.
* The thread count is more than the number of test methods for the tests in one of the suites, ensuring that none of the methods in that suite should have to wait for any other method to complete execution
* There are NO configuration methods
* All test methods pass
* NO ordering is specified
* group-by-instances is NOT set
* There are no method exclusions
```
