### PR TITLE
Add Java9 in Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,35 @@
+sudo: false
 language: java
 
 env:
   global:
     - GRADLE_OPTS=-Xmx512m
 
-jdk:
-  - oraclejdk8
-  - oraclejdk7
-  - openjdk7
+before_script:
+  - if [[ "x$JDK" == *'x9'* ]]; then remove_dir_from_path $JAVA_HOME/bin; export JAVA_HOME=/usr/lib/jvm/java-9-oracle; export PATH=$JAVA_HOME/bin:$PATH; java -Xmx32m -version; fi
+
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - env: JDK=9
+  include:
+    - jdk: oraclejdk8
+    - jdk: oraclejdk8
+      addons:
+        apt:
+          packages:
+            - oracle-java9-installer
+      env: JDK=9
+    - jdk: oraclejdk7
+    - jdk: openjdk7
 
 script:
   - ./gradlew check --stacktrace

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,7 @@ Fixed: GITHUB-1265: JUnit Reporter includes redundant ignored methods (Krishnan 
 Fixed: GITHUB-1266: JUnit Reporter produces a wrong number of total test methods (Krishnan Mahadevan)
 Fixed: GITHUB-1257: Group parameter not applying on included <suite-files>
 Fixed: GITHUB-1284: Listeners on the child suites are not applied (Vimalraj Selvam)
+New: GITHUB-1313: Add Java9 as test environment on Travis (Julien Herr)
 
 6.10
 2016/11/28

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![Build Status](http://img.shields.io/travis/cbeust/testng.svg)](https://travis-ci.org/cbeust/testng)
-[![Java9 EA Build Status](https://img.shields.io/jenkins/s/https/adopt-openjdk.ci.cloudbees.com/TestNG.svg?label="Java9 EA")](https://adopt-openjdk.ci.cloudbees.com/job/TestNG)
 [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/cbeust/testng?svg=true)](https://ci.appveyor.com/project/cbeust/testng)
 [![Dependency Status](https://www.versioneye.com/user/projects/576aecf1c2ea9d00096bf58f/badge.svg)](https://www.versioneye.com/user/projects/576aecf1c2ea9d00096bf58f)
 [![Reference Status](https://www.versioneye.com/java/org.testng:testng/reference_badge.svg)](https://www.versioneye.com/java/org.testng:testng/references)


### PR DESCRIPTION
You can see the effect on my travis: https://travis-ci.org/juherr/testng/builds/194972707

Without surprise, it is not working well on Java9 for the moment.