### PR TITLE
Security: Maven repos should always be https

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,10 +7,10 @@ buildscript {
         mavenCentral()
         jcenter()
         maven {
-            url 'http://dl.bintray.com/cbeust/maven'
+            url 'https://dl.bintray.com/cbeust/maven'
         }
         maven {
-            url 'http://oss.jfrog.org/artifactory/plugins-release'
+            url 'https://oss.jfrog.org/artifactory/plugins-release'
             credentials {
                 username = "${a_user}"
                 password = "${a_password}"


### PR DESCRIPTION
For more details, see http://blog.ontoillogical.com/blog/2014/07/28/how-to-take-over-any-java-developer/
