### PR TITLE
Changing ignored test tag to “skipped”

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,6 @@
 ﻿Current
 Fixed: GITHUB-1046: Provide a mechanism to customize a test method name for reporting (Krishnan Mahadevan)
-Fixed: GITHUB-1211: Include "ignored" test count in JUnit reports (Krishnan Mahadevan)
+Fixed: GITHUB-1211: Include disabled/ ignored test methods in JUnit reports (Krishnan Mahadevan)
 Fixed: GITHUB-1213: Include "ignored" test count in testng-results.xml (Krishnan Mahadevan)
 Fixed: GITHUB-674: Enrich Test method skips due to configuration failures with throwable data (Krishnan Mahadevan)
 Fixed: GITHUB-1240: Enrich the test results showing mechanism in Travis CI (Krishnan Mahadevan)

--- a/src/main/java/org/testng/reporters/JUnitReportReporter.java
+++ b/src/main/java/org/testng/reporters/JUnitReportReporter.java
@@ -183,7 +183,7 @@ public class JUnitReportReporter implements IReporter {
     Properties p2 = new Properties();
     p2.setProperty(XMLConstants.ATTR_CLASSNAME, method.getRealClass().getName());
     p2.setProperty(XMLConstants.ATTR_NAME, method.getMethodName());
-    testTag.childTag = XMLConstants.ATTR_IGNORED;
+    testTag.childTag = XMLConstants.SKIPPED;
     testTag.properties = p2;
     return testTag;
   }

--- a/src/main/java/org/testng/reporters/JUnitXMLReporter.java
+++ b/src/main/java/org/testng/reporters/JUnitXMLReporter.java
@@ -193,7 +193,7 @@ public class JUnitXMLReporter implements IResultListener2 {
     for (ITestNGMethod method : methods) {
       Properties properties = getPropertiesFor(method, 0);
       doc.push(XMLConstants.TESTCASE,properties);
-      doc.addEmptyElement("ignored");
+      doc.addEmptyElement(XMLConstants.ATTR_IGNORED);
       doc.pop();
     }
   }

--- a/src/test/java/test/junitreports/JUnitReportsTest.java
+++ b/src/test/java/test/junitreports/JUnitReportsTest.java
@@ -21,6 +21,7 @@ public class JUnitReportsTest extends SimpleBaseTest {
         Testcase.newInstance("childTest", clazz, "skipped"),
         Testcase.newInstance("masterTest", clazz, "error"),
         Testcase.newInstance("masterTest", clazz, "failure"),
+        Testcase.newInstance("iShouldNeverBeExecuted", clazz, "skipped"),
         Testcase.newInstance("iShouldNeverBeExecuted", clazz, "ignored")
     );
 
@@ -62,7 +63,4 @@ public class JUnitReportsTest extends SimpleBaseTest {
             Assert.assertTrue(testcaseList.contains(actualTestcase));
         }
     }
-
-
-
 }


### PR DESCRIPTION
Fixes # .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

Fixes #1211 
The JUnit XML reports that TestNG produces recently
included the tests that were ignored i.e., had 
@Test(enabled=false). But the tags in the report 
were explicitly included as “ignored” to differentiate
them. Changing this to have their tags included as 
“skipped”.