### PR TITLE
Inject config failure data into test results

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 ﻿Current
+Fixed: GITHUB-674: Enrich Test method skips due to configuration failures with throwable data (Krishnan Mahadevan)
 Fixed: GITHUB-1240: Enrich the test results showing mechanism in Travis CI (Krishnan Mahadevan)
 Fixed: GITHUB-1232: Prevent TestNG from adding duplicate instances of the same listener (Krishnan Mahadevan)
 Fixed: GITHUB-1170: Fixing the test DataProviderTest.shouldNotThrowConcurrentModification (Krishnan Mahadevan)

--- a/src/test/java/test/testng674/BeforeClassSkipExceptionTest.java
+++ b/src/test/java/test/testng674/BeforeClassSkipExceptionTest.java
@@ -69,6 +69,16 @@ public class BeforeClassSkipExceptionTest extends SimpleBaseTest {
         }
     }
 
+    @Test
+    public void testExceptionDetailsWhenFailuresExistInABaseClass() {
+        ReportingListenerFor674 reporter = new ReportingListenerFor674();
+        Class<?>[] classes = {
+            TestClassSampleContainer.A.class,
+            TestClassSampleContainer.B.class
+        };
+        createTestNGInstanceAndRun(reporter, 2, false, classes);
+    }
+
     private static void createTestNGInstanceAndRun(ReportingListenerFor674 reporter, Class<?>... clazz) {
         createTestNGInstanceAndRun(reporter, 1, false, clazz);
     }

--- a/src/test/java/test/testng674/BeforeClassSkipExceptionTest.java
+++ b/src/test/java/test/testng674/BeforeClassSkipExceptionTest.java
@@ -1,0 +1,95 @@
+package test.testng674;
+
+import org.testng.Assert;
+import org.testng.ITestNGListener;
+import org.testng.TestNG;
+import org.testng.annotations.Test;
+import org.testng.xml.XmlSuite;
+import org.testng.xml.XmlTest;
+import test.SimpleBaseTest;
+
+public class BeforeClassSkipExceptionTest extends SimpleBaseTest {
+
+    @Test
+    public void testIfTestMethodHasException() {
+        ReportingListenerFor674 reporter = new ReportingListenerFor674();
+        createTestNGInstanceAndRun(reporter, TestClassSampleContainer.SampleClassWithFailingBeforeClassMethod.class);
+    }
+
+    @Test
+    public void testIfTestMethodHasExceptionInInheritance() {
+        ReportingListenerFor674 reporter = new ReportingListenerFor674();
+        createTestNGInstanceAndRun(reporter, TestClassSampleContainer.ChildClass.class);
+    }
+
+    @Test
+    public void testExceptionDetailsWhenClassHasMultipleFailures() {
+        ReportingListenerFor674 reporter = new ReportingListenerFor674();
+        createTestNGInstanceAndRun(reporter, TestClassSampleContainer.SampleClassWithMultipleFailures.class);
+    }
+
+    @Test
+    public void testExceptionDetailsWhenClassHasExplicitSkipInConfiguration() {
+        ReportingListenerFor674 reporter = new ReportingListenerFor674();
+        createTestNGInstanceAndRun(reporter, TestClassSampleContainer.SampleClassWithExplicitConfigSkip.class);
+    }
+
+    @Test
+    public void testExceptionDetailsWhenConfigHasAlwaysRun() {
+        ReportingListenerFor674 reporter = new ReportingListenerFor674();
+        createTestNGInstanceAndRun(reporter, TestClassSampleContainer.SampleClassWithMultipleFailuresAndAlwaysRun
+            .class);
+    }
+
+    @Test
+    public void testExceptionDetailsUsingGroupsWithFailures() {
+        ReportingListenerFor674 reporter = new ReportingListenerFor674();
+        Class<?>[] classes = {
+            TestClassSampleContainer.GroupsContainer.GroupA.class,
+            TestClassSampleContainer.GroupsContainer.GroupB.class
+        };
+        createTestNGInstanceAndRun(reporter, 2, true, classes);
+    }
+
+    @Test
+    public void testExceptionDetailsWhenFailuresExistInSuiteConfigs() {
+        XmlSuite xmlSuite = createXmlSuite("Suite");
+        XmlTest xmlTest1 = createXmlTest(xmlSuite, "Test1");
+        createXmlClass(xmlTest1, TestClassSampleContainer.SuiteFailureTestClass.class);
+        XmlTest xmlTest2 = createXmlTest(xmlSuite, "Test2");
+        createXmlClass(xmlTest2, TestClassSampleContainer.RegularTestClass.class);
+        TestNG tng = create(xmlSuite);
+        ReportingListenerFor674 reporter = new ReportingListenerFor674();
+        tng.addListener((ITestNGListener) reporter);
+        tng.run();
+        Assert.assertEquals(reporter.getErrors().size(), 2);
+        for (Throwable error : reporter.getErrors()) {
+            Assert.assertEquals(error.getMessage(), TestClassSampleContainer.ERROR_MSG);
+            Assert.assertTrue(error instanceof RuntimeException);
+        }
+    }
+
+    private static void createTestNGInstanceAndRun(ReportingListenerFor674 reporter, Class<?>... clazz) {
+        createTestNGInstanceAndRun(reporter, 1, false, clazz);
+    }
+
+    private static void createTestNGInstanceAndRun(ReportingListenerFor674 reporter, int expectedCount, boolean
+        useGroups, Class<?>... clazzes) {
+        XmlSuite xmlSuite = createXmlSuite("Suite");
+        XmlTest xmlTest = createXmlTest(xmlSuite, "Test");
+        if (useGroups) {
+            xmlTest.addIncludedGroup("foo");
+        }
+        for (Class<?> clazz : clazzes) {
+            createXmlClass(xmlTest, clazz);
+        }
+        TestNG tng = create(xmlSuite);
+        tng.addListener((ITestNGListener) reporter);
+        tng.run();
+        Assert.assertEquals(reporter.getErrors().size(), expectedCount);
+        for (Throwable error : reporter.getErrors()) {
+            Assert.assertEquals(error.getMessage(), TestClassSampleContainer.ERROR_MSG);
+            Assert.assertTrue(error instanceof RuntimeException);
+        }
+    }
+}

--- a/src/test/java/test/testng674/ReportingListenerFor674.java
+++ b/src/test/java/test/testng674/ReportingListenerFor674.java
@@ -1,0 +1,29 @@
+package test.testng674;
+
+import org.testng.*;
+import org.testng.xml.XmlSuite;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+public class ReportingListenerFor674 implements IReporter {
+    private List<Throwable> errors = new ArrayList<>();
+
+    public void generateReport(List<XmlSuite> list, List<ISuite> suites, String s) {
+        for (ISuite suite : suites) {
+            for (ISuiteResult suiteResult : suite.getResults().values()) {
+                ITestContext ctx = suiteResult.getTestContext();
+                Set<ITestResult> results = ctx.getSkippedTests().getAllResults();
+                for (ITestResult result : results) {
+                    Throwable throwable = result.getThrowable();
+                    errors.add(throwable);
+                }
+            }
+        }
+    }
+
+    public List<Throwable> getErrors() {
+        return errors;
+    }
+}

--- a/src/test/java/test/testng674/TestClassSampleContainer.java
+++ b/src/test/java/test/testng674/TestClassSampleContainer.java
@@ -1,0 +1,101 @@
+package test.testng674;
+
+import org.testng.SkipException;
+import org.testng.annotations.*;
+
+public class TestClassSampleContainer {
+    public static final String ERROR_MSG = "GITHUB-674 Exception";
+
+    public static class SampleClassWithFailingBeforeClassMethod {
+        @BeforeClass
+        public void beforeClass() {
+            throw new RuntimeException(ERROR_MSG);
+        }
+
+        @Test
+        public void testMethod() {}
+    }
+
+    public static class ChildClass extends SampleClassWithFailingBeforeClassMethod {
+
+    }
+
+    public static class SampleClassWithMultipleFailures {
+        @BeforeClass
+        public void beforeClass() {
+            throw new RuntimeException(ERROR_MSG);
+        }
+
+        @BeforeMethod
+        public void beforeMethod() {
+            throw new RuntimeException(ERROR_MSG);
+        }
+
+        @Test
+        public void testMethod() {}
+
+    }
+
+    public static class SampleClassWithMultipleFailuresAndAlwaysRun {
+        @BeforeClass
+        public void beforeClass() {
+            throw new RuntimeException(ERROR_MSG);
+        }
+
+        @BeforeMethod(alwaysRun = true)
+        public void beforeMethod() {
+            throw new RuntimeException(ERROR_MSG);
+        }
+
+        @Test
+        public void testMethod() {}
+
+    }
+
+    public static class SampleClassWithExplicitConfigSkip {
+        @BeforeClass
+        public void beforeClass() {
+            throw new SkipException(ERROR_MSG);
+        }
+
+        @Test
+        public void testMethod() {}
+
+    }
+
+    public static class SuiteFailureTestClass {
+        @BeforeSuite
+        public void beforeSuite() {
+            throw new SkipException(ERROR_MSG);
+        }
+        @Test
+        public void testMethod() {
+            System.err.println("Hello World " + getClass().getName());
+        }
+    }
+
+    public static class RegularTestClass {
+        @Test
+        public void testMethod() {
+            System.err.println("Hello World " + getClass().getName());
+        }
+    }
+
+    public static class GroupsContainer {
+
+        public static class GroupA {
+            @BeforeGroups(groups = "foo")
+            public void beforeGroups() {
+                throw new RuntimeException(ERROR_MSG);
+            }
+
+            @Test(groups = "foo")
+            public void testMethod() {}
+        }
+
+        public static class GroupB {
+            @Test(groups = "foo")
+            public void testMethod() {}
+        }
+    }
+}

--- a/src/test/java/test/testng674/TestClassSampleContainer.java
+++ b/src/test/java/test/testng674/TestClassSampleContainer.java
@@ -69,16 +69,12 @@ public class TestClassSampleContainer {
             throw new SkipException(ERROR_MSG);
         }
         @Test
-        public void testMethod() {
-            System.err.println("Hello World " + getClass().getName());
-        }
+        public void testMethod() {}
     }
 
     public static class RegularTestClass {
         @Test
-        public void testMethod() {
-            System.err.println("Hello World " + getClass().getName());
-        }
+        public void testMethod() {}
     }
 
     public static class GroupsContainer {
@@ -97,5 +93,25 @@ public class TestClassSampleContainer {
             @Test(groups = "foo")
             public void testMethod() {}
         }
+    }
+
+    public static class BaseSample {
+
+        @BeforeSuite
+        public void beforeSuite() {
+            throw new RuntimeException(ERROR_MSG);
+        }
+    }
+
+    public static class A extends BaseSample {
+
+        @Test
+        public void testMethod() {}
+    }
+
+    public static class B extends BaseSample {
+
+        @Test
+        public void testMethod() {}
     }
 }

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -126,6 +126,7 @@
       <class name="test.testng387.TestNG387"/>
       <class name="test.testng1231.TestExecutionListenerInvocationOrder"/>
       <class name="test.testng1232.TestListenerInstances"/>
+      <class name="test.testng674.BeforeClassSkipExceptionTest"/>
     </classes>
   </test>
 


### PR DESCRIPTION
Fixes # .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

Fixes #674

Until now there is no way of figuring out why test
methods skipped especially when there is a config
failure/skip involved.

Fixed this by extracting the exception data from the
config failure and then injecting it into the test result
of the skipped test.