### PR TITLE
Document use of @Before/@After... in superclass

### DIFF
--- a/docs/documentation-main.html
+++ b/docs/documentation-main.html
@@ -155,6 +155,19 @@ Here is a quick overview of the annotations available in TestNG along with their
 
 <br><b>@AfterMethod</b>: The annotated method will be run after each test method.
 
+<p>
+<b>Behaviour of annotations in superclass of a TestNG class</b>
+</p>
+<p>
+The annotations above will also be honored (inherited) when placed on a
+superclass of a TestNG class. This is useful for example to centralize test
+setup for multiple test classes in a common superclass.
+</p>
+<p>
+In that case, TestNG guarantees that the "@Before" methods are executed in
+inheritance order (highest superclass first, then going down the inheritance
+chain), and the "@After" methods in reverse order (going up the inheritance chain).
+</p>
 </td>
 </tr>
 


### PR DESCRIPTION
Reading the code and trying some examples, it looks like TestNG guaranatees that methods with @Before/@After annotations in a superclass are executed in inheritance order (down the chain for "Before", and reverse for "After").

However, this is not documented, and this may cause confusion (see e.g. http://stackoverflow.com/questions/20826331/beforemethod-and-inheritance-order-of-execution-testng ). Therefore this pull requests adds documentation explaining the behaviour.

Feel free to point out any errors/omissions.
