### PR TITLE
Fix Javadoc notation for code block

### DIFF
--- a/src/main/java/org/testng/ClassMethodMap.java
+++ b/src/main/java/org/testng/ClassMethodMap.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * This class maintains a map of <CODE><Class, List<ITestNGMethod>></CODE>.
+ * This class maintains a map of {@code <Class, List<ITestNGMethod>>}.
  * It is used by TestWorkers to determine if the method they just ran
  * is the last of its class, in which case it's time to invoke all the
  * afterClass methods.


### PR DESCRIPTION
In the [current API docs](https://jitpack.io/com/github/cbeust/testng/master-6.11-g7bc33ff-100/javadoc/index.html) for `ClassMethodMap`, the first sentence of the class docs is "*This class maintains a map of >.*" - the `>` should be the end of a larger expression, but the use of `<code>...</code>` rather than Javadoc's `{@code ...}` means they other angle brackets aren't escaped.

*Removed template, as this is just a documentation fix*