### PR TITLE
Streamline Sax parser factory instantiation

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-161 : Provide a way to customize SAXParserFactory implementation (Krishnan Mahadevan)
 Fixed: GITHUB-1455: Configure XML output of XmlSuite (Krishnan Mahadevan)
 Fixed: GITHUB-1465: Failure policy CONTINUE handling is broken for tests that are skipped in @BeforeMethod method (Krishnan Mahadevan)
 Fixed: GITHUB-1533: Duplicate child suites get added when working with parent/child suite scenario (Krishnan Mahadevan)

--- a/src/main/java/org/testng/xml/XMLParser.java
+++ b/src/main/java/org/testng/xml/XMLParser.java
@@ -9,7 +9,6 @@ import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
 import org.testng.TestNGException;
-import org.testng.internal.ClassHelper;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 
@@ -41,52 +40,18 @@ abstract public class XMLParser<T> implements IFileParser<T> {
   }
 
   /**
-   * Tries to load a <code>SAXParserFactory</code> by trying in order the following:
-   * <tt>com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl</tt> (SUN JDK5)
-   * <tt>org.apache.crimson.jaxp.SAXParserFactoryImpl</tt> (SUN JDK1.4) and
-   * last <code>SAXParserFactory.newInstance()</code>.
+   * Tries to load a <code>SAXParserFactory</code> via <code>SAXParserFactory.newInstance()</code>.
    *
    * @return a <code>SAXParserFactory</code> implementation
    * @throws TestNGException thrown if no <code>SAXParserFactory</code> can be loaded
    */
   private static SAXParserFactory loadSAXParserFactory() {
-    SAXParserFactory spf = null;
 
-    StringBuilder errorLog= new StringBuilder();
     try {
-      Class factoryClass= ClassHelper.forName("com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl");
-      spf = (SAXParserFactory) factoryClass.newInstance();
+      return SAXParserFactory.newInstance();
+    } catch (FactoryConfigurationError fcerr) {
+      throw new TestNGException("Cannot initialize a SAXParserFactory. Root cause: " + fcerr.getMessage(), fcerr);
     }
-    catch(Exception ex) {
-      errorLog.append("JDK5 SAXParserFactory cannot be loaded: ").append(ex.getMessage());
-    }
-
-    if(null == spf) {
-      // If running with JDK 1.4
-      try {
-        Class factoryClass = ClassHelper.forName("org.apache.crimson.jaxp.SAXParserFactoryImpl");
-        spf = (SAXParserFactory) factoryClass.newInstance();
-      }
-      catch(Exception ex) {
-        errorLog.append("\n").append("JDK1.4 SAXParserFactory cannot be loaded: ").append(ex.getMessage());
-      }
-    }
-
-    Throwable cause= null;
-    if(null == spf) {
-      try {
-        spf= SAXParserFactory.newInstance();
-      }
-      catch(FactoryConfigurationError fcerr) {
-        cause= fcerr;
-      }
-    }
-
-    if(null == spf) {
-      throw new TestNGException("Cannot initialize a SAXParserFactory\n" + errorLog.toString(), cause);
-    }
-
-    return spf;
   }
 
 


### PR DESCRIPTION
Closes #161

Following was done:
* Removed JDK 4 and 5 specific factory implementations because now TestNG requires at-least JDK7.
* TestNG now will fall back to relying on the JDK to instantiate an implementation.

Doing this now lets the users to alternate to a different Sax factory instantiation [1] by passing
the fully qualified class name of a sub class of `javax.xml.parsers.SAXParserFactory` via the JVM argument `-Djavax.xml.parsers.SAXParserFactory`.

This now lets our end-users to customize the working of `org.testng.xml.XMLParser#supportsValidation()` in  TestNG (which is what #161 talks about) by sub-classing `com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl` and overriding `getFeature()` method.

[1] - some of the variants are
listed here : http://www.edankert.com/apis/jaxp.sax-parser-factory.implementations.html

Fixes #161

### Did you remember to?

- [ ] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
