### PR TITLE
Halt execution when invalid testname is provided

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 ﻿Current
 
 Fixed: GITHUB-1064: Incorrect logging of parallel mode of a test
+Fixed: GITHUB-1178: Halt execution when invalid testname is provided. (Krishnan Mahadevan)
 Fixed: GITHUB-1139: DataProvider could support Object[] as a valid return type (Julien Herr)
 
 6.9.13.4 (Bad release: Wrong interna version)

--- a/src/main/java/org/testng/TestNG.java
+++ b/src/main/java/org/testng/TestNG.java
@@ -433,7 +433,7 @@ public class TestNG {
     }
 
     if (tests.size() == 0) {
-      return s;
+      throw new TestNGException("The test(s) <" + testNames.toString() + "> cannot be found.");
     }
     else {
       XmlSuite result = (XmlSuite) s.clone();


### PR DESCRIPTION
Fixes # .
### Did you remember to?
- [ ] Add test case(s)
- [x] Update `CHANGES.txt`

Fixes : #1178

Currently testng continues executing all tests [<test> tags]
when user provides an invalid testname via the command
line.
Changing this to throw an exception if nothing is found.
