### PR TITLE
Refactored sleep delays to speed execution of parallelization tests. …

### DIFF
--- a/src/test/java/test/thread/parallelization/ParallelByMethodsMultipleSuitesTestsClassesTest.java
+++ b/src/test/java/test/thread/parallelization/ParallelByMethodsMultipleSuitesTestsClassesTest.java
@@ -128,7 +128,7 @@ public class ParallelByMethodsMultipleSuitesTestsClassesTest extends BaseParalle
     private EventLog suiteThreeTestThreeListenerOnFinishEventLog;
 
     @BeforeClass
-    public void complexMultipleSuites() {
+    public void complexMultipleSequentialSuites() {
         reset();
 
         XmlSuite suiteOne = createXmlSuite(SUITE_A);
@@ -178,29 +178,29 @@ public class ParallelByMethodsMultipleSuitesTestsClassesTest extends BaseParalle
             }
         }
 
-        addParams(suiteOne, SUITE_A, SUITE_A_TEST_A, "5");
+        addParams(suiteOne, SUITE_A, SUITE_A_TEST_A, "1");
 
-        addParams(suiteTwo, SUITE_B, SUITE_B_TEST_A, "5");
-        addParams(suiteTwo, SUITE_B, SUITE_B_TEST_B, "5");
+        addParams(suiteTwo, SUITE_B, SUITE_B_TEST_A, "1");
+        addParams(suiteTwo, SUITE_B, SUITE_B_TEST_B, "1");
 
-        addParams(suiteThree, SUITE_C, SUITE_C_TEST_A, "5");
-        addParams(suiteThree, SUITE_C, SUITE_C_TEST_B, "5");
-        addParams(suiteThree, SUITE_C, SUITE_C_TEST_C, "5");
+        addParams(suiteThree, SUITE_C, SUITE_C_TEST_A, "1");
+        addParams(suiteThree, SUITE_C, SUITE_C_TEST_B, "1");
+        addParams(suiteThree, SUITE_C, SUITE_C_TEST_C, "1");
 
         TestNG tng = create(suiteOne, suiteTwo, suiteThree);
         tng.addListener((ITestNGListener) new TestNgRunStateListener());
 
         tng.run();
 
-        expectedSuiteExecutionTimes.put(SUITE_A, (long)32000);
-        expectedSuiteExecutionTimes.put(SUITE_B, (long)20000);
-        expectedSuiteExecutionTimes.put(SUITE_C, (long)50000);
+        expectedSuiteExecutionTimes.put(SUITE_A, 10_000L);
+        expectedSuiteExecutionTimes.put(SUITE_B, 7_000L);
+        expectedSuiteExecutionTimes.put(SUITE_C, 16_000L);
 
-        expectedTestExecutionTimes.put(SUITE_B_TEST_A, (long)9000);
-        expectedTestExecutionTimes.put(SUITE_B_TEST_B, (long)9000);
-        expectedTestExecutionTimes.put(SUITE_C_TEST_A, (long)16000);
-        expectedTestExecutionTimes.put(SUITE_C_TEST_B, (long)16000);
-        expectedTestExecutionTimes.put(SUITE_C_TEST_C, (long)16000);
+        expectedTestExecutionTimes.put(SUITE_B_TEST_A, 3_000L);
+        expectedTestExecutionTimes.put(SUITE_B_TEST_B, 3_000L);
+        expectedTestExecutionTimes.put(SUITE_C_TEST_A, 5_000L);
+        expectedTestExecutionTimes.put(SUITE_C_TEST_B, 5_000L);
+        expectedTestExecutionTimes.put(SUITE_C_TEST_C, 5_000L);
 
         suiteLevelEventLogs = getAllSuiteLevelEventLogs();
         testLevelEventLogs = getAllTestLevelEventLogs();

--- a/src/test/java/test/thread/parallelization/ParallelByMethodsParallelSuitesNoSuiteQueuing.java
+++ b/src/test/java/test/thread/parallelization/ParallelByMethodsParallelSuitesNoSuiteQueuing.java
@@ -90,7 +90,7 @@ public class ParallelByMethodsParallelSuitesNoSuiteQueuing extends BaseParalleli
     private EventLog suiteTwoTestTwoListenerOnFinishEventLog;
 
     @BeforeClass
-    public void parallelSuites() {
+    public void parallelSuitesWithoutSuiteQueing() {
         reset();
 
         XmlSuite suiteOne = createXmlSuite(SUITE_A);
@@ -108,10 +108,10 @@ public class ParallelByMethodsParallelSuitesNoSuiteQueuing extends BaseParalleli
         suiteTwo.setThreadCount(14);
 
 
-        addParams(suiteOne, SUITE_A, SUITE_A_TEST_A, "5");
+        addParams(suiteOne, SUITE_A, SUITE_A_TEST_A, "1");
 
-        addParams(suiteTwo, SUITE_B, SUITE_B_TEST_A, "5");
-        addParams(suiteTwo, SUITE_B, SUITE_B_TEST_B, "5");
+        addParams(suiteTwo, SUITE_B, SUITE_B_TEST_A, "1");
+        addParams(suiteTwo, SUITE_B, SUITE_B_TEST_B, "1");
 
         TestNG tng = create(suiteOne, suiteTwo);
         tng.setSuiteThreadPoolSize(2);
@@ -119,11 +119,11 @@ public class ParallelByMethodsParallelSuitesNoSuiteQueuing extends BaseParalleli
 
         tng.run();
 
-        expectedSuiteExecutionTimes.put(SUITE_A, (long)32000);
-        expectedSuiteExecutionTimes.put(SUITE_B, (long)20000);
+        expectedSuiteExecutionTimes.put(SUITE_A, 10_000L);
+        expectedSuiteExecutionTimes.put(SUITE_B, 7_000L);
 
-        expectedTestExecutionTimes.put(SUITE_B_TEST_A, (long)9000);
-        expectedTestExecutionTimes.put(SUITE_B_TEST_B, (long)9000);
+        expectedTestExecutionTimes.put(SUITE_B_TEST_A, 3_000L);
+        expectedTestExecutionTimes.put(SUITE_B_TEST_B, 3_000L);
 
         suiteLevelEventLogs = getAllSuiteLevelEventLogs();
         testLevelEventLogs = getAllTestLevelEventLogs();

--- a/src/test/java/test/thread/parallelization/ParallelByMethodsParallelSuitesWithSuiteQueuing.java
+++ b/src/test/java/test/thread/parallelization/ParallelByMethodsParallelSuitesWithSuiteQueuing.java
@@ -119,7 +119,7 @@ public class ParallelByMethodsParallelSuitesWithSuiteQueuing extends BaseParalle
     private TestNgRunStateTracker.EventLog suiteThreeTestThreeListenerOnFinishEventLog;
 
     @BeforeClass
-    public void complexMultipleSuites() {
+    public void parallelSuitesWithSuiteQueuing() {
         reset();
 
         XmlSuite suiteOne = createXmlSuite(SUITE_A);
@@ -169,14 +169,14 @@ public class ParallelByMethodsParallelSuitesWithSuiteQueuing extends BaseParalle
             }
         }
 
-        addParams(suiteOne, SUITE_A, SUITE_A_TEST_A, "5");
+        addParams(suiteOne, SUITE_A, SUITE_A_TEST_A, "1");
 
-        addParams(suiteTwo, SUITE_B, SUITE_B_TEST_A, "5");
-        addParams(suiteTwo, SUITE_B, SUITE_B_TEST_B, "5");
+        addParams(suiteTwo, SUITE_B, SUITE_B_TEST_A, "1");
+        addParams(suiteTwo, SUITE_B, SUITE_B_TEST_B, "1");
 
-        addParams(suiteThree, SUITE_C, SUITE_C_TEST_A, "5");
-        addParams(suiteThree, SUITE_C, SUITE_C_TEST_B, "5");
-        addParams(suiteThree, SUITE_C, SUITE_C_TEST_C, "5");
+        addParams(suiteThree, SUITE_C, SUITE_C_TEST_A, "1");
+        addParams(suiteThree, SUITE_C, SUITE_C_TEST_B, "1");
+        addParams(suiteThree, SUITE_C, SUITE_C_TEST_C, "1");
 
         TestNG tng = create(suiteOne, suiteTwo, suiteThree);
         tng.setSuiteThreadPoolSize(2);
@@ -184,15 +184,15 @@ public class ParallelByMethodsParallelSuitesWithSuiteQueuing extends BaseParalle
 
         tng.run();
 
-        expectedSuiteExecutionTimes.put(SUITE_A, (long)32000);
-        expectedSuiteExecutionTimes.put(SUITE_B, (long)20000);
-        expectedSuiteExecutionTimes.put(SUITE_C, (long)50000);
+        expectedSuiteExecutionTimes.put(SUITE_A, 10_000L);
+        expectedSuiteExecutionTimes.put(SUITE_B, 7_000L);
+        expectedSuiteExecutionTimes.put(SUITE_C, 16_000L);
 
-        expectedTestExecutionTimes.put(SUITE_B_TEST_A, (long)9000);
-        expectedTestExecutionTimes.put(SUITE_B_TEST_B, (long)9000);
-        expectedTestExecutionTimes.put(SUITE_C_TEST_A, (long)16000);
-        expectedTestExecutionTimes.put(SUITE_C_TEST_B, (long)16000);
-        expectedTestExecutionTimes.put(SUITE_C_TEST_C, (long)16000);
+        expectedTestExecutionTimes.put(SUITE_B_TEST_A, 3_000L);
+        expectedTestExecutionTimes.put(SUITE_B_TEST_B, 3_000L);
+        expectedTestExecutionTimes.put(SUITE_C_TEST_A, 5_000L);
+        expectedTestExecutionTimes.put(SUITE_C_TEST_B, 5_000L);
+        expectedTestExecutionTimes.put(SUITE_C_TEST_C, 5_000L);
 
         suiteLevelEventLogs = getAllSuiteLevelEventLogs();
         testLevelEventLogs = getAllTestLevelEventLogs();

--- a/src/test/java/test/thread/parallelization/ParallelByMethodsSingleSuiteSingleTestSingleClassWithDataProvider.java
+++ b/src/test/java/test/thread/parallelization/ParallelByMethodsSingleSuiteSingleTestSingleClassWithDataProvider.java
@@ -1,20 +1,23 @@
 package test.thread.parallelization;
 
 import com.google.common.collect.Multimap;
+
 import org.testng.ITestNGListener;
 import org.testng.TestNG;
+
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
 import org.testng.xml.XmlSuite;
 
 import test.thread.parallelization.TestNgRunStateTracker.EventLog;
-import test.thread.parallelization.sample.TestClassAFiveMethodsWithNoDepsSample;
+import test.thread.parallelization.sample.TestClassAFiveMethodsWithDataProviderAndNoDepsSample;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.testng.Assert.assertEquals;
-
+import static test.thread.parallelization.TestNgRunStateTracker.getAllEventLogs;
 import static test.thread.parallelization.TestNgRunStateTracker.getAllSuiteAndTestLevelEventLogs;
 import static test.thread.parallelization.TestNgRunStateTracker.getAllSuiteLevelEventLogs;
 import static test.thread.parallelization.TestNgRunStateTracker.getAllTestLevelEventLogs;
@@ -25,13 +28,9 @@ import static test.thread.parallelization.TestNgRunStateTracker.getTestListenerF
 import static test.thread.parallelization.TestNgRunStateTracker.getTestListenerStartEventLog;
 import static test.thread.parallelization.TestNgRunStateTracker.getTestListenerStartThreadId;
 import static test.thread.parallelization.TestNgRunStateTracker.getTestMethodEventLogsForMethod;
-
 import static test.thread.parallelization.TestNgRunStateTracker.reset;
 
-//Verify simple test run with a single suite which consists of a single test with a single test class. The thread count
-//is sufficient to run all methods in parallel at once, so no methods should be queued.
-public class ParallelByMethodsSingleSuiteSingleTestSingleClassTest extends BaseParallelizationTest {
-
+public class ParallelByMethodsSingleSuiteSingleTestSingleClassWithDataProvider extends BaseParallelizationTest {
     private static final String SUITE = "SingleTestSuite";
     private static final String TEST = "SingleTestClassTest";
 
@@ -55,18 +54,19 @@ public class ParallelByMethodsSingleSuiteSingleTestSingleClassTest extends BaseP
     private Multimap<Object, EventLog> testMethodEEventLogs;
 
     @BeforeClass
-    public void singleSuiteSingleTestSingleTestClass() {
+    public void singleSuiteSingleTestSingleTestClassWithDataProvider() {
         reset();
 
         XmlSuite suite = createXmlSuite(SUITE);
         suite.setParallel(XmlSuite.ParallelMode.METHODS);
-        suite.setThreadCount(5);
+        suite.setThreadCount(15);
 
-        createXmlTest(suite, TEST, TestClassAFiveMethodsWithNoDepsSample.class);
+        createXmlTest(suite, TEST, TestClassAFiveMethodsWithDataProviderAndNoDepsSample.class);
 
-        addParams(suite, SUITE, TEST, "1");
+        addParams(suite, SUITE, TEST, "1", "paramOne,paramTwo,paramThree");
 
         TestNG tng = create(suite);
+
         tng.addListener((ITestNGListener)new TestNgRunStateListener());
 
         tng.run();
@@ -77,15 +77,15 @@ public class ParallelByMethodsSingleSuiteSingleTestSingleClassTest extends BaseP
         testMethodLevelEventLogs = getAllTestMethodLevelEventLogs();
 
         testMethodAEventLogs = getTestMethodEventLogsForMethod(SUITE, TEST,
-                TestClassAFiveMethodsWithNoDepsSample.class.getCanonicalName(), "testMethodA");
+                TestClassAFiveMethodsWithDataProviderAndNoDepsSample.class.getCanonicalName(), "testMethodA");
         testMethodBEventLogs = getTestMethodEventLogsForMethod(SUITE, TEST,
-                TestClassAFiveMethodsWithNoDepsSample.class.getCanonicalName(), "testMethodB");
+                TestClassAFiveMethodsWithDataProviderAndNoDepsSample.class.getCanonicalName(), "testMethodB");
         testMethodCEventLogs = getTestMethodEventLogsForMethod(SUITE, TEST,
-                TestClassAFiveMethodsWithNoDepsSample.class.getCanonicalName(), "testMethodC");
+                TestClassAFiveMethodsWithDataProviderAndNoDepsSample.class.getCanonicalName(), "testMethodC");
         testMethodDEventLogs = getTestMethodEventLogsForMethod(SUITE, TEST,
-                TestClassAFiveMethodsWithNoDepsSample.class.getCanonicalName(), "testMethodD");
+                TestClassAFiveMethodsWithDataProviderAndNoDepsSample.class.getCanonicalName(), "testMethodD");
         testMethodEEventLogs = getTestMethodEventLogsForMethod(SUITE, TEST,
-                TestClassAFiveMethodsWithNoDepsSample.class.getCanonicalName(), "testMethodE");
+                TestClassAFiveMethodsWithDataProviderAndNoDepsSample.class.getCanonicalName(), "testMethodE");
 
         suiteListenerOnStartEventLog = getSuiteListenerStartEventLog(SUITE);
         suiteListenerOnFinishEventLog = getSuiteListenerFinishEventLog(SUITE);
@@ -103,8 +103,12 @@ public class ParallelByMethodsSingleSuiteSingleTestSingleClassTest extends BaseP
                 suiteLevelEventLogs);
         assertEquals(testLevelEventLogs.size(), 2, "There should be 2 test level events logged for " + SUITE + ": " +
                 testLevelEventLogs);
-        assertEquals(testMethodLevelEventLogs.size(), 15, "There should be 15 test method level event logged for " +
+        assertEquals(testMethodLevelEventLogs.size(), 45, "There should be 15 test method level event logged for " +
                 SUITE + ": " + testMethodLevelEventLogs);
+
+        for(TestNgRunStateTracker.EventLog eventLog: getAllEventLogs()) {
+            System.out.println(eventLog);
+        }
     }
 
     //Verify that the suite listener and test listener events have timestamps in the following order: suite start,
@@ -134,13 +138,13 @@ public class ParallelByMethodsSingleSuiteSingleTestSingleClassTest extends BaseP
         verifyNumberOfInstancesOfTestClassForMethods(
                 SUITE,
                 TEST,
-                TestClassAFiveMethodsWithNoDepsSample.class,
+                TestClassAFiveMethodsWithDataProviderAndNoDepsSample.class,
                 1);
 
         verifySameInstancesOfTestClassAssociatedWithMethods(
                 SUITE,
                 TEST,
-                TestClassAFiveMethodsWithNoDepsSample.class);
+                TestClassAFiveMethodsWithDataProviderAndNoDepsSample.class);
     }
 
     //Verifies that all the test method level events execute between the test listener onStart and onFinish methods
@@ -204,4 +208,5 @@ public class ParallelByMethodsSingleSuiteSingleTestSingleClassTest extends BaseP
                         testMethodEEventLogs.get(testMethodEEventLogs.keySet().toArray()[0])
         );
     }
+
 }

--- a/src/test/java/test/thread/parallelization/ParallelByMethodsSingleSuiteSingleTestSingleClassWithDataProvider.java
+++ b/src/test/java/test/thread/parallelization/ParallelByMethodsSingleSuiteSingleTestSingleClassWithDataProvider.java
@@ -105,10 +105,6 @@ public class ParallelByMethodsSingleSuiteSingleTestSingleClassWithDataProvider e
                 testLevelEventLogs);
         assertEquals(testMethodLevelEventLogs.size(), 45, "There should be 15 test method level event logged for " +
                 SUITE + ": " + testMethodLevelEventLogs);
-
-        for(TestNgRunStateTracker.EventLog eventLog: getAllEventLogs()) {
-            System.out.println(eventLog);
-        }
     }
 
     //Verify that the suite listener and test listener events have timestamps in the following order: suite start,

--- a/src/test/java/test/thread/parallelization/TestNgRunStateListener.java
+++ b/src/test/java/test/thread/parallelization/TestNgRunStateListener.java
@@ -112,7 +112,7 @@ public class TestNgRunStateListener implements ISuiteListener, ITestListener {
 
     private void delayAfterEvent(TestNgRunEvent event) {
         try {
-            TimeUnit.SECONDS.sleep(1);
+            TimeUnit.MILLISECONDS.sleep(500);
         } catch(InterruptedException e) {
             throw new RuntimeException("Problem with delaying after listener event: " + event, e);
         }

--- a/src/test/java/test/thread/parallelization/TestNgRunStateTracker.java
+++ b/src/test/java/test/thread/parallelization/TestNgRunStateTracker.java
@@ -817,7 +817,8 @@ public class TestNgRunStateTracker {
         TEST_NAME,
         CLASS_NAME,
         METHOD_NAME,
-        CLASS_INSTANCE
+        CLASS_INSTANCE,
+        DATA_PROVIDER_PARAM
     }
 
     public static class EventLog {

--- a/src/test/java/test/thread/parallelization/sample/TestClassAFiveMethodsWithDataProviderAndNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/sample/TestClassAFiveMethodsWithDataProviderAndNoDepsSample.java
@@ -1,0 +1,153 @@
+package test.thread.parallelization.sample;
+
+import org.testng.ITestContext;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import test.thread.parallelization.TestNgRunStateTracker;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_INSTANCE;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_NAME;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.DATA_PROVIDER_PARAM;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHOD_NAME;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.SUITE_NAME;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.TEST_NAME;
+
+public class TestClassAFiveMethodsWithDataProviderAndNoDepsSample {
+
+    @Test(dataProvider = "data-provider")
+    public void testMethodA(String suiteName, String testName, String sleepFor, String dpVal) throws
+            InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThread(Thread.currentThread())
+                        .addData(METHOD_NAME, "testMethodA")
+                        .addData(CLASS_NAME, getClass().getCanonicalName())
+                        .addData(CLASS_INSTANCE, this)
+                        .addData(TEST_NAME, testName)
+                        .addData(SUITE_NAME, suiteName)
+                        .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .build()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Test(dataProvider = "data-provider")
+    public void testMethodB(String suiteName, String testName, String sleepFor, String dpVal) throws
+            InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThread(Thread.currentThread())
+                        .addData(METHOD_NAME, "testMethodB")
+                        .addData(CLASS_NAME, getClass().getCanonicalName())
+                        .addData(CLASS_INSTANCE, this)
+                        .addData(TEST_NAME, testName)
+                        .addData(SUITE_NAME, suiteName)
+                        .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .build()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Test(dataProvider = "data-provider")
+    public void testMethodC(String suiteName, String testName, String sleepFor, String dpVal) throws
+            InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThread(Thread.currentThread())
+                        .addData(METHOD_NAME, "testMethodC")
+                        .addData(CLASS_NAME, getClass().getCanonicalName())
+                        .addData(CLASS_INSTANCE, this)
+                        .addData(TEST_NAME, testName)
+                        .addData(SUITE_NAME, suiteName)
+                        .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .build()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Test(dataProvider = "data-provider")
+    public void testMethodD(String suiteName, String testName, String sleepFor, String dpVal) throws
+            InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThread(Thread.currentThread())
+                        .addData(METHOD_NAME, "testMethodD")
+                        .addData(CLASS_NAME, getClass().getCanonicalName())
+                        .addData(CLASS_INSTANCE, this)
+                        .addData(TEST_NAME, testName)
+                        .addData(SUITE_NAME, suiteName)
+                        .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .build()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @Test(dataProvider = "data-provider")
+    public void testMethodE(String suiteName, String testName, String sleepFor, String dpVal) throws
+            InterruptedException {
+        long time = System.currentTimeMillis();
+
+        TestNgRunStateTracker.logEvent(
+                TestNgRunStateTracker.EventLog.builder()
+                        .setEvent(TestNgRunStateTracker.TestNgRunEvent.TEST_METHOD_EXECUTION)
+                        .setTimeOfEvent(time)
+                        .setThread(Thread.currentThread())
+                        .addData(METHOD_NAME, "testMethodE")
+                        .addData(CLASS_NAME, getClass().getCanonicalName())
+                        .addData(CLASS_INSTANCE, this)
+                        .addData(TEST_NAME, testName)
+                        .addData(SUITE_NAME, suiteName)
+                        .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .build()
+        );
+
+        TimeUnit.SECONDS.sleep(Integer.parseInt(sleepFor));
+    }
+
+    @DataProvider(name = "data-provider")
+    public Object[][] dataProvider(ITestContext context) {
+        Map<String,String> params = context.getCurrentXmlTest().getAllParameters();
+
+        String suiteName = params.get("suiteName");
+        String testName = params.get("testName");
+        String sleepFor = params.get("sleepFor");
+
+        String dataProviderParam = params.get("dataProviderParam");
+        String[] dataProviderVals = dataProviderParam.split(",");
+
+        Object[][] dataToProvide = new Object[dataProviderVals.length][4];
+
+        for(int i = 0; i < dataProviderVals.length; i ++)  {
+            dataToProvide[i][0] = suiteName;
+            dataToProvide[i][1] = testName;
+            dataToProvide[i][2] = sleepFor;
+            dataToProvide[i][3] = dataProviderVals[i];
+        }
+
+        return dataToProvide;
+    }
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -776,6 +776,7 @@
       <class name="test.thread.parallelization.ParallelByMethodsMultipleSuitesTestsClassesTest"/>
       <class name="test.thread.parallelization.ParallelByMethodsParallelSuitesNoSuiteQueuing"/>
       <class name="test.thread.parallelization.ParallelByMethodsParallelSuitesWithSuiteQueuing"/>
+      <class name="test.thread.parallelization.ParallelByMethodsSingleSuiteSingleTestSingleClassWithDataProvider"/>
     </classes>
   </test>
 


### PR DESCRIPTION
1) Refactored sleep delays to cut running time for the parallelization test classes.
2) Updated per comments from code review on my last pull request
3) Added support for tracking data provider information for a model execution in the state tracker
4) Added a sample class using a data provider
5) Updated some source comments on the base parallelization test class and some of the individual test classes to correspond to the refactored behavior from my last pull request
6) Refactored the simultaneous method verification code in the base parallelization test class to accurately reflect the intent of the  method. 
7) Added a test class for the following scenario for test case PTP-TC-3 (Parallel by methods mode with sequential test suites using a non-parallel data provider but no dependencies and no factories)

Single suite with a single test consisting of a single test class with five methods with a data provider specifying 3 sets of data

```
    * Thread count and parallel mode are specified at the suite level
    * The thread count is equal to the number of test methods times 3, the number of times each method will be invoked with a data set from the data provider. Expectation is that only 5 threads will be spawned, one for each of the methods and that in this thread, the method will be invoked 3 times, once for each set of data from the data provider.
    * There are NO configuration methods
    * All test methods pass
    * NO ordering is specified
    * group-by-instances is NOT set
    * There are no method exclusions
```

8) Added the new test class to testng.xml
