### PR TITLE
Fix GitHub issue 1493

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,7 @@
 Current
+Fixed: GITHUB-1493: Wrong exception msg when timeout on test (Krishnan Mahadevan)
+
+6.12
 Fixed: GITHUB-1484: Remove irrelevant "targets" for TestNG annotations (Krishnan Mahadevan)
 Fixed: GITHUB-1405: Skip considering main() method when @Test used at class level (Krishnan Mahadevan)
 Fixed: GITHUB-799: @Factory with dataProvider changes order of iterations (Krishnan Mahadevan & Julien Herr)

--- a/src/main/java/org/testng/internal/MethodInvocationHelper.java
+++ b/src/main/java/org/testng/internal/MethodInvocationHelper.java
@@ -288,7 +288,10 @@ public class MethodInvocationHelper {
       ThreadTimeoutException exception = new ThreadTimeoutException("Method "
           + tm.getQualifiedName() + "()"
           + " didn't finish within the time-out " + realTimeOut);
-      exception.setStackTrace(exec.getStackTraces()[0]);
+      StackTraceElement[][] stacktraces = exec.getStackTraces();
+      if (stacktraces.length > 0) {
+        exception.setStackTrace(stacktraces[0]);
+      }
       testResult.setThrowable(exception);
       testResult.setStatus(ITestResult.FAILURE);
     } else {

--- a/src/main/java/org/testng/internal/thread/ThreadUtil.java
+++ b/src/main/java/org/testng/internal/thread/ThreadUtil.java
@@ -99,6 +99,13 @@ public class ThreadUtil {
     }
 
     @Override
+    public Thread newThread(Runnable r) {
+      Thread t = super.newThread(r);
+      threads.add(t);
+      return t;
+    }
+
+    @Override
     public List<Thread> getThreads() {
       return threads;
     }

--- a/src/test/java/test/timeout/TimeOutTest.java
+++ b/src/test/java/test/timeout/TimeOutTest.java
@@ -1,13 +1,22 @@
 package test.timeout;
 
+import org.testng.Assert;
+import org.testng.ITestNGListener;
+import org.testng.ITestResult;
+import org.testng.TestListenerAdapter;
+import org.testng.TestNG;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.testng.internal.thread.ThreadTimeoutException;
 import org.testng.xml.XmlSuite;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 
 import test.BaseTest;
+import test.timeout.github1493.TestClassSample;
 
 public class TimeOutTest extends BaseTest {
   private final long m_id;
@@ -66,6 +75,19 @@ public class TimeOutTest extends BaseTest {
     verifyPassedTests("shouldPass");
     verifyFailedTests("shouldFail");
   }
+
+  @Test
+  public void testWithOnlyOneThread() {
+    addClass(TestClassSample.class);
+    run();
+    Collection<List<ITestResult>> failed = getFailedTests().values();
+    Assert.assertEquals(failed.size(), 1);
+    ITestResult failedResult = failed.iterator().next().get(0);
+    Assert.assertTrue(failedResult.getThrowable() instanceof ThreadTimeoutException);
+    Assert.assertEquals(failedResult.getThrowable().getMessage(),
+            String.format("Method %s.testMethod() didn't finish within the time-out 1000", TestClassSample.class.getName()));
+  }
+
 
   @Override
   public Long getId() {

--- a/src/test/java/test/timeout/github1493/TestClassSample.java
+++ b/src/test/java/test/timeout/github1493/TestClassSample.java
@@ -1,0 +1,13 @@
+package test.timeout.github1493;
+
+import org.testng.annotations.Test;
+
+import java.util.concurrent.TimeUnit;
+
+public class TestClassSample {
+    @Test(timeOut = 1000)
+    public void testMethod() throws Exception {
+        TimeUnit.SECONDS.sleep(2);
+    }
+}
+


### PR DESCRIPTION
Closes #1493

When TestNG triggers a timeout for a test because
it ran for too long, we are trying to construct 
the stack trace based on the number of threads.
But merely instantiating an exception object itself
gives us the current thread’s stack trace. 
Fixed this by removing the stack trace construction
logic.

Fixes #1493 .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
