### PR TITLE
Be able to start parameterized tests with specified parameter values

### DIFF
--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -622,6 +622,7 @@ public class Invoker implements IInvoker {
                                  0,
                                  m_testContext);
       testResult.setParameters(parameterValues);
+      testResult.setParameterIndex(parametersIndex);
       testResult.setHost(m_testContext.getHost());
       testResult.setStatus(ITestResult.STARTED);
 

--- a/src/main/java/org/testng/internal/TestResult.java
+++ b/src/main/java/org/testng/internal/TestResult.java
@@ -37,6 +37,7 @@ public class TestResult implements ITestResult, IAlterTestName {
   transient private Object m_instance;
   private String m_instanceName;
   private ITestContext m_context;
+  private int parameterIndex;
 
   public TestResult() {
 
@@ -323,6 +324,14 @@ public class TestResult implements ITestResult, IAlterTestName {
   @Override
   public void setTestName(String name) {
     m_name = name;
+  }
+
+  public void setParameterIndex(int parameterIndex) {
+    this.parameterIndex = parameterIndex;
+  }
+
+  public int getParameterIndex() {
+    return parameterIndex;
   }
 }
 


### PR DESCRIPTION
Now it's possible to restart failed tests by index but this index is not available for passed tests, so for passed tests it's impossible to restart the test with the same parameters. The PR makes this information available. 