### PR TITLE
Enhance TestNGAntTask to be customizable

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+New: Enhance TestNGAntTask to be customizable (Denys Kurylenko)
 New: Make EmailableReporter2 W3C Compliant[XHTML 1.1] (Chris Rankin)
 Fixed: GITHUB-1336: (parallel=‘classes’) not working when coupled with priority (Krishnan Mahadevan)
 Fixed: GITHUB-1365: Be able to override default XML parser (@ChristiKh & Julien Herr)

--- a/src/main/java/org/testng/TestNGAntTask.java
+++ b/src/main/java/org/testng/TestNGAntTask.java
@@ -538,7 +538,7 @@ public class TestNGAntTask extends Task {
     actOnResult(exitValue, wasKilled);
   }
 
-  private List<String> createArguments() {
+  protected List<String> createArguments() {
 	List<String> argv= Lists.newArrayList();
     addBooleanIfTrue(argv, CommandLineArgs.JUNIT, mode == Mode.junit);
     addBooleanIfTrue(argv, CommandLineArgs.MIXED, mode == Mode.mixed);


### PR DESCRIPTION
Closes #143

Made TestNGAntTask.createArguments() protected so classes that extend TestNGAntTask can reuse it in it's own execute methods

### Did you remember to?

- [ ] Add test case(s)
- [X] Update `CHANGES.txt`
