### PR TITLE
while set parallel to classes the program may occur the exception:

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+Current
 Fixed: GITHUB-1302: while set parallel to classes the program may occur the exception: 
 Fixed: GITHUB-772: Severe thread contention while running large test with parallel methods (Shaburov Oleg)
 Fixed: GITHUB-1298: ITestResult injection is failing in BeforeMethod method (Krishnan Mahadevan)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,5 @@
 Current
-Fixed: GITHUB-1302: while set parallel to classes the program may occur the exception(Jianhua Li)
+Fixed: GITHUB-1302: When 'parallel' is set to 'classes', ConcurrentModificationException can be thrown(Jianhua Li)
 Fixed: GITHUB-772: Severe thread contention while running large test with parallel methods (Shaburov Oleg)
 Fixed: GITHUB-1298: ITestResult injection is failing in BeforeMethod method (Krishnan Mahadevan)
 Fixed: GITHUB-1293: Beanshell based execution does not work any more (Krishnan Mahadevan)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 ﻿Current
+Fixed: GITHUB-1302: while set parallel to classes the program may occur the exception: 
 Fixed: GITHUB-1298: ITestResult injection is failing in BeforeMethod method (Krishnan Mahadevan)
 Fixed: GITHUB-1293: Beanshell based execution does not work any more (Krishnan Mahadevan)
 Fixed: GITHUB-1262: Testcases out of order in XML file in junitreport folder when using testng (Krishnan Mahadevan)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,5 @@
 Current
-Fixed: GITHUB-1302: while set parallel to classes the program may occur the exception: 
+Fixed: GITHUB-1302: while set parallel to classes the program may occur the exception(Jianhua Li)
 Fixed: GITHUB-772: Severe thread contention while running large test with parallel methods (Shaburov Oleg)
 Fixed: GITHUB-1298: ITestResult injection is failing in BeforeMethod method (Krishnan Mahadevan)
 Fixed: GITHUB-1293: Beanshell based execution does not work any more (Krishnan Mahadevan)

--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -88,12 +88,14 @@ public class Invoker implements IInvoker {
   private static final Predicate<ITestNGMethod, IClass> SAME_CLASS = new SameClassNamePredicate();
 
   private void setClassInvocationFailure(Class<?> clazz, Object instance) {
-    Set<Object> instances = m_classInvocationResults.get( clazz );
-    if (instances == null) {
-      instances = Sets.newHashSet();
-      m_classInvocationResults.put(clazz, instances);
+    synchronized(this){
+       Set<Object> instances = m_classInvocationResults.get( clazz );
+       if (instances == null) {
+         instances = Sets.newHashSet();
+         m_classInvocationResults.put(clazz, instances);
+       }
+       instances.add(instance);
     }
-    instances.add(instance);
   }
 
   private void setMethodInvocationFailure(ITestNGMethod method, Object instance) {
@@ -397,12 +399,14 @@ public class Invoker implements IInvoker {
    * @return true if this class or a parent class failed to initialize.
    */
   private boolean classConfigurationFailed(Class<?> cls) {
-    for (Class<?> c : m_classInvocationResults.keySet()) {
-      if (c == cls || c.isAssignableFrom(cls)) {
-        return true;
-      }
+    synchronized(this){
+       for (Class<?> c : m_classInvocationResults.keySet()) {
+         if (c == cls || c.isAssignableFrom(cls)) {
+           return true;
+         }
+       }
+       return false;
     }
-    return false;
   }
 
   /**
@@ -423,7 +427,9 @@ public class Invoker implements IInvoker {
         if (! m_continueOnFailedConfiguration) {
           result = !classConfigurationFailed(cls);
         } else {
-          result = !m_classInvocationResults.get(cls).contains(instance);
+          synchronized(this){
+             result = !m_classInvocationResults.get(cls).contains(instance);
+          }
         }
       }
       // if method is BeforeClass, currentTestMethod will be null
@@ -433,12 +439,14 @@ public class Invoker implements IInvoker {
         result = !m_methodInvocationResults.get(currentTestMethod).contains(getMethodInvocationToken(currentTestMethod, instance));
       }
       else if (! m_continueOnFailedConfiguration) {
-        for(Class<?> clazz: m_classInvocationResults.keySet()) {
+        synchronized(this){
+           for(Class<?> clazz: m_classInvocationResults.keySet()) {
 //          if (clazz == cls) {
-          if(clazz.isAssignableFrom(cls)) {
-            result= false;
-            break;
-          }
+             if(clazz.isAssignableFrom(cls)) {
+               result= false;
+               break;
+             }
+           }
         }
       }
     }

--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -88,7 +88,7 @@ public class Invoker implements IInvoker {
   private static final Predicate<ITestNGMethod, IClass> SAME_CLASS = new SameClassNamePredicate();
 
   private void setClassInvocationFailure(Class<?> clazz, Object instance) {
-    synchronized(this){
+    synchronized(m_classInvocationResults){
        Set<Object> instances = m_classInvocationResults.get( clazz );
        if (instances == null) {
          instances = Sets.newHashSet();
@@ -399,7 +399,7 @@ public class Invoker implements IInvoker {
    * @return true if this class or a parent class failed to initialize.
    */
   private boolean classConfigurationFailed(Class<?> cls) {
-    synchronized(this){
+    synchronized(m_classInvocationResults){
        for (Class<?> c : m_classInvocationResults.keySet()) {
          if (c == cls || c.isAssignableFrom(cls)) {
            return true;
@@ -427,7 +427,7 @@ public class Invoker implements IInvoker {
         if (! m_continueOnFailedConfiguration) {
           result = !classConfigurationFailed(cls);
         } else {
-          synchronized(this){
+          synchronized(m_classInvocationResults){
              result = !m_classInvocationResults.get(cls).contains(instance);
           }
         }
@@ -439,7 +439,7 @@ public class Invoker implements IInvoker {
         result = !m_methodInvocationResults.get(currentTestMethod).contains(getMethodInvocationToken(currentTestMethod, instance));
       }
       else if (! m_continueOnFailedConfiguration) {
-        synchronized(this){
+        synchronized(m_classInvocationResults){
            for(Class<?> clazz: m_classInvocationResults.keySet()) {
 //          if (clazz == cls) {
              if(clazz.isAssignableFrom(cls)) {


### PR DESCRIPTION
Set `parallel = classes` and `thread-count = 20`.
If there are a lot of testcase failed or throw skiptest, the program may occur the exception(Lots):
```
java.util.ConcurrentModificationException
at java.util.Hashtable.next(Hashtable.java:1167)
at org.testng.internal.Invoker.classConfigurationFailed(Invoker.java:401)
...
```

Fixes # .

### Did you remember to?

- [ ] Add test case(s)
- [x] Update `CHANGES.txt`
