### PR TITLE
Fix OpenJDK7 failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: required
 language: java
 
 
@@ -33,7 +33,11 @@ matrix:
     - jdk: oraclejdk7
       dist: precise
     - jdk: openjdk7
-      dist: precise
+      env: FLAVOR=openjdk
+
+before_install:
+  - sh ./bin/openjdk7.sh
+
 
 script:
   - ./gradlew check --stacktrace --scan

--- a/bin/openjdk7.sh
+++ b/bin/openjdk7.sh
@@ -1,0 +1,14 @@
+var=${FLAVOR:-unknown}
+
+if [ "$var" = "openjdk" ]; then
+    echo "Running setup for Open JDK"
+    # Workaround to using openjdk7 with Gradle due to security issue:
+    # https://github.com/gradle/gradle/issues/2421
+    BCPROV_FILENAME=bcprov-ext-jdk15on-158.jar
+    wget "https://bouncycastle.org/download/${BCPROV_FILENAME}"
+    sudo mv $BCPROV_FILENAME /usr/lib/jvm/java-7-openjdk-amd64/jre/lib/ext
+    sudo perl -pi.bak -e 's/^(security\.provider\.)([0-9]+)/$1.($2+1)/ge' /etc/java-7-openjdk/security/java.security
+    echo "security.provider.1=org.bouncycastle.jce.provider.BouncyCastleProvider" | sudo tee -a /etc/java-7-openjdk/security/java.security
+else
+    echo "Skipping Open JDK specific setup"
+fi;


### PR DESCRIPTION
Currently OpenJDK7 build on travis fails due to
security provider issue coupled with Gradle using
ECDHE cipher with Java 7.

For more details, please see
https://github.com/gradle/gradle/issues/2421

Fixes # .

### Did you remember to?

- [ ] Add test case(s)
- [ ] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
