### PR TITLE
Possibility to retry a test until it FAILED

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-1519: Possibility to retry a test until it FAILED (Krishnan Mahadevan)
 Fixed: GITHUB-980: TestNG run inherited method twice (Krishnan Mahadevan)
 Fixed: GITHUB-1409: Regression: on expectedExceptionsMessageRegExp expected and actual messages are not printed (Krishnan Mahadevan)
 Fixed: GITHUB-1517: TestNG exits with a zero when there are configuration failures (Krishnan Mahadevan)

--- a/src/main/java/org/testng/collections/Maps.java
+++ b/src/main/java/org/testng/collections/Maps.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class Maps {
 
@@ -14,6 +15,10 @@ public class Maps {
 
   public static <K, V> Map<K,V> newHashtable() {
     return new Hashtable<>();
+  }
+
+  public static <K, V> Map<K,V> newConcurrentMap() {
+    return new ConcurrentHashMap<>();
   }
 
   public static <K, V> ListMultiMap<K, V> newListMultiMap() {

--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -75,17 +75,17 @@ public class Invoker implements IInvoker {
   private final Collection<IDataProviderListener> m_dataproviderListeners;
 
   /** Group failures must be synced as the Invoker is accessed concurrently */
-  private Map<String, Boolean> m_beforegroupsFailures = Maps.newHashtable();
+  private final Map<String, Boolean> m_beforegroupsFailures = Maps.newConcurrentMap();
 
   /** Class failures must be synced as the Invoker is accessed concurrently */
-  private Map<Class<?>, Set<Object>> m_classInvocationResults = Maps.newHashtable();
+  private final Map<Class<?>, Set<Object>> m_classInvocationResults = Maps.newConcurrentMap();
 
   /** Test methods whose configuration methods have failed. */
-  private Map<ITestNGMethod, Set<Object>> m_methodInvocationResults = Maps.newHashtable();
+  private final Map<ITestNGMethod, Set<Object>> m_methodInvocationResults = Maps.newConcurrentMap();
   private IConfiguration m_configuration;
 
   /** Predicate to filter methods */
-  private static Predicate<ITestNGMethod, IClass> CAN_RUN_FROM_CLASS = new CanRunFromClassPredicate();
+  private static final Predicate<ITestNGMethod, IClass> CAN_RUN_FROM_CLASS = new CanRunFromClassPredicate();
   /** Predicate to filter methods */
   private static final Predicate<ITestNGMethod, IClass> SAME_CLASS = new SameClassNamePredicate();
 
@@ -245,9 +245,7 @@ public class Invoker implements IInvoker {
               + " is not enabled");
         }
       }
-      catch(InvocationTargetException ex) {
-        handleConfigurationFailure(ex, tm, testResult, configurationAnnotation, currentTestMethod, instance, suite);
-      } catch(Throwable ex) { // covers the non-wrapper exceptions
+      catch(Throwable ex) {
         handleConfigurationFailure(ex, tm, testResult, configurationAnnotation, currentTestMethod, instance, suite);
       }
     } // for methods
@@ -341,9 +339,7 @@ public class Invoker implements IInvoker {
       }
     }
 
-    XmlClass[] result= vResult.values().toArray(new XmlClass[vResult.size()]);
-
-    return result;
+    return vResult.values().toArray(new XmlClass[vResult.size()]);
   }
 
   /**
@@ -592,8 +588,7 @@ public class Invoker implements IInvoker {
     //
     // Invoke beforeGroups configurations
     //
-    invokeBeforeGroupsConfigurations(testClass, tm, groupMethods, suite, params,
-        instance);
+    invokeBeforeGroupsConfigurations(tm, groupMethods, suite, params, instance);
 
     //
     // Invoke beforeMethods only if
@@ -622,7 +617,7 @@ public class Invoker implements IInvoker {
           suite, params, parameterValues,
           instance,
           testResult);
-      invokeAfterGroupsConfigurations(testClass, tm, groupMethods, suite, params, instance);
+      invokeAfterGroupsConfigurations(tm, groupMethods, suite, params, instance);
 
       return result;
     }
@@ -706,7 +701,7 @@ public class Invoker implements IInvoker {
 
       // Run invokedMethodListeners after updating TestResult
       runInvokedMethodListeners(AFTER_INVOCATION, invokedMethod, testResult);
-      handleInvocationResults(tm, testResult, expectedExceptionClasses, failureContext, holder);
+      handleInvocationResults(tm, testResult, failureContext, holder);
 
       // If this method has a data provider and just failed, memorize the number
       // at which it failed.
@@ -741,8 +736,7 @@ public class Invoker implements IInvoker {
       //
       // Invoke afterGroups configurations
       //
-      invokeAfterGroupsConfigurations(testClass, tm, groupMethods, suite,
-          params, instance);
+      invokeAfterGroupsConfigurations(tm, groupMethods, suite, params, instance);
 
       // Reset the test result last. If we do this too early, Reporter.log()
       // invocations from listeners will be discarded
@@ -799,7 +793,7 @@ public class Invoker implements IInvoker {
     return (configResult.getInstance()!= null ) && (configResult.getInstance().equals(instance));
   }
 
-  void collectResults(ITestNGMethod testMethod, ITestResult result) {
+  private void collectResults(ITestNGMethod testMethod, ITestResult result) {
       // Collect the results
       final int status = result.getStatus();
       if(ITestResult.SUCCESS == status) {
@@ -878,19 +872,16 @@ public class Invoker implements IInvoker {
     // Mark this method with the current thread id
     tm.setId(ThreadUtil.currentThreadInfo());
 
-    ITestResult result = invokeMethod(instance, tm, parameterValues, parametersIndex, suite, params,
+    return invokeMethod(instance, tm, parameterValues, parametersIndex, suite, params,
                                       testClass, beforeMethods, afterMethods, groupMethods,
                                       failureContext);
-
-    return result;
   }
 
   /**
    * Filter all the beforeGroups methods and invoke only those that apply
    * to the current test method
    */
-  private void invokeBeforeGroupsConfigurations(ITestClass testClass,
-                                                ITestNGMethod currentTestMethod,
+  private void invokeBeforeGroupsConfigurations(ITestNGMethod currentTestMethod,
                                                 ConfigurationGroupMethods groupMethods,
                                                 XmlSuite suite,
                                                 Map<String, String> params,
@@ -924,8 +915,7 @@ public class Invoker implements IInvoker {
     groupMethods.removeBeforeGroups(groups);
   }
 
-  private void invokeAfterGroupsConfigurations(ITestClass testClass,
-                                               ITestNGMethod currentTestMethod,
+  private void invokeAfterGroupsConfigurations(ITestNGMethod currentTestMethod,
                                                ConfigurationGroupMethods groupMethods,
                                                XmlSuite suite,
                                                Map<String, String> params,
@@ -1010,14 +1000,11 @@ public class Invoker implements IInvoker {
     do {
       failure.instances = Lists.newArrayList ();
       Map<String, String> allParameters = Maps.newHashMap();
-      /**
-       * TODO: This recreates all the parameters every time when we only need
-       * one specific set. Should optimize it by only recreating the set needed.
-       */
+      //TODO: This recreates all the parameters every time when we only need
+      //one specific set. Should optimize it by only recreating the set needed.
       ParameterBag bag = createParameters(tm, parameters,
           allParameters, suite, testContext, null /* fedInstance */);
-      Object[] parameterValues =
-          getParametersFromIndex(bag.parameterHolder.parameters, parametersIndex);
+      Object[] parameterValues = getParametersFromIndex(bag.parameterHolder.parameters, parametersIndex);
 
       result.add(invokeMethod(instance, tm, parameterValues, parametersIndex, suite,
           allParameters, testClass, beforeMethods, afterMethods, groupMethods, failure));
@@ -1041,10 +1028,9 @@ public class Invoker implements IInvoker {
       instance = testMethod.getInstance();
     }
 
-    ParameterBag bag = handleParameters(testMethod,
+    return handleParameters(testMethod,
         instance, allParameterNames, parameters, null, suite, testContext, fedInstance, null);
 
-    return bag;
   }
 
   /**
@@ -1422,9 +1408,8 @@ public class Invoker implements IInvoker {
     return holder;
   }
 
-  void handleInvocationResults(ITestNGMethod testMethod,
+  private void handleInvocationResults(ITestNGMethod testMethod,
                                ITestResult testResult,
-                               ExpectedExceptionsHolder expectedExceptionsHolder,
                                FailureContext failure,
                                StatusHolder holder) {
     //
@@ -1475,7 +1460,7 @@ public class Invoker implements IInvoker {
     ITestClass testClass= testMethod.getTestClass();
     Object[] instances = testClass.getInstances(true);
     for(Object instance: instances) {
-      invokeBeforeGroupsConfigurations(testClass, testMethod, groupMethods, suite, parameters, instance);
+      invokeBeforeGroupsConfigurations(testMethod, groupMethods, suite, parameters, instance);
     }
 
 
@@ -1501,7 +1486,7 @@ public class Invoker implements IInvoker {
     }
 
     for(Object instance: instances) {
-      invokeAfterGroupsConfigurations(testClass, testMethod, groupMethods, suite, parameters, instance);
+      invokeAfterGroupsConfigurations(testMethod, groupMethods, suite, parameters, instance);
     }
 
     return result;
@@ -1640,7 +1625,7 @@ public class Invoker implements IInvoker {
 
   }
 
-  static interface Predicate<K, T> {
+  interface Predicate<K, T> {
     boolean isTrue(K k, T v);
   }
 
@@ -1762,17 +1747,17 @@ public class Invoker implements IInvoker {
     final ParameterHolder parameterHolder;
     final ITestResult errorResult;
 
-    public ParameterBag(ParameterHolder parameterHolder) {
+    ParameterBag(ParameterHolder parameterHolder) {
       this.parameterHolder = parameterHolder;
       this.errorResult = null;
     }
 
-    public ParameterBag(ITestResult errorResult) {
+    ParameterBag(ITestResult errorResult) {
       this.parameterHolder = null;
       this.errorResult = errorResult;
     }
 
-    public boolean hasErrors() {
+    boolean hasErrors() {
       return errorResult != null;
     }
   }

--- a/src/test/java/test/retryAnalyzer/RetryAnalyzerTest.java
+++ b/src/test/java/test/retryAnalyzer/RetryAnalyzerTest.java
@@ -6,12 +6,16 @@ import static org.testng.Assert.assertTrue;
 
 import java.util.List;
 
+import org.assertj.core.api.Assertions;
+import org.testng.ITestNGListener;
 import org.testng.ITestResult;
 import org.testng.TestListenerAdapter;
 import org.testng.TestNG;
 import org.testng.annotations.Test;
 
 import test.SimpleBaseTest;
+import test.retryAnalyzer.github1519.MyListener;
+import test.retryAnalyzer.github1519.TestClassSample;
 
 public class RetryAnalyzerTest extends SimpleBaseTest {
     @Test
@@ -33,5 +37,13 @@ public class RetryAnalyzerTest extends SimpleBaseTest {
 
         List<ITestResult> skipped = tla.getSkippedTests();
         assertEquals(skipped.size(), InvocationCountTest.invocations.size() - fsp.size());
+    }
+
+    @Test
+    public void testIfRetryIsInvokedBeforeListener() {
+        TestNG tng = create(TestClassSample.class);
+        tng.addListener((ITestNGListener)new MyListener());
+        tng.run();
+        Assertions.assertThat(TestClassSample.messages).containsExactly("afterInvocation", "retry","afterInvocation");
     }
 }

--- a/src/test/java/test/retryAnalyzer/RetryAnalyzerTest.java
+++ b/src/test/java/test/retryAnalyzer/RetryAnalyzerTest.java
@@ -1,12 +1,12 @@
 package test.retryAnalyzer;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 import java.util.List;
 
-import org.assertj.core.api.Assertions;
 import org.testng.ITestNGListener;
 import org.testng.ITestResult;
 import org.testng.TestListenerAdapter;
@@ -44,6 +44,6 @@ public class RetryAnalyzerTest extends SimpleBaseTest {
         TestNG tng = create(TestClassSample.class);
         tng.addListener((ITestNGListener)new MyListener());
         tng.run();
-        Assertions.assertThat(TestClassSample.messages).containsExactly("afterInvocation", "retry","afterInvocation");
+        assertThat(TestClassSample.messages).containsExactly("afterInvocation", "retry", "afterInvocation");
     }
 }

--- a/src/test/java/test/retryAnalyzer/github1519/MyAnalyzer.java
+++ b/src/test/java/test/retryAnalyzer/github1519/MyAnalyzer.java
@@ -1,0 +1,14 @@
+package test.retryAnalyzer.github1519;
+
+import org.testng.IRetryAnalyzer;
+import org.testng.ITestResult;
+
+public class MyAnalyzer implements IRetryAnalyzer {
+
+    @Override
+    public boolean retry(ITestResult iTestResult) {
+        TestClassSample.messages.add("retry");
+        TestClassSample.retry = true;
+        return true;
+    }
+}

--- a/src/test/java/test/retryAnalyzer/github1519/MyListener.java
+++ b/src/test/java/test/retryAnalyzer/github1519/MyListener.java
@@ -1,0 +1,17 @@
+package test.retryAnalyzer.github1519;
+
+import org.testng.IInvokedMethod;
+import org.testng.IInvokedMethodListener;
+import org.testng.ITestResult;
+
+public class MyListener implements IInvokedMethodListener {
+    @Override
+    public void beforeInvocation(IInvokedMethod iInvokedMethod, ITestResult iTestResult) {
+    }
+
+    @Override
+    public void afterInvocation(IInvokedMethod iInvokedMethod, ITestResult iTestResult) {
+        TestClassSample.messages.add("afterInvocation");
+    }
+
+}

--- a/src/test/java/test/retryAnalyzer/github1519/TestClassSample.java
+++ b/src/test/java/test/retryAnalyzer/github1519/TestClassSample.java
@@ -1,0 +1,17 @@
+package test.retryAnalyzer.github1519;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.testng.collections.Lists;
+
+import java.util.List;
+
+public class TestClassSample {
+    static boolean retry = false;
+    public static List<String> messages = Lists.newArrayList();
+
+    @Test(retryAnalyzer = MyAnalyzer.class)
+    public void testMethod() {
+        Assert.assertTrue(retry);
+    }
+}


### PR DESCRIPTION
Fixes #1519 .

For a failing test following would happen:
* Inspect the exception to consider “expectedExceptions”
* Run “afterInvocations()”
* Invoke a “RetryAnalyzer” if provided.

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.