### PR TITLE
set the defaultOutputDir other than '${project.projectDir}/bin'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,9 +44,16 @@ apply plugin: 'groovy'
 apply plugin: 'jacoco'
 apply plugin: 'osgi'
 apply plugin: 'version-injection'
+apply plugin: 'eclipse'
 
 targetCompatibility = "1.7"
 sourceCompatibility = "1.7"
+
+eclipse {
+    classpath {
+        defaultOutputDir = file('target/classes')
+    }
+}
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
the defaultOutputDir is `${project.projectDir}/bin`, when import TestNG into Eclipse workspace with Buildship (the gradle eclipse plugin), all the files under `${project.projectDir}/bin` were removed. to avoid the conflict, now specify defaultOutputDir to target/classes
