### PR TITLE
IInvokedMethodListener implementation called for skipped methods

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-1465: Failure policy CONTINUE handling is broken for tests that are skipped in @BeforeMethod method (Krishnan Mahadevan)
 Fixed: GITHUB-949: dependsOnMethods with alwaysRun = true and inheritance fails to find method (Krishnan Mahadevan)
 Fixed: GITHUB-1519: Possibility to retry a test until it FAILED (Krishnan Mahadevan)
 Fixed: GITHUB-980: TestNG run inherited method twice (Krishnan Mahadevan)

--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -610,7 +610,8 @@ public class Invoker implements IInvoker {
               getExceptionDetails(instance));
       m_notifier.addSkippedTest(tm, result);
       tm.incrementCurrentInvocationCount();
-
+      testResult.setMethod(tm);
+      runInvokedMethodListeners(BEFORE_INVOCATION, invokedMethod, testResult);
       runInvokedMethodListeners(AFTER_INVOCATION, invokedMethod, testResult);
       invokeConfigurations(testClass, tm,
           filterConfigurationMethods(tm, afterMethods, false /* beforeMethods */),

--- a/src/test/java/test/listeners/github1465/ExampleClassListener.java
+++ b/src/test/java/test/listeners/github1465/ExampleClassListener.java
@@ -1,0 +1,63 @@
+package test.listeners.github1465;
+
+import org.testng.IInvokedMethod;
+import org.testng.IInvokedMethodListener;
+import org.testng.ITestNGMethod;
+import org.testng.ITestResult;
+
+import java.lang.reflect.Method;
+import java.util.LinkedList;
+import java.util.List;
+
+public class ExampleClassListener implements IInvokedMethodListener {
+    List<String> messages = new LinkedList<>();
+    List<String> configMsgs = new LinkedList<>();
+
+    @Override
+    public void beforeInvocation(IInvokedMethod method, ITestResult testResult) {
+        log("beforeInvocation:", method, testResult);
+    }
+
+    @Override
+    public void afterInvocation(IInvokedMethod method, ITestResult testResult) {
+        log("afterInvocation:", method, testResult);
+    }
+
+    private void log(String prefix, IInvokedMethod method, ITestResult testResult) {
+        String msg = prefix + "_" + typeOfMethod(method);
+        msg += method.getTestMethod().getMethodName() + parameters(testResult);
+        if (method.isConfigurationMethod()) {
+            configMsgs.add(msg);
+        } else {
+            messages.add(msg);
+        }
+    }
+
+    private static String typeOfMethod(IInvokedMethod method) {
+        ITestNGMethod tm = method.getTestMethod();
+        if (tm.isBeforeMethodConfiguration()) {
+            return "before_method: ";
+        }
+        if (tm.isAfterMethodConfiguration()) {
+            return "after_method: ";
+        }
+        return "test_method: ";
+    }
+
+    private static String parameters(ITestResult testResult) {
+        Object[] parameters = testResult.getParameters();
+        if (parameters != null) {
+            StringBuilder builder = new StringBuilder();
+            for (Object parameter : parameters) {
+                if (parameter instanceof Method) {
+                    builder.append(((Method) parameter).getName());
+                }
+            }
+            if (builder.length() != 0) {
+                return "[" + builder.toString() + "]";
+            }
+        }
+        return "";
+
+    }
+}

--- a/src/test/java/test/listeners/github1465/ExampleClassListener.java
+++ b/src/test/java/test/listeners/github1465/ExampleClassListener.java
@@ -10,8 +10,8 @@ import java.util.LinkedList;
 import java.util.List;
 
 public class ExampleClassListener implements IInvokedMethodListener {
-    List<String> messages = new LinkedList<>();
-    List<String> configMsgs = new LinkedList<>();
+    final List<String> messages = new LinkedList<>();
+    final List<String> configMsgs = new LinkedList<>();
 
     @Override
     public void beforeInvocation(IInvokedMethod method, ITestResult testResult) {
@@ -46,18 +46,20 @@ public class ExampleClassListener implements IInvokedMethodListener {
 
     private static String parameters(ITestResult testResult) {
         Object[] parameters = testResult.getParameters();
-        if (parameters != null) {
-            StringBuilder builder = new StringBuilder();
-            for (Object parameter : parameters) {
-                if (parameter instanceof Method) {
-                    builder.append(((Method) parameter).getName());
-                }
-            }
-            if (builder.length() != 0) {
-                return "[" + builder.toString() + "]";
+        if (parameters == null) {
+            return "";
+        }
+        String returnValue = "";
+        StringBuilder builder = new StringBuilder();
+        for (Object parameter : parameters) {
+            if (parameter instanceof Method) {
+                builder.append(((Method) parameter).getName());
             }
         }
-        return "";
+        if (builder.length() != 0) {
+            returnValue =  "[" + builder.toString() + "]";
+        }
+        return returnValue;
 
     }
 }

--- a/src/test/java/test/listeners/github1465/ExampleClassSample.java
+++ b/src/test/java/test/listeners/github1465/ExampleClassSample.java
@@ -1,0 +1,33 @@
+package test.listeners.github1465;
+
+import org.testng.SkipException;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Method;
+
+import static org.testng.Assert.assertTrue;
+
+public class ExampleClassSample {
+    @BeforeMethod
+    public void beforeMethod(Method method) {
+        if ("test1".equals(method.getName())) {
+            throw new SkipException("Skip from [before]");
+        }
+    }
+
+    @Test
+    public void test1() {
+        assertTrue(true);
+    }
+
+    @Test
+    public void test2() {
+        assertTrue(true);
+    }
+
+    @AfterMethod
+    public void afterMethod(Method method) {
+    }
+}

--- a/src/test/java/test/listeners/github1465/IssueTest.java
+++ b/src/test/java/test/listeners/github1465/IssueTest.java
@@ -18,13 +18,11 @@ public class IssueTest extends SimpleBaseTest {
         ExampleClassListener listener = new ExampleClassListener();
         testNG.addListener((ITestNGListener) listener);
         testNG.run();
-        assertThat(listener.messages.size()).isEqualTo(4);
         String[] expected = new String[]{
                 "beforeInvocation:_test_method: test1", "afterInvocation:_test_method: test1",
                 "beforeInvocation:_test_method: test2", "afterInvocation:_test_method: test2"
         };
         assertThat(listener.messages).containsExactly(expected);
-        assertThat(listener.configMsgs.size()).isEqualTo(expectedMsgs.length);
         assertThat(listener.configMsgs).containsExactly(expectedMsgs);
     }
 

--- a/src/test/java/test/listeners/github1465/IssueTest.java
+++ b/src/test/java/test/listeners/github1465/IssueTest.java
@@ -1,0 +1,52 @@
+package test.listeners.github1465;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.testng.ITestNGListener;
+import org.testng.TestNG;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.testng.xml.XmlSuite;
+import test.SimpleBaseTest;
+
+public class IssueTest extends SimpleBaseTest {
+
+    @Test(dataProvider = "dp")
+    public void reproduceIssue(XmlSuite.FailurePolicy policy, String[] expectedMsgs) {
+        TestNG testNG = create(ExampleClassSample.class);
+        testNG.setConfigFailurePolicy(policy);
+        ExampleClassListener listener = new ExampleClassListener();
+        testNG.addListener((ITestNGListener) listener);
+        testNG.run();
+        assertThat(listener.messages.size()).isEqualTo(4);
+        String[] expected = new String[]{
+                "beforeInvocation:_test_method: test1", "afterInvocation:_test_method: test1",
+                "beforeInvocation:_test_method: test2", "afterInvocation:_test_method: test2"
+        };
+        assertThat(listener.messages).containsExactly(expected);
+        assertThat(listener.configMsgs.size()).isEqualTo(expectedMsgs.length);
+        assertThat(listener.configMsgs).containsExactly(expectedMsgs);
+    }
+
+    @DataProvider(name = "dp")
+    public Object[][] getdata() {
+        String[] continueFailurePolicyExpected = new String[]{
+                "beforeInvocation:_before_method: beforeMethod[test1]",
+                "afterInvocation:_before_method: beforeMethod[test1]",
+                "beforeInvocation:_after_method: afterMethod[test1]",
+                "afterInvocation:_after_method: afterMethod[test1]",
+                "beforeInvocation:_before_method: beforeMethod[test2]",
+                "afterInvocation:_before_method: beforeMethod[test2]",
+                "beforeInvocation:_after_method: afterMethod[test2]",
+                "afterInvocation:_after_method: afterMethod[test2]"
+        };
+        String[] skipFailurePolicyExpected = new String[]{
+                "beforeInvocation:_before_method: beforeMethod[test1]",
+                "afterInvocation:_before_method: beforeMethod[test1]"
+        };
+        return new Object[][]{
+                {XmlSuite.FailurePolicy.CONTINUE, continueFailurePolicyExpected},
+                {XmlSuite.FailurePolicy.SKIP, skipFailurePolicyExpected}
+        };
+    }
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -195,6 +195,7 @@
       <class name="test.multiplelisteners.TestMaker" />
       <class name="test.listeners.github1130.GitHub1130Test"/>
       <class name="test.listeners.github1296.GitHub1296Test"/>
+      <class name="test.listeners.github1465.IssueTest"/>
     </classes>
   </test>
 


### PR DESCRIPTION
Closes #1465

Ensure that IInvokedMethodListener’s before and 
afterInvocation() are always invoked (Even for 
skipped methods as well)

Fixes #1465 .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.