### PR TITLE
Include “ignored” test count in TestNG and JUnit reports

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,6 @@
 ﻿Current
+Fixed: GITHUB-1211: Include "ignored" test count in JUnit reports (Krishnan Mahadevan)
+Fixed: GITHUB-1213: Include "ignored" test count in testng-results.xml (Krishnan Mahadevan)
 Fixed: GITHUB-674: Enrich Test method skips due to configuration failures with throwable data (Krishnan Mahadevan)
 Fixed: GITHUB-1240: Enrich the test results showing mechanism in Travis CI (Krishnan Mahadevan)
 Fixed: GITHUB-1232: Prevent TestNG from adding duplicate instances of the same listener (Krishnan Mahadevan)

--- a/src/main/java/org/testng/reporters/JUnitXMLReporter.java
+++ b/src/main/java/org/testng/reporters/JUnitXMLReporter.java
@@ -310,10 +310,9 @@ public class JUnitXMLReporter implements IResultListener2 {
     }
 
 	/**
-	 * Borojevic Created this method to guarantee unique file names for
-	 *         reports.<br>
-	 *         Also, this will guarantee that the old reports are overwritten
-	 *         when tests are run again.
+	 * This method guarantees unique file names for reports.<br>
+	 * Also, this will guarantee that the old reports are overwritten when tests are run again.
+     * 
 	 * @param context
 	 *            test context
 	 * @return unique name for the file associated with this test context.

--- a/src/main/java/org/testng/reporters/JUnitXMLReporter.java
+++ b/src/main/java/org/testng/reporters/JUnitXMLReporter.java
@@ -14,12 +14,15 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Calendar;
 import java.util.Collections;
-import java.util.Date;
+import java.util.Collection;
+import java.util.TimeZone;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Pattern;
+
+import java.text.SimpleDateFormat;
 
 /**
  * A JUnit XML report generator (replacing the original JUnitXMLReporter that was
@@ -43,13 +46,7 @@ public class JUnitXMLReporter implements IResultListener2 {
   }
 
 
-  /**
-   * keep lists of all the results
-   */
-  private int m_numPassed= 0;
   private int m_numFailed= 0;
-  private int m_numSkipped= 0;
-  private int m_numFailedButIgnored= 0;
   private List<ITestResult> m_allTests =
       Collections.synchronizedList(Lists.<ITestResult>newArrayList());
   private List<ITestResult> m_configIssues =
@@ -71,13 +68,11 @@ public class JUnitXMLReporter implements IResultListener2 {
   @Override
   public void onTestSuccess(ITestResult tr) {
     m_allTests.add(tr);
-    m_numPassed++;
   }
 
   @Override
   public void onTestFailedButWithinSuccessPercentage(ITestResult tr) {
     m_allTests.add(tr);
-    m_numFailedButIgnored++;
   }
 
   /**
@@ -95,7 +90,6 @@ public class JUnitXMLReporter implements IResultListener2 {
   @Override
   public void onTestSkipped(ITestResult tr) {
     m_allTests.add(tr);
-    m_numSkipped++;
   }
 
   /**
@@ -153,6 +147,7 @@ public class JUnitXMLReporter implements IResultListener2 {
       Properties attrs= new Properties();
       attrs.setProperty(XMLConstants.ATTR_ERRORS, "0");
       attrs.setProperty(XMLConstants.ATTR_FAILURES, "" + m_numFailed);
+      attrs.setProperty(XMLConstants.ATTR_IGNORED, "" + context.getExcludedMethods().size());
       try {
         attrs.setProperty(XMLConstants.ATTR_HOSTNAME, InetAddress.getLocalHost().getHostName());
       } catch (UnknownHostException e) {
@@ -168,26 +163,50 @@ public class JUnitXMLReporter implements IResultListener2 {
       attrs.setProperty(XMLConstants.ATTR_TIME, ""
           + ((context.getEndDate().getTime() - context.getStartDate().getTime()) / 1000.0));
 
-      Date timeStamp = Calendar.getInstance().getTime();
-      attrs.setProperty(XMLConstants.ATTR_TIMESTAMP, timeStamp.toGMTString());
+      attrs.setProperty(XMLConstants.ATTR_TIMESTAMP, timeAsGmt());
 
       document.push(XMLConstants.TESTSUITE, attrs);
-//      document.addEmptyElement(XMLConstants.PROPERTIES);
 
       createElementFromTestResults(document, m_configIssues);
       createElementFromTestResults(document, m_allTests);
+      createElementFromIgnoredTests(document, context);
 
       document.pop();
       Utils.writeUtf8File(context.getOutputDirectory(),generateFileName(context) + ".xml", document.toXML());
   }
 
-  private void createElementFromTestResults(XMLStringBuffer document, List<ITestResult> results) {
-    synchronized(results) {
-      for(ITestResult tr : results) {
-        createElement(document, tr);
-      }
+  static String timeAsGmt() {
+    SimpleDateFormat sdf = new SimpleDateFormat();
+    sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
+    sdf.applyPattern("dd MMM yyyy HH:mm:ss z");
+    return sdf.format(Calendar.getInstance().getTime());
+  }
+
+  private synchronized void createElementFromTestResults(XMLStringBuffer document, List<ITestResult> results) {
+    for(ITestResult tr : results) {
+      createElement(document, tr);
     }
   }
+
+  private synchronized void createElementFromIgnoredTests(XMLStringBuffer doc, ITestContext context) {
+    Collection<ITestNGMethod> methods = context.getExcludedMethods();
+    for (ITestNGMethod method : methods) {
+      Properties properties = getPropertiesFor(method, 0);
+      doc.push(XMLConstants.TESTCASE,properties);
+      doc.addEmptyElement("ignored");
+      doc.pop();
+    }
+  }
+
+  private Properties getPropertiesFor(ITestNGMethod method, long elapsedTimeMillis) {
+    Properties attrs= new Properties();
+    String name= Utils.detailedMethodName(method, false);
+    attrs.setProperty(XMLConstants.ATTR_NAME, name);
+    attrs.setProperty(XMLConstants.ATTR_CLASSNAME, method.getRealClass().getName());
+    attrs.setProperty(XMLConstants.ATTR_TIME, "" + (((double) elapsedTimeMillis) / 1000));
+    return attrs;
+  }
+
 
   private Set<String> getPackages(ITestContext context) {
     Set<String> result = Sets.newHashSet();
@@ -201,12 +220,12 @@ public class JUnitXMLReporter implements IResultListener2 {
   }
 
   private void createElement(XMLStringBuffer doc, ITestResult tr) {
-    Properties attrs= new Properties();
+
     long elapsedTimeMillis= tr.getEndMillis() - tr.getStartMillis();
-    String name= tr.getMethod().isTest() ? tr.getName() : Utils.detailedMethodName(tr.getMethod(), false);
-    attrs.setProperty(XMLConstants.ATTR_NAME, name);
-    attrs.setProperty(XMLConstants.ATTR_CLASSNAME, tr.getTestClass().getRealClass().getName());
-    attrs.setProperty(XMLConstants.ATTR_TIME, "" + (((double) elapsedTimeMillis) / 1000));
+    Properties attrs= getPropertiesFor(tr.getMethod(), elapsedTimeMillis);
+    if (tr.getMethod().isTest()) {
+      attrs.setProperty(XMLConstants.ATTR_NAME, tr.getName());
+    }
 
     if((ITestResult.FAILURE == tr.getStatus()) || (ITestResult.SKIP == tr.getStatus())) {
       doc.push(XMLConstants.TESTCASE, attrs);
@@ -215,7 +234,7 @@ public class JUnitXMLReporter implements IResultListener2 {
         createFailureElement(doc, tr);
       }
       else if(ITestResult.SKIP == tr.getStatus()) {
-        createSkipElement(doc, tr);
+        createSkipElement(doc);
       }
 
       doc.pop();
@@ -235,7 +254,7 @@ public class JUnitXMLReporter implements IResultListener2 {
         attrs.setProperty(XMLConstants.ATTR_MESSAGE, encodeAttr(message)); // ENCODE
       }
       doc.push(XMLConstants.FAILURE, attrs);
-      doc.addCDATA(Utils.stackTrace(t, false)[0]);
+      doc.addCDATA(Utils.shortStackTrace(t, false));
       doc.pop();
     }
     else {
@@ -243,8 +262,8 @@ public class JUnitXMLReporter implements IResultListener2 {
     }
   }
 
-  private void createSkipElement(XMLStringBuffer doc, ITestResult tr) {
-    doc.addEmptyElement("skipped");
+  private void createSkipElement(XMLStringBuffer doc) {
+    doc.addEmptyElement(XMLConstants.SKIPPED);
   }
 
   private String encodeAttr(String attr) {
@@ -262,7 +281,7 @@ public class JUnitXMLReporter implements IResultListener2 {
     if(idx == -1) {
       return str;
     }
-    StringBuffer result= new StringBuffer();
+    StringBuilder result= new StringBuilder();
     while(idx != -1) {
       result.append(str.substring(start, idx));
       if(pattern.matcher(str.substring(idx)).matches()) {
@@ -288,13 +307,10 @@ public class JUnitXMLReporter implements IResultListener2 {
 		m_allTests = Collections.synchronizedList(Lists.<ITestResult>newArrayList());
 		m_configIssues = Collections.synchronizedList(Lists.<ITestResult>newArrayList());
 		m_numFailed = 0;
-		m_numFailedButIgnored = 0;
-		m_numPassed = 0;
-		m_numSkipped = 0;
-	}
+    }
 
 	/**
-	 * @author Borojevic Created this method to guarantee unique file names for
+	 * Borojevic Created this method to guarantee unique file names for
 	 *         reports.<br>
 	 *         Also, this will guarantee that the old reports are overwritten
 	 *         when tests are run again.
@@ -303,7 +319,7 @@ public class JUnitXMLReporter implements IResultListener2 {
 	 * @return unique name for the file associated with this test context.
 	 * */
 	private String generateFileName(ITestContext context) {
-		String fileName = null;
+		String fileName;
 		String keyToSearch = context.getSuite().getName() + context.getName();
 		if (m_fileNameMap.get(keyToSearch) == null) {
 			fileName = context.getName();

--- a/src/main/java/org/testng/reporters/XMLConstants.java
+++ b/src/main/java/org/testng/reporters/XMLConstants.java
@@ -21,6 +21,8 @@ public interface XMLConstants {
   /** the failure element */
   String FAILURE = "failure";
 
+  String SKIPPED = "skipped";
+
   /** the system-err element */
   String SYSTEM_ERR = "system-err";
 
@@ -41,6 +43,9 @@ public interface XMLConstants {
 
   /** failures attribute for testsuite elements */
   String ATTR_FAILURES = "failures";
+
+  /** ignored attribute for testsuite elements */
+  String ATTR_IGNORED = "ignored";
 
   /** tests attribute for testsuite elements */
   String ATTR_TESTS = "tests";

--- a/src/main/java/org/testng/reporters/XMLReporter.java
+++ b/src/main/java/org/testng/reporters/XMLReporter.java
@@ -42,6 +42,7 @@ public class XMLReporter implements IReporter {
     int passed = 0;
     int failed = 0;
     int skipped = 0;
+    int ignored = 0;
     for (ISuite s : suites) {
       Map<String, ISuiteResult> suiteResults = s.getResults();
       synchronized(suiteResults) {
@@ -50,6 +51,7 @@ public class XMLReporter implements IReporter {
           passed += testContext.getPassedTests().size();
           failed += testContext.getFailedTests().size();
           skipped += testContext.getSkippedTests().size();
+          ignored += testContext.getExcludedMethods().size();
         }
       }
     }
@@ -59,7 +61,8 @@ public class XMLReporter implements IReporter {
     p.put("passed", passed);
     p.put("failed", failed);
     p.put("skipped", skipped);
-    p.put("total", passed + failed + skipped);
+    p.put("ignored", ignored);
+    p.put("total", passed + failed + skipped + ignored);
     rootBuffer.push(XMLReporterConfig.TAG_TESTNG_RESULTS, p);
     writeReporterOutput(rootBuffer);
     for (ISuite suite : suites) {

--- a/src/test/java/test/junitreports/JUnitReportsTest.java
+++ b/src/test/java/test/junitreports/JUnitReportsTest.java
@@ -1,0 +1,68 @@
+package test.junitreports;
+
+import org.testng.Assert;
+import org.testng.ITestNGListener;
+import org.testng.TestNG;
+import org.testng.annotations.Test;
+import org.testng.xml.XmlSuite;
+import org.testng.xml.XmlTest;
+import test.SimpleBaseTest;
+import test.TestHelper;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+public class JUnitReportsTest extends SimpleBaseTest {
+
+    private static String clazz = SimpleTestSample.class.getName();
+    private static List<Testcase> testcaseList = Arrays.asList(
+        Testcase.newInstance("childTest", clazz, "skipped"),
+        Testcase.newInstance("masterTest", clazz, "error"),
+        Testcase.newInstance("masterTest", clazz, "failure"),
+        Testcase.newInstance("iShouldNeverBeExecuted", clazz, "ignored")
+    );
+
+    @Test
+    public void testJUnitXMLReporter() throws IOException {
+        runTest(2, 0, 1, 1, 0, new LocalJUnitXMLReporter(), false);
+    }
+
+    @Test
+    public void testJUnitReportReporter() throws IOException {
+        runTest(2, 1, 1, 0, 1, new LocalJUnitReportReporter(), true);
+    }
+
+    private void runTest(int tests,
+        int errors, int ignored, int failures, int skipped, ITestNGListener reporter, boolean useClazzAsSuiteName)
+        throws IOException {
+        Path outputDir = TestHelper.createRandomDirectory();
+        XmlSuite xmlSuite = createXmlSuite("suite");
+        XmlTest xmlTest = createXmlTest(xmlSuite, "test");
+        createXmlClass(xmlTest, SimpleTestSample.class);
+        TestNG tng = create(outputDir, xmlSuite);
+        TestsuiteRetriever reportReporter = (TestsuiteRetriever) reporter;
+        tng.addListener(reporter);
+        tng.run();
+        String suitename = SimpleTestSample.class.getName();
+        if (! useClazzAsSuiteName) {
+            suitename = xmlTest.getName();
+        }
+        Testsuite suite = reportReporter.getTestsuite(suitename);
+        Assert.assertEquals(suite.getName(), suitename);
+        Assert.assertEquals(suite.getTests(), tests);
+        Assert.assertEquals(suite.getErrors(), errors);
+        Assert.assertEquals(suite.getIgnored(), ignored);
+        Assert.assertEquals(suite.getFailures(), failures);
+        Assert.assertEquals(suite.getSkipped(), skipped);
+        Assert.assertEquals(suite.getTestcase().size(), 3);
+        List<Testcase> actualTestcases = suite.getTestcase();
+        for (Testcase actualTestcase : actualTestcases) {
+            Assert.assertTrue(testcaseList.contains(actualTestcase));
+        }
+    }
+
+
+
+}

--- a/src/test/java/test/junitreports/LocalJUnitReportReporter.java
+++ b/src/test/java/test/junitreports/LocalJUnitReportReporter.java
@@ -1,0 +1,37 @@
+package test.junitreports;
+
+import org.testng.ISuite;
+import org.testng.reporters.JUnitReportReporter;
+import org.testng.xml.XmlSuite;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.util.ArrayList;
+import java.util.List;
+
+public class LocalJUnitReportReporter extends JUnitReportReporter implements TestsuiteRetriever {
+    private List<Testsuite> testsuites = new ArrayList<>();
+
+    @Override
+    public void generateReport(List<XmlSuite> xmlSuites, List<ISuite> suites, String defaultOutputDirectory) {
+        super.generateReport(xmlSuites, suites, defaultOutputDirectory);
+        String dir = defaultOutputDirectory + File.separator + "junitreports";
+        File directory = new File(dir);
+        File[] files = directory.listFiles(new FilenameFilter() {
+            @Override
+            public boolean accept(File dir, String name) {
+                return name.endsWith(".xml");
+            }
+        });
+        testsuites.addAll(LocalJUnitXMLReporter.getSuites(files));
+    }
+
+    public Testsuite getTestsuite(String name) {
+        for (Testsuite suite : testsuites) {
+            if (suite.getName().equals(name)) {
+                return suite;
+            }
+        }
+        return null;
+    }
+}

--- a/src/test/java/test/junitreports/LocalJUnitXMLReporter.java
+++ b/src/test/java/test/junitreports/LocalJUnitXMLReporter.java
@@ -1,0 +1,52 @@
+package test.junitreports;
+
+import org.testng.ITestContext;
+import org.testng.reporters.JUnitXMLReporter;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FilenameFilter;
+import java.util.ArrayList;
+import java.util.List;
+
+public class LocalJUnitXMLReporter extends JUnitXMLReporter implements TestsuiteRetriever {
+    private List<Testsuite> testsuites = new ArrayList<>();
+
+    protected void generateReport(ITestContext context) {
+        super.generateReport(context);
+        String dir = context.getOutputDirectory();
+        File directory = new File(dir);
+        File[] files = directory.listFiles(new FilenameFilter() {
+            @Override
+            public boolean accept(File dir, String name) {
+                return name.endsWith(".xml");
+            }
+        });
+        testsuites.addAll(getSuites(files));
+    }
+
+    public Testsuite getTestsuite(String name) {
+        for (Testsuite suite : testsuites) {
+            if (suite.getName().equals(name)) {
+                return suite;
+            }
+        }
+        return null;
+    }
+
+    static List<Testsuite> getSuites(File[] files) {
+        List<Testsuite> testsuites = new ArrayList<>();
+        if (files != null) {
+            for (File file : files) {
+                TestsuiteXmlParser parser = new TestsuiteXmlParser();
+                try {
+                    testsuites.add(parser.parse("", new FileInputStream(file), false));
+                } catch (FileNotFoundException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+        return testsuites;
+    }
+}

--- a/src/test/java/test/junitreports/SimpleTestSample.java
+++ b/src/test/java/test/junitreports/SimpleTestSample.java
@@ -1,0 +1,17 @@
+package test.junitreports;
+
+import org.testng.annotations.Test;
+
+public class SimpleTestSample {
+
+    @Test (enabled = false)
+    public void iShouldNeverBeExecuted() {}
+
+    @Test
+    public void masterTest() {
+        throw new IllegalStateException("Simulating a llegal state.");
+    }
+
+    @Test(dependsOnMethods = "masterTest")
+    public void childTest() {}
+}

--- a/src/test/java/test/junitreports/TestSuiteHandler.java
+++ b/src/test/java/test/junitreports/TestSuiteHandler.java
@@ -1,0 +1,52 @@
+package test.junitreports;
+
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.DefaultHandler;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Stack;
+
+public class TestSuiteHandler extends DefaultHandler {
+    private static List<String> tags = Arrays.asList("error", "skipped", "ignored", "failure");
+    private Testsuite testsuite = new Testsuite();
+    private Stack<String> elementStack = new Stack();
+    private Stack<Testcase> testcaseStack = new Stack<>();
+
+    @Override
+    public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
+        this.elementStack.push(qName);
+        if ("testsuite".equals(qName)) {
+            if (attributes != null) {
+                testsuite.init(attributes);
+            }
+        }
+        if ("testcase".equals(qName)) {
+            Testcase testcase = new Testcase();
+            if (attributes != null) {
+                testcase.init(attributes);
+            }
+            testcaseStack.push(testcase);
+        }
+        if (tags.contains(qName)) {
+            Testcase testcase = testcaseStack.pop();
+            String innerTag = qName;
+            testcase.setInnerTagType(innerTag);
+            testcaseStack.push(testcase);
+        }
+    }
+
+    @Override
+    public void endElement(String uri, String localName, String qName) throws SAXException {
+        elementStack.pop();
+        if ("testcase".equals(qName)) {
+            Testcase testcase = testcaseStack.pop();
+            testsuite.addTestcase(testcase);
+        }
+    }
+
+    public Testsuite getTestsuite() {
+        return testsuite;
+    }
+}

--- a/src/test/java/test/junitreports/Testcase.java
+++ b/src/test/java/test/junitreports/Testcase.java
@@ -1,0 +1,82 @@
+package test.junitreports;
+
+import org.xml.sax.Attributes;
+
+public class Testcase {
+    private String name;
+    private String classname;
+    private String innerTagType;
+
+    public String getName() {
+        return name;
+    }
+
+    public String getClassname() {
+        return classname;
+    }
+
+    public String getInnerTagType() {
+        return innerTagType;
+    }
+
+    public void setInnerTagType(String innerTagType) {
+        this.innerTagType = innerTagType;
+    }
+
+    public void init(Attributes attributes) {
+        String value = attributes.getValue("name");
+        if (value != null) {
+            this.name = value;
+        }
+        value = attributes.getValue("classname");
+        if (value != null) {
+            this.classname = value;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "Testcase{" +
+            "name='" + name + '\'' +
+            ", classname='" + classname + '\'' +
+            ", innerTagType='" + innerTagType + '\'' +
+            '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Testcase testcase = (Testcase) o;
+
+        if (! name.equals(testcase.name)) {
+            return false;
+        }
+        if (! classname.equals(testcase.classname)) {
+            return false;
+        }
+        return innerTagType.equals(testcase.innerTagType);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name.hashCode();
+        result = 31 * result + classname.hashCode();
+        result = 31 * result + innerTagType.hashCode();
+        return result;
+    }
+
+    public static Testcase newInstance(String name, String classname, String innerTagType) {
+        Testcase testcase = new Testcase();
+        testcase.name = name;
+        testcase.classname = classname;
+        testcase.innerTagType = innerTagType;
+        return testcase;
+    }
+}

--- a/src/test/java/test/junitreports/Testsuite.java
+++ b/src/test/java/test/junitreports/Testsuite.java
@@ -1,0 +1,90 @@
+package test.junitreports;
+
+import org.xml.sax.Attributes;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class Testsuite {
+
+    public String getName() {
+        return name;
+    }
+
+    public int getTests() {
+        return tests;
+    }
+
+    public int getIgnored() {
+        return ignored;
+    }
+
+
+    public int getFailures() {
+        return failures;
+    }
+
+    public int getSkipped() {
+        return skipped;
+    }
+
+    public int getErrors() {
+        return errors;
+    }
+
+    public List<Testcase> getTestcase() {
+        return testcase;
+    }
+
+    public void addTestcase(Testcase testcase) {
+        this.testcase.add(testcase);
+    }
+
+    public void init(Attributes attributes) {
+        String value = attributes.getValue("name");
+        if (value != null) {
+            this.name = value;
+        }
+        value = attributes.getValue("tests");
+        if (value != null) {
+            this.tests = Integer.parseInt(value);
+        }
+        value = attributes.getValue("ignored");
+        if (value != null) {
+            this.ignored = Integer.parseInt(value);
+        }
+        value = attributes.getValue("failures");
+        if (value != null) {
+            this.failures = Integer.parseInt(value);
+        }
+        value = attributes.getValue("skipped");
+        if (value != null) {
+            this.skipped = Integer.parseInt(value);
+        }
+        value = attributes.getValue("errors");
+        if (value != null) {
+            this.errors = Integer.parseInt(value);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "Testsuite{" +
+            "name='" + name + '\'' +
+            ", tests=" + tests +
+            ", ignored=" + ignored +
+            ", failures=" + failures +
+            ", skipped=" + skipped +
+            ", errors=" + errors +
+            ", testcase=" + testcase +
+            '}';
+    }
+
+    private String name;
+    private int tests;
+    private int ignored;
+    private int failures;
+    private int skipped;
+    private int errors;
+    private List<Testcase> testcase = new LinkedList<>();
+}

--- a/src/test/java/test/junitreports/TestsuiteRetriever.java
+++ b/src/test/java/test/junitreports/TestsuiteRetriever.java
@@ -1,0 +1,5 @@
+package test.junitreports;
+
+public interface TestsuiteRetriever {
+    Testsuite getTestsuite(String name);
+}

--- a/src/test/java/test/junitreports/TestsuiteXmlParser.java
+++ b/src/test/java/test/junitreports/TestsuiteXmlParser.java
@@ -1,0 +1,22 @@
+package test.junitreports;
+
+import org.testng.TestNGException;
+import org.testng.xml.XMLParser;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class TestsuiteXmlParser extends XMLParser<Testsuite> {
+
+    @Override
+    public Testsuite parse(String filePath, InputStream is, boolean loadClasses) throws TestNGException {
+        TestSuiteHandler handler = new TestSuiteHandler();
+        try {
+            super.parse(is, handler);
+            return handler.getTestsuite();
+        } catch (SAXException | IOException e) {
+            throw new TestNGException(e);
+        }
+    }
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -103,6 +103,7 @@
       <class name="test.EclipseTest" />
       <class name="test.ReporterApiTest" />
       <class name="test.reports.UniqueReporterInjectionTest"/>
+      <class name="test.junitreports.JUnitReportsTest"/>
       <class name="test.abstractmethods.AbstractTest" />
       <class name="test.override.OverrideTest" />
       <class name="test.priority.PriorityTest" />


### PR DESCRIPTION
Fixes # .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

Fixes #1211, #1213

Included the count of “ignored” tests [tests are 
marked as ignored by TestNG when `@Test(enabled=false)` 
is used] in both TestNG and JUnit reports.