### PR TITLE
Testcase ordering based on priority in JUnit reports

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 ﻿Current
+Fixed: GITHUB-1262: Testcases out of order in XML file in junitreport folder when using testng (Krishnan Mahadevan)
 Fixed: GITHUB-1265: JUnit Reporter includes redundant ignored methods (Krishnan Mahadevan)
 Fixed: GITHUB-1266: JUnit Reporter produces a wrong number of total test methods (Krishnan Mahadevan)
 Fixed: GITHUB-1257: Group parameter not applying on included <suite-files>

--- a/src/main/java/org/testng/reporters/JUnitReportReporter.java
+++ b/src/main/java/org/testng/reporters/JUnitReportReporter.java
@@ -21,7 +21,10 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -96,7 +99,9 @@ public class JUnitReportReporter implements IReporter {
       int testCount = 0;
       float totalTime = 0;
 
-      for (ITestResult tr: entry.getValue()) {
+      Collection<ITestResult> iTestResults = sort(entry.getValue());
+
+      for (ITestResult tr: iTestResults) {
 
         long time = tr.getEndMillis() - tr.getStartMillis();
 
@@ -169,6 +174,18 @@ public class JUnitReportReporter implements IReporter {
       Utils.writeUtf8File(outputDirectory, getFileName(cls), xsb.toXML());
     }
 
+  }
+
+  private static Collection<ITestResult> sort(Set<ITestResult> results) {
+    List<ITestResult> sortedResults = new ArrayList<>(results);
+    Collections.sort(sortedResults, new Comparator<ITestResult> () {
+
+      @Override
+      public int compare(ITestResult o1, ITestResult o2) {
+        return Integer.compare(o1.getMethod().getPriority(), o2.getMethod().getPriority());
+      }
+    });
+    return sortedResults;
   }
 
   private static int getDisabledTestCount(Set<ITestNGMethod> methods) {

--- a/src/test/java/test/junitreports/Issue1262TestSample.java
+++ b/src/test/java/test/junitreports/Issue1262TestSample.java
@@ -1,0 +1,20 @@
+package test.junitreports;
+
+import org.testng.annotations.Test;
+
+public class Issue1262TestSample {
+
+    @Test (priority = 3)
+    public void testRoles003_Post() {}
+
+    @Test (priority = 4)
+    public void testRoles004_Post() {}
+
+    @Test (priority = 1)
+    public void testRoles001_Post() {
+    }
+
+    @Test (priority = 2)
+    public void testRoles002_Post() {
+    }
+}


### PR DESCRIPTION
Fixes #1262  .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

Fixes #1262