### PR TITLE
Fix SCM related URLs

### DIFF
--- a/kobalt/src/Build.kt
+++ b/kobalt/src/Build.kt
@@ -35,8 +35,8 @@ val p = project {
         })
         scm = Scm().apply {
             url = "http://github.com/cbeust/testng"
-            connection = "https://github.com/cbeust/testng.git"
-            developerConnection = "git@github.com:cbeust/testng.git"
+            connection = "scm:git:https://github.com/cbeust/testng.git"
+            developerConnection = "scm:git:git@github.com:cbeust/testng.git"
         }
         developers = listOf(Developer().apply {
             name = "Cedric Beust"


### PR DESCRIPTION
The URLs need to start with "scm" followed by the provider name. For details
see https://maven.apache.org/pom.html#SCM.

Fixes # .

### Did you remember to?

- [ ] Add test case(s)
- [ ] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
