### PR TITLE
fix #1221 ConcurrentModificationException in TextReporter by returning new list

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -17,6 +17,7 @@ Fixed: GITHUB-1139: DataProvider could support Object[] as a valid return type (
 Fixed: GITHUB-1182: Cannot run multiple @Factory-annotated methods in the same class (Ian Donovan & Julien Herr)
 New: Hierarchy on order features (from less important to more important): groupByInstance, preserveOrder, priority, dependsOnGroups, dependsOnMethods
 Fixed: GITHUB-1156: test execution dependant upon class name order and fails with TestNGException: No free nodes found (@t-weil & Julien Herr)
+Fixed: GITHUB-1221: ConcurrentModificationException in TextReporter (Nick Tan)
 
 6.9.13.6
 2016/09/23

--- a/src/main/java/org/testng/TestListenerAdapter.java
+++ b/src/main/java/org/testng/TestListenerAdapter.java
@@ -77,25 +77,25 @@ public class TestListenerAdapter implements IResultListener2 {
    * @return Returns the failedButWithinSuccessPercentageTests.
    */
   public List<ITestResult> getFailedButWithinSuccessPercentageTests() {
-    return m_failedButWSPerTests;
+    return new ArrayList<>(m_failedButWSPerTests);
   }
   /**
    * @return Returns the failedTests.
    */
   public List<ITestResult> getFailedTests() {
-    return m_failedTests;
+    return new ArrayList<>(m_failedTests);
   }
   /**
    * @return Returns the passedTests.
    */
   public List<ITestResult> getPassedTests() {
-    return m_passedTests;
+    return new ArrayList<>(m_passedTests);
   }
   /**
    * @return Returns the skippedTests.
    */
   public List<ITestResult> getSkippedTests() {
-    return m_skippedTests;
+    return new ArrayList<>(m_skippedTests);
   }
 
   private static void ppp(String s) {


### PR DESCRIPTION
Fixes #1221

### Did you remember to?

- [ ] Add test case(s)
- [x] Update `CHANGES.txt`

the fix here is returning new list of test result, to bypass ConcurrentModificationException when iterating in TestReporter.