### PR TITLE
use log level 3 for writeFile logs

### DIFF
--- a/src/main/java/org/testng/internal/Utils.java
+++ b/src/main/java/org/testng/internal/Utils.java
@@ -30,7 +30,6 @@ import org.testng.annotations.ITestAnnotation;
 import org.testng.collections.Lists;
 import org.testng.internal.annotations.AnnotationHelper;
 import org.testng.internal.annotations.IAnnotationFinder;
-import org.testng.log.TextFormatter;
 import org.testng.reporters.XMLStringBuffer;
 import org.testng.xml.XmlClass;
 
@@ -167,8 +166,8 @@ public final class Utils {
       File outputFile = new File(outDir, fileName);
       if (!append) {
         outputFile.delete();
-        log("Attempting to create " + outputFile);
-        log("  Directory " + outDir + " exists: " + outDir.exists());
+        log("[Utils]", 3, "Attempting to create " + outputFile);
+        log("[Utils]", 3, "  Directory " + outDir + " exists: " + outDir.exists());
         outputFile.createNewFile();
       }
       writeFile(outputFile, sb, encoding, append);


### PR DESCRIPTION
Fixes https://github.com/cbeust/testng-eclipse/issues/253 and https://github.com/cbeust/testng-eclipse/issues/288

the default log level is 2, set by Eclipse plugin when launching the testng process.
however, some '[Utils]' logs are way too verbose for level 2, for example:

```
[TestNG] Running:
  /private/var/folders/54/wsbhhvxs4v92kc0d9rh6h2zr0000gp/T/testng-eclipse--1476110065/testng-customsuite.xml

[Utils] Attempting to create /home/nick/workspace/testng-sample/test-output/Default suite/Default test.xml
[Utils]   Directory /home/nick/workspace/testng-sample/test-output/Default suite exists: true
FAILED: testfailed
java.lang.RuntimeException: trigger an exception, just let it go.
  at mymixed.GreetingTest.testfailed(GreetingTest.java:118)
  at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
  at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
  at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
  at java.lang.reflect.Method.invoke(Method.java:498)
  at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:100)
  at org.testng.internal.Invoker.invokeMethod(Invoker.java:646)
  at org.testng.internal.Invoker.invokeTestMethod(Invoker.java:811)
  at org.testng.internal.Invoker.invokeTestMethods(Invoker.java:1137)
  at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:129)
  at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:112)
  at org.testng.TestRunner.privateRun(TestRunner.java:753)
  at org.testng.TestRunner.run(TestRunner.java:607)
  at org.testng.SuiteRunner.runTest(SuiteRunner.java:368)
  at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:363)
  at org.testng.SuiteRunner.privateRun(SuiteRunner.java:321)
  at org.testng.SuiteRunner.run(SuiteRunner.java:270)
  at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
  at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:86)
  at org.testng.TestNG.runSuitesSequentially(TestNG.java:1284)
  at org.testng.TestNG.runSuitesLocally(TestNG.java:1209)
  at org.testng.TestNG.runSuites(TestNG.java:1124)
  at org.testng.TestNG.run(TestNG.java:1096)
  at org.testng.remote.AbstractRemoteTestNG.run(AbstractRemoteTestNG.java:132)
  at org.testng.remote.RemoteTestNG.initAndRun(RemoteTestNG.java:236)
  at org.testng.remote.RemoteTestNG.main(RemoteTestNG.java:81)


===============================================
    Default test
    Tests run: 1, Failures: 1, Skips: 0
===============================================


===============================================
Default suite
Total tests run: 1, Failures: 1, Skips: 0
===============================================

[Utils] Attempting to create /home/nick/workspace/testng-sample/test-output/testng-failed.xml
[Utils]   Directory /home/nick/workspace/testng-sample/test-output exists: true
[Utils] Attempting to create /home/nick/workspace/testng-sample/test-output/Default suite/testng-failed.xml
[Utils]   Directory /home/nick/workspace/testng-sample/test-output/Default suite exists: true
[TestNG] Time taken by [FailedReporter passed=0 failed=0 skipped=0]: 3 ms
[TestNG] Time taken by org.testng.reporters.EmailableReporter2@153f5a29: 8 ms
[TestNG] Time taken by org.testng.reporters.XMLReporter@12843fce: 4 ms
[TestNG] Time taken by org.testng.reporters.jq.Main@531be3c5: 19 ms
[Utils] Attempting to create /home/nick/workspace/testng-sample/test-output/junitreports/TEST-mymixed.GreetingTest.xml
[Utils]   Directory /home/nick/workspace/testng-sample/test-output/junitreports exists: true
[TestNG] Time taken by org.testng.reporters.JUnitReportReporter@13a57a3b: 4 ms
[Utils] Attempting to create /home/nick/workspace/testng-sample/test-output/old/Default suite/toc.html
[Utils]   Directory /home/nick/workspace/testng-sample/test-output/old/Default suite exists: true
[Utils] Attempting to create /home/nick/workspace/testng-sample/test-output/old/Default suite/Default test.properties
[Utils]   Directory /home/nick/workspace/testng-sample/test-output/old/Default suite exists: true
[Utils] Attempting to create /home/nick/workspace/testng-sample/test-output/old/Default suite/index.html
[Utils]   Directory /home/nick/workspace/testng-sample/test-output/old/Default suite exists: true
[Utils] Attempting to create /home/nick/workspace/testng-sample/test-output/old/Default suite/main.html
[Utils]   Directory /home/nick/workspace/testng-sample/test-output/old/Default suite exists: true
[Utils] Attempting to create /home/nick/workspace/testng-sample/test-output/old/Default suite/groups.html
[Utils]   Directory /home/nick/workspace/testng-sample/test-output/old/Default suite exists: true
[Utils] Attempting to create /home/nick/workspace/testng-sample/test-output/old/Default suite/classes.html
[Utils]   Directory /home/nick/workspace/testng-sample/test-output/old/Default suite exists: true
[Utils] Attempting to create /home/nick/workspace/testng-sample/test-output/old/Default suite/reporter-output.html
[Utils]   Directory /home/nick/workspace/testng-sample/test-output/old/Default suite exists: true
[Utils] Attempting to create /home/nick/workspace/testng-sample/test-output/old/Default suite/methods-not-run.html
[Utils]   Directory /home/nick/workspace/testng-sample/test-output/old/Default suite exists: true
[Utils] Attempting to create /home/nick/workspace/testng-sample/test-output/old/Default suite/testng.xml.html
[Utils]   Directory /home/nick/workspace/testng-sample/test-output/old/Default suite exists: true
[Utils] Attempting to create /home/nick/workspace/testng-sample/test-output/old/index.html
[Utils]   Directory /home/nick/workspace/testng-sample/test-output/old exists: true
[TestNG] Time taken by org.testng.reporters.SuiteHTMLReporter@36f6e879: 12 ms
```

we'd better to adjust the logs like '[Utils]   Directory ...' and '[Utils] Attempting ...' less verbose
