### PR TITLE
Control Stacktrace verbosity in Xml Reports

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 ﻿Current
+Fixed: GITHUB-1228: Control stacktrace levels in XmlReports via a JVM configuration (Krishnan Mahadevan)
 Fixed: GITHUB-1203: Add flush to BufferedWriter; fixes incomplete XML reports (Nathan Bruning)
 Fixed: GITHUB-1181: Fix MethodMatcherException: Data provider mismatch (Krishnan Mahadevan)
 Fixed: GITHUB-1107: TestNG does not report/print/log throwables in data providers (Krishnan Mahadevan)

--- a/src/main/java/org/testng/internal/Utils.java
+++ b/src/main/java/org/testng/internal/Utils.java
@@ -495,30 +495,61 @@ public final class Utils {
 
   /**
    * @return an array of two strings: the short stack trace and the long stack trace.
+   * @deprecated - Please consider using :
+   * <ul>
+   *     <li>{@link Utils#longStackTrace(Throwable, boolean)} - for getting full stack trace</li>
+   *     <li>{@link Utils#shortStackTrace(Throwable, boolean)} - for getting short stack trace</li>
+   * </ul>
    */
+  @Deprecated
   public static String[] stackTrace(Throwable t, boolean toHtml) {
+    return new String[] {
+        shortStackTrace(t, toHtml), longStackTrace(t, toHtml)
+    };
+  }
+
+  /**
+   * Helper that returns a short stack trace.
+   * @param t - The {@link Throwable} exception
+   * @param toHtml - <code>true</code> if the stacktrace should be translated to html as well
+   * @return - A string that represents the short stack trace.
+   */
+  public static String longStackTrace(Throwable t, boolean toHtml) {
+    return buildStrackTrace(t, toHtml, StackTraceType.FULL);
+  }
+
+  /**
+   * Helper that returns a long stack trace.
+   * @param t - The {@link Throwable} exception
+   * @param toHtml - <code>true</code> if the stacktrace should be translated to html as well
+   * @return - A string that represents the full stack trace.
+   */
+  public static String shortStackTrace(Throwable t, boolean toHtml) {
+    return buildStrackTrace(t, toHtml, StackTraceType.SHORT);
+  }
+
+  private static String buildStrackTrace(Throwable t, boolean toHtml, StackTraceType type) {
     StringWriter sw = new StringWriter();
     PrintWriter pw = new PrintWriter(sw);
     t.printStackTrace(pw);
     pw.flush();
-
-    String fullStackTrace = sw.getBuffer().toString();
-    String shortStackTrace;
-
-    if (Boolean.getBoolean(TestNG.SHOW_TESTNG_STACK_FRAMES) || TestRunner.getVerbose() >= 2) {
-      shortStackTrace = fullStackTrace;
-    } else {
-      shortStackTrace = filterTrace(sw.getBuffer().toString());
+    String stackTrace = sw.getBuffer().toString();
+    if (type == StackTraceType.SHORT && !isTooVerbose()) {
+      stackTrace = filterTrace(sw.getBuffer().toString());
     }
-
     if (toHtml) {
-      shortStackTrace = escapeHtml(shortStackTrace);
-      fullStackTrace = escapeHtml(fullStackTrace);
+      stackTrace = escapeHtml(stackTrace);
     }
+    return stackTrace;
+  }
 
-    return new String[] {
-        shortStackTrace, fullStackTrace
-    };
+  private static boolean isTooVerbose() {
+    return (Boolean.getBoolean(TestNG.SHOW_TESTNG_STACK_FRAMES) || TestRunner.getVerbose() >= 2);
+  }
+
+
+  private enum StackTraceType {
+    SHORT,FULL;
   }
 
   private static final Map<Character, String> ESCAPES = new HashMap<Character, String>() {

--- a/src/main/java/org/testng/reporters/XMLReporterConfig.java
+++ b/src/main/java/org/testng/reporters/XMLReporterConfig.java
@@ -117,6 +117,9 @@ public class XMLReporterConfig {
    */
   private int stackTraceOutputMethod = STACKTRACE_FULL;
 
+  private int stackTraceOutputLevel = Integer.parseInt(System.getProperty("stacktrace.success.output.level",Integer
+      .toString(STACKTRACE_FULL)));
+
   /**
    * The root output directory where the XMLs will be written. This will default
    * for now to the default TestNG output directory
@@ -171,6 +174,10 @@ public class XMLReporterConfig {
 
   public int getStackTraceOutputMethod() {
     return stackTraceOutputMethod;
+  }
+
+  public int getStackTraceOutputLevelForPassedTests() {
+    return stackTraceOutputLevel;
   }
 
   public void setStackTraceOutputMethod(int stackTraceOutputMethod) {

--- a/src/main/java/org/testng/reporters/XMLReporterConfig.java
+++ b/src/main/java/org/testng/reporters/XMLReporterConfig.java
@@ -84,23 +84,6 @@ public class XMLReporterConfig {
    */
   public static final int FF_LEVEL_SUITE_RESULT = 3;
 
-  /**
-   * No stacktrace will be written in the output file
-   */
-  public static final int STACKTRACE_NONE = 0;
-  /**
-   * Write only a short version of the stacktrace
-   */
-  public static final int STACKTRACE_SHORT = 1;
-  /**
-   * Write only the full version of the stacktrace
-   */
-  public static final int STACKTRACE_FULL = 2;
-  /**
-   * Write both types of stacktrace
-   */
-  public static final int STACKTRACE_BOTH = 3;
-
   // note: We're hardcoding the 'Z' because Java doesn't support all the
   // intricacies of ISO-8601.
   static final String FMT_DEFAULT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
@@ -115,10 +98,10 @@ public class XMLReporterConfig {
    * Stack trace output method for the failed tests using one of the
    * STACKTRACE_* constants.
    */
-  private int stackTraceOutputMethod = STACKTRACE_FULL;
+  private StackTraceLevels stackTraceOutputMethod = StackTraceLevels.FULL;
 
-  private int stackTraceOutputLevel = Integer.parseInt(System.getProperty("stacktrace.success.output.level",Integer
-      .toString(STACKTRACE_FULL)));
+  private StackTraceLevels stackTraceOutputLevel = StackTraceLevels.parse(System.getProperty("stacktrace.success"
+          + ".output.level", StackTraceLevels.FULL.toString()));
 
   /**
    * The root output directory where the XMLs will be written. This will default
@@ -172,16 +155,33 @@ public class XMLReporterConfig {
     this.fileFragmentationLevel = fileFragmentationLevel;
   }
 
+  /**
+   * @deprecated - Please use {@link XMLReporterConfig#getStackTraceOutput()} instead.
+   */
+  @Deprecated
   public int getStackTraceOutputMethod() {
+    return stackTraceOutputMethod.getLevel();
+  }
+
+  public StackTraceLevels getStackTraceOutput() {
     return stackTraceOutputMethod;
   }
 
-  public int getStackTraceOutputLevelForPassedTests() {
+  public void setStackTraceOutput(StackTraceLevels stackTraceOutputMethod) {
+    this.stackTraceOutputMethod = stackTraceOutputMethod;
+  }
+
+  public StackTraceLevels getStackTraceOutputLevelForPassedTests() {
     return stackTraceOutputLevel;
   }
 
+  /**
+   * @param stackTraceOutputMethod
+   * @deprecated - Please use {@link XMLReporterConfig#setStackTraceOutput(StackTraceLevels)} instead.
+   */
+  @Deprecated
   public void setStackTraceOutputMethod(int stackTraceOutputMethod) {
-    this.stackTraceOutputMethod = stackTraceOutputMethod;
+    this.stackTraceOutputMethod = StackTraceLevels.parse(stackTraceOutputMethod);
   }
 
   public String getOutputDirectory() {
@@ -238,5 +238,50 @@ public class XMLReporterConfig {
 
   public boolean isGenerateTestResultAttributes() {
     return generateTestResultAttributes;
+  }
+
+  public enum StackTraceLevels {
+    /**
+     * No stacktrace will be written in the output file
+     */
+    NONE(0),
+    /**
+     * Write only a short version of the stacktrace
+     */
+    SHORT(1),
+    /**
+     * Write only the full version of the stacktrace
+     */
+    FULL(2),
+    /**
+     * Write both types of stacktrace
+     */
+    BOTH(3);
+    StackTraceLevels(int level) {
+      this.level = level;
+    }
+    private int level;
+
+    public int getLevel() {
+      return level;
+    }
+
+    @Override
+    public String toString() {
+      return Integer.toString(level);
+    }
+
+    public static StackTraceLevels parse(int level) {
+      for (StackTraceLevels value : values()) {
+        if (value.getLevel() == level) {
+          return value;
+        }
+      }
+      throw new IllegalArgumentException(level + " is not a valid StackTrace level");
+    }
+
+    public static StackTraceLevels parse(String raw) {
+      return parse(Integer.parseInt(raw));
+    }
   }
 }

--- a/src/main/java/org/testng/reporters/XMLSuiteResultWriter.java
+++ b/src/main/java/org/testng/reporters/XMLSuiteResultWriter.java
@@ -284,21 +284,37 @@ public class XMLSuiteResultWriter {
       }
 
       String[] stackTraces = Utils.stackTrace(exception, false);
-      if ((config.getStackTraceOutputMethod() & XMLReporterConfig.STACKTRACE_SHORT) == XMLReporterConfig
-              .STACKTRACE_SHORT) {
-        xmlBuffer.push(XMLReporterConfig.TAG_SHORT_STACKTRACE);
-        xmlBuffer.addCDATA(stackTraces[0]);
-        xmlBuffer.pop();
-      }
-      if ((config.getStackTraceOutputMethod() & XMLReporterConfig.STACKTRACE_FULL) == XMLReporterConfig
-              .STACKTRACE_FULL) {
-        xmlBuffer.push(XMLReporterConfig.TAG_FULL_STACKTRACE);
-        xmlBuffer.addCDATA(stackTraces[1]);
-        xmlBuffer.pop();
+      int level = calculateStackTraceLevels(testResult);
+      switch (level) {
+        case XMLReporterConfig.STACKTRACE_SHORT:
+          xmlBuffer.push(XMLReporterConfig.TAG_SHORT_STACKTRACE);
+          xmlBuffer.addCDATA(stackTraces[0]);
+          xmlBuffer.pop();
+          break;
+        case XMLReporterConfig.STACKTRACE_FULL:
+          xmlBuffer.push(XMLReporterConfig.TAG_FULL_STACKTRACE);
+          xmlBuffer.addCDATA(stackTraces[1]);
+          xmlBuffer.pop();
+          break;
+        default:
       }
 
       xmlBuffer.pop();
     }
+  }
+
+  private int calculateStackTraceLevels(ITestResult testResult) {
+    int stackTraceoutputMethod = config.getStackTraceOutputMethod();
+    if (testResult.isSuccess()) {
+      stackTraceoutputMethod = config.getStackTraceOutputLevelForPassedTests();
+    }
+    if ((stackTraceoutputMethod & XMLReporterConfig.STACKTRACE_SHORT) == XMLReporterConfig.STACKTRACE_SHORT) {
+      return XMLReporterConfig.STACKTRACE_SHORT;
+    }
+    if ((stackTraceoutputMethod & XMLReporterConfig.STACKTRACE_FULL) == XMLReporterConfig.STACKTRACE_FULL) {
+      return XMLReporterConfig.STACKTRACE_FULL;
+    }
+    return XMLReporterConfig.STACKTRACE_BOTH;
   }
 
   private void addTestResultOutput(XMLStringBuffer xmlBuffer, ITestResult testResult) {

--- a/src/main/java/org/testng/reporters/XMLSuiteResultWriter.java
+++ b/src/main/java/org/testng/reporters/XMLSuiteResultWriter.java
@@ -283,38 +283,32 @@ public class XMLSuiteResultWriter {
         xmlBuffer.pop();
       }
 
-      String[] stackTraces = Utils.stackTrace(exception, false);
-      int level = calculateStackTraceLevels(testResult);
+      XMLReporterConfig.StackTraceLevels level = calculateStackTraceLevels(testResult);
       switch (level) {
-        case XMLReporterConfig.STACKTRACE_SHORT:
+        case SHORT:
           xmlBuffer.push(XMLReporterConfig.TAG_SHORT_STACKTRACE);
-          xmlBuffer.addCDATA(stackTraces[0]);
+          xmlBuffer.addCDATA(Utils.shortStackTrace(exception, false));
           xmlBuffer.pop();
           break;
-        case XMLReporterConfig.STACKTRACE_FULL:
+        case FULL:
           xmlBuffer.push(XMLReporterConfig.TAG_FULL_STACKTRACE);
-          xmlBuffer.addCDATA(stackTraces[1]);
+          xmlBuffer.addCDATA(Utils.longStackTrace(exception, false));
           xmlBuffer.pop();
           break;
         default:
+          //everything else is ignored for now.
       }
 
       xmlBuffer.pop();
     }
   }
 
-  private int calculateStackTraceLevels(ITestResult testResult) {
-    int stackTraceoutputMethod = config.getStackTraceOutputMethod();
+  private XMLReporterConfig.StackTraceLevels calculateStackTraceLevels(ITestResult testResult) {
+    XMLReporterConfig.StackTraceLevels stackTraceoutputMethod = config.getStackTraceOutput();
     if (testResult.isSuccess()) {
       stackTraceoutputMethod = config.getStackTraceOutputLevelForPassedTests();
     }
-    if ((stackTraceoutputMethod & XMLReporterConfig.STACKTRACE_SHORT) == XMLReporterConfig.STACKTRACE_SHORT) {
-      return XMLReporterConfig.STACKTRACE_SHORT;
-    }
-    if ((stackTraceoutputMethod & XMLReporterConfig.STACKTRACE_FULL) == XMLReporterConfig.STACKTRACE_FULL) {
-      return XMLReporterConfig.STACKTRACE_FULL;
-    }
-    return XMLReporterConfig.STACKTRACE_BOTH;
+    return stackTraceoutputMethod;
   }
 
   private void addTestResultOutput(XMLStringBuffer xmlBuffer, ITestResult testResult) {


### PR DESCRIPTION
Fixes # .

### Did you remember to?

- [] Add test case(s)
- [X] Update `CHANGES.txt`

Fixes #1228

Providing a new JVM argument named “stacktrace.output.level”
via which one can control the verbosity of stacktrace in 
xml reports.