### PR TITLE
Prevent duplicate instances of Reporter from being wired in.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 ﻿Current
 Fixed: GITHUB-1231: Make IExecutionListener implementation be the last reporter call before JVM exit(Krishnan Mahadevan)
+Fixed: GITHUB-1227: Prevent multiple instances of same Reporter from being injected into TestNG (Krishnan Mahadevan)
 Fixed: GITHUB-1228: Control stacktrace levels in XmlReports via a JVM configuration (Krishnan Mahadevan)
 Fixed: GITHUB-1203: Add flush to BufferedWriter; fixes incomplete XML reports (Nathan Bruning)
 Fixed: GITHUB-1181: Fix MethodMatcherException: Data provider mismatch (Krishnan Mahadevan)

--- a/src/main/java/org/testng/TestNG.java
+++ b/src/main/java/org/testng/TestNG.java
@@ -137,7 +137,7 @@ public class TestNG {
   private List<IClassListener> m_classListeners = Lists.newArrayList();
   private List<ITestListener> m_testListeners = Lists.newArrayList();
   private List<ISuiteListener> m_suiteListeners = Lists.newArrayList();
-  private Map<Class< ? extends IReporter>,IReporter> m_reporters = Maps.newHashMap();
+  private Map<Class<? extends IReporter>, IReporter> m_reporters = Maps.newHashMap();
 
   protected static final int HAS_FAILURE = 1;
   protected static final int HAS_SKIPPED = 2;
@@ -805,7 +805,7 @@ public class TestNG {
   // TODO remove later
   @Deprecated
   public void addListener(IReporter listener) {
-    if (!m_reporters.values().contains(listener)) {
+    if (!m_reporters.containsValue(listener)) {
       addListener((ITestNGListener) listener);
     }
   }
@@ -930,7 +930,9 @@ public class TestNG {
     }
   }
   private void addReporter(Class<? extends IReporter> r) {
-    m_reporters.put(r, ClassHelper.newInstance(r));
+    if (!m_reporters.containsKey(r)) {
+      m_reporters.put(r, ClassHelper.newInstance(r));
+    }
   }
 
   private void initializeDefaultListeners() {

--- a/src/test/java/test/reports/UniqueReporterInjectionSample1.java
+++ b/src/test/java/test/reports/UniqueReporterInjectionSample1.java
@@ -1,0 +1,13 @@
+package test.reports;
+
+import org.testng.Assert;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+@Listeners(UniqueReporterInjectionTest.ReporterListenerForIssue1227.class)
+public class UniqueReporterInjectionSample1 {
+    @Test
+    public void testMethod() {
+        Assert.assertTrue(true);
+    }
+}

--- a/src/test/java/test/reports/UniqueReporterInjectionSample2.java
+++ b/src/test/java/test/reports/UniqueReporterInjectionSample2.java
@@ -1,0 +1,13 @@
+package test.reports;
+
+import org.testng.Assert;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+@Listeners(UniqueReporterInjectionTest.ReporterListenerForIssue1227.class)
+public class UniqueReporterInjectionSample2 {
+    @Test
+    public void testMethod() {
+        Assert.assertTrue(true);
+    }
+}

--- a/src/test/java/test/reports/UniqueReporterInjectionTest.java
+++ b/src/test/java/test/reports/UniqueReporterInjectionTest.java
@@ -19,11 +19,15 @@ public class UniqueReporterInjectionTest extends SimpleBaseTest {
         tng.setUseDefaultListeners(false);
         tng.addListener((ITestNGListener) new ReporterListenerForIssue1227());
         tng.run();
-        Assert.assertTrue(tng.getReporters().size() == 1);
+        Assert.assertEquals(tng.getReporters().size(),1);
+        Assert.assertEquals(ReporterListenerForIssue1227.counter, 1);
     }
 
     public static class ReporterListenerForIssue1227 implements IReporter {
+        static int counter = 0;
         @Override
-        public void generateReport(List<XmlSuite> xmlSuites, List<ISuite> suites, String outputDirectory) {}
+        public void generateReport(List<XmlSuite> xmlSuites, List<ISuite> suites, String outputDirectory) {
+            counter++;
+        }
     }
 }

--- a/src/test/java/test/reports/UniqueReporterInjectionTest.java
+++ b/src/test/java/test/reports/UniqueReporterInjectionTest.java
@@ -1,0 +1,29 @@
+package test.reports;
+
+import org.testng.*;
+import org.testng.annotations.Test;
+import org.testng.xml.XmlSuite;
+import org.testng.xml.XmlTest;
+import test.SimpleBaseTest;
+
+import java.util.List;
+
+public class UniqueReporterInjectionTest extends SimpleBaseTest {
+    @Test
+    public void testPruningOfDuplicateReporter() {
+        XmlSuite xmlSuite = createXmlSuite("Suite");
+        XmlTest xmlTest = createXmlTest(xmlSuite, "Test");
+        createXmlClass(xmlTest, UniqueReporterInjectionSample1.class);
+        createXmlClass(xmlTest, UniqueReporterInjectionSample2.class);
+        TestNG tng = create(xmlSuite);
+        tng.setUseDefaultListeners(false);
+        tng.addListener((ITestNGListener) new ReporterListenerForIssue1227());
+        tng.run();
+        Assert.assertTrue(tng.getReporters().size() == 1);
+    }
+
+    public static class ReporterListenerForIssue1227 implements IReporter {
+        @Override
+        public void generateReport(List<XmlSuite> xmlSuites, List<ISuite> suites, String outputDirectory) {}
+    }
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -98,6 +98,7 @@
       <class name="test.CountTest" />
       <class name="test.EclipseTest" />
       <class name="test.ReporterApiTest" />
+      <class name="test.reports.UniqueReporterInjectionTest"/>
       <class name="test.abstractmethods.AbstractTest" />
       <class name="test.override.OverrideTest" />
       <class name="test.priority.PriorityTest" />


### PR DESCRIPTION
Fixes # .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

Fixes #1227

* Added checks to ensure that duplicate instances of a reporter
are not being injected into TestNG.
* Also added unit tests.