### PR TITLE
	Skipped methods are not supposed to be notified as executed

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+New: Skipped methods are not supposed to be executed (Julien Herr)
 Fixed: GITHUB-1197: Ability to dynamically set the status and exception of a test via ITestResult (Anthony Nguyen)
 Fixed: GITHUB-1302: When 'parallel' is set to 'classes', ConcurrentModificationException can be thrown(Jianhua Li)
 Fixed: GITHUB-772: Severe thread contention while running large test with parallel methods (Shaburov Oleg)

--- a/src/main/java/org/testng/ITestNGMethod.java
+++ b/src/main/java/org/testng/ITestNGMethod.java
@@ -166,11 +166,10 @@ public interface ITestNGMethod extends Serializable, Cloneable {
   void setInvocationCount(int count);
 
   /**
-   * @return the total number of thimes this method needs to be invoked, including possible
-   *         clones of this method - this is relevant when threadPoolSize is bigger than 1
-   *         where each clone of this method is only invoked once individually, i.e.
-   *         {@link org.testng.ITestNGMethod#getInvocationCount()} would always return 1.
+   * @deprecated Will always return 0
+   * @return 0
    */
+  @Deprecated
   int getTotalInvocationCount();
 
   /**

--- a/src/main/java/org/testng/internal/BaseTestMethod.java
+++ b/src/main/java/org/testng/internal/BaseTestMethod.java
@@ -321,11 +321,10 @@ public abstract class BaseTestMethod implements ITestNGMethod {
 
   /**
    * {@inheritDoc}
-   * @return the number of times this method or one of its clones must be invoked.
    */
   @Override
   public int getTotalInvocationCount() {
-    return 1;
+    return 0;
   }
 
   /**

--- a/src/main/java/org/testng/internal/ClonedMethod.java
+++ b/src/main/java/org/testng/internal/ClonedMethod.java
@@ -112,7 +112,7 @@ public class ClonedMethod implements ITestNGMethod {
 
   @Override
   public int getTotalInvocationCount() {
-    return 1;
+    return 0;
   }
 
   @Override

--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -196,6 +196,7 @@ public class Invoker implements IInvoker {
           if (MethodHelper.isEnabled(configurationAnnotation)) {
 
             if (!confInvocationPassed(tm, currentTestMethod, testClass, instance) && !alwaysRun) {
+              log(3, "Skipping " + Utils.detailedMethodName(tm, true));
               handleConfigurationSkip(tm, testResult, configurationAnnotation, currentTestMethod, instance, suite);
               continue;
             }
@@ -415,14 +416,13 @@ public class Invoker implements IInvoker {
    */
   private boolean confInvocationPassed(ITestNGMethod method, ITestNGMethod currentTestMethod,
       IClass testClass, Object instance) {
-    boolean result= true;
+    boolean result = true;
 
     Class<?> cls = testClass.getRealClass();
 
     if(m_suiteState.isFailed()) {
-      result= false;
-    }
-    else {
+      result = false;
+    } else {
       if (classConfigurationFailed(cls)) {
         if (! m_continueOnFailedConfiguration) {
           result = !classConfigurationFailed(cls);
@@ -440,10 +440,9 @@ public class Invoker implements IInvoker {
       }
       else if (! m_continueOnFailedConfiguration) {
         synchronized(m_classInvocationResults){
-           for(Class<?> clazz: m_classInvocationResults.keySet()) {
-//          if (clazz == cls) {
-             if(clazz.isAssignableFrom(cls)) {
-               result= false;
+           for(Class<?> clazz : m_classInvocationResults.keySet()) {
+             if (clazz.isAssignableFrom(cls)) {
+               result = false;
                break;
              }
            }
@@ -452,11 +451,11 @@ public class Invoker implements IInvoker {
     }
 
     // check if there are failed @BeforeGroups
-    String[] groups= method.getGroups();
+    String[] groups = method.getGroups();
     if(null != groups && groups.length > 0) {
-      for(String group: groups) {
+      for(String group : groups) {
         if(m_beforegroupsFailures.containsKey(group)) {
-          result= false;
+          result = false;
           break;
         }
       }
@@ -466,8 +465,8 @@ public class Invoker implements IInvoker {
 
    // Creates a token for tracking a unique invocation of a method on an instance.
    // Is used when configFailurePolicy=continue.
-  private Object getMethodInvocationToken(ITestNGMethod method, Object instance) {
-    return String.format("%s+%d", instance.toString(), method.getCurrentInvocationCount());
+  private static Object getMethodInvocationToken(ITestNGMethod method, Object instance) {
+    return String.format("%s+%d+%d", instance.toString(), method.getCurrentInvocationCount(), method.getParameterInvocationCount());
   }
 
   /**
@@ -599,6 +598,15 @@ public class Invoker implements IInvoker {
       suite, params, parameterValues,
       instance, testResult);
 
+    if (!confInvocationPassed(tm, tm, testClass, instance)) {
+      ITestResult result = registerSkippedTestResult(tm, instance, System.currentTimeMillis(),
+              getExceptionDetails(instance));
+      m_notifier.addSkippedTest(tm, result);
+      tm.incrementCurrentInvocationCount();
+
+      return result;
+    }
+
     //
     // Create the ExtraOutput for this method
     //
@@ -629,38 +637,31 @@ public class Invoker implements IInvoker {
         runTestListeners(testResult);
       }
 
+      log(3, "Invoking " + tm.getQualifiedName());
       runInvokedMethodListeners(BEFORE_INVOCATION, invokedMethod, testResult);
 
       m_notifier.addInvokedMethod(invokedMethod);
 
       Method thisMethod = tm.getConstructorOrMethod().getMethod();
 
-      if(confInvocationPassed(tm, tm, testClass, instance)) {
-        log(3, "Invoking " + tm.getQualifiedName());
+      // If this method is a IHookable, invoke its run() method
+      IHookable hookableInstance =
+          IHookable.class.isAssignableFrom(tm.getRealClass()) ?
+          (IHookable) instance : m_configuration.getHookable();
 
-        // If this method is a IHookable, invoke its run() method
-        IHookable hookableInstance =
-            IHookable.class.isAssignableFrom(tm.getRealClass()) ?
-            (IHookable) instance : m_configuration.getHookable();
-
-        if (MethodHelper.calculateTimeOut(tm) <= 0) {
-          if (hookableInstance != null) {
-            MethodInvocationHelper.invokeHookable(instance,
-                parameterValues, hookableInstance, thisMethod, testResult);
-          } else {
-            // Not a IHookable, invoke directly
-            MethodInvocationHelper.invokeMethod(thisMethod, instance,
-                parameterValues);
-          }
-          setTestStatus(testResult, ITestResult.SUCCESS);
+      if (MethodHelper.calculateTimeOut(tm) <= 0) {
+        if (hookableInstance != null) {
+          MethodInvocationHelper.invokeHookable(instance,
+              parameterValues, hookableInstance, thisMethod, testResult);
         } else {
-          // Method with a timeout
-          MethodInvocationHelper.invokeWithTimeout(tm, instance, parameterValues, testResult, hookableInstance);
+          // Not a IHookable, invoke directly
+          MethodInvocationHelper.invokeMethod(thisMethod, instance,
+              parameterValues);
         }
-      }
-      else {
-        setTestStatus(testResult, ITestResult.SKIP);
-        addExceptionDetailsToTestResult(testResult, instance);
+        setTestStatus(testResult, ITestResult.SUCCESS);
+      } else {
+        // Method with a timeout
+        MethodInvocationHelper.invokeWithTimeout(tm, instance, parameterValues, testResult, hookableInstance);
       }
     }
     catch(InvocationTargetException ite) {
@@ -744,27 +745,26 @@ public class Invoker implements IInvoker {
     }
   }
 
-  private void addExceptionDetailsToTestResult(ITestResult testResult, Object instance) {
+  private Throwable getExceptionDetails(Object instance) {
     Set<ITestResult> configResults = m_testContext.getFailedConfigurations().getAllResults();
     if (configResults.isEmpty()) {
       configResults = m_testContext.getSkippedConfigurations().getAllResults();
     }
     for (ITestResult configResult : configResults) {
       if (sameInstance(configResult, instance)) {
-        testResult.setThrowable(configResult.getThrowable());
-        return;
+        return configResult.getThrowable();
       }
     }
     if (configResults.isEmpty()) {
       //if we are here it means we have a test method skip due to a @BeforeSuite failure in a different <test> maybe
       //So we will have to find out that first failure/skip and get its throwable and pack that information into our
       //current test method's test result.
-      testResult.setThrowable(getConfigFailureException());
+      return getConfigFailureException();
     } else {
       //If we are here it perhaps means that the test method is being skipped because there was a configuration
       //failure in a different class due to @BeforeGroups being used.
       //So lets just find the first exception information and then just pack it in.
-      testResult.setThrowable(configResults.iterator().next().getThrowable());
+      return configResults.iterator().next().getThrowable();
     }
   }
 

--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -1269,6 +1269,7 @@ public class Invoker implements IInvoker {
         System.currentTimeMillis(),
         m_testContext);
     result.setStatus(TestResult.SKIP);
+    Reporter.setCurrentTestResult(result);
     runTestListeners(result);
 
     return result;

--- a/src/main/java/org/testng/internal/Parameters.java
+++ b/src/main/java/org/testng/internal/Parameters.java
@@ -482,7 +482,7 @@ public class Parameters {
    * @return An Iterator over the values for each parameter of this
    * method.
    */
-  public static ParameterHolder handleParameters(ITestNGMethod testMethod,
+  public static ParameterHolder handleParameters(final ITestNGMethod testMethod,
       Map<String, String> allParameterNames,
       Object instance,
       MethodParameters methodParams,
@@ -534,6 +534,7 @@ public class Parameters {
 
         @Override
         public Object[] next() {
+          testMethod.setParameterInvocationCount(index);
           Object[] next = parameters.next();
           if (!allIndices.isEmpty() && !allIndices.contains(index)) {
             next = null;

--- a/src/main/java/org/testng/internal/TestNGMethod.java
+++ b/src/main/java/org/testng/internal/TestNGMethod.java
@@ -29,7 +29,6 @@ public class TestNGMethod extends BaseTestMethod implements Serializable {
   private static final long serialVersionUID = -1742868891986775307L;
   private int m_threadPoolSize = 0;
   private int m_invocationCount = 1;
-  private int m_totalInvocationCount = m_invocationCount;
   private int m_successPercentage = 100;
 
   /**
@@ -57,14 +56,6 @@ public class TestNGMethod extends BaseTestMethod implements Serializable {
   @Override
   public int getInvocationCount() {
     return m_invocationCount;
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public int getTotalInvocationCount() {
-    return m_totalInvocationCount;
   }
 
   /**
@@ -105,7 +96,6 @@ public class TestNGMethod extends BaseTestMethod implements Serializable {
         m_successPercentage = testAnnotation.getSuccessPercentage();
 
         setInvocationCount(testAnnotation.getInvocationCount());
-        m_totalInvocationCount = testAnnotation.getInvocationCount();
         setThreadPoolSize(testAnnotation.getThreadPoolSize());
         setAlwaysRun(testAnnotation.getAlwaysRun());
         setDescription(findDescription(testAnnotation, xmlTest));
@@ -195,7 +185,6 @@ public class TestNGMethod extends BaseTestMethod implements Serializable {
     clone.setEnabled(getEnabled());
     clone.setParameterInvocationCount(getParameterInvocationCount());
     clone.setInvocationCount(getInvocationCount());
-    clone.m_totalInvocationCount = getTotalInvocationCount();
     clone.m_successPercentage = getSuccessPercentage();
     clone.setTimeOut(getTimeOut());
     clone.setRetryAnalyzer(getRetryAnalyzer());

--- a/src/test/java/test/InvokedMethodNameListener.java
+++ b/src/test/java/test/InvokedMethodNameListener.java
@@ -21,7 +21,6 @@ public class InvokedMethodNameListener implements IInvokedMethodListener, ITestL
   private final List<String> failedMethodNames = new ArrayList<>();
   private final List<String> failedBeforeInvocationMethodNames = new ArrayList<>();
   private final List<String> skippedMethodNames = new ArrayList<>();
-  private final List<String> skippedBeforeInvocationMethodNames = new ArrayList<>();
   private final List<String> succeedMethodNames = new ArrayList<>();
   private final Map<String, ITestResult> results = new HashMap<>();
   private final boolean skipConfiguration;
@@ -52,7 +51,7 @@ public class InvokedMethodNameListener implements IInvokedMethodListener, ITestL
         break;
       case ITestResult.SKIP:
         if (!(skipConfiguration && method.isConfigurationMethod())) {
-          skippedMethodNames.add(name);
+          throw new IllegalStateException("A skipped test is not supposed to be invoked");
         }
         break;
       case ITestResult.SUCCESS:
@@ -92,9 +91,7 @@ public class InvokedMethodNameListener implements IInvokedMethodListener, ITestL
   public void onTestSkipped(ITestResult result) {
     String name = getName(result);
     results.put(name, result);
-    if (!skippedMethodNames.contains(name)) {
-      skippedBeforeInvocationMethodNames.add(name);
-    }
+    skippedMethodNames.add(name);
   }
 
   @Override
@@ -163,10 +160,6 @@ public class InvokedMethodNameListener implements IInvokedMethodListener, ITestL
 
   public List<String> getFailedBeforeInvocationMethodNames() {
     return Collections.unmodifiableList(failedBeforeInvocationMethodNames);
-  }
-
-  public List<String> getSkippedBeforeInvocationMethodNames() {
-    return Collections.unmodifiableList(skippedBeforeInvocationMethodNames);
   }
 
   public ITestResult getResult(String name) {

--- a/src/test/java/test/configurationfailurepolicy/FailurePolicyTest.java
+++ b/src/test/java/test/configurationfailurepolicy/FailurePolicyTest.java
@@ -1,8 +1,10 @@
 package test.configurationfailurepolicy;
 
 import static org.testng.Assert.assertEquals;
+import static test.SimpleBaseTest.getPathToResource;
 
 import org.testng.ITestContext;
+import org.testng.ITestNGListener;
 import org.testng.TestListenerAdapter;
 import org.testng.TestNG;
 import org.testng.annotations.BeforeClass;
@@ -23,7 +25,7 @@ public class FailurePolicyTest {
   @DataProvider( name="dp" )
   public Object[][] getData() {
     Object[][] data = new Object[][] {
-      // params - confFail, confSkip, skipedTests
+      // params - confFail, confSkip, skippedTests
       new Object[] { new Class[] { ClassWithFailedBeforeClassMethod.class }, 1, 1, 1 },
       new Object[] { new Class[] { ClassWithFailedBeforeMethodAndMultipleTests.class }, 2, 0, 2 },
       new Object[] { new Class[] { ClassWithFailedBeforeMethodAndMultipleInvocations.class }, 4, 0, 4 },
@@ -46,7 +48,7 @@ public class FailurePolicyTest {
     TestNG testng = new TestNG();
     testng.setOutputDirectory(OutputDirectoryPatch.getOutputDirectory());
     testng.setTestClasses(classesUnderTest);
-    testng.addListener(tla);
+    testng.addListener((ITestNGListener) tla);
     testng.setVerbose(0);
     testng.setConfigFailurePolicy(XmlSuite.FailurePolicy.CONTINUE);
     testng.run();
@@ -58,7 +60,7 @@ public class FailurePolicyTest {
   public void commandLineTest_policyAsSkip() {
     String[] argv = new String[] { "-log", "0", "-d", OutputDirectoryPatch.getOutputDirectory(),
             "-configfailurepolicy", "skip",
-            "-testclass", "test.configurationfailurepolicy.ClassWithFailedBeforeMethodAndMultipleTests" };
+            "-testclass", ClassWithFailedBeforeMethodAndMultipleTests.class.getCanonicalName() };
     TestListenerAdapter tla = new TestListenerAdapter();
     TestNG.privateMain(argv, tla);
 
@@ -69,7 +71,7 @@ public class FailurePolicyTest {
   public void commandLineTest_policyAsContinue() {
     String[] argv = new String[] { "-log", "0", "-d", OutputDirectoryPatch.getOutputDirectory(),
             "-configfailurepolicy", "continue",
-            "-testclass", "test.configurationfailurepolicy.ClassWithFailedBeforeMethodAndMultipleTests" };
+            "-testclass", ClassWithFailedBeforeMethodAndMultipleTests.class.getCanonicalName() };
     TestListenerAdapter tla = new TestListenerAdapter();
     TestNG.privateMain(argv, tla);
 
@@ -79,7 +81,7 @@ public class FailurePolicyTest {
   @Test
   public void commandLineTestWithXMLFile_policyAsSkip() {
     String[] argv = new String[] { "-log", "0", "-d", OutputDirectoryPatch.getOutputDirectory(),
-            "-configfailurepolicy", "skip", "src/test/resources/testng-configfailure.xml" };
+            "-configfailurepolicy", "skip", getPathToResource("testng-configfailure.xml") };
     TestListenerAdapter tla = new TestListenerAdapter();
     TestNG.privateMain(argv, tla);
 
@@ -89,7 +91,7 @@ public class FailurePolicyTest {
   @Test
   public void commandLineTestWithXMLFile_policyAsContinue() {
     String[] argv = new String[] { "-log", "0", "-d", OutputDirectoryPatch.getOutputDirectory(),
-            "-configfailurepolicy", "continue", "src/test/resources/testng-configfailure.xml" };
+            "-configfailurepolicy", "continue", getPathToResource("testng-configfailure.xml") };
     TestListenerAdapter tla = new TestListenerAdapter();
     TestNG.privateMain(argv, tla);
 

--- a/src/test/java/test/dataprovider/DataProviderTest.java
+++ b/src/test/java/test/dataprovider/DataProviderTest.java
@@ -92,7 +92,7 @@ public class DataProviderTest extends SimpleBaseTest {
     InvokedMethodNameListener listener = run(DependentSample.class);
 
     assertThat(listener.getSucceedMethodNames()).containsExactly("method1(ok)");
-    assertThat(listener.getSkippedBeforeInvocationMethodNames()).containsExactly("method2");
+    assertThat(listener.getSkippedMethodNames()).containsExactly("method2");
     assertThat(listener.getFailedMethodNames()).containsExactly("method1(not ok)");
   }
 

--- a/src/test/java/test/dataprovider/FailingDataProviderTest.java
+++ b/src/test/java/test/dataprovider/FailingDataProviderTest.java
@@ -12,7 +12,7 @@ public class FailingDataProviderTest extends SimpleBaseTest {
   public void failingDataProvider() {
     InvokedMethodNameListener listener = run(FailingDataProviderSample.class);
 
-    assertThat(listener.getSkippedBeforeInvocationMethodNames()).containsExactly("dpThrowingException");
+    assertThat(listener.getSkippedMethodNames()).containsExactly("dpThrowingException");
   }
 
   @Test(description = "TESTNG-447: Abort when two data providers have the same name")
@@ -26,7 +26,7 @@ public class FailingDataProviderTest extends SimpleBaseTest {
   public void failingDataProviderAndInvocationCount() {
     InvokedMethodNameListener listener = run(DataProviderWithErrorSample.class);
 
-    assertThat(listener.getSkippedBeforeInvocationMethodNames()).containsExactly(
+    assertThat(listener.getSkippedMethodNames()).containsExactly(
         "testShouldSkip", "testShouldSkip", "testShouldSkipEvenIfSuccessPercentage", "testShouldSkipEvenIfSuccessPercentage"
     );
   }

--- a/src/test/java/test/timeout/GitHub1314Sample.java
+++ b/src/test/java/test/timeout/GitHub1314Sample.java
@@ -1,0 +1,24 @@
+package test.timeout;
+
+import org.testng.annotations.Test;
+
+public class GitHub1314Sample {
+
+    @Test
+    private void iWorkWell() {
+        System.out.println("Test1");
+    }
+
+    @Test(timeOut = 100, dependsOnMethods = {"iWorkWell"})
+    private void iHangHorribly() {
+        System.out.println("Test2");
+        while (true) {
+            int two = 1 + 1;
+        }
+    }
+
+    @Test(dependsOnMethods = {"iHangHorribly"})
+    private void iAmNeverRun() {
+        System.out.println("Test3");
+    }
+}

--- a/src/test/java/test/timeout/TimeOutIntegrationTest.java
+++ b/src/test/java/test/timeout/TimeOutIntegrationTest.java
@@ -1,26 +1,42 @@
 package test.timeout;
 
-import org.testng.Assert;
-import org.testng.TestListenerAdapter;
+import org.testng.ITestNGListener;
 import org.testng.TestNG;
 import org.testng.annotations.Test;
 import org.testng.xml.XmlSuite;
+import test.InvokedMethodNameListener;
+import test.SimpleBaseTest;
 
-public class TimeOutIntegrationTest {
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TimeOutIntegrationTest extends SimpleBaseTest {
 
     @Test(description = "https://github.com/cbeust/testng/issues/811")
     public void testTimeOutWhenParallelIsTest() {
-        TestNG tng = new TestNG();
+        TestNG tng = create(TimeOutWithParallelSample.class);
         tng.setParallel(XmlSuite.ParallelMode.TESTS);
-        tng.setTestClasses(new Class[]{TimeOutWithParallelSample.class});
 
-        TestListenerAdapter tla = new TestListenerAdapter();
-        tng.addListener(tla);
+        InvokedMethodNameListener listener = new InvokedMethodNameListener();
+        tng.addListener((ITestNGListener) listener);
 
         tng.run();
 
-        Assert.assertEquals(tla.getFailedTests().size(), 1);
-        Assert.assertEquals(tla.getSkippedTests().size(), 0);
-        Assert.assertEquals(tla.getPassedTests().size(), 0);
+        assertThat(listener.getFailedMethodNames()).containsExactly("myTestMethod");
+        assertThat(listener.getSkippedMethodNames()).isEmpty();
+        assertThat(listener.getSucceedMethodNames()).isEmpty();
+    }
+
+    @Test(description = "https://github.com/cbeust/testng/issues/1314")
+    public void testGitHub1314() {
+        TestNG tng = create(GitHub1314Sample.class);
+
+        InvokedMethodNameListener listener = new InvokedMethodNameListener();
+        tng.addListener((ITestNGListener) listener);
+
+        tng.run();
+
+        assertThat(listener.getSucceedMethodNames()).containsExactly("iWorkWell");
+        assertThat(listener.getFailedMethodNames()).containsExactly("iHangHorribly");
+        assertThat(listener.getSkippedMethodNames()).containsExactly("iAmNeverRun");
     }
 }

--- a/src/test/java/test_result/GitHub1197Test.java
+++ b/src/test/java/test_result/GitHub1197Test.java
@@ -14,13 +14,14 @@ public class GitHub1197Test extends SimpleBaseTest {
     public void testGitHub1197() {
         TestNG tng = create(GitHub1197Sample.class);
 
-        InvokedMethodNameListener listener = new InvokedMethodNameListener(true);
+        // A skipped method is not supposed to be run but, here, it's the goal of the feature
+        InvokedMethodNameListener listener = new InvokedMethodNameListener(true, true);
         tng.addListener((ITestNGListener) listener);
 
         tng.run();
 
         assertThat(listener.getSucceedMethodNames()).containsExactly("succeedTest", "succeedTest2");
         assertThat(listener.getFailedMethodNames()).containsExactly("failedTest"); // , "failedTest2");
-        assertThat(listener.getSkippedMethodNames()).containsExactly("skippedTest");
+        assertThat(listener.getSkippedAfterInvocationMethodNames()).containsExactly("skippedTest");
     }
 }


### PR DESCRIPTION
When I played around #1314, I found that skipped methods were notified in listeners as run.
It is not the case anymore :)

