### PR TITLE
#1393 fail a test from onTestStart method

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -19,6 +19,7 @@ Fixed: GITHUB-1380: Circular dependencies may fail in parallel (Julien Herr)
 Fixed: GITHUB-1400: TestNG, Multiple duplicate listener warnings on implementing multiple listener interfaces (@bipo1980 & Nick Tan)
 Fixed: GITHUB-1426: @AfterMethod(alwaysRun = true) is not getting called if we have exception in @BeforeMethod (@dipak-pawar)
 Fixed: GITHUB-128: Using Object[] and Method as parameters for a test in a certain order yields an IllegalArgumentException, citing a type mismatch (@leef590 & Julien Herr,Krishnan Mahadevan)
+Fixed: GITHUB-1393: Revert commit 50d534a to allow fail a test from onTestStart method
 
 6.11
 2017/02/27

--- a/src/main/java/org/testng/TestRunner.java
+++ b/src/main/java/org/testng/TestRunner.java
@@ -1198,15 +1198,11 @@ public class TestRunner
    */
   private void fireEvent(boolean isStart) {
     for (ITestListener itl : m_testListeners) {
-      try {
-        if (isStart) {
-          itl.onStart(this);
-        }
-        else {
-          itl.onFinish(this);
-        }
-      } catch (Exception e) {
-        e.printStackTrace();
+      if (isStart) {
+        itl.onStart(this);
+      }
+      else {
+        itl.onFinish(this);
       }
     }
   }

--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -1725,34 +1725,32 @@ public class Invoker implements IInvoker {
   // TODO: move this from here as it is directly called from TestNG
   public static void runTestListeners(ITestResult tr, List<ITestListener> listeners) {
     for (ITestListener itl : listeners) {
-      try {
-        switch(tr.getStatus()) {
-          case ITestResult.SKIP: {
-            itl.onTestSkipped(tr);
-            break;
-          }
-          case ITestResult.SUCCESS_PERCENTAGE_FAILURE: {
-            itl.onTestFailedButWithinSuccessPercentage(tr);
-            break;
-          }
-          case ITestResult.FAILURE: {
-            itl.onTestFailure(tr);
-            break;
-          }
-          case ITestResult.SUCCESS: {
-            itl.onTestSuccess(tr);
-            break;
-          }
-          case ITestResult.STARTED: {
-            itl.onTestStart(tr);
-            break;
-          }
-          default: {
-            assert false : "UNKNOWN STATUS:" + tr;
-          }
+      switch(tr.getStatus()) {
+        case ITestResult.SKIP: {
+          itl.onTestSkipped(tr);
+          break;
         }
-      } catch (Exception e) {
-        e.printStackTrace();
+        case ITestResult.SUCCESS_PERCENTAGE_FAILURE: {
+          itl.onTestFailedButWithinSuccessPercentage(tr);
+          break;
+        }
+        case ITestResult.FAILURE: {
+          itl.onTestFailure(tr);
+          break;
+        }
+        case ITestResult.SUCCESS: {
+          itl.onTestSuccess(tr);
+          break;
+        }
+
+        case ITestResult.STARTED: {
+          itl.onTestStart(tr);
+          break;
+        }
+
+        default: {
+          assert false : "UNKNOWN STATUS:" + tr;
+        }
       }
     }
   }

--- a/src/test/java/test/listeners/ListenerTest.java
+++ b/src/test/java/test/listeners/ListenerTest.java
@@ -7,6 +7,7 @@ import org.testng.collections.Lists;
 
 import org.testng.xml.XmlSuite;
 import test.SimpleBaseTest;
+import test.listeners.github1393.Listener1393;
 import test.listeners.github956.ListenerFor956;
 import test.listeners.github956.TestClassContainer;
 
@@ -249,4 +250,14 @@ public class ListenerTest extends SimpleBaseTest {
     Assert.assertEquals(messages.get(0), "Executing test956");
   }
 
+  @Test(description = "GITHUB-1393: fail a test from onTestStart method")
+  public void testFailATestFromOnTestStart() {
+    TestNG tng = create(SimpleSample.class);
+    TestListenerAdapter adapter = new TestListenerAdapter();
+    tng.addListener((ITestNGListener) adapter);
+    tng.addListener(new Listener1393());
+    tng.run();
+    Assert.assertEquals(adapter.getPassedTests().size(), 0);
+    Assert.assertEquals(adapter.getFailedTests().size(), 1);
+  }
 }

--- a/src/test/java/test/listeners/github1393/Listener1393.java
+++ b/src/test/java/test/listeners/github1393/Listener1393.java
@@ -1,0 +1,14 @@
+package test.listeners.github1393;
+
+import org.testng.ITestResult;
+import org.testng.TestListenerAdapter;
+
+public class Listener1393 extends TestListenerAdapter {
+
+  public void onTestStart(ITestResult testContext) {
+    super.onTestStart(testContext);
+    System.out.println("In onTestStart");
+    testContext.setStatus(ITestResult.FAILURE);
+    throw new RuntimeException("Trying to fail a test");
+  }
+}


### PR DESCRIPTION
Fixes #1393  .

Revert PR #1246 to allow fail a test from onTestStart method by throwing Exception

### Did you remember to?

- [x] Add test case(s)
- [x] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
