### PR TITLE
Explicitly specify UTF-8 with javac

### DIFF
--- a/kobalt/src/Build.kt
+++ b/kobalt/src/Build.kt
@@ -73,7 +73,7 @@ val p = project {
     }
 
     javaCompiler {
-        args("-target", "1.7", "-source", "1.7")
+        args("-target", "1.7", "-source", "1.7", "-encoding", "UTF-8")
     }
 
     assemble {


### PR DESCRIPTION
Fixes compilation errors on OpenBSD 6.1, caused by the use of UTF-8 in `Version.java` ("C**é**dric Beust"). I ran `xxd` to verify that `é` is encoded as `c3 a9`, which is UTF-8 and not ISO-8859-1 ([more info](https://stackoverflow.com/questions/10021594/character-set-special-characters)).