### PR TITLE
Configure XML output of XmlSuite

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-1455: Configure XML output of XmlSuite (Krishnan Mahadevan)
 Fixed: GITHUB-1465: Failure policy CONTINUE handling is broken for tests that are skipped in @BeforeMethod method (Krishnan Mahadevan)
 Fixed: GITHUB-1533: Duplicate child suites get added when working with parent/child suite scenario (Krishnan Mahadevan)
 Fixed: GITHUB-949: dependsOnMethods with alwaysRun = true and inheritance fails to find method (Krishnan Mahadevan)

--- a/src/main/java/org/testng/reporters/XMLStringBuffer.java
+++ b/src/main/java/org/testng/reporters/XMLStringBuffer.java
@@ -14,7 +14,7 @@ import javax.annotation.Nullable;
  */
 public class XMLStringBuffer {
   /** End of line, value of 'line.separator' system property or '\n' */
-  private static final String EOL = System.getProperty("line.separator", "\n");
+  public static final String EOL = System.getProperty("line.separator", "\n");
 
   /** Tab space indent for XML document */
   private static final String DEFAULT_INDENT_INCREMENT = "  ";
@@ -27,6 +27,8 @@ public class XMLStringBuffer {
 
   /** A string of space character representing the current indentation. */
   private String m_currentIndent = "";
+
+  private String defaultComment = null;
 
   public XMLStringBuffer() {
     init(Buffer.create(), "", "1.0", "UTF-8");
@@ -178,8 +180,12 @@ public class XMLStringBuffer {
             "Popping the wrong tag: " + t.tagName + " but expected " + tagName);
       }
     }
-    XMLUtils.xmlClose(m_buffer, m_currentIndent, t.tagName,
-        XMLUtils.extractComment(tagName, t.properties));
+
+    String comment = defaultComment;
+    if (comment == null) {
+        comment = XMLUtils.extractComment(tagName, t.properties);
+    }
+      XMLUtils.xmlClose(m_buffer, m_currentIndent, t.tagName, comment);
   }
 
   /**
@@ -291,7 +297,11 @@ public class XMLStringBuffer {
     m_buffer.append(s);
   }
 
-  private static void ppp(String s) {
+    public void setDefaultComment(String defaultComment) {
+        this.defaultComment = defaultComment;
+    }
+
+    private static void ppp(String s) {
     System.out.println("[XMLStringBuffer] " + s);
   }
 
@@ -339,25 +349,6 @@ public class XMLStringBuffer {
     return INVALID_XML_CHARS.matcher(m_buffer.toString()).replaceAll("");
   }
 
-  public static void main(String[] argv) {
-    IBuffer result = Buffer.create();
-    XMLStringBuffer sb = new XMLStringBuffer(result, "");
-
-    sb.push("family");
-    Properties p = new Properties();
-    p.setProperty("prop1", "value1");
-    p.setProperty("prop2", "value2");
-    sb.addRequired("cedric", "true", p);
-    sb.addRequired("alois", "true");
-    sb.addOptional("anne-marie", (String) null);
-    sb.pop();
-
-    System.out.println(result.toString());
-
-    assert ("<family>" + EOL + "<cedric>true</cedric>" + EOL + "<alois>true</alois>" + EOL + "</family>"  + EOL)
-      .equals(result.toString());
-  }
-
   public String getCurrentIndent() {
     return m_currentIndent;
   }
@@ -366,7 +357,6 @@ public class XMLStringBuffer {
     m_buffer.toWriter(fw);
   }
 }
-
 
 ////////////////////////
 

--- a/src/main/java/org/testng/reporters/XMLStringBuffer.java
+++ b/src/main/java/org/testng/reporters/XMLStringBuffer.java
@@ -301,10 +301,6 @@ public class XMLStringBuffer {
         this.defaultComment = defaultComment;
     }
 
-    private static void ppp(String s) {
-    System.out.println("[XMLStringBuffer] " + s);
-  }
-
   /**
    * Add a CDATA tag.
    */

--- a/src/main/java/org/testng/reporters/XMLUtils.java
+++ b/src/main/java/org/testng/reporters/XMLUtils.java
@@ -114,7 +114,7 @@ public final class XMLUtils {
 
   public static void xmlClose(IBuffer result, String indent, String tag, String comment) {
     result.append(indent).append("</").append(tag).append(">")
-        .append(Strings.isNotNullAndNotEmpty(comment) ? comment : "")
+        .append(Strings.getValueOrEmpty(comment))
         .append(EOL);
   }
 

--- a/src/main/java/org/testng/reporters/XMLUtils.java
+++ b/src/main/java/org/testng/reporters/XMLUtils.java
@@ -1,5 +1,7 @@
 package org.testng.reporters;
 
+import org.testng.util.Strings;
+
 import java.text.CharacterIterator;
 import java.text.StringCharacterIterator;
 import java.util.Map.Entry;
@@ -112,7 +114,7 @@ public final class XMLUtils {
 
   public static void xmlClose(IBuffer result, String indent, String tag, String comment) {
     result.append(indent).append("</").append(tag).append(">")
-        .append(comment != null ? comment : "")
+        .append(Strings.isNotNullAndNotEmpty(comment) ? comment : "")
         .append(EOL);
   }
 

--- a/src/main/java/org/testng/util/Strings.java
+++ b/src/main/java/org/testng/util/Strings.java
@@ -1,10 +1,7 @@
 package org.testng.util;
 
 import org.testng.collections.Maps;
-import org.testng.internal.collections.Pair;
 
-import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 
 public final class Strings {
@@ -19,18 +16,21 @@ public final class Strings {
     return ! (isNullOrEmpty(string));
   }
 
-  private static List<Pair<String, String>> ESCAPE_HTML_LIST = Arrays.asList(
-          Pair.create("&", "&amp;"),
-          Pair.create("<", "&lt;"),
-          Pair.create(">", "&gt;")
-  );
+  /**
+   * @param string - The input String.
+   * @return - Returns an empty string if the input String is <code>null</code> (or) empty, else it returns
+   * back the input string.
+   */
+  public static String getValueOrEmpty(String string) {
+    return isNotNullAndNotEmpty(string) ? string : "";
+  }
 
   private static final Map<String, String> ESCAPE_HTML_MAP = Maps.newLinkedHashMap();
 
   static {
-    for (Pair<String,String> each : ESCAPE_HTML_LIST) {
-      ESCAPE_HTML_MAP.put(each.first(), each.second());
-    }
+    ESCAPE_HTML_MAP.put("&", "&amp;");
+    ESCAPE_HTML_MAP.put("<", "&lt;");
+    ESCAPE_HTML_MAP.put(">", "&gt;");
   }
 
   public static String escapeHtml(String text) {

--- a/src/main/java/org/testng/util/Strings.java
+++ b/src/main/java/org/testng/util/Strings.java
@@ -1,31 +1,35 @@
 package org.testng.util;
 
-import org.testng.collections.Lists;
 import org.testng.collections.Maps;
+import org.testng.internal.collections.Pair;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-public class Strings {
+public final class Strings {
+  private Strings() {
+    //Utility class. Defeat instantiation.
+  }
   public static boolean isNullOrEmpty(String string) {
-    return string == null || string.trim().length() == 0; // string.isEmpty() in Java 6
+    return string == null || string.trim().isEmpty();
   }
 
   public static boolean isNotNullAndNotEmpty(String string) {
     return ! (isNullOrEmpty(string));
   }
 
-  private static List<String> ESCAPE_HTML_LIST = Lists.newArrayList(
-    "&", "&amp;",
-    "<", "&lt;",
-    ">", "&gt;"
+  private static List<Pair<String, String>> ESCAPE_HTML_LIST = Arrays.asList(
+          Pair.create("&", "&amp;"),
+          Pair.create("<", "&lt;"),
+          Pair.create(">", "&gt;")
   );
-  
+
   private static final Map<String, String> ESCAPE_HTML_MAP = Maps.newLinkedHashMap();
 
   static {
-    for (int i = 0; i < ESCAPE_HTML_LIST.size(); i += 2) {
-      ESCAPE_HTML_MAP.put(ESCAPE_HTML_LIST.get(i), ESCAPE_HTML_LIST.get(i + 1));
+    for (Pair<String,String> each : ESCAPE_HTML_LIST) {
+      ESCAPE_HTML_MAP.put(each.first(), each.second());
     }
   }
 
@@ -37,7 +41,4 @@ public class Strings {
     return result;
   }
 
-  public static void main(String[] args) {
-    System.out.println(escapeHtml("10 < 20 && 30 > 20"));
-  }
 }

--- a/src/main/java/org/testng/xml/CommentDisabledXmlWeaver.java
+++ b/src/main/java/org/testng/xml/CommentDisabledXmlWeaver.java
@@ -4,7 +4,7 @@ package org.testng.xml;
  * This class provides String representation of both {@link XmlSuite} and {@link XmlTest} without adding
  * an XML comment as the test name and  suite name at the end of the corresponding tags.
  */
-class CommentDisabledXmlWeaver extends DefaultXmlWeaver {
+final class CommentDisabledXmlWeaver extends DefaultXmlWeaver {
     CommentDisabledXmlWeaver() {
         super("");
     }

--- a/src/main/java/org/testng/xml/CommentDisabledXmlWeaver.java
+++ b/src/main/java/org/testng/xml/CommentDisabledXmlWeaver.java
@@ -1,0 +1,11 @@
+package org.testng.xml;
+
+/**
+ * This class provides String representation of both {@link XmlSuite} and {@link XmlTest} without adding
+ * an XML comment as the test name and  suite name at the end of the corresponding tags.
+ */
+class CommentDisabledXmlWeaver extends DefaultXmlWeaver {
+    CommentDisabledXmlWeaver() {
+        super("");
+    }
+}

--- a/src/main/java/org/testng/xml/DefaultXmlWeaver.java
+++ b/src/main/java/org/testng/xml/DefaultXmlWeaver.java
@@ -1,0 +1,275 @@
+package org.testng.xml;
+
+import org.testng.reporters.XMLStringBuffer;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.testng.collections.CollectionUtils.hasElements;
+import static org.testng.internal.Utils.isStringNotEmpty;
+import static org.testng.xml.XmlSuite.*;
+
+/**
+ * This class provides String representation of both {@link XmlSuite} and {@link XmlTest} but adds
+ * an XML comment as the test name and  suite name at the end of the corresponding tags.
+ */
+class DefaultXmlWeaver implements IWeaveXml {
+
+    private String defaultComment;
+
+    DefaultXmlWeaver(){
+        this(null);
+    }
+
+    DefaultXmlWeaver(String defaultComment) {
+        this.defaultComment = defaultComment;
+    }
+
+    @Override
+    public String asXml(XmlSuite xmlSuite) {
+        XMLStringBuffer xsb = new XMLStringBuffer();
+        xsb.setDefaultComment(defaultComment);
+        xsb.setDocType("suite SYSTEM \"" + Parser.TESTNG_DTD_URL + '\"');
+        Properties p = new Properties();
+        p.setProperty("name", xmlSuite.getName());
+        if (xmlSuite.getVerbose() != null) {
+            XmlUtils.setProperty(p, "verbose", xmlSuite.getVerbose().toString(), DEFAULT_VERBOSE.toString());
+        }
+        final XmlSuite.ParallelMode parallel = xmlSuite.getParallel();
+        if (parallel != null && !XmlSuite.DEFAULT_PARALLEL.equals(parallel)) {
+            p.setProperty("parallel", parallel.toString());
+        }
+        XmlUtils.setProperty(p, "group-by-instances", String.valueOf(xmlSuite.getGroupByInstances()),
+                DEFAULT_GROUP_BY_INSTANCES.toString());
+        XmlUtils.setProperty(p, "configfailurepolicy", xmlSuite.getConfigFailurePolicy().toString(),
+                DEFAULT_CONFIG_FAILURE_POLICY.toString());
+        XmlUtils.setProperty(p, "thread-count", String.valueOf(xmlSuite.getThreadCount()),
+                DEFAULT_THREAD_COUNT.toString());
+        XmlUtils.setProperty(p, "data-provider-thread-count", String.valueOf(xmlSuite.getDataProviderThreadCount()),
+                DEFAULT_DATA_PROVIDER_THREAD_COUNT.toString());
+        if (!DEFAULT_JUNIT.equals(xmlSuite.isJUnit())) {
+            p.setProperty("junit", xmlSuite.isJUnit() != null ? xmlSuite.isJUnit().toString() : "false"); // TESTNG-141
+        }
+        XmlUtils.setProperty(p, "skipfailedinvocationcounts", xmlSuite.skipFailedInvocationCounts().toString(),
+                DEFAULT_SKIP_FAILED_INVOCATION_COUNTS.toString());
+        if (null != xmlSuite.getObjectFactory()) {
+            p.setProperty("object-factory", xmlSuite.getObjectFactory().getClass().getName());
+        }
+        if (isStringNotEmpty(xmlSuite.getParentModule())) {
+            p.setProperty("parent-module", xmlSuite.getParentModule());
+        }
+        if (isStringNotEmpty(xmlSuite.getGuiceStage())) {
+            p.setProperty("guice-stage", xmlSuite.getGuiceStage());
+        }
+        XmlUtils.setProperty(p, "allow-return-values", String.valueOf(xmlSuite.getAllowReturnValues()),
+                DEFAULT_ALLOW_RETURN_VALUES.toString());
+        xsb.push("suite", p);
+
+        XmlUtils.dumpParameters(xsb, xmlSuite.getParameters());
+
+        if (hasElements(xmlSuite.getListeners())) {
+            xsb.push("listeners");
+            for (String listenerName : xmlSuite.getListenersList()) {
+                Properties listenerProps = new Properties();
+                listenerProps.setProperty("class-name", listenerName);
+                xsb.addEmptyElement("listener", listenerProps);
+            }
+            xsb.pop("listeners");
+        }
+
+        if (hasElements(xmlSuite.getXmlPackages())) {
+            xsb.push("packages");
+
+            for (XmlPackage pack : xmlSuite.getXmlPackages()) {
+                xsb.getStringBuffer().append(pack.toXml("    "));
+            }
+
+            xsb.pop("packages");
+        }
+
+        if (xmlSuite.getXmlMethodSelectors() != null) {
+            xsb.getStringBuffer().append(xmlSuite.getXmlMethodSelectors().toXml("  "));
+        } else {
+            // deprecated
+            if (hasElements(xmlSuite.getMethodSelectors())) {
+                xsb.push("method-selectors");
+                for (XmlMethodSelector selector : xmlSuite.getMethodSelectors()) {
+                    xsb.getStringBuffer().append(selector.toXml("  "));
+                }
+
+                xsb.pop("method-selectors");
+            }
+        }
+
+        List<String> suiteFiles = xmlSuite.getSuiteFiles();
+        if (suiteFiles.size() > 0) {
+            xsb.push("suite-files");
+            for (String sf : suiteFiles) {
+                Properties prop = new Properties();
+                prop.setProperty("path", sf);
+                xsb.addEmptyElement("suite-file", prop);
+            }
+            xsb.pop("suite-files");
+        }
+
+        List<String> included = xmlSuite.getIncludedGroups();
+        List<String> excluded = xmlSuite.getExcludedGroups();
+        if (hasElements(included) || hasElements(excluded)) {
+            xsb.push("groups");
+            xsb.push("run");
+            for (String g : included) {
+                xsb.addEmptyElement("include", "name", g);
+            }
+            for (String g : excluded) {
+                xsb.addEmptyElement("exclude", "name", g);
+            }
+            xsb.pop("run");
+            xsb.pop("groups");
+        }
+
+        if (xmlSuite.getGroups() != null) {
+            xsb.getStringBuffer().append(xmlSuite.getGroups().toXml("  "));
+        }
+
+        for (XmlTest test : xmlSuite.getTests()) {
+            xsb.getStringBuffer().append(test.toXml("  "));
+        }
+
+        xsb.pop("suite");
+
+        return xsb.toXML();
+    }
+
+    @Override
+    public String asXml(XmlTest xmlTest, String indent) {
+        XMLStringBuffer xsb = new XMLStringBuffer(indent);
+        xsb.setDefaultComment(defaultComment);
+        Properties p = new Properties();
+        p.setProperty("name", xmlTest.getName());
+        XmlUtils.setProperty(p, "junit", Boolean.toString(xmlTest.isJUnit()), XmlSuite.DEFAULT_JUNIT.toString());
+        XmlUtils.setProperty(p, "parallel", xmlTest.getParallel().toString(), XmlSuite.DEFAULT_PARALLEL.toString());
+        XmlUtils.setProperty(p, "verbose", Integer.toString(xmlTest.getVerbose()), XmlSuite.DEFAULT_VERBOSE.toString());
+
+        if (null != xmlTest.getTimeOut()) {
+            p.setProperty("time-out", xmlTest.getTimeOut());
+        }
+
+        if (xmlTest.getPreserveOrder() != null && ! XmlSuite.DEFAULT_PRESERVE_ORDER.equals(xmlTest.getPreserveOrder())) {
+            p.setProperty("preserve-order", xmlTest.getPreserveOrder().toString());
+        }
+
+        if (xmlTest.getThreadCount() != -1) {
+            p.setProperty("thread-count", Integer.toString(xmlTest.getThreadCount()));
+        }
+
+        XmlUtils.setProperty(p, "group-by-instances", String.valueOf(xmlTest.getGroupByInstances()),
+                    XmlSuite.DEFAULT_GROUP_BY_INSTANCES.toString());
+
+        xsb.push("test", p);
+
+
+        if (null != xmlTest.getMethodSelectors() && !xmlTest.getMethodSelectors().isEmpty()) {
+            xsb.push("method-selectors");
+            for (XmlMethodSelector selector: xmlTest.getMethodSelectors()) {
+                xsb.getStringBuffer().append(selector.toXml(indent + "    "));
+            }
+
+            xsb.pop("method-selectors");
+        }
+
+        XmlUtils.dumpParameters(xsb, xmlTest.getLocalParameters());
+
+        // groups
+
+        if ((xmlTest.getXmlGroups() != null &&
+                (!xmlTest.getXmlGroups().getDefines().isEmpty() ||
+                        (xmlTest.getXmlGroups().getRun() != null &&
+                                (!xmlTest.getXmlGroups().getRun().getIncludes().isEmpty() ||
+                                        !xmlTest.getXmlGroups().getRun().getExcludes().isEmpty()
+                                )
+                        )
+                )
+        ) || !xmlTest.getXmlDependencyGroups().isEmpty()) {
+            xsb.push("groups");
+
+            // define
+            if (xmlTest.getXmlGroups() != null) {
+                for (XmlDefine define : xmlTest.getXmlGroups().getDefines()) {
+                    Properties metaGroupProp = new Properties();
+                    metaGroupProp.setProperty("name", define.getName());
+
+                    xsb.push("define", metaGroupProp);
+
+                    for (String groupName : define.getIncludes()) {
+                        Properties includeProps = new Properties();
+                        includeProps.setProperty("name", groupName);
+
+                        xsb.addEmptyElement("include", includeProps);
+                    }
+
+                    xsb.pop("define");
+                }
+            }
+
+            // run
+            if ((xmlTest.getXmlGroups() != null && xmlTest.getXmlGroups().getRun() != null) && (!xmlTest.getXmlGroups().getRun().getIncludes().isEmpty() || !xmlTest.getXmlGroups().getRun().getExcludes().isEmpty())) {
+                xsb.push("run");
+
+                for (String includeGroupName : xmlTest.getXmlGroups().getRun().getIncludes()) {
+                    Properties includeProps = new Properties();
+                    includeProps.setProperty("name", includeGroupName);
+
+                    xsb.addEmptyElement("include", includeProps);
+                }
+
+                for (String excludeGroupName : xmlTest.getXmlGroups().getRun().getExcludes()) {
+                    Properties excludeProps = new Properties();
+                    excludeProps.setProperty("name", excludeGroupName);
+
+                    xsb.addEmptyElement("exclude", excludeProps);
+                }
+
+                xsb.pop("run");
+            }
+
+            // group dependencies
+
+            if (xmlTest.getXmlDependencyGroups() != null && !xmlTest.getXmlDependencyGroups().isEmpty()) {
+                xsb.push("dependencies");
+                for (Map.Entry<String, String> entry : xmlTest.getXmlDependencyGroups().entrySet()) {
+                    xsb.addEmptyElement("group", "name", entry.getKey(), "depends-on", entry.getValue());
+                }
+                xsb.pop("dependencies");
+            }
+
+            xsb.pop("groups");
+        }
+
+
+        if (null != xmlTest.getXmlPackages() && !xmlTest.getXmlPackages().isEmpty()) {
+            xsb.push("packages");
+
+            for (XmlPackage pack: xmlTest.getXmlPackages()) {
+                xsb.getStringBuffer().append(pack.toXml("      "));
+            }
+
+            xsb.pop("packages");
+        }
+
+        // classes
+        if (null != xmlTest.getXmlClasses() && !xmlTest.getXmlClasses().isEmpty()) {
+            xsb.push("classes");
+            for (XmlClass cls : xmlTest.getXmlClasses()) {
+                xsb.getStringBuffer().append(cls.toXml(indent + "    "));
+            }
+            xsb.pop("classes");
+        }
+
+        xsb.pop("test");
+
+        return xsb.toXML();
+    }
+
+
+}

--- a/src/main/java/org/testng/xml/DefaultXmlWeaver.java
+++ b/src/main/java/org/testng/xml/DefaultXmlWeaver.java
@@ -16,7 +16,7 @@ import static org.testng.xml.XmlSuite.*;
  */
 class DefaultXmlWeaver implements IWeaveXml {
 
-    private String defaultComment;
+    private final String defaultComment;
 
     DefaultXmlWeaver(){
         this(null);
@@ -70,7 +70,7 @@ class DefaultXmlWeaver implements IWeaveXml {
 
         if (hasElements(xmlSuite.getListeners())) {
             xsb.push("listeners");
-            for (String listenerName : xmlSuite.getListenersList()) {
+            for (String listenerName : xmlSuite.getLocalListeners()) {
                 Properties listenerProps = new Properties();
                 listenerProps.setProperty("class-name", listenerName);
                 xsb.addEmptyElement("listener", listenerProps);
@@ -103,7 +103,7 @@ class DefaultXmlWeaver implements IWeaveXml {
         }
 
         List<String> suiteFiles = xmlSuite.getSuiteFiles();
-        if (suiteFiles.size() > 0) {
+        if (!suiteFiles.isEmpty()) {
             xsb.push("suite-files");
             for (String sf : suiteFiles) {
                 Properties prop = new Properties();

--- a/src/main/java/org/testng/xml/IWeaveXml.java
+++ b/src/main/java/org/testng/xml/IWeaveXml.java
@@ -1,0 +1,22 @@
+package org.testng.xml;
+
+/**
+ * Represents the capabilities of a XML serialiser (As string)
+ */
+public interface IWeaveXml {
+    /**
+     * Helps represent the contents of {@link XmlSuite} as a String.
+     *
+     * @param xmlSuite - The {@link XmlSuite} that needs to be transformed to a String.
+     * @return - The String representation
+     */
+    String asXml(XmlSuite xmlSuite);
+
+    /**
+     * Helps represent the contents of {@link XmlTest} as a String.
+     * @param xmlTest - The {@link XmlTest} that needs to be transformed to a String.
+     * @param indent - The indentation.
+     * @return - The String representation
+     */
+    String asXml(XmlTest xmlTest, String indent);
+}

--- a/src/main/java/org/testng/xml/XmlSuite.java
+++ b/src/main/java/org/testng/xml/XmlSuite.java
@@ -518,7 +518,11 @@ public class XmlSuite implements Cloneable {
     return XmlWeaver.asXml(this);
   }
 
-  public List<String> getListenersList() {
+  /**
+   *
+   * @return - The list of listener names that are local to the current &lt;suite&gt;
+   */
+  public List<String> getLocalListeners() {
     return m_listeners;
   }
 

--- a/src/main/java/org/testng/xml/XmlWeaver.java
+++ b/src/main/java/org/testng/xml/XmlWeaver.java
@@ -1,0 +1,80 @@
+package org.testng.xml;
+
+import org.testng.TestNGException;
+import org.testng.internal.ClassHelper;
+import org.testng.internal.reflect.ReflectionRecipes;
+
+/**
+ * A Utility class that helps represent a {@link XmlSuite} and {@link XmlTest} as String.
+ */
+final class XmlWeaver {
+    private static IWeaveXml instance = null;
+    private static boolean testMode = Boolean.parseBoolean(System.getProperty("testng.testmode"));
+
+    private XmlWeaver() {
+    }
+
+    private static IWeaveXml getInstance() {
+        if (testMode) {
+            //Donot resort to caching when running Unit tests for TestNG, because we have to check
+            //both implementations. If we cache the instance, then its not possible to do that.
+            return attemptDefaultImplementationInstantiation();
+        }
+        return instantiateIfRequired();
+    }
+
+    private static IWeaveXml instantiateIfRequired() {
+        if (instance != null) {
+            return instance;
+        }
+        instance = attemptDefaultImplementationInstantiation();
+        if (instance != null) {
+            return instance;
+        }
+        Class<?> clazz = ClassHelper.forName(getClassName());
+        boolean isValid = ReflectionRecipes.isOrImplementsInterface(IWeaveXml.class, clazz);
+        if (!isValid) {
+            String msg = "In order for " + getClassName() + " to be used by TestNG for generating suite/test xmls, "
+                    + getClassName()
+                    + " needs to implement " + IWeaveXml.class.getName();
+            throw new TestNGException(msg);
+        }
+        instance = (IWeaveXml) ClassHelper.newInstance(clazz);
+        return instance;
+    }
+
+    private static String getClassName() {
+        return System.getProperty("testng.xml.weaver", DefaultXmlWeaver.class.getName());
+    }
+
+    /**
+     * Helps represent the contents of {@link XmlSuite} as a String.
+     *
+     * @param suite - The {@link XmlSuite} that needs to be transformed to a String.
+     * @return - The String representation
+     */
+    static String asXml(XmlSuite suite) {
+        return getInstance().asXml(suite);
+    }
+
+    /**
+     * Helps represent the contents of {@link XmlTest} as a String.
+     * @param xmlTest - The {@link XmlTest} that needs to be transformed to a String.
+     * @param indent - The indentation.
+     * @return - The String representation
+     */
+    static String asXml(XmlTest xmlTest, String indent) {
+        return getInstance().asXml(xmlTest, indent);
+    }
+
+    private static IWeaveXml attemptDefaultImplementationInstantiation() {
+        String clazz = getClassName();
+        if (clazz.equals(DefaultXmlWeaver.class.getName())) {
+            return new DefaultXmlWeaver();
+        }
+        if (clazz.equals(CommentDisabledXmlWeaver.class.getName())) {
+            return new CommentDisabledXmlWeaver();
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/testng/xml/XmlWeaver.java
+++ b/src/main/java/org/testng/xml/XmlWeaver.java
@@ -9,7 +9,7 @@ import org.testng.internal.reflect.ReflectionRecipes;
  */
 final class XmlWeaver {
     private static IWeaveXml instance = null;
-    private static boolean testMode = Boolean.parseBoolean(System.getProperty("testng.testmode"));
+    private static final boolean testMode = Boolean.parseBoolean(System.getProperty("testng.testmode"));
 
     private XmlWeaver() {
     }

--- a/src/test/java/test/SimpleBaseTest.java
+++ b/src/test/java/test/SimpleBaseTest.java
@@ -266,7 +266,7 @@ public class SimpleBaseTest {
   }
 
   public static String getPathToResource(String fileName) {
-    String result = System.getProperty(TEST_RESOURCES_DIR);
+    String result = System.getProperty(TEST_RESOURCES_DIR, "src/test/resources");
     if (result == null) {
       throw new IllegalArgumentException("System property " + TEST_RESOURCES_DIR + " was not defined.");
     }

--- a/src/test/java/test/xml/XMLStringBufferTest.java
+++ b/src/test/java/test/xml/XMLStringBufferTest.java
@@ -1,0 +1,36 @@
+package test.xml;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.testng.annotations.Test;
+import org.testng.reporters.Buffer;
+import org.testng.reporters.IBuffer;
+import org.testng.reporters.XMLStringBuffer;
+
+import java.util.Properties;
+
+import static org.testng.reporters.XMLStringBuffer.EOL;
+
+public class XMLStringBufferTest {
+
+    @Test
+    public void testMethod() {
+        IBuffer result = Buffer.create();
+        XMLStringBuffer sb = new XMLStringBuffer(result, "");
+
+        sb.push("family");
+        Properties p = new Properties();
+        p.setProperty("prop1", "value1");
+        p.setProperty("prop2", "value2");
+        sb.addRequired("cedric", "true", p);
+        sb.addRequired("alois", "true");
+        sb.addOptional("anne-marie", (String) null);
+        sb.pop();
+        String expected = "<family>" + EOL +
+                "  <cedric prop2=\"value2\" prop1=\"value1\">true</cedric>" + EOL +
+                "  <alois>true</alois>" + EOL +
+                "</family>";
+        assertThat(result.toString().trim()).isEqualTo(expected);
+    }
+
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -109,6 +109,7 @@
       <class name="test.jar.JarTest" />
  -->
       <class name="test.xml.XmlVerifyTest" />
+      <class name="test.xml.XMLStringBufferTest"/>
       <class name="test.invokedmethodlistener.InvokedMethodListenerTest" />
       <class name="test.testng249.VerifyTest"/>
       <class name="test.testng195.AfterMethodTest" />


### PR DESCRIPTION
Closes #1455

The following was done :

* Provided the ability for end-users to optionally inject their own serialization mechanisms for both XmlSuite/XmlTest by passing the fully qualified implementation of `org.testng.xml.IWeaveXml` via the JVM argument `-Dtestng.xml.weaver`

* Provided two default implementations for the interface `org.testng.xml.IWeaveXml` viz.,
  1. `org.testng.xml.DefaultXmlWeaver` - Which by default includes comments (This is enabled by default)
  2. `org.testng.xml.CommentDisabledXmlWeaver` - which doesn’t include comments.

* Also cleaned up some code.

Fixes #1455 .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
