### PR TITLE
Ensure unique listener injection in TestNG

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: java
+
+env:
+  global:
+    - GRADLE_OPTS=-Xmx512m
+
 jdk:
   - oraclejdk8
   - oraclejdk7

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 ﻿Current
+Fixed: GITHUB-1232: Prevent TestNG from adding duplicate instances of the same listener (Krishnan Mahadevan)
 Fixed: GITHUB-1170: Fixing the test DataProviderTest.shouldNotThrowConcurrentModification (Krishnan Mahadevan)
 Fixed: GITHUB-1231: Make IExecutionListener implementation be the last reporter call before JVM exit(Krishnan Mahadevan)
 Fixed: GITHUB-1227: Prevent multiple instances of same Reporter from being injected into TestNG (Krishnan Mahadevan)

--- a/build.gradle
+++ b/build.gradle
@@ -113,6 +113,7 @@ test {
 //    testLogging.showStandardStreams = true
     systemProperties = System.getProperties()
     systemProperties['test.resources.dir'] = 'build/resources/test/'
+	maxHeapSize = '1500m'
 }
 
 if (JavaVersion.current().isJava8Compatible()) {

--- a/src/main/java/org/testng/SuiteRunner.java
+++ b/src/main/java/org/testng/SuiteRunner.java
@@ -104,6 +104,12 @@ public class SuiteRunner implements ISuite, Serializable, IInvokedMethodListener
         null /* class listeners */);
   }
 
+  /**
+   * @deprecated - This constructor stands deprecated.
+   */
+  @Deprecated
+  //There are no external callers for this constructor but for TestNG. But since this method is a protected method
+  //we are following a proper deprecation strategy.
   protected SuiteRunner(IConfiguration configuration,
       XmlSuite suite,
       String outputDir,
@@ -117,15 +123,28 @@ public class SuiteRunner implements ISuite, Serializable, IInvokedMethodListener
     init(configuration, suite, outputDir, runnerFactory, useDefaultListeners, methodInterceptors, invokedMethodListeners, testListeners, classListeners);
   }
 
+  protected SuiteRunner(IConfiguration configuration,
+      XmlSuite suite,
+      String outputDir,
+      ITestRunnerFactory runnerFactory,
+      boolean useDefaultListeners,
+      List<IMethodInterceptor> methodInterceptors,
+      Collection<IInvokedMethodListener> invokedMethodListeners,
+      Collection<ITestListener> testListeners,
+      Collection<IClassListener> classListeners)
+  {
+    init(configuration, suite, outputDir, runnerFactory, useDefaultListeners, methodInterceptors, invokedMethodListeners, testListeners, classListeners);
+  }
+
   private void init(IConfiguration configuration,
     XmlSuite suite,
     String outputDir,
     ITestRunnerFactory runnerFactory,
     boolean useDefaultListeners,
     List<IMethodInterceptor> methodInterceptors,
-    List<IInvokedMethodListener> invokedMethodListener,
-    List<ITestListener> testListeners,
-    List<IClassListener> classListeners)
+    Collection<IInvokedMethodListener> invokedMethodListener,
+    Collection<ITestListener> testListeners,
+    Collection<IClassListener> classListeners)
   {
     m_configuration = configuration;
     m_suite = suite;

--- a/src/main/java/org/testng/TestNG.java
+++ b/src/main/java/org/testng/TestNG.java
@@ -134,10 +134,10 @@ public class TestNG {
   private ITestRunnerFactory m_testRunnerFactory;
 
   // These listeners can be overridden from the command line
-  private Map<Class<? extends IClassListener>, IClassListener> m_classListeners = Maps.newHashMap();
-  private Map<Class<? extends ITestListener>, ITestListener> m_testListeners = Maps.newHashMap();
-  private Map<Class<? extends ISuiteListener>, ISuiteListener> m_suiteListeners = Maps.newHashMap();
-  private Map<Class<? extends IReporter>, IReporter> m_reporters = Maps.newHashMap();
+  private final Map<Class<? extends IClassListener>, IClassListener> m_classListeners = Maps.newHashMap();
+  private final Map<Class<? extends ITestListener>, ITestListener> m_testListeners = Maps.newHashMap();
+  private final Map<Class<? extends ISuiteListener>, ISuiteListener> m_suiteListeners = Maps.newHashMap();
+  private final Map<Class<? extends IReporter>, IReporter> m_reporters = Maps.newHashMap();
 
   protected static final int HAS_FAILURE = 1;
   protected static final int HAS_SKIPPED = 2;
@@ -162,7 +162,8 @@ public class TestNG {
 
   private ITestObjectFactory m_objectFactory;
 
-  private Map<Class<? extends IInvokedMethodListener>, IInvokedMethodListener> m_invokedMethodListeners = Maps.newHashMap();
+  private final Map<Class<? extends IInvokedMethodListener>, IInvokedMethodListener> m_invokedMethodListeners = Maps
+      .newHashMap();
 
   private Integer m_dataProviderThreadCount = null;
 
@@ -178,9 +179,8 @@ public class TestNG {
   protected long m_end;
   protected long m_start;
 
-  private Map<Class<? extends IExecutionListener>, IExecutionListener> m_executionListeners = Maps.newHashMap();
-
-  private Map<Class<? extends IAlterSuiteListener>, IAlterSuiteListener> m_alterSuiteListeners= Maps.newHashMap();
+  private final Map<Class<? extends IExecutionListener>, IExecutionListener> m_executionListeners = Maps.newHashMap();
+  private final Map<Class<? extends IAlterSuiteListener>, IAlterSuiteListener> m_alterSuiteListeners= Maps.newHashMap();
 
   private boolean m_isInitialized = false;
 
@@ -712,33 +712,33 @@ public class TestNG {
     addListener((ITestNGListener) listener);
   }
 
+  private static <E> void wireListenerIfNotDuplicate(Map<Class<? extends E>, E> map, Class<? extends E> type, E value) {
+    if (map.containsKey(value.getClass())) {
+      LOGGER.warn("Skipping wiring in of the duplicate listener instance for the class : " + value.getClass().getName());
+    } else {
+      map.put(type, value);
+    }
+  }
+
   public void addListener(ITestNGListener listener) {
     if (listener == null) {
       return;
     }
     if (listener instanceof ISuiteListener) {
       ISuiteListener suite = (ISuiteListener) listener;
-      if (! m_suiteListeners.containsKey(suite.getClass())) {
-        m_suiteListeners.put(suite.getClass(), (ISuiteListener) listener);
-      }
+      wireListenerIfNotDuplicate(m_suiteListeners, suite.getClass(),  suite);
     }
     if (listener instanceof ITestListener) {
       ITestListener test = (ITestListener) listener;
-      if (! m_testListeners.containsKey(test.getClass())) {
-        m_testListeners.put(test.getClass(), test);
-      }
+      wireListenerIfNotDuplicate(m_testListeners, test.getClass(), test);
     }
     if (listener instanceof IClassListener) {
       IClassListener clazz = (IClassListener) listener;
-      if (! m_classListeners.containsKey(clazz)) {
-        m_classListeners.put(clazz.getClass(), clazz);
-      }
+      wireListenerIfNotDuplicate(m_classListeners, clazz.getClass(), clazz);
     }
     if (listener instanceof IReporter) {
       IReporter reporter = (IReporter) listener;
-      if (! m_reporters.containsKey(reporter.getClass())) {
-        m_reporters.put(reporter.getClass(), reporter);
-      }
+      wireListenerIfNotDuplicate(m_reporters, reporter.getClass(), reporter);
     }
     if (listener instanceof IAnnotationTransformer) {
       setAnnotationTransformer((IAnnotationTransformer) listener);
@@ -748,9 +748,7 @@ public class TestNG {
     }
     if (listener instanceof IInvokedMethodListener) {
       IInvokedMethodListener method = (IInvokedMethodListener) listener;
-      if (! m_invokedMethodListeners.containsKey(method)) {
-        m_invokedMethodListeners.put(method.getClass(), method);
-      }
+      wireListenerIfNotDuplicate(m_invokedMethodListeners, method.getClass(), method);
     }
     if (listener instanceof IHookable) {
       setHookable((IHookable) listener);
@@ -760,18 +758,14 @@ public class TestNG {
     }
     if (listener instanceof IExecutionListener) {
       IExecutionListener execution = (IExecutionListener) listener;
-      if (! m_executionListeners.containsKey(execution.getClass())) {
-        m_executionListeners.put(execution.getClass(), execution);
-      }
+      wireListenerIfNotDuplicate(m_executionListeners, execution.getClass(), execution);
     }
     if (listener instanceof IConfigurationListener) {
       getConfiguration().addConfigurationListener((IConfigurationListener) listener);
     }
     if (listener instanceof IAlterSuiteListener) {
       IAlterSuiteListener alter = (IAlterSuiteListener) listener;
-      if (! m_alterSuiteListeners.containsKey(alter.getClass())) {
-        m_alterSuiteListeners.put(alter.getClass(), alter);
-      }
+      wireListenerIfNotDuplicate(m_alterSuiteListeners, alter.getClass(), alter);
     }
   }
 
@@ -1376,9 +1370,9 @@ public class TestNG {
         m_testRunnerFactory,
         m_useDefaultListeners,
         m_methodInterceptors,
-        Lists.newArrayList(m_invokedMethodListeners.values()),
-        Lists.newArrayList(m_testListeners.values()),
-        Lists.newArrayList(m_classListeners.values()));
+        m_invokedMethodListeners.values(),
+        m_testListeners.values(),
+        m_classListeners.values());
 
     for (ISuiteListener isl : m_suiteListeners.values()) {
       result.addListener(isl);

--- a/src/main/java/org/testng/TestNG.java
+++ b/src/main/java/org/testng/TestNG.java
@@ -712,9 +712,9 @@ public class TestNG {
     addListener((ITestNGListener) listener);
   }
 
-  private static <E> void wireListenerIfNotDuplicate(Map<Class<? extends E>, E> map, Class<? extends E> type, E value) {
+  private static <E> void maybeAddListener(Map<Class<? extends E>, E> map, Class<? extends E> type, E value) {
     if (map.containsKey(value.getClass())) {
-      LOGGER.warn("Skipping wiring in of the duplicate listener instance for the class : " + value.getClass().getName());
+      LOGGER.warn("Ignoring duplicate listener : " + value.getClass().getName());
     } else {
       map.put(type, value);
     }
@@ -726,19 +726,19 @@ public class TestNG {
     }
     if (listener instanceof ISuiteListener) {
       ISuiteListener suite = (ISuiteListener) listener;
-      wireListenerIfNotDuplicate(m_suiteListeners, suite.getClass(),  suite);
+      maybeAddListener(m_suiteListeners, suite.getClass(),  suite);
     }
     if (listener instanceof ITestListener) {
       ITestListener test = (ITestListener) listener;
-      wireListenerIfNotDuplicate(m_testListeners, test.getClass(), test);
+      maybeAddListener(m_testListeners, test.getClass(), test);
     }
     if (listener instanceof IClassListener) {
       IClassListener clazz = (IClassListener) listener;
-      wireListenerIfNotDuplicate(m_classListeners, clazz.getClass(), clazz);
+      maybeAddListener(m_classListeners, clazz.getClass(), clazz);
     }
     if (listener instanceof IReporter) {
       IReporter reporter = (IReporter) listener;
-      wireListenerIfNotDuplicate(m_reporters, reporter.getClass(), reporter);
+      maybeAddListener(m_reporters, reporter.getClass(), reporter);
     }
     if (listener instanceof IAnnotationTransformer) {
       setAnnotationTransformer((IAnnotationTransformer) listener);
@@ -748,7 +748,7 @@ public class TestNG {
     }
     if (listener instanceof IInvokedMethodListener) {
       IInvokedMethodListener method = (IInvokedMethodListener) listener;
-      wireListenerIfNotDuplicate(m_invokedMethodListeners, method.getClass(), method);
+      maybeAddListener(m_invokedMethodListeners, method.getClass(), method);
     }
     if (listener instanceof IHookable) {
       setHookable((IHookable) listener);
@@ -758,14 +758,14 @@ public class TestNG {
     }
     if (listener instanceof IExecutionListener) {
       IExecutionListener execution = (IExecutionListener) listener;
-      wireListenerIfNotDuplicate(m_executionListeners, execution.getClass(), execution);
+      maybeAddListener(m_executionListeners, execution.getClass(), execution);
     }
     if (listener instanceof IConfigurationListener) {
       getConfiguration().addConfigurationListener((IConfigurationListener) listener);
     }
     if (listener instanceof IAlterSuiteListener) {
       IAlterSuiteListener alter = (IAlterSuiteListener) listener;
-      wireListenerIfNotDuplicate(m_alterSuiteListeners, alter.getClass(), alter);
+      maybeAddListener(m_alterSuiteListeners, alter.getClass(), alter);
     }
   }
 

--- a/src/main/java/org/testng/TestNG.java
+++ b/src/main/java/org/testng/TestNG.java
@@ -134,9 +134,9 @@ public class TestNG {
   private ITestRunnerFactory m_testRunnerFactory;
 
   // These listeners can be overridden from the command line
-  private List<IClassListener> m_classListeners = Lists.newArrayList();
-  private List<ITestListener> m_testListeners = Lists.newArrayList();
-  private List<ISuiteListener> m_suiteListeners = Lists.newArrayList();
+  private Map<Class<? extends IClassListener>, IClassListener> m_classListeners = Maps.newHashMap();
+  private Map<Class<? extends ITestListener>, ITestListener> m_testListeners = Maps.newHashMap();
+  private Map<Class<? extends ISuiteListener>, ISuiteListener> m_suiteListeners = Maps.newHashMap();
   private Map<Class<? extends IReporter>, IReporter> m_reporters = Maps.newHashMap();
 
   protected static final int HAS_FAILURE = 1;
@@ -162,7 +162,7 @@ public class TestNG {
 
   private ITestObjectFactory m_objectFactory;
 
-  private List<IInvokedMethodListener> m_invokedMethodListeners = Lists.newArrayList();
+  private Map<Class<? extends IInvokedMethodListener>, IInvokedMethodListener> m_invokedMethodListeners = Maps.newHashMap();
 
   private Integer m_dataProviderThreadCount = null;
 
@@ -178,9 +178,9 @@ public class TestNG {
   protected long m_end;
   protected long m_start;
 
-  private List<IExecutionListener> m_executionListeners = Lists.newArrayList();
+  private Map<Class<? extends IExecutionListener>, IExecutionListener> m_executionListeners = Maps.newHashMap();
 
-  private List<IAlterSuiteListener> m_alterSuiteListeners= Lists.newArrayList();
+  private Map<Class<? extends IAlterSuiteListener>, IAlterSuiteListener> m_alterSuiteListeners= Maps.newHashMap();
 
   private boolean m_isInitialized = false;
 
@@ -717,17 +717,28 @@ public class TestNG {
       return;
     }
     if (listener instanceof ISuiteListener) {
-      m_suiteListeners.add((ISuiteListener) listener);
+      ISuiteListener suite = (ISuiteListener) listener;
+      if (! m_suiteListeners.containsKey(suite.getClass())) {
+        m_suiteListeners.put(suite.getClass(), (ISuiteListener) listener);
+      }
     }
     if (listener instanceof ITestListener) {
-      m_testListeners.add((ITestListener) listener);
+      ITestListener test = (ITestListener) listener;
+      if (! m_testListeners.containsKey(test.getClass())) {
+        m_testListeners.put(test.getClass(), test);
+      }
     }
     if (listener instanceof IClassListener) {
-      m_classListeners.add((IClassListener) listener);
+      IClassListener clazz = (IClassListener) listener;
+      if (! m_classListeners.containsKey(clazz)) {
+        m_classListeners.put(clazz.getClass(), clazz);
+      }
     }
     if (listener instanceof IReporter) {
       IReporter reporter = (IReporter) listener;
-      m_reporters.put(reporter.getClass(), reporter);
+      if (! m_reporters.containsKey(reporter.getClass())) {
+        m_reporters.put(reporter.getClass(), reporter);
+      }
     }
     if (listener instanceof IAnnotationTransformer) {
       setAnnotationTransformer((IAnnotationTransformer) listener);
@@ -736,7 +747,10 @@ public class TestNG {
       m_methodInterceptors.add((IMethodInterceptor) listener);
     }
     if (listener instanceof IInvokedMethodListener) {
-      m_invokedMethodListeners.add((IInvokedMethodListener) listener);
+      IInvokedMethodListener method = (IInvokedMethodListener) listener;
+      if (! m_invokedMethodListeners.containsKey(method)) {
+        m_invokedMethodListeners.put(method.getClass(), method);
+      }
     }
     if (listener instanceof IHookable) {
       setHookable((IHookable) listener);
@@ -745,13 +759,19 @@ public class TestNG {
       setConfigurable((IConfigurable) listener);
     }
     if (listener instanceof IExecutionListener) {
-      m_executionListeners.add((IExecutionListener) listener);
+      IExecutionListener execution = (IExecutionListener) listener;
+      if (! m_executionListeners.containsKey(execution.getClass())) {
+        m_executionListeners.put(execution.getClass(), execution);
+      }
     }
     if (listener instanceof IConfigurationListener) {
       getConfiguration().addConfigurationListener((IConfigurationListener) listener);
     }
     if (listener instanceof IAlterSuiteListener) {
-      m_alterSuiteListeners.add((IAlterSuiteListener) listener);
+      IAlterSuiteListener alter = (IAlterSuiteListener) listener;
+      if (! m_alterSuiteListeners.containsKey(alter.getClass())) {
+        m_alterSuiteListeners.put(alter.getClass(), alter);
+      }
     }
   }
 
@@ -761,9 +781,7 @@ public class TestNG {
   // TODO remove later
   @Deprecated
   public void addListener(IInvokedMethodListener listener) {
-    if (!m_invokedMethodListeners.contains(listener)) {
-      addListener((ITestNGListener) listener);
-    }
+    addListener((ITestNGListener) listener);
   }
 
   /**
@@ -772,9 +790,7 @@ public class TestNG {
   // TODO remove later
   @Deprecated
   public void addListener(ISuiteListener listener) {
-    if (!m_suiteListeners.contains(listener)) {
-      addListener((ITestNGListener) listener);
-    }
+    addListener((ITestNGListener) listener);
   }
 
   /**
@@ -783,9 +799,7 @@ public class TestNG {
   // TODO remove later
   @Deprecated
   public void addListener(ITestListener listener) {
-    if (!m_testListeners.contains(listener)) {
-      addListener((ITestNGListener) listener);
-    }
+    addListener((ITestNGListener) listener);
   }
 
   /**
@@ -794,9 +808,7 @@ public class TestNG {
   // TODO remove later
   @Deprecated
   public void addListener(IClassListener listener) {
-    if (!m_classListeners.contains(listener)) {
-      addListener((ITestNGListener) listener);
-    }
+    addListener((ITestNGListener) listener);
   }
 
   /**
@@ -805,9 +817,7 @@ public class TestNG {
   // TODO remove later
   @Deprecated
   public void addListener(IReporter listener) {
-    if (!m_reporters.containsValue(listener)) {
-      addListener((ITestNGListener) listener);
-    }
+    addListener((ITestNGListener) listener);
   }
 
   /**
@@ -816,9 +826,7 @@ public class TestNG {
   // TODO remove later
   @Deprecated
   public void addInvokedMethodListener(IInvokedMethodListener listener) {
-    if (!m_invokedMethodListeners.contains(listener)) {
-      addListener((ITestNGListener) listener);
-    }
+    addListener((ITestNGListener) listener);
   }
 
   public Set<IReporter> getReporters() {
@@ -828,11 +836,11 @@ public class TestNG {
   }
 
   public List<ITestListener> getTestListeners() {
-    return m_testListeners;
+    return Lists.newArrayList(m_testListeners.values());
   }
 
   public List<ISuiteListener> getSuiteListeners() {
-    return m_suiteListeners;
+    return Lists.newArrayList(m_suiteListeners.values());
   }
 
   /** If m_verbose gets set, it will override the verbose setting in testng.xml */
@@ -936,7 +944,7 @@ public class TestNG {
   }
 
   private void initializeDefaultListeners() {
-    m_testListeners.add(new ExitCodeListener(this));
+    m_testListeners.put(ExitCodeListener.class, new ExitCodeListener(this));
 
     if (m_useDefaultListeners) {
       addReporter(SuiteHTMLReporter.class);
@@ -1132,8 +1140,8 @@ public class TestNG {
   }
 
   private void runSuiteAlterationListeners() {
-    for (List<IAlterSuiteListener> listeners
-        : Arrays.asList(m_alterSuiteListeners, m_configuration.getAlterSuiteListeners())) {
+    for (Collection<IAlterSuiteListener> listeners
+        : Arrays.asList(m_alterSuiteListeners.values(), m_configuration.getAlterSuiteListeners())) {
       for (IAlterSuiteListener l : listeners) {
         l.alter(m_suites);
       }
@@ -1141,8 +1149,8 @@ public class TestNG {
   }
 
   private void runExecutionListeners(boolean start) {
-    for (List<IExecutionListener> listeners
-        : Arrays.asList(m_executionListeners, m_configuration.getExecutionListeners())) {
+    for (Collection<IExecutionListener> listeners
+        : Arrays.asList(m_executionListeners.values(), m_configuration.getExecutionListeners())) {
       for (IExecutionListener l : listeners) {
         if (start) l.onExecutionStart();
         else l.onExecutionFinish();
@@ -1368,11 +1376,11 @@ public class TestNG {
         m_testRunnerFactory,
         m_useDefaultListeners,
         m_methodInterceptors,
-        m_invokedMethodListeners,
-        m_testListeners,
-        m_classListeners);
+        Lists.newArrayList(m_invokedMethodListeners.values()),
+        Lists.newArrayList(m_testListeners.values()),
+        Lists.newArrayList(m_classListeners.values()));
 
-    for (ISuiteListener isl : m_suiteListeners) {
+    for (ISuiteListener isl : m_suiteListeners.values()) {
       result.addListener(isl);
     }
 
@@ -2057,7 +2065,7 @@ public class TestNG {
   //
 
   private URLClassLoader m_serviceLoaderClassLoader;
-  private List<ITestNGListener> m_serviceLoaderListeners = Lists.newArrayList();
+  private Map<Class<? extends ITestNGListener>, ITestNGListener> m_serviceLoaderListeners = Maps.newHashMap();
 
   /*
    * Used to test ServiceClassLoader
@@ -2070,14 +2078,16 @@ public class TestNG {
    * Used to test ServiceClassLoader
    */
   private void addServiceLoaderListener(ITestNGListener l) {
-    m_serviceLoaderListeners.add(l);
+    if (! m_serviceLoaderListeners.containsKey(l.getClass())) {
+      m_serviceLoaderListeners.put(l.getClass(), l);
+    }
   }
 
   /*
    * Used to test ServiceClassLoader
    */
   public List<ITestNGListener> getServiceLoaderListeners() {
-    return m_serviceLoaderListeners;
+    return Lists.newArrayList(m_serviceLoaderListeners.values());
   }
 
   //

--- a/src/test/java/test/reports/UniqueReporterInjectionTest.java
+++ b/src/test/java/test/reports/UniqueReporterInjectionTest.java
@@ -19,7 +19,9 @@ public class UniqueReporterInjectionTest extends SimpleBaseTest {
         tng.setUseDefaultListeners(false);
         tng.addListener((ITestNGListener) new ReporterListenerForIssue1227());
         tng.run();
-        Assert.assertEquals(tng.getReporters().size(),1);
+        //Since we have another reporting listener that is injected via the service loader file
+        //reporting listeners size will now have to be two.
+        Assert.assertEquals(tng.getReporters().size(),2);
         Assert.assertEquals(ReporterListenerForIssue1227.counter, 1);
     }
 

--- a/src/test/java/test/serviceloader/ServiceLoaderTest.java
+++ b/src/test/java/test/serviceloader/ServiceLoaderTest.java
@@ -43,7 +43,7 @@ public class ServiceLoaderTest extends SimpleBaseTest {
     TestNG tng = create(ServiceLoaderSampleTest.class);
     tng.run();
 
-    Assert.assertEquals(1, tng.getServiceLoaderListeners().size());
+    Assert.assertEquals(2, tng.getServiceLoaderListeners().size());
     ListenerAssert.assertListenerType(tng.getServiceLoaderListeners(), MyConfigurationListener.class);
   }
 }

--- a/src/test/java/test/testng1232/ListenerTemplate.java
+++ b/src/test/java/test/testng1232/ListenerTemplate.java
@@ -1,0 +1,106 @@
+package test.testng1232;
+
+import org.testng.*;
+import org.testng.xml.XmlSuite;
+
+import java.util.List;
+
+/**
+ * This class provides "void" implementations for all listener invocations so that one can tweak
+ * behavior of only those methods which need customization. (Mainly to circumvent verbosity in
+ * actual listener implementations)
+ */
+public class ListenerTemplate implements
+    IInvokedMethodListener,
+    IClassListener,
+    ITestListener,
+    ISuiteListener,
+    IAlterSuiteListener,
+    IExecutionListener,
+    IReporter {
+
+    @Override
+    public void onBeforeClass(ITestClass testClass) {
+
+    }
+
+    @Override
+    public void onAfterClass(ITestClass testClass) {
+
+    }
+
+    @Override
+    public void onStart(ISuite suite) {
+
+    }
+
+    @Override
+    public void onFinish(ISuite suite) {
+
+    }
+
+    @Override
+    public void beforeInvocation(IInvokedMethod method, ITestResult testResult) {
+
+    }
+
+    @Override
+    public void afterInvocation(IInvokedMethod method, ITestResult testResult) {
+
+    }
+
+    @Override
+    public void onTestStart(ITestResult result) {
+
+    }
+
+    @Override
+    public void onTestSuccess(ITestResult result) {
+
+    }
+
+    @Override
+    public void onTestFailure(ITestResult result) {
+
+    }
+
+    @Override
+    public void onTestSkipped(ITestResult result) {
+
+    }
+
+    @Override
+    public void onTestFailedButWithinSuccessPercentage(ITestResult result) {
+
+    }
+
+    @Override
+    public void onStart(ITestContext context) {
+
+    }
+
+    @Override
+    public void onFinish(ITestContext context) {
+
+    }
+
+    @Override
+    public void onExecutionStart() {
+
+    }
+
+    @Override
+    public void onExecutionFinish() {
+
+    }
+
+    @Override
+    public void alter(List<XmlSuite> suites) {
+
+    }
+
+    @Override
+    public void generateReport(List<XmlSuite> xmlSuites, List<ISuite> suites, String outputDirectory) {
+
+    }
+}

--- a/src/test/java/test/testng1232/TestClassContainer.java
+++ b/src/test/java/test/testng1232/TestClassContainer.java
@@ -1,0 +1,24 @@
+package test.testng1232;
+
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/**
+ * This Class houses all the test classes that are required by {@link TestListenerInstances}
+ */
+public class TestClassContainer {
+
+    public static class SimpleTestClass {
+        @Test
+        public void testMethod() {
+        }
+    }
+
+    @Listeners(TestListenerFor1232.class)
+    public static class SimpleTestClassWithListener {
+        @Test
+        public void testMethod() {
+        }
+    }
+
+}

--- a/src/test/java/test/testng1232/TestListenerFor1232.java
+++ b/src/test/java/test/testng1232/TestListenerFor1232.java
@@ -1,0 +1,71 @@
+package test.testng1232;
+
+import org.testng.*;
+import org.testng.collections.Maps;
+import org.testng.xml.XmlSuite;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class TestListenerFor1232 extends ListenerTemplate {
+    static Map<CounterTypes, AtomicInteger> counters = Maps.newHashMap();
+
+    static synchronized void resetCounters() {
+        counters = Maps.newHashMap();
+    }
+
+    @Override
+    public void beforeInvocation(IInvokedMethod method, ITestResult testResult) {
+        incrementCounter(CounterTypes.METHOD);
+    }
+
+    @Override
+    public void onBeforeClass(ITestClass testClass) {
+        incrementCounter(CounterTypes.CLASS);
+    }
+
+    @Override
+    public void onStart(ITestContext context) {
+        incrementCounter(CounterTypes.TEST);
+    }
+
+    @Override
+    public void onStart(ISuite suite) {
+        incrementCounter(CounterTypes.SUITE);
+    }
+
+    @Override
+    public void alter(List<XmlSuite> suites) {
+        incrementCounter(CounterTypes.ALTER_SUITE);
+    }
+
+    @Override
+    public void onExecutionStart() {
+        incrementCounter(CounterTypes.EXECUTION);
+    }
+
+    @Override
+    public void generateReport(List<XmlSuite> xmlSuites, List<ISuite> suites, String outputDirectory) {
+        incrementCounter(CounterTypes.REPORTER);
+    }
+
+    private void incrementCounter(CounterTypes type) {
+        if (!counters.containsKey(type)){
+            counters.put(type, new AtomicInteger(0));
+        }
+        AtomicInteger value = counters.get(type);
+        value.incrementAndGet();
+        counters.put(type, value);
+    }
+
+    enum CounterTypes {
+        METHOD,
+        CLASS,
+        TEST,
+        SUITE,
+        ALTER_SUITE,
+        EXECUTION,
+        REPORTER
+    }
+}

--- a/src/test/java/test/testng1232/TestListenerInstances.java
+++ b/src/test/java/test/testng1232/TestListenerInstances.java
@@ -26,11 +26,11 @@ public class TestListenerInstances extends SimpleBaseTest {
         runTestForTestClass(TestClassContainer.SimpleTestClass.class, true);
     }
 
-    private void runTestForTestClass(Class clazz) {
+    private static void runTestForTestClass(Class<?> clazz) {
         runTestForTestClass(clazz, false);
     }
 
-    private void runTestForTestClass(Class clazz, boolean injectListenerViaTag) {
+    private static void runTestForTestClass(Class<?> clazz, boolean injectListenerViaTag) {
         TestNG tng = createTestNGInstanceFor(clazz, injectListenerViaTag);
         TestListenerFor1232.resetCounters();
         TestListenerFor1232 listener = new TestListenerFor1232();
@@ -41,10 +41,9 @@ public class TestListenerInstances extends SimpleBaseTest {
         for (CounterTypes type : CounterTypes.values()) {
             Assert.assertEquals(TestListenerFor1232.counters.get(type).intValue(), 1);
         }
-
     }
 
-    private TestNG createTestNGInstanceFor(Class clazz, boolean addListenerTag) {
+    private static TestNG createTestNGInstanceFor(Class<?> clazz, boolean addListenerTag) {
         XmlSuite xmlSuite = createXmlSuite("Suite");
         if (addListenerTag) {
             xmlSuite.addListener(TestListenerFor1232.class.getName());

--- a/src/test/java/test/testng1232/TestListenerInstances.java
+++ b/src/test/java/test/testng1232/TestListenerInstances.java
@@ -1,0 +1,57 @@
+package test.testng1232;
+
+import org.testng.Assert;
+import org.testng.ITestNGListener;
+import org.testng.TestNG;
+import org.testng.annotations.Test;
+import org.testng.xml.XmlSuite;
+import org.testng.xml.XmlTest;
+import test.SimpleBaseTest;
+import test.testng1232.TestListenerFor1232.CounterTypes;
+
+public class TestListenerInstances extends SimpleBaseTest {
+
+    @Test
+    public void testIfOnlyOneListenerInstanceExists() {
+        runTestForTestClass(TestClassContainer.SimpleTestClass.class);
+    }
+
+    @Test
+    public void testIfOnlyOneListenerInstanceExistsUsingAnnotations() {
+        runTestForTestClass(TestClassContainer.SimpleTestClassWithListener.class);
+    }
+
+    @Test
+    public void testIfOnlyOneListenerInstanceExistsUsingListenerTag() {
+        runTestForTestClass(TestClassContainer.SimpleTestClass.class, true);
+    }
+
+    private void runTestForTestClass(Class clazz) {
+        runTestForTestClass(clazz, false);
+    }
+
+    private void runTestForTestClass(Class clazz, boolean injectListenerViaTag) {
+        TestNG tng = createTestNGInstanceFor(clazz, injectListenerViaTag);
+        TestListenerFor1232.resetCounters();
+        TestListenerFor1232 listener = new TestListenerFor1232();
+        tng.addListener((ITestNGListener) listener);
+        TestListenerFor1232 anotherListener = new TestListenerFor1232();
+        tng.addListener((ITestNGListener) anotherListener);
+        tng.run();
+        for (CounterTypes type : CounterTypes.values()) {
+            Assert.assertEquals(TestListenerFor1232.counters.get(type).intValue(), 1);
+        }
+
+    }
+
+    private TestNG createTestNGInstanceFor(Class clazz, boolean addListenerTag) {
+        XmlSuite xmlSuite = createXmlSuite("Suite");
+        if (addListenerTag) {
+            xmlSuite.addListener(TestListenerFor1232.class.getName());
+        }
+        XmlTest xmlTest = createXmlTest(xmlSuite, "Test");
+        createXmlClass(xmlTest, clazz);
+        return create(xmlSuite);
+    }
+
+}

--- a/src/test/resources/META-INF/services/org.testng.ITestNGListener
+++ b/src/test/resources/META-INF/services/org.testng.ITestNGListener
@@ -1,1 +1,2 @@
 test.serviceloader.MyConfigurationListener
+test.testng1232.TestListenerFor1232

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -121,6 +121,7 @@
       <class name="test.reports.ReporterLogTest" />
       <class name="test.testng387.TestNG387"/>
       <class name="test.testng1231.TestExecutionListenerInvocationOrder"/>
+      <class name="test.testng1232.TestListenerInstances"/>
     </classes>
   </test>
 


### PR DESCRIPTION
Fixes # .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

Fixes #1232

Altered TestNG logic to ensure that TestNG now 
adds only one instance per listener class so that
duplicate listener invocation can be prevented.