### PR TITLE
Fixing DynamicGraph issue with not separating priorities

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,7 @@
 6.11
 2016/02/27
 
+Fixed: GITHUB-1360: TestNG does not distinguish between methods of different priorities (Krishnan Mahadevan)
 Fixed: GITHUB-1351: FailurePolicy failing with YAML (Steven Zaluk & Julien Herr)
 New: The name of all TestNG threads follow "TestNG-<thread type>-<number>" pattern (Julien Herr)
 Fixed: GITHUB-1339: Alter ClassHelper to use Maps instead of Lists for extracting methods (Krishnan Mahadevan)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,9 +1,8 @@
 ﻿Current
+Fixed: GITHUB-1360: TestNG does not distinguish between methods of different priorities (Krishnan Mahadevan)
 
 6.11
 2016/02/27
-
-Fixed: GITHUB-1360: TestNG does not distinguish between methods of different priorities (Krishnan Mahadevan)
 Fixed: GITHUB-1351: FailurePolicy failing with YAML (Steven Zaluk & Julien Herr)
 New: The name of all TestNG threads follow "TestNG-<thread type>-<number>" pattern (Julien Herr)
 Fixed: GITHUB-1339: Alter ClassHelper to use Maps instead of Lists for extracting methods (Krishnan Mahadevan)

--- a/src/main/java/org/testng/TestRunner.java
+++ b/src/main/java/org/testng/TestRunner.java
@@ -990,7 +990,7 @@ public class TestRunner
       Integer currentPriority = availablePriorities.get(i);
       for (ITestNGMethod p0Method : methodsByPriority.get(previousPriority)) {
         for (ITestNGMethod p1Method : methodsByPriority.get(currentPriority)) {
-          result.addEdge(PriorityWeight.priority.ordinal(), p1Method, p0Method, p1Method.getPriority());
+          result.addEdge(PriorityWeight.priority.ordinal(), p1Method.getPriority(), p1Method, p0Method);
         }
       }
       previousPriority = currentPriority;

--- a/src/main/java/org/testng/TestRunner.java
+++ b/src/main/java/org/testng/TestRunner.java
@@ -990,7 +990,7 @@ public class TestRunner
       Integer currentPriority = availablePriorities.get(i);
       for (ITestNGMethod p0Method : methodsByPriority.get(previousPriority)) {
         for (ITestNGMethod p1Method : methodsByPriority.get(currentPriority)) {
-          result.addEdge(PriorityWeight.priority.ordinal(), p1Method, p0Method);
+          result.addEdge(PriorityWeight.priority.ordinal(), p1Method, p0Method, p1Method.getPriority());
         }
       }
       previousPriority = currentPriority;

--- a/src/main/java/org/testng/internal/DynamicGraph.java
+++ b/src/main/java/org/testng/internal/DynamicGraph.java
@@ -31,14 +31,14 @@ public class DynamicGraph<T> {
   private static class Edge<T> {
     private final T from;
     private final T to;
-    private int weight;
-    private int order;
+    private final int weight;
+    private final int order;
 
-    private Edge(T from, T to, int weight) {
-      this(from, to, weight, 0);
+    private Edge(int weight, T from, T to) {
+      this(weight, 0, from, to);
     }
 
-    private Edge(T from, T to, int weight, int order) {
+    private Edge(int weight, int order, T from, T to) {
       this.from = from;
       this.to = to;
       this.weight = weight;
@@ -53,8 +53,16 @@ public class DynamicGraph<T> {
     m_nodesReady.add(node);
   }
 
-  public void addEdge(int weight, T from, T to, int order) {
-    addEdges(Collections.singletonList(new Edge<>(from, to, weight, order)));
+  /**
+   *
+   * @param weight - Represents one of {@link org.testng.TestRunner.PriorityWeight} ordinals indicating
+   *               the weightage of a particular node in the graph
+   * @param order - Represents an ordering of nodes that have the same weight.
+   * @param from - Represents the edge that depends on another edge.
+   * @param to - Represents the edge on which another edge depends upon.
+   */
+  public void addEdge(int weight, int order, T from, T to) {
+    addEdges(Collections.singletonList(new Edge<>(weight, order, from, to)));
   }
 
   /**
@@ -70,7 +78,7 @@ public class DynamicGraph<T> {
   public void addEdge(int weight, T from, Iterable<T> tos) {
     List<Edge<T>> edges = Lists.newArrayList();
     for (T to : tos) {
-      edges.add(new Edge<>(from, to, weight));
+      edges.add(new Edge<>(weight, from, to));
     }
     addEdges(edges);
   }

--- a/src/test/java/test/DynamicGraphTest.java
+++ b/src/test/java/test/DynamicGraphTest.java
@@ -154,34 +154,27 @@ public class DynamicGraphTest extends SimpleBaseTest {
       Integer currentPriority = availablePriorities.get(i);
       for (ITestNGMethod p0Method : methodsByPriority.get(previousPriority)) {
         for (ITestNGMethod p1Method : methodsByPriority.get(currentPriority)) {
-          graph.addEdge(1, p1Method, p0Method, p1Method.getPriority());
+          graph.addEdge(1, p1Method.getPriority(), p1Method, p0Method);
         }
       }
       previousPriority = currentPriority;
     }
     List<String> expected = Arrays.asList("TestNG1.test1TestNG1", "TestNG2.test1TestNG2", "TestNG3.test1TestNG3");
+    runAssertion(graph, expected);
+    expected = Arrays.asList("TestNG1.test2TestNG1", "TestNG2.test2TestNG2", "TestNG3.test2TestNG3");
+    runAssertion(graph, expected);
+
+    expected = Arrays.asList("TestNG1.test3TestNG1", "TestNG2.test3TestNG2", "TestNG3.test3TestNG3");
+    runAssertion(graph, expected);
+  }
+
+  private static void runAssertion(DynamicGraph<ITestNGMethod> graph, List<String> expected) {
     List<ITestNGMethod> p1Methods = graph.getFreeNodes();
     Assert.assertEquals(p1Methods.size(), 3);
     graph.setStatus(p1Methods, Status.FINISHED);
     for (ITestNGMethod p1Method : p1Methods) {
       Assert.assertTrue(expected.contains(constructName(p1Method)));
     }
-    expected = Arrays.asList("TestNG1.test2TestNG1", "TestNG2.test2TestNG2", "TestNG3.test2TestNG3");
-    List<ITestNGMethod> p2Methods = graph.getFreeNodes();
-    Assert.assertEquals(p2Methods.size(), 3);
-    graph.setStatus(p2Methods, Status.FINISHED);
-    for (ITestNGMethod p2Method : p2Methods) {
-      Assert.assertTrue(expected.contains(constructName(p2Method)));
-    }
-
-    expected = Arrays.asList("TestNG1.test3TestNG1", "TestNG2.test3TestNG2", "TestNG3.test3TestNG3");
-    List<ITestNGMethod> p3Methods = graph.getFreeNodes();
-    Assert.assertEquals(p3Methods.size(), 3);
-    graph.setStatus(p3Methods, Status.FINISHED);
-    for (ITestNGMethod p3Method : p3Methods) {
-      Assert.assertTrue(expected.contains(constructName(p3Method)));
-    }
-
   }
 
   private static String constructName(ITestNGMethod method) {

--- a/src/test/java/test/SimpleBaseTest.java
+++ b/src/test/java/test/SimpleBaseTest.java
@@ -2,9 +2,15 @@ package test;
 
 import org.testng.Assert;
 import org.testng.ITestNGListener;
+import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
 import org.testng.TestNG;
+import org.testng.annotations.ITestAnnotation;
 import org.testng.collections.Lists;
+import org.testng.internal.annotations.AnnotationHelper;
+import org.testng.internal.annotations.DefaultAnnotationTransformer;
+import org.testng.internal.annotations.IAnnotationFinder;
+import org.testng.internal.annotations.JDK15AnnotationFinder;
 import org.testng.xml.XmlClass;
 import org.testng.xml.XmlGroups;
 import org.testng.xml.XmlInclude;
@@ -242,6 +248,23 @@ public class SimpleBaseTest {
     }
     return result + File.separatorChar + fileName;
   }
+
+  public static List<ITestNGMethod> extractTestNGMethods(Class<?>... classes) {
+    XmlSuite xmlSuite = new XmlSuite();
+    xmlSuite.setName("suite");
+    XmlTest xmlTest = createXmlTest(xmlSuite, "tests", classes);
+    IAnnotationFinder annotationFinder = new JDK15AnnotationFinder(new DefaultAnnotationTransformer());
+    List<ITestNGMethod> methods = Lists.newArrayList();
+    for (Class<?> clazz : classes) {
+      methods.addAll(
+          Arrays.asList(
+              AnnotationHelper.findMethodsWithAnnotation(clazz, ITestAnnotation.class, annotationFinder, xmlTest)
+          )
+      );
+    }
+    return methods;
+  }
+
 
   /**
    * Compare a list of ITestResult with a list of String method names,

--- a/src/test/java/test/TestClassContainerForGitHubIssue1360.java
+++ b/src/test/java/test/TestClassContainerForGitHubIssue1360.java
@@ -1,0 +1,57 @@
+package test;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestClassContainerForGitHubIssue1360 {
+    public static class TestNG1 {
+        @Test(priority = 1)
+        public void test1TestNG1() {
+            Assert.assertTrue(true);
+        }
+
+        @Test(priority = 2)
+        public void test2TestNG1() {
+            Assert.assertTrue(true);
+        }
+
+        @Test(priority = 3)
+        public void test3TestNG1() {
+            Assert.assertTrue(true);
+        }
+    }
+
+    public static class TestNG2 {
+        @Test(priority = 1)
+        public void test1TestNG2() {
+            Assert.assertTrue(true);
+        }
+
+        @Test(priority = 2)
+        public void test2TestNG2() {
+            Assert.assertTrue(true);
+        }
+
+        @Test(priority = 3)
+        public void test3TestNG2() {
+            Assert.assertTrue(true);
+        }
+    }
+
+    public static class TestNG3 {
+        @Test(priority = 1)
+        public void test1TestNG3() {
+            Assert.assertTrue(true);
+        }
+
+        @Test(priority = 2)
+        public void test2TestNG3() {
+            Assert.assertTrue(true);
+        }
+
+        @Test(priority = 3)
+        public void test3TestNG3() {
+            Assert.assertTrue(true);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1360 
Closes #1360 

Currently DynamicGraph does not group 
dependent methods (i.e., methods which have lower
priorities and need higher priority methods to run
first before they can get executed) based on priorities.
This causes TestNG to just segregate independent 
methods (method with the lowest priority) and 
dependent methods.

Fixed this anomaly by introducing grouping of same 
weighted edges with the same priority.

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`
