### PR TITLE
Make IExecutionListener implementation be the last reporter call before JVM exits

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 ﻿Current
+Fixed: GITHUB-1231: Make IExecutionListener implementation be the last reporter call before JVM exit(Krishnan Mahadevan)
 Fixed: GITHUB-1228: Control stacktrace levels in XmlReports via a JVM configuration (Krishnan Mahadevan)
 Fixed: GITHUB-1203: Add flush to BufferedWriter; fixes incomplete XML reports (Nathan Bruning)
 Fixed: GITHUB-1181: Fix MethodMatcherException: Data provider mismatch (Krishnan Mahadevan)

--- a/src/main/java/org/testng/IExecutionListener.java
+++ b/src/main/java/org/testng/IExecutionListener.java
@@ -2,6 +2,14 @@ package org.testng;
 
 /**
  * A listener used to monitor when a TestNG run starts and ends.
+ * When implementation of this listener is wired into TestNG, TestNG will ensure that
+ * <ul>
+ * <li>{@link IExecutionListener#onExecutionStart()} gets invoked before TestNG proceeds with invoking any other
+ * listener.</li>
+ * <li>{@link IExecutionListener#onExecutionFinish()} gets invoked at the very last (after report generation phase),
+ * before TestNG exits the JVM.
+ * </li>
+ * </ul>
  *
  * @author Cedric Beust <cedric@beust.com>
  */

--- a/src/main/java/org/testng/TestNG.java
+++ b/src/main/java/org/testng/TestNG.java
@@ -1089,18 +1089,20 @@ public class TestNG {
 
     List<ISuite> suiteRunners = null;
 
-    runSuiteAlterationListeners();
     runExecutionListeners(true /* start */);
+
+    runSuiteAlterationListeners();
 
     m_start = System.currentTimeMillis();
     suiteRunners = runSuites();
 
     m_end = System.currentTimeMillis();
-    runExecutionListeners(false /* finish */);
 
     if(null != suiteRunners) {
       generateReports(suiteRunners);
     }
+
+    runExecutionListeners(false /* finish */);
 
     if(!m_hasTests) {
       setStatus(HAS_NO_TEST);

--- a/src/test/java/test/testng1231/ListenerOrderTestSample.java
+++ b/src/test/java/test/testng1231/ListenerOrderTestSample.java
@@ -1,0 +1,8 @@
+package test.testng1231;
+
+import org.testng.annotations.Test;
+
+public class ListenerOrderTestSample {
+    @Test
+    public void testMethod() {}
+}

--- a/src/test/java/test/testng1231/TestExecutionListenerInvocationOrder.java
+++ b/src/test/java/test/testng1231/TestExecutionListenerInvocationOrder.java
@@ -1,0 +1,65 @@
+package test.testng1231;
+
+import com.beust.jcommander.internal.Lists;
+import org.testng.*;
+import org.testng.annotations.Test;
+import org.testng.xml.XmlSuite;
+import org.testng.xml.XmlTest;
+import test.SimpleBaseTest;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
+public class TestExecutionListenerInvocationOrder extends SimpleBaseTest {
+    @Test
+    public void testListenerOrder() {
+        XmlSuite xmlSuite = createXmlSuite("Suite");
+        XmlTest xmlTest = createXmlTest(xmlSuite, "Test");
+        createXmlClass(xmlTest, ListenerOrderTestSample.class);
+        TestNG tng = create(xmlSuite);
+        TestListenerFor1231 listener = new TestListenerFor1231();
+        tng.addListener((ITestNGListener) listener);
+        tng.run();
+        List<Integer> expected = Arrays.asList(1,2,3,4,5,6);
+        Assert.assertEquals(TestListenerFor1231.order, expected);
+    }
+
+    public static class TestListenerFor1231 implements IExecutionListener, IAlterSuiteListener, IReporter, ISuiteListener {
+        public static LinkedList<Integer> order = Lists.newLinkedList();
+
+        @Override
+        public void onExecutionStart() {
+            order.add(new Integer(1));
+
+        }
+
+        @Override
+        public void onExecutionFinish() {
+            order.add(new Integer(6));
+        }
+
+        @Override
+        public void generateReport(List<XmlSuite> xmlSuites, List<ISuite> suites, String outputDirectory) {
+            order.add(new Integer(5));
+        }
+
+        @Override
+        public void alter(List<XmlSuite> suites) {
+            order.add(new Integer(2));
+        }
+
+        @Override
+        public void onStart(ISuite suite) {
+            order.add(new Integer(3));
+
+        }
+
+        @Override
+        public void onFinish(ISuite suite) {
+            order.add(new Integer(4));
+
+        }
+    }
+
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -119,6 +119,7 @@
       <class name="test.failedreporter.FailedReporterParametersTest"/>
       <class name="test.reports.ReporterLogTest" />
       <class name="test.testng387.TestNG387"/>
+      <class name="test.testng1231.TestExecutionListenerInvocationOrder"/>
     </classes>
   </test>
 


### PR DESCRIPTION
Fixes # .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

Fixes #1231

Through this delivery listener invocation has been 
streamlined such that IExecutionListener’s implementation
will be the first and last call invoked by TestNG.

* onExecutionStart - Is the first call by TestNG before any other listener is invoked.
* onExecutionFinish - Is the last call by TestNG (after report generation is completed). After this call TestNG will exit the JVM.