### PR TITLE
Adding fix for anonymous classes in TestNGClassFinder

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 ﻿Current
 Fixed: GITHUB-772: Severe thread contention while running large test with parallel methods (Shaburov Oleg)
+Fixed: GITHUB-1307: TestNGException when using an anonymous class in Factory (Mike Cowan)
 Fixed: GITHUB-1298: ITestResult injection is failing in BeforeMethod method (Krishnan Mahadevan)
 Fixed: GITHUB-1293: Beanshell based execution does not work any more (Krishnan Mahadevan)
 Fixed: GITHUB-1262: Testcases out of order in XML file in junitreport folder when using testng (Krishnan Mahadevan)

--- a/src/main/java/org/testng/internal/TestNGClassFinder.java
+++ b/src/main/java/org/testng/internal/TestNGClassFinder.java
@@ -125,6 +125,11 @@ public class TestNGClassFinder extends BaseClassFinder {
           continue;
         }
 
+        if((null == thisInstance) && cls.isAnonymousClass()) {
+          Utils.log("", 5, "[WARN] Found an anonymous class with no valid instance attached" + cls);
+          continue;
+        }
+        
         IClass ic= findOrCreateIClass(m_testContext, cls, cim.getXmlClass(cls), thisInstance,
             xmlTest, annotationFinder, objectFactory);
         if(null != ic) {

--- a/src/test/java/test/factory/nested/AbstractBaseSample.java
+++ b/src/test/java/test/factory/nested/AbstractBaseSample.java
@@ -1,0 +1,15 @@
+package test.factory.nested;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public abstract class AbstractBaseSample {
+
+  protected abstract String someMethod(String param);
+
+  @Test
+  public void test() {
+    String result = someMethod("hello");
+    Assert.assertEquals(result, "hello world");
+  }
+}

--- a/src/test/java/test/factory/nested/BaseFactorySample.java
+++ b/src/test/java/test/factory/nested/BaseFactorySample.java
@@ -1,0 +1,14 @@
+package test.factory.nested;
+
+import org.testng.annotations.Factory;
+
+public abstract class BaseFactorySample {
+
+  public abstract AbstractBaseSample buildTest();
+
+  @Factory
+  public Object[] createObjects() {
+    AbstractBaseSample test = buildTest();
+    return new Object[]{test};
+  }
+}

--- a/src/test/java/test/factory/nested/FactoryWithAnonymousTestsSample.java
+++ b/src/test/java/test/factory/nested/FactoryWithAnonymousTestsSample.java
@@ -1,0 +1,14 @@
+package test.factory.nested;
+
+public class FactoryWithAnonymousTestsSample extends BaseFactorySample {
+
+  @Override
+  public AbstractBaseSample buildTest() {
+    return new AbstractBaseSample() {
+      @Override
+      protected String someMethod(String param) {
+        return param + " world";
+      }
+    };
+  }
+}

--- a/src/test/java/test/factory/nested/GitHub1307Test.java
+++ b/src/test/java/test/factory/nested/GitHub1307Test.java
@@ -1,0 +1,26 @@
+package test.factory.nested;
+
+import org.testng.ITestNGListener;
+import org.testng.TestNG;
+import org.testng.annotations.Test;
+import test.InvokedMethodNameListener;
+import test.SimpleBaseTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GitHub1307Test extends SimpleBaseTest {
+
+    @Test
+    public void testGitHub1307() {
+        TestNG tng = create(FactoryWithAnonymousTestsSample.class);
+
+        InvokedMethodNameListener listener = new InvokedMethodNameListener();
+        tng.addListener((ITestNGListener) listener);
+
+        tng.run();
+
+        assertThat(listener.getFailedMethodNames()).isEmpty();
+        assertThat(listener.getSkippedMethodNames()).isEmpty();
+        assertThat(listener.getSucceedMethodNames()).containsExactly("test");
+    }
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -336,6 +336,7 @@
       <class name="test.factory.EmptyFactoryDataProviderTest" />
 
       <class name="test.factory.github1131.GitHub1131Test" />
+      <class name="test.factory.nested.GitHub1307Test"/>
     </classes>
   </test>
 


### PR DESCRIPTION
Fixes #1307 

### Did you remember to?
- [X] Add test case(s)
- [X] Update `CHANGES.txt`

This fixes an issue where if a `Factory` is used to create anonymous classes when testing as a _package_, then an exception is thrown:
```java
An error occurred while instantiating class test.factory.nested.FactoryWithAnonymousTestsTest$1. Check to make sure it can be accessed/instantiated.
```