### PR TITLE
Code refactoring

### DIFF
--- a/src/main/java/org/testng/TestRunner.java
+++ b/src/main/java/org/testng/TestRunner.java
@@ -445,12 +445,9 @@ public class TestRunner
     List<ITestNGMethod> afterXmlTestMethods = Lists.newArrayList();
 
     ClassInfoMap classMap = new ClassInfoMap(m_testClassesFromXml);
-    m_testClassFinder= new TestNGClassFinder(classMap,
-                                             m_xmlTest,
-                                             m_configuration,
-                                             this, m_dataProviderListeners);
-    ITestMethodFinder testMethodFinder
-      = new TestNGMethodFinder(m_runInfo, m_annotationFinder, comparator);
+    m_testClassFinder= new TestNGClassFinder(classMap,Maps.<Class<?>, List<Object>>newHashMap(),
+                                             m_configuration, this, m_dataProviderListeners);
+    ITestMethodFinder testMethodFinder = new TestNGMethodFinder(m_runInfo, m_annotationFinder, comparator);
 
     m_runInfo.setTestMethods(testMethods);
 

--- a/src/main/java/org/testng/internal/BaseClassFinder.java
+++ b/src/main/java/org/testng/internal/BaseClassFinder.java
@@ -34,15 +34,25 @@ public abstract class BaseClassFinder implements ITestClassFinder {
    * @param cls
    * @return An IClass for the given class, or null if we have
    * already treated this class.
+   * @deprecated - This method stands deprecated as of TestNG v6.13
    */
+  @Deprecated
+  @SuppressWarnings("unused")
   protected IClass findOrCreateIClass(ITestContext context, Class<?> cls, XmlClass xmlClass,
       Object instance, XmlTest xmlTest, IAnnotationFinder annotationFinder,
       ITestObjectFactory objectFactory)
   {
+    return findOrCreateIClass(context, cls, xmlClass, instance, annotationFinder, objectFactory);
+  }
+
+  protected IClass findOrCreateIClass(ITestContext context, Class<?> cls, XmlClass xmlClass,
+                                      Object instance, IAnnotationFinder annotationFinder,
+                                      ITestObjectFactory objectFactory)
+  {
     IClass result = m_classes.get(cls);
     if (null == result) {
-      result = new ClassImpl(context, cls, xmlClass, instance, m_classes, xmlTest, annotationFinder,
-          objectFactory);
+      result = new ClassImpl(context, cls, xmlClass, instance, m_classes, annotationFinder,
+              objectFactory);
       m_classes.put(cls, result);
     }
 

--- a/src/main/java/org/testng/internal/ClassImpl.java
+++ b/src/main/java/org/testng/internal/ClassImpl.java
@@ -30,7 +30,6 @@ public class ClassImpl implements IClass {
 
   private final Class<?> m_class;
   private Object m_defaultInstance = null;
-  private final XmlTest m_xmlTest;
   private final IAnnotationFinder m_annotationFinder;
   private List<Object> m_instances = Lists.newArrayList();
   private final Map<Class<?>, IClass> m_classes;
@@ -43,14 +42,24 @@ public class ClassImpl implements IClass {
   private final ITestContext m_testContext;
   private final boolean m_hasParentModule;
 
+  /**
+   * @deprecated - This constructor is un-used within TestNG and hence stands deprecated as of TestNG v6.13
+   */
+  @Deprecated
+  @SuppressWarnings("unused")
   public ClassImpl(ITestContext context, Class<?> cls, XmlClass xmlClass, Object instance,
       Map<Class<?>, IClass> classes, XmlTest xmlTest, IAnnotationFinder annotationFinder,
       ITestObjectFactory objectFactory) {
+    this(context, cls, xmlClass, instance, classes, annotationFinder, objectFactory);
+  }
+
+  public ClassImpl(ITestContext context, Class<?> cls, XmlClass xmlClass, Object instance,
+                   Map<Class<?>, IClass> classes, IAnnotationFinder annotationFinder,
+                   ITestObjectFactory objectFactory) {
     m_testContext = context;
     m_class = cls;
     m_classes = classes;
     m_xmlClass = xmlClass;
-    m_xmlTest = xmlTest;
     m_annotationFinder = annotationFinder;
     m_instance = instance;
     m_objectFactory = objectFactory;
@@ -94,7 +103,7 @@ public class ClassImpl implements IClass {
 
   @Override
   public XmlTest getXmlTest() {
-    return m_xmlTest;
+    return m_testContext.getCurrentXmlTest();
   }
 
   @Override
@@ -113,7 +122,7 @@ public class ClassImpl implements IClass {
           m_defaultInstance = instance;
         } else {
           m_defaultInstance =
-              ClassHelper.createInstance(m_class, m_classes, m_xmlTest,
+              ClassHelper.createInstance(m_class, m_classes, m_testContext.getCurrentXmlTest(),
                   m_annotationFinder, m_objectFactory);
         }
       }
@@ -147,7 +156,7 @@ public class ClassImpl implements IClass {
       if (m_hasParentModule) {
         Class<Module> parentModule = (Class<Module>) ClassHelper.forName(suite.getParentModule());
         if (parentModule == null) {
-          throw new TestNGException("Cannot load parent Guice module class: " + parentModule);
+          throw new TestNGException("Cannot load parent Guice module class: " + suite.getParentModule());
         }
         Module module = newModule(parentModule);
         injector = com.google.inject.Guice.createInjector(stage, module);
@@ -172,10 +181,10 @@ public class ClassImpl implements IClass {
   public Object[] getInstances(boolean create) {
     Object[] result = {};
 
-    if (m_xmlTest.isJUnit()) {
+    if (m_testContext.getCurrentXmlTest().isJUnit()) {
       if (create) {
         result = new Object[] { ClassHelper.createInstance(m_class, m_classes,
-            m_xmlTest, m_annotationFinder, m_objectFactory) };
+                m_testContext.getCurrentXmlTest(), m_annotationFinder, m_objectFactory) };
       }
     } else {
       Object defaultInstance = getDefaultInstance();

--- a/src/main/java/org/testng/internal/TestNGClassFinder.java
+++ b/src/main/java/org/testng/internal/TestNGClassFinder.java
@@ -170,7 +170,6 @@ public class TestNGClassFinder extends BaseClassFinder {
               FactoryMethod fm = new FactoryMethod(
                       factoryMethod,
                       instance,
-                      xmlTest,
                       annotationFinder,
                       m_testContext, objectFactory, m_dataProviderListeners);
               ClassInfoMap moreClasses = new ClassInfoMap();

--- a/src/main/java/org/testng/internal/TestNGClassFinder.java
+++ b/src/main/java/org/testng/internal/TestNGClassFinder.java
@@ -16,6 +16,7 @@ import org.testng.ITestContext;
 import org.testng.ITestObjectFactory;
 import org.testng.TestNGException;
 import org.testng.annotations.IAnnotation;
+import org.testng.annotations.IObjectFactoryAnnotation;
 import org.testng.collections.Lists;
 import org.testng.collections.Maps;
 import org.testng.internal.annotations.AnnotationHelper;
@@ -32,195 +33,93 @@ import static org.testng.internal.ClassHelper.getAvailableMethods;
  */
 public class TestNGClassFinder extends BaseClassFinder {
 
+  private static final String PREFIX = "[TestNGClassFinder]";
   private final ITestContext m_testContext;
   private final Map<Class<?>, List<Object>> m_instanceMap = Maps.newHashMap();
   private final Map<Class<? extends IDataProviderListener>, IDataProviderListener>  m_dataProviderListeners;
+  private final ITestObjectFactory objectFactory;
+  private final IAnnotationFinder annotationFinder;
 
+  /**
+   * @deprecated - This constructor is un-used within TestNG and hence stands deprecated as of TestNG v6.13
+   */
+  @Deprecated
+  @SuppressWarnings("unused")
   public TestNGClassFinder(ClassInfoMap cim,
                            XmlTest xmlTest,
                            IConfiguration configuration,
                            ITestContext testContext) {
-    this(cim,  xmlTest, configuration, testContext,
+    this(cim,  Maps.<Class<?>, List<Object>>newHashMap(), configuration, testContext,
             Collections.<Class<? extends IDataProviderListener>, IDataProviderListener>emptyMap());
   }
 
+  /**
+   * @deprecated - This constructor is un-used within TestNG and hence stands deprecated as of TestNG v6.13
+   */
+  @Deprecated
+  @SuppressWarnings("unused")
   public TestNGClassFinder(ClassInfoMap cim,
                            XmlTest xmlTest,
                            IConfiguration configuration,
                            ITestContext testContext,
                            Map<Class<? extends IDataProviderListener>, IDataProviderListener>  dataProviderListeners) {
-    this(cim,  Maps.<Class<?>, List<Object>>newHashMap(), xmlTest, configuration, testContext, dataProviderListeners);
+    this(cim,  Maps.<Class<?>, List<Object>>newHashMap(), configuration, testContext, dataProviderListeners);
   }
 
-
+  /**
+   * @deprecated - This constructor is un-used within TestNG and hence stands deprecated as of TestNG v6.13
+   */
+  @Deprecated
+  @SuppressWarnings("unused")
   public TestNGClassFinder(ClassInfoMap cim,
-                           Map<Class<?>, List<Object>> instanceMap,
-                           XmlTest xmlTest,
-                           IConfiguration configuration,
-                           ITestContext testContext) {
-    this(cim, instanceMap, xmlTest, configuration, testContext,
+                            Map<Class<?>, List<Object>> instanceMap,
+                            XmlTest xmlTest,
+                            IConfiguration configuration,
+                            ITestContext testContext) {
+    this(cim, instanceMap, configuration, testContext,
             Collections.<Class<? extends IDataProviderListener>, IDataProviderListener>emptyMap());
   }
 
+  /**
+   * @deprecated - This constructor is un-used within TestNG and hence stands deprecated as of TestNG v6.13
+   */
+  @Deprecated
+  @SuppressWarnings("unused")
   public TestNGClassFinder(ClassInfoMap cim,
                            Map<Class<?>, List<Object>> instanceMap,
                            XmlTest xmlTest,
                            IConfiguration configuration,
                            ITestContext testContext,
                            Map<Class<? extends IDataProviderListener>, IDataProviderListener>  dataProviderListeners) {
-    m_testContext = testContext;
-    m_dataProviderListeners = dataProviderListeners;
+    this(cim, instanceMap, configuration, testContext, dataProviderListeners);
+  }
 
+  public TestNGClassFinder(ClassInfoMap cim,
+                           Map<Class<?>, List<Object>> instanceMap,
+                           IConfiguration configuration,
+                           ITestContext testContext,
+                           Map<Class<? extends IDataProviderListener>, IDataProviderListener>  dataProviderListeners) {
     if (instanceMap == null) {
       throw new IllegalArgumentException("instanceMap must not be null");
     }
 
-    IAnnotationFinder annotationFinder = configuration.getAnnotationFinder();
-    ITestObjectFactory objectFactory = configuration.getObjectFactory();
+    m_testContext = testContext;
+    m_dataProviderListeners = dataProviderListeners;
+    annotationFinder = configuration.getAnnotationFinder();
 
     // Find all the new classes and their corresponding instances
     Set<Class<?>> allClasses= cim.getClasses();
 
     //very first pass is to find ObjectFactory, can't create anything else until then
-    if(objectFactory == null) {
-      objectFactory = new ObjectFactoryImpl();
-      outer:
-      for (Class<?> cls : allClasses) {
-        try {
-          if (null != cls) {
-            Method[] ms;
-            try {
-              ms = cls.getMethods();
-            } catch (NoClassDefFoundError e) {
-              // https://github.com/cbeust/testng/issues/602
-              Utils.log("TestNGClassFinder", 5, "[WARN] Can't link and determine methods of " + cls + "(" + e.getMessage() + ")");
-              ms = new Method[0];
-            }
-            for (Method m : ms) {
-              IAnnotation a = annotationFinder.findAnnotation(m,
-                  org.testng.annotations.IObjectFactoryAnnotation.class);
-              if (null != a) {
-                if (!ITestObjectFactory.class.isAssignableFrom(m.getReturnType())) {
-                  throw new TestNGException("Return type of " + m + " is not IObjectFactory");
-                }
-                try {
-                  Object instance = cls.newInstance();
-                  if (m.getParameterTypes().length > 0 && m.getParameterTypes()[0].equals(ITestContext.class)) {
-                    objectFactory = (ITestObjectFactory) m.invoke(instance, testContext);
-                  } else {
-                    objectFactory = (ITestObjectFactory) m.invoke(instance);
-                  }
-                  break outer;
-                }
-                catch (Exception ex) {
-                  throw new TestNGException("Error creating object factory: " + cls,
-                      ex);
-                }
-              }
-            }
-          }
-        } catch (NoClassDefFoundError e) {
-          Utils.log("[TestNGClassFinder]", 1, "Unable to read methods on class " + cls.getName()
-              + " - unable to resolve class reference " + e.getMessage());
-          for (XmlClass xmlClass : xmlTest.getXmlClasses()) {
-            if (xmlClass.loadClasses() && xmlClass.getName().equals(cls.getName())) {
-              throw e;
-            }
-          }
-
-        }
-      }
+    if(configuration.getObjectFactory() == null) {
+      objectFactory = createObjectFactory(allClasses);
+    } else {
+      objectFactory = configuration.getObjectFactory();
     }
 
     for(Class<?> cls : allClasses) {
-      if (null == cls) {
-        Utils.log("TestNGClassFinder", 5, "[WARN] FOUND NULL CLASS");
-        continue;
-      }
-
-      if(isTestNGClass(cls, annotationFinder)) {
-        List<Object> allInstances = instanceMap.get(cls);
-        Object thisInstance = (allInstances != null && !allInstances.isEmpty()) ? allInstances.get(0) : null;
-
-        // If annotation class and instances are abstract, skip them
-        if ((null == thisInstance) && Modifier.isAbstract(cls.getModifiers())) {
-          Utils.log("", 5, "[WARN] Found an abstract class with no valid instance attached: " + cls);
-          continue;
-        }
-
-        if((null == thisInstance) && cls.isAnonymousClass()) {
-          Utils.log("", 5, "[WARN] Found an anonymous class with no valid instance attached" + cls);
-          continue;
-        }
-        
-        IClass ic= findOrCreateIClass(m_testContext, cls, cim.getXmlClass(cls), thisInstance,
-            xmlTest, annotationFinder, objectFactory);
-        if(null != ic) {
-          putIClass(cls, ic);
-
-          List<ConstructorOrMethod> factoryMethods = ClassHelper.findDeclaredFactoryMethods(cls, annotationFinder);
-          for (ConstructorOrMethod factoryMethod : factoryMethods) {
-            if (factoryMethod.getEnabled()) {
-              Object[] theseInstances = ic.getInstances(false);
-              if (theseInstances.length == 0) {
-                theseInstances = ic.getInstances(true);
-              }
-
-              Object instance = theseInstances.length != 0 ? theseInstances[0] : null;
-              FactoryMethod fm = new FactoryMethod(
-                      factoryMethod,
-                      instance,
-                      annotationFinder,
-                      m_testContext, objectFactory, m_dataProviderListeners);
-              ClassInfoMap moreClasses = new ClassInfoMap();
-
-              boolean excludeFactory = fm.getGroups().length != 0
-                  && xmlTest.getExcludedGroups().containsAll(Arrays.asList(fm.getGroups()));
-              if (!excludeFactory) {
-                // If the factory returned IInstanceInfo, get the class from it,
-                // otherwise, just call getClass() on the returned instances
-                int i = 0;
-                for (Object o : fm.invoke()) {
-                  if (o == null) {
-                    throw new TestNGException("The factory " + fm + " returned a null instance" +
-                        "at index " + i);
-                  }
-                  Class<?> oneMoreClass;
-                  if (IInstanceInfo.class.isAssignableFrom(o.getClass())) {
-                    IInstanceInfo<?> ii = (IInstanceInfo) o;
-                    addInstance(ii);
-                    oneMoreClass = ii.getInstanceClass();
-                  } else {
-                    addInstance(o);
-                    oneMoreClass = o.getClass();
-                  }
-                  if (!classExists(oneMoreClass)) {
-                    moreClasses.addClass(oneMoreClass);
-                  }
-                  i++;
-                }
-              }
-
-              if(!moreClasses.isEmpty()) {
-                TestNGClassFinder finder =
-                        new TestNGClassFinder(moreClasses,
-                                m_instanceMap,
-                                xmlTest,
-                                configuration,
-                                m_testContext);
-
-                for(IClass ic2 : finder.findTestClasses()) {
-                  putIClass(ic2.getRealClass(), ic2);
-                }
-              }
-            }
-          }
-        } // null != ic
-      } // if not TestNG class
-      else {
-        Utils.log("TestNGClassFinder", 3, "SKIPPING CLASS " + cls + " no TestNG annotations found");
-      }
-    } // for
+      processClass(cim, instanceMap, configuration, cls);
+    }
 
     //
     // Add all the instances we found to their respective IClasses
@@ -237,6 +136,164 @@ public class TestNGClassFinder extends BaseClassFinder {
 
   }
 
+  private void processClass(ClassInfoMap cim, Map<Class<?>, List<Object>> instanceMap, IConfiguration configuration, Class<?> cls) {
+    if (null == cls) {
+      Utils.log(PREFIX, 5, "[WARN] FOUND NULL CLASS");
+      return;
+    }
+
+    if (isNotTestNGClass(cls, annotationFinder)) { // if not TestNG class
+      Utils.log(PREFIX, 3, "SKIPPING CLASS " + cls + " no TestNG annotations found");
+      return;
+    }
+    List<Object> allInstances = instanceMap.get(cls);
+    Object thisInstance = (allInstances != null && !allInstances.isEmpty()) ? allInstances.get(0) : null;
+
+    // If annotation class and instances are abstract, skip them
+    if ((null == thisInstance) && Modifier.isAbstract(cls.getModifiers())) {
+      Utils.log("", 5, "[WARN] Found an abstract class with no valid instance attached: " + cls);
+      return;
+    }
+
+    if ((null == thisInstance) && cls.isAnonymousClass()) {
+      Utils.log("", 5, "[WARN] Found an anonymous class with no valid instance attached" + cls);
+      return;
+    }
+
+    IClass ic = findOrCreateIClass(m_testContext, cls, cim.getXmlClass(cls), thisInstance, annotationFinder, objectFactory);
+    if (ic == null) {
+      return;
+    }
+    putIClass(cls, ic);
+
+    List<ConstructorOrMethod> factoryMethods = ClassHelper.findDeclaredFactoryMethods(cls, annotationFinder);
+    for (ConstructorOrMethod factoryMethod : factoryMethods) {
+      processMethod(configuration, ic, factoryMethod);
+    }
+  }
+
+  private void processMethod(IConfiguration configuration, IClass ic, ConstructorOrMethod factoryMethod) {
+    if (!factoryMethod.getEnabled()) {
+      return;
+    }
+    ClassInfoMap moreClasses = processFactory(ic, factoryMethod);
+
+    if (moreClasses.isEmpty()) {
+      return;
+    }
+
+    TestNGClassFinder finder =
+            new TestNGClassFinder(moreClasses,
+                    m_instanceMap,
+                    configuration,
+                    m_testContext,
+                    Collections.<Class<? extends IDataProviderListener>, IDataProviderListener>emptyMap());
+
+    for (IClass ic2 : finder.findTestClasses()) {
+      putIClass(ic2.getRealClass(), ic2);
+    }
+  }
+
+  private static boolean excludeFactory(FactoryMethod fm, ITestContext ctx) {
+    return fm.getGroups().length != 0
+            && ctx.getCurrentXmlTest().getExcludedGroups().containsAll(Arrays.asList(fm.getGroups()));
+  }
+
+  private ClassInfoMap processFactory(IClass ic, ConstructorOrMethod factoryMethod) {
+    Object[] theseInstances = ic.getInstances(false);
+    if (theseInstances.length == 0) {
+      theseInstances = ic.getInstances(true);
+    }
+
+    Object instance = theseInstances.length != 0 ? theseInstances[0] : null;
+    FactoryMethod fm = new FactoryMethod(
+            factoryMethod,
+            instance,
+            annotationFinder,
+            m_testContext, objectFactory, m_dataProviderListeners);
+    ClassInfoMap moreClasses = new ClassInfoMap();
+
+    if (excludeFactory(fm, m_testContext)) {
+      return moreClasses;
+    }
+
+    // If the factory returned IInstanceInfo, get the class from it,
+    // otherwise, just call getClass() on the returned instances
+    int i = 0;
+    for (Object o : fm.invoke()) {
+      if (o == null) {
+        throw new TestNGException("The factory " + fm + " returned a null instance" + "at index " + i);
+      }
+      Class<?> oneMoreClass;
+      if (IInstanceInfo.class.isAssignableFrom(o.getClass())) {
+        IInstanceInfo<?> ii = (IInstanceInfo) o;
+        addInstance(ii);
+        oneMoreClass = ii.getInstanceClass();
+      } else {
+        addInstance(o);
+        oneMoreClass = o.getClass();
+      }
+      if (!classExists(oneMoreClass)) {
+        moreClasses.addClass(oneMoreClass);
+      }
+      i++;
+    }
+    return moreClasses;
+  }
+
+  private ITestObjectFactory createObjectFactory(Set<Class<?>> allClasses) {
+    ITestObjectFactory objectFactory;
+    objectFactory = new ObjectFactoryImpl();
+    for (Class<?> cls : allClasses) {
+      try {
+        if (cls == null) {
+          continue;
+        }
+        Method[] ms;
+        try {
+          ms = cls.getMethods();
+        } catch (NoClassDefFoundError e) {
+          // https://github.com/cbeust/testng/issues/602
+          Utils.log(PREFIX, 5, "[WARN] Can't link and determine methods of " + cls + "(" + e.getMessage() + ")");
+          ms = new Method[0];
+        }
+        for (Method m : ms) {
+          IAnnotation a = annotationFinder.findAnnotation(m, IObjectFactoryAnnotation.class);
+          if (a == null) {
+            continue;
+          }
+          if (!ITestObjectFactory.class.isAssignableFrom(m.getReturnType())) {
+            throw new TestNGException("Return type of " + m + " is not IObjectFactory");
+          }
+          try {
+            Object instance = cls.newInstance();
+            if (m.getParameterTypes().length > 0 && m.getParameterTypes()[0].equals(ITestContext.class)) {
+              objectFactory = (ITestObjectFactory) m.invoke(instance, m_testContext);
+            } else {
+              objectFactory = (ITestObjectFactory) m.invoke(instance);
+            }
+            return objectFactory;
+          } catch (Exception ex) {
+            throw new TestNGException("Error creating object factory: " + cls, ex);
+          }
+        }
+      } catch (NoClassDefFoundError e) {
+        Utils.log(PREFIX, 1, "Unable to read methods on class " + cls.getName()
+            + " - unable to resolve class reference " + e.getMessage());
+        for (XmlClass xmlClass : m_testContext.getCurrentXmlTest().getXmlClasses()) {
+          if (xmlClass.loadClasses() && xmlClass.getName().equals(cls.getName())) {
+            throw e;
+          }
+        }
+
+      }
+    }
+    return objectFactory;
+  }
+
+  private static boolean isNotTestNGClass(Class<?> c, IAnnotationFinder annotationFinder) {
+    return (!isTestNGClass(c, annotationFinder));
+  }
 
   /**
    * @return true if this class contains TestNG annotations (either on itself
@@ -275,14 +332,15 @@ public class TestNGClassFinder extends BaseClassFinder {
       return false;
 
     } catch (NoClassDefFoundError e) {
-      Utils.log("[TestNGClassFinder]", 1,
+      Utils.log(PREFIX, 1,
           "Unable to read methods on class " + cls.getName()
           + " - unable to resolve class reference " + e.getMessage());
       return false;
     }
   }
 
-  // IInstanceInfo<T> should be replaced by IInstanceInfo<?> but eclipse complains against it: https://github.com/cbeust/testng/issues/1070
+  // IInstanceInfo<T> should be replaced by IInstanceInfo<?> but eclipse complains against it.
+  // See: https://github.com/cbeust/testng/issues/1070
   private <T> void addInstance(IInstanceInfo<T> ii) {
     addInstance(ii.getInstanceClass(), ii.getInstance());
   }
@@ -291,7 +349,8 @@ public class TestNGClassFinder extends BaseClassFinder {
     addInstance(o.getClass(), o);
   }
 
-  // Class<S> should be replaced by Class<? extends T> but java doesn't fail as expected: https://github.com/cbeust/testng/issues/1070
+  // Class<S> should be replaced by Class<? extends T> but java doesn't fail as expected
+  // See: https://github.com/cbeust/testng/issues/1070
   private <T, S extends T> void addInstance(Class<S> clazz, T instance) {
     List<Object> instances = m_instanceMap.get(clazz);
 


### PR DESCRIPTION
Code cleanup: 

* Reduce complexity : Attempted at reducing code complexity of TestNGClassFinder by doing the following :
    * Remove nested ifs
    * Extract complex logic into methods for better understanding.

* Remove redundant method parameter
    * Remove redundant xmltest as a parameter being passed around
    * Deprecated a bunch of constructors