### PR TITLE
prevent the main process from exceptional exit with catching the ption in listeners and keep going

### DIFF
--- a/src/main/java/org/testng/TestRunner.java
+++ b/src/main/java/org/testng/TestRunner.java
@@ -1202,11 +1202,15 @@ public class TestRunner
    */
   private void fireEvent(boolean isStart) {
     for (ITestListener itl : m_testListeners) {
-      if (isStart) {
-        itl.onStart(this);
-      }
-      else {
-        itl.onFinish(this);
+      try {
+        if (isStart) {
+          itl.onStart(this);
+        }
+        else {
+          itl.onFinish(this);
+        }
+      } catch (Exception e) {
+        e.printStackTrace();
       }
     }
   }

--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -1702,32 +1702,34 @@ public class Invoker implements IInvoker {
   // TODO: move this from here as it is directly called from TestNG
   public static void runTestListeners(ITestResult tr, List<ITestListener> listeners) {
     for (ITestListener itl : listeners) {
-      switch(tr.getStatus()) {
-        case ITestResult.SKIP: {
-          itl.onTestSkipped(tr);
-          break;
+      try {
+        switch(tr.getStatus()) {
+          case ITestResult.SKIP: {
+            itl.onTestSkipped(tr);
+            break;
+          }
+          case ITestResult.SUCCESS_PERCENTAGE_FAILURE: {
+            itl.onTestFailedButWithinSuccessPercentage(tr);
+            break;
+          }
+          case ITestResult.FAILURE: {
+            itl.onTestFailure(tr);
+            break;
+          }
+          case ITestResult.SUCCESS: {
+            itl.onTestSuccess(tr);
+            break;
+          }
+          case ITestResult.STARTED: {
+            itl.onTestStart(tr);
+            break;
+          }
+          default: {
+            assert false : "UNKNOWN STATUS:" + tr;
+          }
         }
-        case ITestResult.SUCCESS_PERCENTAGE_FAILURE: {
-          itl.onTestFailedButWithinSuccessPercentage(tr);
-          break;
-        }
-        case ITestResult.FAILURE: {
-          itl.onTestFailure(tr);
-          break;
-        }
-        case ITestResult.SUCCESS: {
-          itl.onTestSuccess(tr);
-          break;
-        }
-
-        case ITestResult.STARTED: {
-          itl.onTestStart(tr);
-          break;
-        }
-
-        default: {
-          assert false : "UNKNOWN STATUS:" + tr;
-        }
+      } catch (Exception e) {
+        e.printStackTrace();
       }
     }
   }


### PR DESCRIPTION
it's a complementary PR for #1221 , the idea is, any exception in reporter (or, listener) should not make the main process exceptional exit.

 @cbeust , @juherr , @krmahadevan 