### PR TITLE
Resort to using current <test> name for String param in Constructor

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-1456: Remove/Warn support of constructor with String param (Krishnan Mahadevan)
 Fixed: GITHUB-1509: Improve error message when data provider returns a null value (Krishnan Mahadevan)
 Fixed: GITHUB-1507: TestNG runs all methods when filtering via <include> fails (Krishnan Mahadevan)
 Fixed: GITHUB-1493: Wrong exception msg when timeout on test (Krishnan Mahadevan)

--- a/src/main/java/org/testng/internal/ClassHelper.java
+++ b/src/main/java/org/testng/internal/ClassHelper.java
@@ -413,7 +413,7 @@ public final class ClassHelper {
         }
         catch (NoSuchMethodException ex) {
           ct = declaringClass.getDeclaredConstructor(String.class);
-          parameters = new Object[] { "Default test name" };
+          parameters = new Object[] { xmlTest.getName() };
           // If ct == null here, we'll pass a null
           // constructor to the factory and hope it can deal with it
         }

--- a/src/test/java/org/testng/internal/ClassHelperTest.java
+++ b/src/test/java/org/testng/internal/ClassHelperTest.java
@@ -1,16 +1,42 @@
-package test.issue1339;
+package org.testng.internal;
 
 import org.testng.Assert;
+import org.testng.IClass;
+import org.testng.IObjectFactory;
+import org.testng.ITest;
 import org.testng.annotations.Test;
-import org.testng.internal.ClassHelper;
+import org.testng.collections.Maps;
+import org.testng.internal.annotations.DefaultAnnotationTransformer;
+import org.testng.internal.annotations.IAnnotationFinder;
+import org.testng.internal.annotations.JDK15AnnotationFinder;
+import org.testng.internal.issue1339.BabyPanda;
+import org.testng.internal.issue1339.LittlePanda;
+import org.testng.internal.issue1456.TestClassSample;
+import org.testng.xml.XmlSuite;
+import org.testng.xml.XmlTest;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class ClassHelperTest {
+    private static final String GITHUB_1456 = "GITHUB-1456";
+
+    @Test(description = GITHUB_1456)
+    public void testCreateInstance1WithOneArgStringParamForConstructor() {
+        Class<?> declaringClass = TestClassSample.class;
+        Map<Class<?>, IClass> classes = Maps.newHashMap();
+        XmlTest xmlTest = new XmlTest(new XmlSuite());
+        xmlTest.setName(GITHUB_1456);
+        IAnnotationFinder finder = new JDK15AnnotationFinder(new DefaultAnnotationTransformer());
+        IObjectFactory objectFactory = new ObjectFactoryImpl();
+        Object object = ClassHelper.createInstance1(declaringClass, classes, xmlTest,finder, objectFactory);
+        Assert.assertTrue(object instanceof ITest);
+        Assert.assertEquals(((ITest) object).getTestName(), GITHUB_1456);
+    }
 
     @Test
     public void testGetAvailableMethods() {

--- a/src/test/java/org/testng/internal/issue1339/BabyPanda.java
+++ b/src/test/java/org/testng/internal/issue1339/BabyPanda.java
@@ -1,4 +1,4 @@
-package test.issue1339;
+package org.testng.internal.issue1339;
 
 public class BabyPanda extends LittlePanda {
     String name;

--- a/src/test/java/org/testng/internal/issue1339/GrandpaBear.java
+++ b/src/test/java/org/testng/internal/issue1339/GrandpaBear.java
@@ -1,4 +1,4 @@
-package test.issue1339;
+package org.testng.internal.issue1339;
 
 public class GrandpaBear {
     private void secretMethod() {

--- a/src/test/java/org/testng/internal/issue1339/LittlePanda.java
+++ b/src/test/java/org/testng/internal/issue1339/LittlePanda.java
@@ -1,4 +1,4 @@
-package test.issue1339;
+package org.testng.internal.issue1339;
 
 public class LittlePanda extends PapaBear {
 }

--- a/src/test/java/org/testng/internal/issue1339/PapaBear.java
+++ b/src/test/java/org/testng/internal/issue1339/PapaBear.java
@@ -1,4 +1,4 @@
-package test.issue1339;
+package org.testng.internal.issue1339;
 
 public class PapaBear extends GrandpaBear {
     private void secretMethod(String foo) {

--- a/src/test/java/org/testng/internal/issue1456/TestClassSample.java
+++ b/src/test/java/org/testng/internal/issue1456/TestClassSample.java
@@ -1,0 +1,16 @@
+package org.testng.internal.issue1456;
+
+import org.testng.ITest;
+
+public class TestClassSample implements ITest {
+    private String testname;
+
+    public TestClassSample(String testname) {
+        this.testname = testname;
+    }
+
+    @Override
+    public String getTestName() {
+        return testname;
+    }
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -690,7 +690,7 @@
   <test name="Utils">
     <classes>
       <class name="org.testng.internal.UtilsTest" />
-      <class name="test.issue1339.ClassHelperTest"/>
+      <class name="org.testng.internal.ClassHelperTest"/>
       <class name="test.issue1430.TestFileToClass"/>
     </classes>
   </test>


### PR DESCRIPTION
Closes #1456

TestNG has been resorting to injecting a static string
“Default test name” as value to the 1 arg string based constructor
of a test class, in its attempt at creating the test
class. 
Changed the string constant to instead use the current
<test> name.

Fixes #1456  .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
