### PR TITLE
Parallelization refactor

### DIFF
--- a/src/test/java/test/thread/parallelization/BaseParallelizationTest.java
+++ b/src/test/java/test/thread/parallelization/BaseParallelizationTest.java
@@ -11,6 +11,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -24,9 +25,11 @@ import test.thread.parallelization.TestNgRunStateTracker.TestNgRunEvent;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 import static org.testng.Assert.fail;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_INSTANCE;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHOD_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.SUITE_NAME;
@@ -40,13 +43,6 @@ import static test.thread.parallelization.TestNgRunStateTracker.TestNgRunEvent.T
 import static test.thread.parallelization.TestNgRunStateTracker.getTestMethodEventLogsForMethod;
 
 public class BaseParallelizationTest extends SimpleBaseTest {
-
-    private static final Logger logger = Logger.getLogger(BaseParallelizationTest.class.getCanonicalName());
-
-    {
-        System.setProperty("java.util.logging.SimpleFormatter.format","%n [%4$s] %2$s - %5$s");
-        logger.setLevel(Level.INFO);
-    }
 
     //Get a list of the names of declared methods with the @Test annotation from the specified class
     public static List<String> getDeclaredTestMethods(Class<?> clazz) {
@@ -312,129 +308,106 @@ public class BaseParallelizationTest extends SimpleBaseTest {
     }
 
     //Verify that methods associated with the specified event logs execute simultaneously in parallel fashion, in
-    //accordance with the thread count. This verification is for blocks of parallel methods that have the same sleep
-    //delays for their execution bodies and which do not have any BeforeMethod AfterMethod, BeforeGroup or AfterGroup
+    //accordance with the thread count. This verification is for blocks of parallel methods, none of which use
+    //data providers. This verification is for blocks of parallel methods that have the same sleep delays for their
+    //execution bodies and which do not have any BeforeMethod AfterMethod, BeforeGroup or AfterGroup
     //configuration methods.
-    public static void verifySimultaneousTestMethods(List<EventLog> testMethodEventLogs, String testName, int
-            maxSimultaneousTestMethods) {
-
-//        logger.log(Level.INFO,"Verifying parallel execution of test methods for test named {0} with thread count {1}",
-//                new Object[] {testName, maxSimultaneousTestMethods});
-//
-//        logger.log(Level.INFO, "{0} test method event logs for {1} test methods: ",
-//                new Object[]{ testMethodEventLogs.size(), testMethodEventLogs.size()/3} );
+    public static void verifySimultaneousTestMethods(List<EventLog> testMethodEventLogs, String
+            testName, int  threadCount) {
 
         System.out.println("Verifying parallel execution of test methods for test named " + testName  + " with " +
-                "thread count " + maxSimultaneousTestMethods);
-        System.out.println(testMethodEventLogs.size() + " test method event logs for " + testMethodEventLogs.size()/3
+                "thread count " + threadCount);
+        System.out.println(testMethodEventLogs.size() + " test method event logs for " + testMethodEventLogs.size() / 3
                 + " test methods");
 
-        //There are three test method events expected per test method: a start event, an execution event, and a test
-        //method pass event. All methods take exactly the same amount of time to execute. Each one of their events
-        //takes exactly the same time to execute. The reason for this is that it makes it possible to assume that blocks
-        //of methods should execute in parallel in lockstep, starting and finishing at the same time.
-        //
-        //The TestNgRunStateListener logs the start and pass events. The test method execution event is logged by the
-        //test method itself. See the sample test classes for examples. This test method verifies the parallel
-        //execution of test methods for parallelization tests involving parallel-by-methods mode. Therefore, the
-        //expectation is that there are simultaneously executing blocks of methods. The'size' of the block is either
-        //equal to the thread count or less in the event that the total number of methods is not a multiple of the
-        //thread count and we are processing the final block of methods to execute.
-        //
-        //This smaller, last block size is calculated using the number of events logged, the number of events logged
-        // per method (3) and the thread count to find the number of events expected for that remainder block.
-        int remainder = (testMethodEventLogs.size() / 3) % maxSimultaneousTestMethods;
+        //Keep track of the methods that have started, but not completed execution.
+        Map<String, EventLog> methodsExecuting = new HashMap<>();
 
-        int numBlocks = testMethodEventLogs.size() / 3 < maxSimultaneousTestMethods ? 1 :
-                (testMethodEventLogs.size() / 3) / maxSimultaneousTestMethods + (remainder > 0 ? 1 : 0);
+        //Keep track of the methods whose start, execute and test method pass events have all been found in the list
+        //of logs
+        Map<String, EventLog> methodsCompleted = new HashMap<>();
 
-        log(testMethodEventLogs.size(), maxSimultaneousTestMethods, remainder);
+        //Keep track of the thread IDs for all the methods that are executing and check that all a method's events
+        //run in the same thread.
+        List<Long> executingMethodThreadIds = new ArrayList<>();
 
-        int loopNum = 1;
+        //Make a list of the all the thread IDs of the first batch of start method events and check that no other
+        //thread IDs are found in the rest of the event logs.
+        List<Long> allThreadIds = new ArrayList<>();
 
-        //Loop over the event logs. The increment is equal the thread count times the number of events logged for each
-        //test method.
-        for (int i = 1; i < testMethodEventLogs.size(); i = i + maxSimultaneousTestMethods * 3) {
+        //If number of test methods is more than the thread count, then the first block of methods will be equal to
+        //the thread count. If not, it will be equal to the total number of methods.
+        int blockSize = testMethodEventLogs.size() / 3 >= threadCount ? threadCount :
+                testMethodEventLogs.size() / 3;
 
-//            logger.log(Level.INFO, "Processing block {0} of {1}", new Object[] {loopNum, numBlocks});
+        //Get the start events for the first batch of methods.
+        List<EventLog> eventLogTestMethodListenerStartEvents = testMethodEventLogs.subList(0, blockSize);
 
-            System.out.println("Processing block " + loopNum + " of " + numBlocks);
+        System.out.println("First " + blockSize + " test method event logs should all be test method start events: " +
+                getStringForEventLogList(eventLogTestMethodListenerStartEvents));
 
-            //The size of the block is equal to the thread count or the number of methods left over in the last block
-            //if the total number of methods is not a multiple of the thread count. Example: For a test run with 19
-            //methods in total and a thread count of 7, the remainder is 5 methods. The last block of methods to execute
-            //would have 5 methods executing simultaneously. If the remainder is non-zero, and we are processing the
-            //last block of methods then the block size is less than the thread count. Otherwise, the block size is
-            //equal to the thread count.
-            int blockSize = (remainder != 0 && testMethodEventLogs.size() - i < maxSimultaneousTestMethods * 3) ?
-                    remainder :
-                    maxSimultaneousTestMethods;
+        //Verify that all the events in the sublist extracted for the start events of the block of methods expected
+        //to execute in parallel all have the test method start event type and that they all executed in different
+        //threads.
+        verifySimultaneousTestMethodListenerStartEvents(eventLogTestMethodListenerStartEvents, testName, blockSize);
 
-            //The expectation for the block of methods executing in parallel is that the test method start events are
-            //logged first, then the test method execution events, followed by the test method pass events. These
-            //offset values are used to extract the sublists of start events, execution events and pass events for the
-            //block of event logs to process in the current loop execution.
-            int offsetOne = (remainder != 0 && testMethodEventLogs.size() - i < maxSimultaneousTestMethods * 3) ?
-                    testMethodEventLogs.size() - (remainder * 3) :
-                    i - 1;
+        //Keep track of the current methods that are executing and their thread IDs
+        for(EventLog eventLog : eventLogTestMethodListenerStartEvents) {
+            String classAndMethodNameAndInstanceHash = (String)eventLog.getData(CLASS_NAME) + "." +
+                    (String)eventLog.getData(METHOD_NAME) + ":" + eventLog.getData(CLASS_INSTANCE).hashCode();
 
-            int offsetTwo = (remainder != 0 && testMethodEventLogs.size() - i < maxSimultaneousTestMethods * 3) ?
-                    testMethodEventLogs.size() - (remainder * 3) + blockSize :
-                    i + maxSimultaneousTestMethods - 1;
+            assertNull(methodsExecuting.get(classAndMethodNameAndInstanceHash), "There should only be one start " +
+                    "event logged for a method in the first block of test method events");
+            assertFalse(executingMethodThreadIds.contains(eventLog.getThreadId()), "The first block of test method " +
+                    "events should all have different thread IDs");
 
-//            logger.log(Level.INFO, "Expecting {0} test method start events, followed by {0} test method execution " +
-//                    "events, followed by {0} test method pass events", blockSize);
+            methodsExecuting.put(classAndMethodNameAndInstanceHash, eventLog);
+            executingMethodThreadIds.add(eventLog.getThreadId());
+            allThreadIds.add(eventLog.getThreadId());
+        }
 
-            System.out.println("Expecting " + blockSize + " test method start events, followed by " + blockSize +
-                    " test method execution events , followed by " + blockSize + " test method pass events");
+        for(int i = blockSize; i < testMethodEventLogs.size(); i++) {
+            EventLog eventLog = testMethodEventLogs.get(i);
 
-            List<EventLog> eventLogMethodListenerStartSublist = testMethodEventLogs.subList(offsetOne, offsetTwo);
-            List<EventLog> eventLogMethodExecuteSublist = testMethodEventLogs.subList(offsetTwo, offsetTwo + blockSize);
-            List<EventLog> eventLogMethodListenerPassSublist = testMethodEventLogs.subList(offsetTwo + blockSize,
-                    offsetTwo + 2 * blockSize);
+            System.out.println("Processing test method event log at index " + i + ": " + eventLog);
 
-            log(offsetOne, offsetTwo, blockSize, eventLogMethodListenerStartSublist, eventLogMethodExecuteSublist,
-                    eventLogMethodListenerPassSublist);
+            String classAndMethodNameAndInstanceHash = (String)eventLog.getData(CLASS_NAME) + "." +
+                    (String)eventLog.getData(METHOD_NAME) + ":" + eventLog.getData(CLASS_INSTANCE).hashCode();
 
-            //Verify that all the events in the sublist extracted for the start events of the block of methods expected
-            //to execute in parallel all have the test method start event type and that they all executed in different
-            //threads.
-            verifySimultaneousTestMethodListenerStartEvents(eventLogMethodListenerStartSublist, testName,
-                    blockSize);
+            if(eventLog.getEvent() == LISTENER_TEST_METHOD_START) {
+                assertTrue(methodsExecuting.get(classAndMethodNameAndInstanceHash) == null &&
+                        methodsCompleted.get(classAndMethodNameAndInstanceHash) == null, "There should only be one " +
+                        "execution of any given method");
+                assertFalse(executingMethodThreadIds.contains(eventLog.getThreadId()), "Event logs for currently " +
+                        "executing test methods should have different thread IDs");
+                assertTrue(allThreadIds.contains(eventLog.getThreadId()), "All of the test method event logs should " +
+                        "have the same " + threadCount + " thread IDs: " + allThreadIds.toString());
+                assertTrue(methodsExecuting.size() < threadCount, "The current event log is a test method start " +
+                        "event. The list of currently executing methods should be less than the thread count. " +
+                        "Thread count: " + threadCount + ". Currently executing methods: " +
+                        getStringForEventLogList(methodsExecuting.values()));
 
-            //Verify that all the events in the sublist extracted for the test method execution events of the block of
-            //methods expected to execute in parallel all have the test method execution event type and that they all
-            //executed in different threads.
-            verifySimultaneousTestMethodExecutionEvents(eventLogMethodExecuteSublist, testName,
-                    blockSize);
+                methodsExecuting.put(classAndMethodNameAndInstanceHash, eventLog);
+                executingMethodThreadIds.add(eventLog.getThreadId());
+            }
 
-            //Verify that the test method start events and the test method execution events in the two sublists belong
-            //to the same methods. This is done by verifying that the test class names and method names are the same for
-            //for both sublists.
-            verifyEventsBelongToSameMethods(eventLogMethodListenerStartSublist, eventLogMethodExecuteSublist, "The " +
-                    "expected maximum number of methods to execute simultaneously is " + maxSimultaneousTestMethods +
-                    " for " + testName + " so no more than " + maxSimultaneousTestMethods + " methods should be " +
-                    "running at the same time. The test execution event logs for a block of simultaneously running " +
-                    "test methods should all belong to the same methods as the test method listener onTestStart " +
-                    "event logs immediately preceding");
+            if(eventLog.getEvent() == TEST_METHOD_EXECUTION) {
+                assertTrue(methodsExecuting.get(classAndMethodNameAndInstanceHash) != null, "Found a test method " +
+                        "execution event log that does not have a corresponding test method start event log");
+                assertTrue(methodsExecuting.get(classAndMethodNameAndInstanceHash).getThreadId() ==
+                        eventLog.getThreadId(), "All the event logs for a given method should have the same thread ID");
+            }
 
-            //Verify that all the events in the sublist extracted for the test method pass events of the block of
-            //methods expected to execute in parallel all have the test method pass event type and that they all
-            //executed in different threads.
-            verifySimultaneousTestMethodListenerPassEvents(eventLogMethodListenerPassSublist, testName,
-                    blockSize);
+            if(eventLog.getEvent() == LISTENER_TEST_METHOD_PASS) {
 
-            //Verify that the test method execution events and the test method pass events in the two sublists belong
-            //to the same methods. This is done by verifying that the test class names and method names are the same for
-            //for both sublists.
-            verifyEventsBelongToSameMethods(eventLogMethodExecuteSublist, eventLogMethodListenerPassSublist, "The " +
-                    "expected maximum number of methods to execute simultaneously is " + maxSimultaneousTestMethods +
-                    " for " + testName + " so no more than " + maxSimultaneousTestMethods + " methods should be " +
-                    "running at the same time. The test method listener on onTestSuccess event logs for a block of " +
-                    "simultaneously running test methods should all belong to the same methods as the test method " +
-                    "execution event logs immediately preceding");
-
-            loopNum++;
+                assertTrue(methodsExecuting.get(classAndMethodNameAndInstanceHash) != null, "Found a test method " +
+                        "pass event log that does not have a corresponding test method start event log");
+                assertTrue(methodsExecuting.get(classAndMethodNameAndInstanceHash).getThreadId() ==
+                        eventLog.getThreadId(), "All the event logs for a given method should have the same thread ID");
+                methodsExecuting.remove(classAndMethodNameAndInstanceHash);
+                executingMethodThreadIds.remove(eventLog.getThreadId());
+                methodsCompleted.put(classAndMethodNameAndInstanceHash, eventLog);
+            }
         }
     }
 
@@ -444,38 +417,19 @@ public class BaseParallelizationTest extends SimpleBaseTest {
     //instances. This verification is for blocks of parallel methods that have the same sleep delays for their
     //execution bodies and which do not have any BeforeMethod AfterMethod, BeforeGroup or AfterGroup
     //configuration methods.
+    //
+    //Some of the test methods use non-parallel data providers without factories. All the invocations of those
+    //test methods will occur serially within the same thread on the same class instances. There are three test
+    //method events expected per test method: a start event, an execution event, and a test method pass event.
     public static void verifyParallelTestMethodsWithNonParallelDataProvider(List<EventLog> testMethodEventLogs, String
-            testName, Map<String, Integer> expectedInvocationCounts, int numUniqueMethods, int
-            maxSimultaneousTestMethods) {
-
-//        logger.log(Level.INFO,"Verifying parallel execution of test methods using non-parallel data providers for " +
-//                "test named {0} with thread count {1}", new Object[] {testName, maxSimultaneousTestMethods});
-//
-//        logger.log(Level.INFO, "{0} test method event logs for {1} unique methods: ",
-//                new Object[] {testMethodEventLogs.size(), numUniqueMethods});
+            testName, Map<String, Integer> expectedInvocationCounts, int numUniqueMethods, int threadCount) {
 
         System.out.println("Verifying parallel execution of test methods using non-parallel data providers for " +
-                "test named " + testName + " with thread count " + maxSimultaneousTestMethods);
+                "test named " + testName + " with thread count " + threadCount);
         System.out.println(testMethodEventLogs.size() + " test method event logs for " + numUniqueMethods +
                 " unique methods");
 
-
-        //Some of the test methods use non-parallel data providers without factories. All the invocations of those
-        //test methods will occur serially within the same thread on the same class instances. In order to ensure that
-        //the loop logic below works properly, it is necessary to keep state information about which methods are
-        //supposed to be executing within a block of parallel methods that are running simultaneously. Unlike the
-        //logic in verifySimultaneousTestMethods, it is not possible to assume that methods within a block of
-        //simultaneously executing methods start and finish at the same time because the methods will frequently be
-        //invoked a varying number of times, depending on their use of data providers.
-        //
-        //However, each _invocation_ of a test method should take exactly the same amount of time. There are three test
-        //method events expected per test method: a start event, an execution event, and a test method pass event. All
-        //test method events of the same time take the same amount of time to execute. The reason for this is that it
-        //makes it possible to assume that blocks of method invocations should execute in parallel in lockstep,
-        //starting and finishing at the same time.
         Map<String, EventLog> methodsExecuting = new HashMap<>();
-
-        //This isn't actually used for any verification logic. I may remove it in the future.
         Map<String, EventLog> methodsCompleted = new HashMap<>();
 
         //Because this method verifies combination of parallel-by-methods mode and the use of non-parallel data
@@ -489,229 +443,126 @@ public class BaseParallelizationTest extends SimpleBaseTest {
         //block of simultaneously executing methods.
         Map<String, Long> executingMethodThreadIds = new HashMap<>();
 
+        //Make a list of the all the thread IDs of the first batch of start method events and check that no other
+        //thread IDs are found in the rest of the event logs.
+        List<Long> allThreadIds = new ArrayList<>();
+
         //The logic for determining the block size of simultaneously executing parallel methods is initially determined
         //by whether the total number of unique methods less than the thread count. If it is less than the thread count,
         //then the block size is equal to the number of unique methods. Those methods will execute in parallel
         //until all invocations of all the methods completes. Otherwise, there are more methods queued up than the
         //thread count, so the block size is equal to the thread count.
-        int blockSize = numUniqueMethods >= maxSimultaneousTestMethods ? maxSimultaneousTestMethods :
-                numUniqueMethods;
+        int blockSize = numUniqueMethods >= threadCount ? threadCount : numUniqueMethods;
 
-        int loopNum = 1;
+        //Get the start events for the first batch of methods.
+        List<EventLog> eventLogTestMethodListenerStartEvents = testMethodEventLogs.subList(0, blockSize);
 
-        for (int i = 1; i < testMethodEventLogs.size(); i = i + blockSize * 3) {
+        System.out.println("First " + blockSize + " test method event logs should all be test method start events: "+
+                "\n" + getStringForEventLogList(eventLogTestMethodListenerStartEvents));
+        System.out.println(getStringForEventLogList(eventLogTestMethodListenerStartEvents));
 
-//            logger.log(Level.INFO, "Processing block {0}", loopNum);
+        //Keep track of the current methods that are executing and their thread IDs
+        for(EventLog eventLog : eventLogTestMethodListenerStartEvents) {
+            String classAndMethodName = (String)eventLog.getData(CLASS_NAME) + "." +
+                    (String)eventLog.getData(METHOD_NAME);
 
-            System.out.println("Processing block " + loopNum);
+            assertNull(methodsExecuting.get(classAndMethodName), "There should only be one start event logged for a " +
+                    "method in the first block of test method events");
+            assertNull(executingMethodThreadIds.get(classAndMethodName), "The first block of test method events " +
+                    "should all have different thread IDs");
 
-            //If the loop is executing more than once, then the block size needs to be updated. The number of remaining
-            //unique methods to execute determines the block size of parallel methods expected to execute
-            //simultaneously.
-            if(i != 1) {
+            methodsExecuting.put(classAndMethodName, eventLog);
+            executingMethodThreadIds.put(classAndMethodName, eventLog.getThreadId());
+            allThreadIds.add(eventLog.getThreadId());
+            methodInvocationsCounts.put(classAndMethodName, 1);
+        }
 
+        //Verify that all the events in the sublist extracted for the test method execution events of the block of
+        //methods expected to execute in parallel all have the test method execution event type and that they all
+        //executed in different threads.
+        verifySimultaneousTestMethodListenerStartEvents(eventLogTestMethodListenerStartEvents, testName, blockSize);
+
+        for(int i = blockSize; i < testMethodEventLogs.size(); i++) {
+
+            EventLog eventLog = testMethodEventLogs.get(i);
+
+            System.out.println("Processing test method event log at index " + i + ": " + eventLog);
+
+            String classAndMethodName = (String)eventLog.getData(CLASS_NAME) + "." +
+                    (String)eventLog.getData(METHOD_NAME);
+
+            if(i != blockSize) {
                 //All methods that are in the list of currently executing methods should still have invocations left.
                 //Otherwise, they would have been removed from that list and added to the completed methods list.
                 allExecutingMethodsHaveMoreInvocations(methodsExecuting, methodInvocationsCounts,
                         expectedInvocationCounts);
+            }
 
-                //If there are no remaining unique methods, the block size of methods expected to be executing in
-                //parallel is equal to the number of methods using data providers that are already executing. The only
-                //test method event logs to verify in this loop should belong to test methods which use data providers
-                //and are executed multiple times as a result.
-                if(numUniqueMethods == 0) {
-                    blockSize = methodsExecuting.keySet().size();
+            if(eventLog.getEvent() == LISTENER_TEST_METHOD_START) {
+                assertTrue(executingMethodThreadIds.get(classAndMethodName) == null ||
+                        executingMethodThreadIds.get(classAndMethodName) == eventLog.getThreadId(),
+                        "Event logs for all invocations of a method on a give class instance should have the same " +
+                                "thread ID ");
+
+                for(String key : executingMethodThreadIds.keySet()) {
+                   if(!key.equals(classAndMethodName)) {
+                       assertFalse(executingMethodThreadIds.get(key) == eventLog.getThreadId(), "Events for " +
+                               "different methods should have different thread IDs");
+                   }
+                }
+
+                assertTrue(allThreadIds.contains(eventLog.getThreadId()), "All of the test method event logs should " +
+                        "have the same " + threadCount + " thread IDs: " + allThreadIds.toString());
+
+                if(methodsExecuting.get(classAndMethodName) == null) {
+                    assertTrue(methodsExecuting.size() < threadCount, "The current event log is a test method start " +
+                            "event for a method that has not yet been invoked. The list of currently executing " +
+                            "methods should be less than the thread count. Thread count: " + threadCount +
+                            ". Currently executing methods: " + getStringForEventLogList(methodsExecuting.values()));
+
+                    methodsExecuting.put(classAndMethodName, eventLog);
+                    executingMethodThreadIds.put(classAndMethodName, eventLog.getThreadId());
+                    methodInvocationsCounts.put(classAndMethodName, 1);
                 } else {
-                    //Otherwise, if the number of unique methods left is non-zero, but less than the thread count,
-                    //the block size is dependent on whether the number of currently executing methods is equal to the
-                    //thread count. If so, then the block size is equal to the thread count and no new unique methods
-                    //will begin executing this block of methods. If the number of methods already executing is less
-                    //than the thread count and the sum of the number of unique methods left and the number of currently
-                    //executing methods is equal to or greater than the thread count, the block size is equal to the
-                    //thread count. If the sum is less than the thread count, the block size is equal to the sum.
-                    if(numUniqueMethods < maxSimultaneousTestMethods) {
-
-                        if (methodsExecuting.keySet().size() == maxSimultaneousTestMethods ||
-                                numUniqueMethods + methodsExecuting.keySet().size() >= maxSimultaneousTestMethods) {
-                            blockSize = maxSimultaneousTestMethods;
-                        } else {
-                            blockSize = numUniqueMethods + methodsExecuting.keySet().size();
-                        }
-                        //If the number of unique methods left is more than or equal to the thread count, the block size
-                        //is equal to the thread count.
-                    } else {
-                        blockSize = maxSimultaneousTestMethods;
-                    }
+                    methodInvocationsCounts.put(
+                            classAndMethodName,
+                            methodInvocationsCounts.get(classAndMethodName) + 1);
+                    assertTrue(methodInvocationsCounts.get(classAndMethodName) <=
+                            expectedInvocationCounts.get(classAndMethodName),
+                            "Method '" + classAndMethodName + "' is expected to execute only " +
+                                    expectedInvocationCounts.get(classAndMethodName) + " times, but event logs show " +
+                                    "that it was execute at least " +
+                                    methodInvocationsCounts.get(classAndMethodName) + " times");
                 }
             }
 
-            int offsetOne = i - 1;
-
-            int offsetTwo = i + blockSize - 1;
-
-//            logger.log(Level.INFO, "Expecting {0} test method start events, followed by {0} test method execution " +
-//                    "events, followed by {0} test method pass events", blockSize);
-
-            System.out.println("Expecting " + blockSize + " test method start events, followed by " + blockSize
-                    + " test method execution, followed by " + blockSize + " test method pass events");
-
-            List<EventLog> eventLogMethodListenerStartSublist = testMethodEventLogs.subList(offsetOne, offsetTwo);
-            List<EventLog> eventLogMethodExecuteSublist = testMethodEventLogs.subList(offsetTwo, offsetTwo + blockSize);
-            List<EventLog> eventLogMethodListenerPassSublist = testMethodEventLogs.subList(offsetTwo + blockSize,
-                    offsetTwo + 2 * blockSize);
-
-            log(offsetOne, offsetTwo, blockSize, eventLogMethodListenerStartSublist, eventLogMethodExecuteSublist,
-                    eventLogMethodListenerPassSublist);
-
-            //Verify that all the events in the sublist extracted for the start events of the block of methods expected
-            //to execute in parallel all have the test method start event type and that they all executed in different
-            //threads. The method should return the total number of new unique methods that began executing in the
-            //current block of parallel methods executing in parallel.
-            int decrementUniqueMethods = verifySimultaneousTestMethodListenerStartEvents(
-                    eventLogMethodListenerStartSublist, testName, blockSize, methodsExecuting,
-                    executingMethodThreadIds, methodInvocationsCounts, expectedInvocationCounts
-            );
-
-            //Decrement the unique of unique methods left to execute by the number of new unique methods that began
-            //execution in this block of parallel methods.
-            numUniqueMethods = numUniqueMethods - decrementUniqueMethods;
-
-            //Verify that all the events in the sublist extracted for the test method execution events of the block of
-            //methods expected to execute in parallel all have the test method execution event type and that they all
-            //executed in different threads.
-            verifySimultaneousTestMethodExecutionEvents(eventLogMethodExecuteSublist, testName,
-                    executingMethodThreadIds, blockSize);
-
-            //Verify that the test method start events and the test method execution events in the two sublists belong
-            //to the same methods. This is done by verifying that the test class names and method names are the same for
-            //for both sublists.
-            verifyEventsBelongToSameMethods(eventLogMethodListenerStartSublist, eventLogMethodExecuteSublist, "The " +
-                    "expected maximum number of methods to execute simultaneously is " + maxSimultaneousTestMethods +
-                    " for " + testName + " so no more than " + maxSimultaneousTestMethods + " methods should be " +
-                    "running at the same time. The test execution event logs for a block of simultaneously running " +
-                    "test methods should all belong to the same methods as the test method listener onTestStart " +
-                    "event logs immediately preceding");
-
-            for(String method : methodsExecuting.keySet()) {
-//                logger.log(Level.INFO, "{0} has executed {1} times. Expected to execute {2} more times.",
-//                        new Object[]{method, methodInvocationsCounts.get(method),
-//                                expectedInvocationCounts.get(method) - methodInvocationsCounts.get(method)});
-
-                System.out.println(method + " has executed " + methodInvocationsCounts.get(method) + " times. "
-                        + "Expected to execute " +
-                        (expectedInvocationCounts.get(method) - methodInvocationsCounts.get(method)) + " more times");
+            if(eventLog.getEvent() == TEST_METHOD_EXECUTION) {
+                assertTrue(methodsExecuting.get(classAndMethodName) != null, "Found a test method execution event " +
+                        "log that does not have a corresponding test method start event log");
+                assertTrue(methodsExecuting.get(classAndMethodName).getThreadId() ==
+                        eventLog.getThreadId(), "All the event logs for a given method should have the same thread ID");
             }
 
-            //Verify that all the events in the sublist extracted for the test method pass events of the block of
-            //methods expected to execute in parallel all have the test method pass event type and that they all
-            //executed in different threads.
-            verifySimultaneousTestMethodListenerPassEvents(eventLogMethodListenerPassSublist, testName,
-                    blockSize, methodsExecuting, methodsCompleted, executingMethodThreadIds,
-                    methodInvocationsCounts, expectedInvocationCounts);
+            if(eventLog.getEvent() == LISTENER_TEST_METHOD_PASS) {
 
-            //Verify that the test method execution events and the test method pass events in the two sublists belong
-            //to the same methods. This is done by verifying that the test class names and method names are the same for
-            //for both sublists.
-            verifyEventsBelongToSameMethods(eventLogMethodExecuteSublist, eventLogMethodListenerPassSublist, "The " +
-                    "expected maximum number of methods to execute simultaneously is " + maxSimultaneousTestMethods +
-                    " for " + testName + " so no more than " + maxSimultaneousTestMethods + " methods should be " +
-                    "running at the same time. The test method listener on onTestSuccess event logs for a block of " +
-                    "simultaneously running test methods should all belong to the same methods as the test method " +
-                    "execution event logs immediately preceding");
+                assertTrue(methodsExecuting.get(classAndMethodName) != null, "Found a test method pass event log " +
+                        "that does not have a corresponding test method start event log");
+                assertTrue(methodsExecuting.get(classAndMethodName).getThreadId() ==
+                        eventLog.getThreadId(), "All the event logs for a given method should have the same thread ID");
 
-            loopNum++;
-        }
-    }
+                if(methodInvocationsCounts.get(classAndMethodName)
+                        .equals(expectedInvocationCounts.get(classAndMethodName))) {
+                    methodsExecuting.remove(classAndMethodName);
+                    executingMethodThreadIds.remove(classAndMethodName);
+                    methodsCompleted.put(classAndMethodName, eventLog);
+                }
 
-    public static int verifySimultaneousTestMethodListenerStartEvents(List<EventLog> listenerStartEventLogs, String
-            testName, int blockSize, Map<String, EventLog> methodsExecuting, Map<String, Long>
-            executingMethodThreadIds, Map<String, Integer> methodInvocationsCounts, Map<String, Integer>
-            expectedInvocationCounts) {
-
-        verifySimultaneousTestMethodListenerStartEvents(listenerStartEventLogs, testName, blockSize);
-
-        int decrement = 0;
-
-        for (EventLog eventLog : listenerStartEventLogs) {
-
-            String classAndMethodName = (String)eventLog.getData(CLASS_NAME) + "." +
-                    (String)eventLog.getData(METHOD_NAME);
-
-            if(methodInvocationsCounts.get(classAndMethodName) == null) {
-                methodInvocationsCounts.put(classAndMethodName, 1);
-                decrement++;
-            } else {
-                methodInvocationsCounts.put(classAndMethodName,
-                        methodInvocationsCounts.get(classAndMethodName) + 1);
-            }
-
-            assertFalse(methodInvocationsCounts.get(classAndMethodName) >
-                    expectedInvocationCounts.get(classAndMethodName), "Method '" + classAndMethodName +
-                    "' is expected to execute only " +  expectedInvocationCounts.get(classAndMethodName) +
-                    " times, but event logs show that it was execute at least " +
-                    methodInvocationsCounts.get(classAndMethodName) + " times");
-
-            if (methodsExecuting.keySet().contains(classAndMethodName)) {
-                assertTrue(eventLog.getThreadId() == executingMethodThreadIds.get(classAndMethodName), "All " +
-                        "invocations of method '" + classAndMethodName + "' should execute in the same " +
-                        "thread, but some event logs have different thread IDs");
-            } else {
-                assertFalse(executingMethodThreadIds.values().contains(eventLog.getThreadId()), "Event logs " +
-                        "for different methods currently executing should have different thread IDs, but some event " +
-                        "logs for different methods in the current block being processed have the same thread ID: " +
-                        classAndMethodName);
-            }
-
-            if(methodsExecuting.get(classAndMethodName) == null) {
-                methodsExecuting.put(classAndMethodName, eventLog);
-                executingMethodThreadIds.put(classAndMethodName, eventLog.getThreadId());
+                System.out.println(classAndMethodName + " has executed " +
+                        methodInvocationsCounts.get(classAndMethodName) + " times. Expected to execute " +
+                            (expectedInvocationCounts.get(classAndMethodName) -
+                                    methodInvocationsCounts.get(classAndMethodName)) + " more times");
             }
         }
-
-        return decrement;
-    }
-
-    public static void verifySimultaneousTestMethodExecutionEvents(List<EventLog> testMethodExecutionEventLogs, String
-            testName, Map<String, Long> executingMethodThreadIds, int blockSize) {
-
-        verifySimultaneousTestMethodExecutionEvents(testMethodExecutionEventLogs, testName, blockSize);
-
-        for(EventLog eventLog : testMethodExecutionEventLogs) {
-            String classAndMethodName = (String)eventLog.getData(CLASS_NAME) + "." +
-                    (String)eventLog.getData(METHOD_NAME);
-
-            assertTrue(eventLog.getThreadId() == executingMethodThreadIds.get(classAndMethodName), "All the " +
-                    "test method event logs for a given method using a non-parallel data provider should have the " +
-                    "same thread ID, but some event logs for a method have different thread IDs: " +
-                    classAndMethodName);
-        }
-    }
-
-    public static void verifySimultaneousTestMethodListenerPassEvents(List<EventLog> testMethodListenerPassEventLogs,
-            String testName, int blockSize, Map<String, EventLog> methodsExecuting,
-            Map<String, EventLog> methodsCompleted, Map<String, Long> executingMethodThreadIds, Map<String, Integer>
-            methodInvocationsCounts, Map<String, Integer> expectedInvocationCounts) {
-
-        verifySimultaneousTestMethodListenerPassEvents(testMethodListenerPassEventLogs, testName,
-                blockSize);
-
-        for(EventLog eventLog : testMethodListenerPassEventLogs) {
-            String classAndMethodName = (String)eventLog.getData(CLASS_NAME) + "." +
-                    (String)eventLog.getData(METHOD_NAME);
-
-            assertTrue(eventLog.getThreadId() == executingMethodThreadIds.get(classAndMethodName), "All the " +
-                    "test method event logs for a given method using a non-parallel data provider should have the " +
-                    "same thread ID, but some event logs for a method have different thread IDs: " +
-                    classAndMethodName);
-
-            if(methodInvocationsCounts.get(classAndMethodName)
-                    .equals(expectedInvocationCounts.get(classAndMethodName))) {
-                methodsExecuting.remove(classAndMethodName);
-                executingMethodThreadIds.remove(classAndMethodName);
-                methodsCompleted.put(classAndMethodName, eventLog);
-            }
-        }
-
     }
 
     //Verify that the specified test method listener onTestStart event logs execute simultaneously in parallel fashion
@@ -728,35 +579,6 @@ public class BaseParallelizationTest extends SimpleBaseTest {
                 "event logs to be in a block of methods executing in parallel. Each one of these event logs should " +
                 "be associated with a different thread ID, but found that at two event logs share the same thread " +
                 "ID: " + listenerStartEventLogs);
-    }
-
-    //Verify that the specified test method execution event logs execute simultaneously in parallel fashion according
-    //to the specified thread count. Verifies that each of them has the same event type and all have different thread
-    //IDs.
-    public static void verifySimultaneousTestMethodExecutionEvents(List<EventLog> testMethodExecutionEventLogs,
-            String testName, int blockSize) {
-
-        verifyEventTypeForEventsLogs(testMethodExecutionEventLogs, TEST_METHOD_EXECUTION, "Expected " + blockSize +
-                " test method execution event logs to be in a block of methods executing in parallel. Found an event " +
-                "log of a different type in the block being processed: " + testMethodExecutionEventLogs);
-        verifyDifferentThreadIdsForEvents(testMethodExecutionEventLogs, "Expected " + blockSize + " test method " +
-                "execution event logs to be in a block of methods executing in parallel. Each one of these event " +
-                "logs should be associated with a different thread ID, but found that at two event logs share the " +
-                "same thread ID: " + testMethodExecutionEventLogs);
-    }
-
-    //Verify that the specified test method listener onTestSuccess event logs execute simultaneously in parallel
-    //fashion according to the specified thread count. Verifies that each of them has the same event type and all have
-    //different thread IDs.
-    public static void verifySimultaneousTestMethodListenerPassEvents(List<EventLog> testMethodListenerPassEventLogs,
-            String testName, int blockSize) {
-        verifyEventTypeForEventsLogs(testMethodListenerPassEventLogs, LISTENER_TEST_METHOD_PASS, "Expected " +
-                blockSize + " test method pass event logs to be in a block of methods executing in parallel. Found " +
-                "an event log of a different type in the block being processed: " + testMethodListenerPassEventLogs);
-        verifyDifferentThreadIdsForEvents(testMethodListenerPassEventLogs, "Expected " + blockSize + " test method " +
-                "pass event logs to be in a block of methods executing in parallel. Each one of these event " +
-                "logs should be associated with a different thread ID, but found that at two event logs share the " +
-                "same thread ID: " + testMethodListenerPassEventLogs);
     }
 
     //Verify that the test method level events for the test methods declared in the specified class run in the same
@@ -793,27 +615,6 @@ public class BaseParallelizationTest extends SimpleBaseTest {
                                     " for the test " + suiteName + " should be run in the same thread");
                         }
                     }
-                }
-            }
-        }
-    }
-
-    //Verify that the test method level events for the test methods declared in the specified class run in the same
-    //thread for each instance of the test class for the specified suite and test
-    public static void verifyEventsForTestMethodsInDifferentInstancesRunInDifferentThreads(Class<?> testClass, String
-            suiteName, String testName) {
-
-        for (Method method : testClass.getMethods()) {
-            if (method.getDeclaringClass().equals(testClass)) {
-                Multimap<Object, EventLog> testMethodEventLogs = getTestMethodEventLogsForMethod(suiteName, testName,
-                        testClass.getCanonicalName(), method.getName());
-
-                for(int i = 0; i <= testMethodEventLogs.keySet().size() - 2; i++) {
-                    verifyDifferentThreadIdsForEvents(
-                            new ArrayList<>(testMethodEventLogs.get(testMethodEventLogs.keySet().toArray()[i])),
-                            new ArrayList<>(testMethodEventLogs.get(testMethodEventLogs.keySet().toArray()[i + 1])),
-                            "The test method event logs for " + method.getName() + " for different test class " +
-                                    "instances should run in different threads");
                 }
             }
         }
@@ -971,23 +772,6 @@ public class BaseParallelizationTest extends SimpleBaseTest {
                 "should be different. Event logs: " + suiteListenerStartEventLogs);
     }
 
-    //Helper which verifies that the specified lists of test method level events are associated with the same methods
-    private static void verifyEventsBelongToSameMethods(List<EventLog> firstEventLogs, List<EventLog> secondEventLogs,
-            String faiMessage) {
-
-        List<String> methodNames = new ArrayList<>();
-
-        for (EventLog eventLog : firstEventLogs) {
-            methodNames.add((String)eventLog.getData(CLASS_NAME) + (String)eventLog.getData(METHOD_NAME));
-        }
-
-        for (EventLog eventLog : secondEventLogs) {
-
-            assertTrue(methodNames.contains((String)eventLog.getData(CLASS_NAME) +
-                    (String)eventLog.getData(METHOD_NAME)), faiMessage);
-        }
-    }
-
     //Helper method that retrieves the earliest and latest timestamps for the specified list of event logs
     private static Pair<Long, Long> getEarliestAndLatestTimestamps(List<EventLog> eventLogs) {
 
@@ -1026,91 +810,18 @@ public class BaseParallelizationTest extends SimpleBaseTest {
         return true;
     }
 
-    private static void log(int offsetOne, int offsetTwo, int blockSize, List<EventLog> eventLogMethodListenerStartSublist,
-                List<EventLog> eventLogMethodExecuteSublist, List<EventLog> eventLogMethodListenerPassSublist) {
-//        logger.log(Level.INFO, "Event logs extracted from event log list between index {0} and index {1} should " +
-//                        "be the test method start event logs for a block of {2} simultaneously executing methods",
-//                new Object[] {offsetOne, offsetTwo - 1, blockSize});
+    private static String getStringForEventLogList(Collection<EventLog> list)  {
+        StringBuilder sb = new StringBuilder();
+        ArrayList<EventLog> eventLogs = new ArrayList<>(list);
 
-        System.out.println("Event logs extracted from event log list between index " + offsetOne + " and index "
-                + (offsetTwo - 1) + " should be the test method start event logs for a block of " + blockSize +
-                " simultaneously executing methods");
-
-        int j = offsetOne;
-
-        for(EventLog eventLog : eventLogMethodListenerStartSublist) {
-//            logger.log(Level.INFO, "Event logged at index {0}: {1}", new Object[] {j, eventLog.toString()});
-            System.out.println("Event logged at index " + j + ": " + eventLog.toString());
-            j++;
-        }
-
-//        logger.log(Level.INFO, "Event logs extracted from event log list between index {0} and index {1} should " +
-//                        "be the test method execution event logs for a block of {2} simultaneously executing methods",
-//                new Object[] {offsetTwo, offsetTwo + blockSize - 1, blockSize});
-
-        System.out.println("Event logs extracted from event log list between index " + offsetTwo + " and index "
-                + (offsetTwo + blockSize - 1) + " should be the test method execution event logs for a block of " +
-                blockSize + " simultaneously executing methods");
-
-        j = offsetTwo;
-
-        for(EventLog eventLog : eventLogMethodExecuteSublist) {
-//            logger.log(Level.INFO, "Event logged at index {0}: {1}", new Object[] {j, eventLog.toString()});
-            System.out.println("Event logged at index " + j + ": " + eventLog.toString());
-            j++;
-        }
-
-//        logger.log(Level.INFO, "Event logs extracted from event log list between index {0} and index {1} should " +
-//                        "be the test method pass event logs for a block of {2} simultaneously executing methods",
-//                new Object[] {offsetTwo + blockSize, offsetTwo + 2 * blockSize - 1, blockSize});
-
-        System.out.println("Event logs extracted from event log list between index " + (offsetTwo + blockSize) +
-                " and index " + (offsetTwo + 2 * blockSize - 1) + " should be the test method pass event " +
-                "logs for a block of " + blockSize + " simultaneously executing methods");
-
-        j = offsetTwo + blockSize;
-
-        for(EventLog eventLog : eventLogMethodListenerPassSublist) {
-//            logger.log(Level.INFO, "Event logged at index {0}: {1}", new Object[] {j, eventLog.toString()});
-            System.out.println("Event logged at index " + j + ": " + eventLog.toString());
-            j++;
-        }
-    }
-
-    private static void log(int listSize, int threadCount, int remainder) {
-        if(listSize / 3 < threadCount) {
-//            logger.log(Level.INFO, "Expecting there to be a single block of {0} parallel methods", listSize / 3);
-            System.out.println("Expecting there to be a single block of " + (listSize / 3) + " parallel methods");
-        } else {
-
-            if(remainder > 0) {
-//                logger.log(Level.INFO, "Expecting there to be a series of {0} blocks of {1} parallel methods with a " +
-//                                "final block of {2} parallel methods",
-//
-//                        new Object[]
-//                                {
-//                                        (listSize / 3) / threadCount,
-//                                        threadCount,
-//                                        remainder
-//                                }
-//                );
-
-                System.out.println("Expecting there to be a series of " + ((listSize / 3) / threadCount) + " blocks "
-                        + "of " + threadCount + " parallel methods with a final block of " + remainder + " parallel "
-                        + "methods");
-            } else {
-//                logger.log(Level.INFO, "Expecting there to be a series of {0} blocks of {1} parallel methods",
-//                        new Object[]
-//                                {
-//                                        (listSize / 3) / threadCount,
-//                                        threadCount
-//                                }
-//                        );
-
-                System.out.println("Expecting there to be a series of " + ((listSize / 3) / threadCount) + " blocks "
-                        + "of " + threadCount + " parallel methods");
+        for(int i = 0; i < eventLogs.size(); i++) {
+            sb.append(eventLogs.get(i));
+            if(i != eventLogs.size() - 1) {
+                sb.append("\n");
             }
         }
+
+        return sb.toString();
     }
 }
 

--- a/src/test/java/test/thread/parallelization/BaseParallelizationTest.java
+++ b/src/test/java/test/thread/parallelization/BaseParallelizationTest.java
@@ -48,8 +48,6 @@ public class BaseParallelizationTest extends SimpleBaseTest {
         logger.setLevel(Level.INFO);
     }
 
-//    String x = "%1$tF %1$tT";
-
     //Get a list of the names of declared methods with the @Test annotation from the specified class
     public static List<String> getDeclaredTestMethods(Class<?> clazz) {
         List<String> methodNames = new ArrayList<>();
@@ -320,11 +318,16 @@ public class BaseParallelizationTest extends SimpleBaseTest {
     public static void verifySimultaneousTestMethods(List<EventLog> testMethodEventLogs, String testName, int
             maxSimultaneousTestMethods) {
 
-        logger.log(Level.INFO,"Verifying parallel execution of test methods for test named {0} with thread count {1}",
-                new Object[] {testName, maxSimultaneousTestMethods});
+//        logger.log(Level.INFO,"Verifying parallel execution of test methods for test named {0} with thread count {1}",
+//                new Object[] {testName, maxSimultaneousTestMethods});
+//
+//        logger.log(Level.INFO, "{0} test method event logs for {1} test methods: ",
+//                new Object[]{ testMethodEventLogs.size(), testMethodEventLogs.size()/3} );
 
-        logger.log(Level.INFO, "{0} test method event logs for {1} test methods: ",
-                new Object[]{ testMethodEventLogs.size(), testMethodEventLogs.size()/3} );
+        System.out.println("Verifying parallel execution of test methods for test named " + testName  + " with " +
+                "thread count " + maxSimultaneousTestMethods);
+        System.out.println(testMethodEventLogs.size() + " test method event logs for " + testMethodEventLogs.size()/3
+                + " test methods");
 
         //There are three test method events expected per test method: a start event, an execution event, and a test
         //method pass event. All methods take exactly the same amount of time to execute. Each one of their events
@@ -353,7 +356,9 @@ public class BaseParallelizationTest extends SimpleBaseTest {
         //test method.
         for (int i = 1; i < testMethodEventLogs.size(); i = i + maxSimultaneousTestMethods * 3) {
 
-            logger.log(Level.INFO, "Processing block {0} of {1}", new Object[] {loopNum, numBlocks});
+//            logger.log(Level.INFO, "Processing block {0} of {1}", new Object[] {loopNum, numBlocks});
+
+            System.out.println("Processing block " + loopNum + " of " + numBlocks);
 
             //The size of the block is equal to the thread count or the number of methods left over in the last block
             //if the total number of methods is not a multiple of the thread count. Example: For a test run with 19
@@ -377,8 +382,11 @@ public class BaseParallelizationTest extends SimpleBaseTest {
                     testMethodEventLogs.size() - (remainder * 3) + blockSize :
                     i + maxSimultaneousTestMethods - 1;
 
-            logger.log(Level.INFO, "Expecting {0} test method start events, followed by {0} test method execution " +
-                    "events, followed by {0} test method pass events", blockSize);
+//            logger.log(Level.INFO, "Expecting {0} test method start events, followed by {0} test method execution " +
+//                    "events, followed by {0} test method pass events", blockSize);
+
+            System.out.println("Expecting " + blockSize + " test method start events, followed by " + blockSize +
+                    " test method execution events , followed by " + blockSize + " test method pass events");
 
             List<EventLog> eventLogMethodListenerStartSublist = testMethodEventLogs.subList(offsetOne, offsetTwo);
             List<EventLog> eventLogMethodExecuteSublist = testMethodEventLogs.subList(offsetTwo, offsetTwo + blockSize);
@@ -440,11 +448,17 @@ public class BaseParallelizationTest extends SimpleBaseTest {
             testName, Map<String, Integer> expectedInvocationCounts, int numUniqueMethods, int
             maxSimultaneousTestMethods) {
 
-        logger.log(Level.INFO,"Verifying parallel execution of test methods using non-parallel data providers for " +
-                "test named {0} with thread count {1}", new Object[] {testName, maxSimultaneousTestMethods});
+//        logger.log(Level.INFO,"Verifying parallel execution of test methods using non-parallel data providers for " +
+//                "test named {0} with thread count {1}", new Object[] {testName, maxSimultaneousTestMethods});
+//
+//        logger.log(Level.INFO, "{0} test method event logs for {1} unique methods: ",
+//                new Object[] {testMethodEventLogs.size(), numUniqueMethods});
 
-        logger.log(Level.INFO, "{0} test method event logs for {1} unique methods: ",
-                new Object[] {testMethodEventLogs.size(), numUniqueMethods});
+        System.out.println("Verifying parallel execution of test methods using non-parallel data providers for " +
+                "test named " + testName + " with thread count " + maxSimultaneousTestMethods);
+        System.out.println(testMethodEventLogs.size() + " test method event logs for " + numUniqueMethods +
+                " unique methods");
+
 
         //Some of the test methods use non-parallel data providers without factories. All the invocations of those
         //test methods will occur serially within the same thread on the same class instances. In order to ensure that
@@ -487,7 +501,9 @@ public class BaseParallelizationTest extends SimpleBaseTest {
 
         for (int i = 1; i < testMethodEventLogs.size(); i = i + blockSize * 3) {
 
-            logger.log(Level.INFO, "Processing block {0}", loopNum);
+//            logger.log(Level.INFO, "Processing block {0}", loopNum);
+
+            System.out.println("Processing block " + loopNum);
 
             //If the loop is executing more than once, then the block size needs to be updated. The number of remaining
             //unique methods to execute determines the block size of parallel methods expected to execute
@@ -533,8 +549,11 @@ public class BaseParallelizationTest extends SimpleBaseTest {
 
             int offsetTwo = i + blockSize - 1;
 
-            logger.log(Level.INFO, "Expecting {0} test method start events, followed by {0} test method execution " +
-                    "events, followed by {0} test method pass events", blockSize);
+//            logger.log(Level.INFO, "Expecting {0} test method start events, followed by {0} test method execution " +
+//                    "events, followed by {0} test method pass events", blockSize);
+
+            System.out.println("Expecting " + blockSize + " test method start events, followed by " + blockSize
+                    + " test method execution, followed by " + blockSize + " test method pass events");
 
             List<EventLog> eventLogMethodListenerStartSublist = testMethodEventLogs.subList(offsetOne, offsetTwo);
             List<EventLog> eventLogMethodExecuteSublist = testMethodEventLogs.subList(offsetTwo, offsetTwo + blockSize);
@@ -574,9 +593,13 @@ public class BaseParallelizationTest extends SimpleBaseTest {
                     "event logs immediately preceding");
 
             for(String method : methodsExecuting.keySet()) {
-                logger.log(Level.INFO, "{0} has executed {1} times. Expected to execute {2} more times.",
-                        new Object[]{method, methodInvocationsCounts.get(method),
-                                expectedInvocationCounts.get(method) - methodInvocationsCounts.get(method)});
+//                logger.log(Level.INFO, "{0} has executed {1} times. Expected to execute {2} more times.",
+//                        new Object[]{method, methodInvocationsCounts.get(method),
+//                                expectedInvocationCounts.get(method) - methodInvocationsCounts.get(method)});
+
+                System.out.println(method + " has executed " + methodInvocationsCounts.get(method) + " times. "
+                        + "Expected to execute " +
+                        (expectedInvocationCounts.get(method) - methodInvocationsCounts.get(method)) + " more times");
             }
 
             //Verify that all the events in the sublist extracted for the test method pass events of the block of
@@ -1005,64 +1028,87 @@ public class BaseParallelizationTest extends SimpleBaseTest {
 
     private static void log(int offsetOne, int offsetTwo, int blockSize, List<EventLog> eventLogMethodListenerStartSublist,
                 List<EventLog> eventLogMethodExecuteSublist, List<EventLog> eventLogMethodListenerPassSublist) {
-        logger.log(Level.INFO, "Event logs extracted from event log list between index {0} and index {1} should " +
-                        "be the test method start event logs for a block of {2} simultaneously executing methods",
-                new Object[] {offsetOne, offsetTwo - 1, blockSize});
+//        logger.log(Level.INFO, "Event logs extracted from event log list between index {0} and index {1} should " +
+//                        "be the test method start event logs for a block of {2} simultaneously executing methods",
+//                new Object[] {offsetOne, offsetTwo - 1, blockSize});
+
+        System.out.println("Event logs extracted from event log list between index " + offsetOne + " and index "
+                + (offsetTwo - 1) + " should be the test method start event logs for a block of " + blockSize +
+                " simultaneously executing methods");
 
         int j = offsetOne;
 
         for(EventLog eventLog : eventLogMethodListenerStartSublist) {
-            logger.log(Level.INFO, "Event logged at index {0}: {1}", new Object[] {j, eventLog.toString()});
+//            logger.log(Level.INFO, "Event logged at index {0}: {1}", new Object[] {j, eventLog.toString()});
+            System.out.println("Event logged at index " + j + ": " + eventLog.toString());
             j++;
         }
 
-        logger.log(Level.INFO, "Event logs extracted from event log list between index {0} and index {1} should " +
-                        "be the test method execution event logs for a block of {2} simultaneously executing methods",
-                new Object[] {offsetTwo, offsetTwo + blockSize - 1, blockSize});
+//        logger.log(Level.INFO, "Event logs extracted from event log list between index {0} and index {1} should " +
+//                        "be the test method execution event logs for a block of {2} simultaneously executing methods",
+//                new Object[] {offsetTwo, offsetTwo + blockSize - 1, blockSize});
+
+        System.out.println("Event logs extracted from event log list between index " + offsetTwo + " and index "
+                + (offsetTwo + blockSize - 1) + " should be the test method execution event logs for a block of " +
+                blockSize + " simultaneously executing methods");
 
         j = offsetTwo;
 
         for(EventLog eventLog : eventLogMethodExecuteSublist) {
-            logger.log(Level.INFO, "Event logged at index {0}: {1}", new Object[] {j, eventLog.toString()});
+//            logger.log(Level.INFO, "Event logged at index {0}: {1}", new Object[] {j, eventLog.toString()});
+            System.out.println("Event logged at index " + j + ": " + eventLog.toString());
             j++;
         }
 
-        logger.log(Level.INFO, "Event logs extracted from event log list between index {0} and index {1} should " +
-                        "be the test method pass event logs for a block of {2} simultaneously executing methods",
-                new Object[] {offsetTwo + blockSize, offsetTwo + 2 * blockSize - 1, blockSize});
+//        logger.log(Level.INFO, "Event logs extracted from event log list between index {0} and index {1} should " +
+//                        "be the test method pass event logs for a block of {2} simultaneously executing methods",
+//                new Object[] {offsetTwo + blockSize, offsetTwo + 2 * blockSize - 1, blockSize});
+
+        System.out.println("Event logs extracted from event log list between index " + (offsetTwo + blockSize) +
+                " and index " + (offsetTwo + 2 * blockSize - 1) + " should be the test method pass event " +
+                "logs for a block of " + blockSize + " simultaneously executing methods");
 
         j = offsetTwo + blockSize;
 
         for(EventLog eventLog : eventLogMethodListenerPassSublist) {
-            logger.log(Level.INFO, "Event logged at index {0}: {1}", new Object[] {j, eventLog.toString()});
+//            logger.log(Level.INFO, "Event logged at index {0}: {1}", new Object[] {j, eventLog.toString()});
+            System.out.println("Event logged at index " + j + ": " + eventLog.toString());
             j++;
         }
     }
 
     private static void log(int listSize, int threadCount, int remainder) {
         if(listSize / 3 < threadCount) {
-            logger.log(Level.INFO, "Expecting there to be a single block of {0} parallel methods", listSize / 3);
+//            logger.log(Level.INFO, "Expecting there to be a single block of {0} parallel methods", listSize / 3);
+            System.out.println("Expecting there to be a single block of " + (listSize / 3) + " parallel methods");
         } else {
 
             if(remainder > 0) {
-                logger.log(Level.INFO, "Expecting there to be a series of {0} blocks of {1} parallel methods with a " +
-                                "final block of {2} parallel methods",
+//                logger.log(Level.INFO, "Expecting there to be a series of {0} blocks of {1} parallel methods with a " +
+//                                "final block of {2} parallel methods",
+//
+//                        new Object[]
+//                                {
+//                                        (listSize / 3) / threadCount,
+//                                        threadCount,
+//                                        remainder
+//                                }
+//                );
 
-                        new Object[]
-                                {
-                                        (listSize / 3) / threadCount,
-                                        threadCount,
-                                        remainder
-                                }
-                );
+                System.out.println("Expecting there to be a series of " + ((listSize / 3) / threadCount) + " blocks "
+                        + "of " + threadCount + " parallel methods with a final block of " + remainder + " parallel "
+                        + "methods");
             } else {
-                logger.log(Level.INFO, "Expecting there to be a series of {0} blocks of {1} parallel methods",
-                        new Object[]
-                                {
-                                        (listSize / 3) / threadCount,
-                                        threadCount
-                                }
-                        );
+//                logger.log(Level.INFO, "Expecting there to be a series of {0} blocks of {1} parallel methods",
+//                        new Object[]
+//                                {
+//                                        (listSize / 3) / threadCount,
+//                                        threadCount
+//                                }
+//                        );
+
+                System.out.println("Expecting there to be a series of " + ((listSize / 3) / threadCount) + " blocks "
+                        + "of " + threadCount + " parallel methods");
             }
         }
     }

--- a/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase1Scenario1.java
+++ b/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase1Scenario1.java
@@ -85,12 +85,18 @@ public class ParallelByMethodsTestCase1Scenario1 extends BaseParallelizationTest
         TestNG tng = create(suite);
         tng.addListener((ITestNGListener)new TestNgRunStateListener());
 
-        logger.log(Level.INFO, "Beginning ParallelByMethodsTestCase1Scenario1. This test scenario consists of a " +
+//        logger.log(Level.INFO, "Beginning ParallelByMethodsTestCase1Scenario1. This test scenario consists of a " +
+//                "single suite with a single test which consists of one test class with five test methods. There " +
+//                "are no dependencies, data providers or factories.");
+//
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test class: {2}. Thread count: {3}",
+//                new Object[]{SUITE,TEST,TestClassAFiveMethodsWithNoDepsSample.class.getCanonicalName(), 5});
+
+        System.out.println("Beginning ParallelByMethodsTestCase1Scenario1. This test scenario consists of a " +
                 "single suite with a single test which consists of one test class with five test methods. There " +
                 "are no dependencies, data providers or factories.");
-
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test class: {2}. Thread count: {3}",
-                new Object[]{SUITE,TEST,TestClassAFiveMethodsWithNoDepsSample.class.getCanonicalName(), 5});
+        System.out.println("Suite: " + SUITE + ", Test: " + TEST + ", Test class: "
+                + TestClassAFiveMethodsWithNoDepsSample.class.getCanonicalName() +". Thread count: 5");
 
         tng.run();
 

--- a/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase1Scenario1.java
+++ b/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase1Scenario1.java
@@ -48,12 +48,6 @@ import static test.thread.parallelization.TestNgRunStateTracker.reset;
  */
 public class ParallelByMethodsTestCase1Scenario1 extends BaseParallelizationTest {
 
-    private static final Logger logger = Logger.getLogger(ParallelByMethodsTestCase1Scenario1.class.getCanonicalName());
-
-    {
-        logger.setLevel(Level.INFO);
-    }
-
     private static final String SUITE = "SingleTestSuite";
     private static final String TEST = "SingleTestClassTest";
 
@@ -84,13 +78,6 @@ public class ParallelByMethodsTestCase1Scenario1 extends BaseParallelizationTest
 
         TestNG tng = create(suite);
         tng.addListener((ITestNGListener)new TestNgRunStateListener());
-
-//        logger.log(Level.INFO, "Beginning ParallelByMethodsTestCase1Scenario1. This test scenario consists of a " +
-//                "single suite with a single test which consists of one test class with five test methods. There " +
-//                "are no dependencies, data providers or factories.");
-//
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test class: {2}. Thread count: {3}",
-//                new Object[]{SUITE,TEST,TestClassAFiveMethodsWithNoDepsSample.class.getCanonicalName(), 5});
 
         System.out.println("Beginning ParallelByMethodsTestCase1Scenario1. This test scenario consists of a " +
                 "single suite with a single test which consists of one test class with five test methods. There " +

--- a/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase1Scenario2.java
+++ b/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase1Scenario2.java
@@ -217,45 +217,77 @@ public class ParallelByMethodsTestCase1Scenario2 extends BaseParallelizationTest
         TestNG tng = create(suiteOne, suiteTwo, suiteThree);
         tng.addListener((ITestNGListener) new TestNgRunStateListener());
 
-        logger.log(Level.INFO, "Beginning ParallelByMethodsTestCase1Scenario2. This test scenario consists of three " +
+//        logger.log(Level.INFO, "Beginning ParallelByMethodsTestCase1Scenario2. This test scenario consists of three " +
+//                "sequentially executed suites with 1, 2 and 3 tests respectively. One test for a suite consists of a " +
+//                "single test class while the rest shall consist of more than one test class. There are no " +
+//                "dependencies, data providers or factories.");
+
+        System.out.println("Beginning ParallelByMethodsTestCase1Scenario2. This test scenario consists of three " +
                 "sequentially executed suites with 1, 2 and 3 tests respectively. One test for a suite consists of a " +
                 "single test class while the rest shall consist of more than one test class. There are no " +
                 "dependencies, data providers or factories.");
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-                new Object[]{SUITE_A,SUITE_A_TEST_A,TestClassAFiveMethodsWithNoDepsSample.class.getCanonicalName() +
-                        ", " + TestClassCSixMethodsWithNoDepsSample.class.getCanonicalName(), 3});
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
+//                new Object[]{SUITE_A,SUITE_A_TEST_A,TestClassAFiveMethodsWithNoDepsSample.class.getCanonicalName() +
+//                        ", " + TestClassCSixMethodsWithNoDepsSample.class.getCanonicalName(), 3});
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test class: {2}. Thread count: {3}",
-                new Object[]{SUITE_B,SUITE_B_TEST_A,TestClassEFiveMethodsWithNoDepsSample.class.getCanonicalName(), 6});
+        System.out.println("Suite: " + SUITE_A + ", Test: " + SUITE_A_TEST_A + ", Test classes: " +
+                TestClassAFiveMethodsWithNoDepsSample.class.getCanonicalName() +
+                        ", " + TestClassCSixMethodsWithNoDepsSample.class.getCanonicalName() + ". Thread count: 3");
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-                new Object[]{SUITE_B,SUITE_B_TEST_B,
-                        TestClassDThreeMethodsWithNoDepsSample.class + ", " +
-                                TestClassBFourMethodsWithNoDepsSample.class + ", " +
-                                TestClassFSixMethodsWithNoDepsSample.class,
-                        20});
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test class: {2}. Thread count: {3}",
+//                new Object[]{SUITE_B,SUITE_B_TEST_A,TestClassEFiveMethodsWithNoDepsSample.class.getCanonicalName(), 6});
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-                new Object[]{SUITE_C,SUITE_C_TEST_A,
-                        TestClassGThreeMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-                                TestClassHFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-                                TestClassIFiveMethodsWithNoDepsSample.class,
-                        10});
+        System.out.println("Suite: " + SUITE_B + ", Test: " + SUITE_B_TEST_A + ", Test class: " +
+                TestClassEFiveMethodsWithNoDepsSample.class.getCanonicalName() + ". Thread count: 6");
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-                new Object[]{SUITE_C,SUITE_C_TEST_B,
-                        TestClassJFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-                                TestClassKFiveMethodsWithNoDepsSample.class,
-                        5});
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
+//                new Object[]{SUITE_B,SUITE_B_TEST_B,
+//                        TestClassDThreeMethodsWithNoDepsSample.class + ", " +
+//                                TestClassBFourMethodsWithNoDepsSample.class + ", " +
+//                                TestClassFSixMethodsWithNoDepsSample.class,
+//                        20});
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-                new Object[]{SUITE_C,SUITE_C_TEST_C,
-                        TestClassLThreeMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-                                TestClassMFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-                                TestClassNFiveMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-                                TestClassOSixMethodsWithNoDepsSample.class.getCanonicalName(),
-                        12});
+        System.out.println("Suite " + SUITE_B + ", Test: " + SUITE_B_TEST_B + ", Test classes: " +
+                TestClassDThreeMethodsWithNoDepsSample.class + ", " +
+                TestClassBFourMethodsWithNoDepsSample.class + ", " +
+                TestClassFSixMethodsWithNoDepsSample.class + ". Thread count: 20");
+
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
+//                new Object[]{SUITE_C,SUITE_C_TEST_A,
+//                        TestClassGThreeMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+//                                TestClassHFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+//                                TestClassIFiveMethodsWithNoDepsSample.class,
+//                        10});
+
+        System.out.println("Suite: " + SUITE_C + ", Test: " + SUITE_C_TEST_A + ", Test classes: " +
+                TestClassGThreeMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+                TestClassHFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+                TestClassIFiveMethodsWithNoDepsSample.class + ". Thread count: 10");
+
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
+//                new Object[]{SUITE_C,SUITE_C_TEST_B,
+//                        TestClassJFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+//                                TestClassKFiveMethodsWithNoDepsSample.class,
+//                        5});
+
+        System.out.println("Suite: " + SUITE_C + ", Test: " + SUITE_C_TEST_B + ", Test classes: " +
+                TestClassJFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+                TestClassKFiveMethodsWithNoDepsSample.class + ". Thread count: 5");
+
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
+//                new Object[]{SUITE_C,SUITE_C_TEST_C,
+//                        TestClassLThreeMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+//                                TestClassMFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+//                                TestClassNFiveMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+//                                TestClassOSixMethodsWithNoDepsSample.class.getCanonicalName(),
+//                        12});
+
+        System.out.println("Suite: " + SUITE_C + ", Test: " + SUITE_C_TEST_C + ", Test classes: " +
+                TestClassLThreeMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+                TestClassMFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+                TestClassNFiveMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+                TestClassOSixMethodsWithNoDepsSample.class.getCanonicalName() + ". Thread count: 12.");
 
         tng.run();
 

--- a/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase1Scenario2.java
+++ b/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase1Scenario2.java
@@ -80,12 +80,6 @@ import static test.thread.parallelization.TestNgRunStateTracker.reset;
  */
 public class ParallelByMethodsTestCase1Scenario2 extends BaseParallelizationTest {
 
-    private static final Logger logger = Logger.getLogger(ParallelByMethodsTestCase1Scenario2.class.getCanonicalName());
-
-    {
-        logger.setLevel(Level.INFO);
-    }
-
     private static final String SUITE_A = "TestSuiteA";
     private static final String SUITE_B = "TestSuiteB";
     private static final String SUITE_C = "TestSuiteC";
@@ -217,71 +211,31 @@ public class ParallelByMethodsTestCase1Scenario2 extends BaseParallelizationTest
         TestNG tng = create(suiteOne, suiteTwo, suiteThree);
         tng.addListener((ITestNGListener) new TestNgRunStateListener());
 
-//        logger.log(Level.INFO, "Beginning ParallelByMethodsTestCase1Scenario2. This test scenario consists of three " +
-//                "sequentially executed suites with 1, 2 and 3 tests respectively. One test for a suite consists of a " +
-//                "single test class while the rest shall consist of more than one test class. There are no " +
-//                "dependencies, data providers or factories.");
-
         System.out.println("Beginning ParallelByMethodsTestCase1Scenario2. This test scenario consists of three " +
                 "sequentially executed suites with 1, 2 and 3 tests respectively. One test for a suite consists of a " +
                 "single test class while the rest shall consist of more than one test class. There are no " +
                 "dependencies, data providers or factories.");
 
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-//                new Object[]{SUITE_A,SUITE_A_TEST_A,TestClassAFiveMethodsWithNoDepsSample.class.getCanonicalName() +
-//                        ", " + TestClassCSixMethodsWithNoDepsSample.class.getCanonicalName(), 3});
-
         System.out.println("Suite: " + SUITE_A + ", Test: " + SUITE_A_TEST_A + ", Test classes: " +
                 TestClassAFiveMethodsWithNoDepsSample.class.getCanonicalName() +
                         ", " + TestClassCSixMethodsWithNoDepsSample.class.getCanonicalName() + ". Thread count: 3");
 
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test class: {2}. Thread count: {3}",
-//                new Object[]{SUITE_B,SUITE_B_TEST_A,TestClassEFiveMethodsWithNoDepsSample.class.getCanonicalName(), 6});
-
         System.out.println("Suite: " + SUITE_B + ", Test: " + SUITE_B_TEST_A + ", Test class: " +
                 TestClassEFiveMethodsWithNoDepsSample.class.getCanonicalName() + ". Thread count: 6");
-
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-//                new Object[]{SUITE_B,SUITE_B_TEST_B,
-//                        TestClassDThreeMethodsWithNoDepsSample.class + ", " +
-//                                TestClassBFourMethodsWithNoDepsSample.class + ", " +
-//                                TestClassFSixMethodsWithNoDepsSample.class,
-//                        20});
 
         System.out.println("Suite " + SUITE_B + ", Test: " + SUITE_B_TEST_B + ", Test classes: " +
                 TestClassDThreeMethodsWithNoDepsSample.class + ", " +
                 TestClassBFourMethodsWithNoDepsSample.class + ", " +
                 TestClassFSixMethodsWithNoDepsSample.class + ". Thread count: 20");
 
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-//                new Object[]{SUITE_C,SUITE_C_TEST_A,
-//                        TestClassGThreeMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-//                                TestClassHFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-//                                TestClassIFiveMethodsWithNoDepsSample.class,
-//                        10});
-
         System.out.println("Suite: " + SUITE_C + ", Test: " + SUITE_C_TEST_A + ", Test classes: " +
                 TestClassGThreeMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
                 TestClassHFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
                 TestClassIFiveMethodsWithNoDepsSample.class + ". Thread count: 10");
 
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-//                new Object[]{SUITE_C,SUITE_C_TEST_B,
-//                        TestClassJFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-//                                TestClassKFiveMethodsWithNoDepsSample.class,
-//                        5});
-
         System.out.println("Suite: " + SUITE_C + ", Test: " + SUITE_C_TEST_B + ", Test classes: " +
                 TestClassJFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
                 TestClassKFiveMethodsWithNoDepsSample.class + ". Thread count: 5");
-
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-//                new Object[]{SUITE_C,SUITE_C_TEST_C,
-//                        TestClassLThreeMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-//                                TestClassMFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-//                                TestClassNFiveMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-//                                TestClassOSixMethodsWithNoDepsSample.class.getCanonicalName(),
-//                        12});
 
         System.out.println("Suite: " + SUITE_C + ", Test: " + SUITE_C_TEST_C + ", Test classes: " +
                 TestClassLThreeMethodsWithNoDepsSample.class.getCanonicalName() + ", " +

--- a/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase2Scenario1.java
+++ b/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase2Scenario1.java
@@ -144,24 +144,42 @@ public class ParallelByMethodsTestCase2Scenario1 extends BaseParallelizationTest
         tng.setSuiteThreadPoolSize(2);
         tng.addListener((ITestNGListener) new TestNgRunStateListener());
 
-        logger.log(Level.INFO, "Beginning ParallelByMethodsTestCase2Scenario1. This test scenario consists of two " +
+//        logger.log(Level.INFO, "Beginning ParallelByMethodsTestCase2Scenario1. This test scenario consists of two " +
+//                "suites with 1 and 2 tests respectively. The suites run in parallel and the thread pool size is 2. " +
+//                "One test for a suite shall consist of a single test class while the rest shall consist of more than " +
+//                "one test class. There are no dependencies, data providers or factories.");
+
+        System.out.println("Beginning ParallelByMethodsTestCase2Scenario1. This test scenario consists of two " +
                 "suites with 1 and 2 tests respectively. The suites run in parallel and the thread pool size is 2. " +
                 "One test for a suite shall consist of a single test class while the rest shall consist of more than " +
                 "one test class. There are no dependencies, data providers or factories.");
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-                new Object[]{SUITE_A,SUITE_A_TEST_A,TestClassAFiveMethodsWithNoDepsSample.class.getCanonicalName() +
-                        ", " + TestClassCSixMethodsWithNoDepsSample.class.getCanonicalName(), 3});
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
+//                new Object[]{SUITE_A,SUITE_A_TEST_A,TestClassAFiveMethodsWithNoDepsSample.class.getCanonicalName() +
+//                        ", " + TestClassCSixMethodsWithNoDepsSample.class.getCanonicalName(), 3});
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test class: {2}. Thread count: {3}",
-                new Object[]{SUITE_B,SUITE_B_TEST_A,TestClassEFiveMethodsWithNoDepsSample.class.getCanonicalName(), 14});
+        System.out.println("Suite: " + SUITE_A + ", Test: " + SUITE_A_TEST_A + ", Test classes: " +
+                TestClassAFiveMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+                TestClassCSixMethodsWithNoDepsSample.class.getCanonicalName() + ". Thread count: 3");
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-                new Object[]{SUITE_B,SUITE_B_TEST_B,
-                        TestClassDThreeMethodsWithNoDepsSample.class + ", " +
-                                TestClassBFourMethodsWithNoDepsSample.class + ", " +
-                                TestClassFSixMethodsWithNoDepsSample.class,
-                        14});
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test class: {2}. Thread count: {3}",
+//                new Object[]{SUITE_B,SUITE_B_TEST_A,TestClassEFiveMethodsWithNoDepsSample.class.getCanonicalName(),
+//                        14});
+
+        System.out.println("Suite: " + SUITE_B + ", Test: " + SUITE_B_TEST_A + ", Test class: " +
+                TestClassEFiveMethodsWithNoDepsSample.class.getCanonicalName() + ". Thread count: 14");
+
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
+//                new Object[]{SUITE_B,SUITE_B_TEST_B,
+//                        TestClassDThreeMethodsWithNoDepsSample.class + ", " +
+//                                TestClassBFourMethodsWithNoDepsSample.class + ", " +
+//                                TestClassFSixMethodsWithNoDepsSample.class,
+//                        14});
+
+        System.out.println("Suite: " + SUITE_B + ", Test: " + SUITE_B_TEST_B + ", Test classes: " +
+                TestClassDThreeMethodsWithNoDepsSample.class + ", " +
+                TestClassBFourMethodsWithNoDepsSample.class + ", " +
+                TestClassFSixMethodsWithNoDepsSample.class + ". Thread count: 14");
 
         tng.run();
 

--- a/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase2Scenario1.java
+++ b/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase2Scenario1.java
@@ -66,12 +66,6 @@ import static test.thread.parallelization.TestNgRunStateTracker.reset;
  */
 public class ParallelByMethodsTestCase2Scenario1 extends BaseParallelizationTest {
 
-    private static final Logger logger = Logger.getLogger(ParallelByMethodsTestCase2Scenario1.class.getCanonicalName());
-
-    {
-        logger.setLevel(Level.INFO);
-    }
-
     private static final String SUITE_A = "TestSuiteA";
     private static final String SUITE_B = "TestSuiteB";
 
@@ -144,37 +138,17 @@ public class ParallelByMethodsTestCase2Scenario1 extends BaseParallelizationTest
         tng.setSuiteThreadPoolSize(2);
         tng.addListener((ITestNGListener) new TestNgRunStateListener());
 
-//        logger.log(Level.INFO, "Beginning ParallelByMethodsTestCase2Scenario1. This test scenario consists of two " +
-//                "suites with 1 and 2 tests respectively. The suites run in parallel and the thread pool size is 2. " +
-//                "One test for a suite shall consist of a single test class while the rest shall consist of more than " +
-//                "one test class. There are no dependencies, data providers or factories.");
-
         System.out.println("Beginning ParallelByMethodsTestCase2Scenario1. This test scenario consists of two " +
                 "suites with 1 and 2 tests respectively. The suites run in parallel and the thread pool size is 2. " +
                 "One test for a suite shall consist of a single test class while the rest shall consist of more than " +
                 "one test class. There are no dependencies, data providers or factories.");
 
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-//                new Object[]{SUITE_A,SUITE_A_TEST_A,TestClassAFiveMethodsWithNoDepsSample.class.getCanonicalName() +
-//                        ", " + TestClassCSixMethodsWithNoDepsSample.class.getCanonicalName(), 3});
-
         System.out.println("Suite: " + SUITE_A + ", Test: " + SUITE_A_TEST_A + ", Test classes: " +
                 TestClassAFiveMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
                 TestClassCSixMethodsWithNoDepsSample.class.getCanonicalName() + ". Thread count: 3");
 
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test class: {2}. Thread count: {3}",
-//                new Object[]{SUITE_B,SUITE_B_TEST_A,TestClassEFiveMethodsWithNoDepsSample.class.getCanonicalName(),
-//                        14});
-
         System.out.println("Suite: " + SUITE_B + ", Test: " + SUITE_B_TEST_A + ", Test class: " +
                 TestClassEFiveMethodsWithNoDepsSample.class.getCanonicalName() + ". Thread count: 14");
-
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-//                new Object[]{SUITE_B,SUITE_B_TEST_B,
-//                        TestClassDThreeMethodsWithNoDepsSample.class + ", " +
-//                                TestClassBFourMethodsWithNoDepsSample.class + ", " +
-//                                TestClassFSixMethodsWithNoDepsSample.class,
-//                        14});
 
         System.out.println("Suite: " + SUITE_B + ", Test: " + SUITE_B_TEST_B + ", Test classes: " +
                 TestClassDThreeMethodsWithNoDepsSample.class + ", " +

--- a/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase2Scenario2.java
+++ b/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase2Scenario2.java
@@ -75,12 +75,6 @@ import static test.thread.parallelization.TestNgRunStateTracker.reset;
  */
 public class ParallelByMethodsTestCase2Scenario2 extends BaseParallelizationTest {
 
-    private static final Logger logger = Logger.getLogger(ParallelByMethodsTestCase2Scenario2.class.getCanonicalName());
-
-    {
-        logger.setLevel(Level.INFO);
-    }
-
     private static final String SUITE_A = "TestSuiteA";
     private static final String SUITE_B = "TestSuiteB";
     private static final String SUITE_C = "TestSuiteC";
@@ -214,71 +208,31 @@ public class ParallelByMethodsTestCase2Scenario2 extends BaseParallelizationTest
         tng.setSuiteThreadPoolSize(2);
         tng.addListener((ITestNGListener) new TestNgRunStateListener());
 
-//        logger.log(Level.INFO, "Beginning ParallelByMethodsTestCase2Scenario2. This test scenario consists of three " +
-//                "suites with 1, 2 and 3 tests respectively. The suites run in parallel and the thread pool size is 3 " +
-//                "One test for a suite shall consist of a single test class while the rest shall consist of more than " +
-//                "one test class. There are no dependencies, data providers or factories.");
-
         System.out.println("Beginning ParallelByMethodsTestCase2Scenario2. This test scenario consists of three " +
                 "suites with 1, 2 and 3 tests respectively. The suites run in parallel and the thread pool size is 3 " +
                 "One test for a suite shall consist of a single test class while the rest shall consist of more than " +
                 "one test class. There are no dependencies, data providers or factories.");
 
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-//                new Object[]{SUITE_A,SUITE_A_TEST_A,TestClassAFiveMethodsWithNoDepsSample.class.getCanonicalName() +
-//                        ", " + TestClassCSixMethodsWithNoDepsSample.class.getCanonicalName(), 3});
-
         System.out.println("Suite: " + SUITE_A + ", Test: " + SUITE_A_TEST_A + ", Test classes: " +
                 TestClassAFiveMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
                 TestClassCSixMethodsWithNoDepsSample.class.getCanonicalName() + ". Thread count: 3");
 
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test class: {2}. Thread count: {3}",
-//                new Object[]{SUITE_B,SUITE_B_TEST_A,TestClassEFiveMethodsWithNoDepsSample.class.getCanonicalName(), 6});
-
         System.out.println("Suite: " + SUITE_B + ", Test: " + SUITE_B_TEST_A + ", Test class: " +
                 TestClassEFiveMethodsWithNoDepsSample.class.getCanonicalName() + ". Thread count: 6");
-
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-//                new Object[]{SUITE_B,SUITE_B_TEST_B,
-//                        TestClassDThreeMethodsWithNoDepsSample.class + ", " +
-//                                TestClassBFourMethodsWithNoDepsSample.class + ", " +
-//                                TestClassFSixMethodsWithNoDepsSample.class,
-//                        20});
 
         System.out.println("Suite: " + SUITE_B + ", Test: " + SUITE_B_TEST_B + ", Test classes: " +
                 TestClassDThreeMethodsWithNoDepsSample.class + ", " +
                 TestClassBFourMethodsWithNoDepsSample.class + ", " +
                 TestClassFSixMethodsWithNoDepsSample.class + ". Thread count: 20");
 
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-//                new Object[]{SUITE_C,SUITE_C_TEST_A,
-//                        TestClassGThreeMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-//                                TestClassHFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-//                                TestClassIFiveMethodsWithNoDepsSample.class,
-//                        10});
-
         System.out.println("Suite: " + SUITE_C + ", Test: " + SUITE_C_TEST_A + ", Test classes: " +
                 TestClassGThreeMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
                 TestClassHFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
                 TestClassIFiveMethodsWithNoDepsSample.class + ". Thread count: 10");
 
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-//                new Object[]{SUITE_C,SUITE_C_TEST_B,
-//                        TestClassJFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-//                                TestClassKFiveMethodsWithNoDepsSample.class,
-//                        5});
-
         System.out.println("Suite: " + SUITE_C + ", Test: " + SUITE_C_TEST_B + ", Test classes: " +
                 TestClassJFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
                 TestClassKFiveMethodsWithNoDepsSample.class + ". Thread count: 5");
-
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-//                new Object[]{SUITE_C,SUITE_C_TEST_C,
-//                        TestClassLThreeMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-//                                TestClassMFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-//                                TestClassNFiveMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-//                                TestClassOSixMethodsWithNoDepsSample.class.getCanonicalName(),
-//                        12});
 
         System.out.println("Suite: " + SUITE_C + ", Test: " + SUITE_C_TEST_C + ", Test classes: " +
                 TestClassLThreeMethodsWithNoDepsSample.class.getCanonicalName() + ", " +

--- a/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase2Scenario2.java
+++ b/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase2Scenario2.java
@@ -6,6 +6,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.testng.xml.XmlSuite;
 import org.testng.xml.XmlTest;
+
 import test.thread.parallelization.sample.TestClassAFiveMethodsWithNoDepsSample;
 import test.thread.parallelization.sample.TestClassBFourMethodsWithNoDepsSample;
 import test.thread.parallelization.sample.TestClassCSixMethodsWithNoDepsSample;
@@ -213,45 +214,77 @@ public class ParallelByMethodsTestCase2Scenario2 extends BaseParallelizationTest
         tng.setSuiteThreadPoolSize(2);
         tng.addListener((ITestNGListener) new TestNgRunStateListener());
 
-        logger.log(Level.INFO, "Beginning ParallelByMethodsTestCase2Scenario2. This test scenario consists of three " +
+//        logger.log(Level.INFO, "Beginning ParallelByMethodsTestCase2Scenario2. This test scenario consists of three " +
+//                "suites with 1, 2 and 3 tests respectively. The suites run in parallel and the thread pool size is 3 " +
+//                "One test for a suite shall consist of a single test class while the rest shall consist of more than " +
+//                "one test class. There are no dependencies, data providers or factories.");
+
+        System.out.println("Beginning ParallelByMethodsTestCase2Scenario2. This test scenario consists of three " +
                 "suites with 1, 2 and 3 tests respectively. The suites run in parallel and the thread pool size is 3 " +
                 "One test for a suite shall consist of a single test class while the rest shall consist of more than " +
                 "one test class. There are no dependencies, data providers or factories.");
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-                new Object[]{SUITE_A,SUITE_A_TEST_A,TestClassAFiveMethodsWithNoDepsSample.class.getCanonicalName() +
-                        ", " + TestClassCSixMethodsWithNoDepsSample.class.getCanonicalName(), 3});
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
+//                new Object[]{SUITE_A,SUITE_A_TEST_A,TestClassAFiveMethodsWithNoDepsSample.class.getCanonicalName() +
+//                        ", " + TestClassCSixMethodsWithNoDepsSample.class.getCanonicalName(), 3});
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test class: {2}. Thread count: {3}",
-                new Object[]{SUITE_B,SUITE_B_TEST_A,TestClassEFiveMethodsWithNoDepsSample.class.getCanonicalName(), 6});
+        System.out.println("Suite: " + SUITE_A + ", Test: " + SUITE_A_TEST_A + ", Test classes: " +
+                TestClassAFiveMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+                TestClassCSixMethodsWithNoDepsSample.class.getCanonicalName() + ". Thread count: 3");
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-                new Object[]{SUITE_B,SUITE_B_TEST_B,
-                        TestClassDThreeMethodsWithNoDepsSample.class + ", " +
-                                TestClassBFourMethodsWithNoDepsSample.class + ", " +
-                                TestClassFSixMethodsWithNoDepsSample.class,
-                        20});
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test class: {2}. Thread count: {3}",
+//                new Object[]{SUITE_B,SUITE_B_TEST_A,TestClassEFiveMethodsWithNoDepsSample.class.getCanonicalName(), 6});
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-                new Object[]{SUITE_C,SUITE_C_TEST_A,
-                        TestClassGThreeMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-                                TestClassHFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-                                TestClassIFiveMethodsWithNoDepsSample.class,
-                        10});
+        System.out.println("Suite: " + SUITE_B + ", Test: " + SUITE_B_TEST_A + ", Test class: " +
+                TestClassEFiveMethodsWithNoDepsSample.class.getCanonicalName() + ". Thread count: 6");
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-                new Object[]{SUITE_C,SUITE_C_TEST_B,
-                        TestClassJFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-                                TestClassKFiveMethodsWithNoDepsSample.class,
-                        5});
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
+//                new Object[]{SUITE_B,SUITE_B_TEST_B,
+//                        TestClassDThreeMethodsWithNoDepsSample.class + ", " +
+//                                TestClassBFourMethodsWithNoDepsSample.class + ", " +
+//                                TestClassFSixMethodsWithNoDepsSample.class,
+//                        20});
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-                new Object[]{SUITE_C,SUITE_C_TEST_C,
-                        TestClassLThreeMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-                                TestClassMFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-                                TestClassNFiveMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-                                TestClassOSixMethodsWithNoDepsSample.class.getCanonicalName(),
-                        12});
+        System.out.println("Suite: " + SUITE_B + ", Test: " + SUITE_B_TEST_B + ", Test classes: " +
+                TestClassDThreeMethodsWithNoDepsSample.class + ", " +
+                TestClassBFourMethodsWithNoDepsSample.class + ", " +
+                TestClassFSixMethodsWithNoDepsSample.class + ". Thread count: 20");
+
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
+//                new Object[]{SUITE_C,SUITE_C_TEST_A,
+//                        TestClassGThreeMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+//                                TestClassHFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+//                                TestClassIFiveMethodsWithNoDepsSample.class,
+//                        10});
+
+        System.out.println("Suite: " + SUITE_C + ", Test: " + SUITE_C_TEST_A + ", Test classes: " +
+                TestClassGThreeMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+                TestClassHFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+                TestClassIFiveMethodsWithNoDepsSample.class + ". Thread count: 10");
+
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
+//                new Object[]{SUITE_C,SUITE_C_TEST_B,
+//                        TestClassJFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+//                                TestClassKFiveMethodsWithNoDepsSample.class,
+//                        5});
+
+        System.out.println("Suite: " + SUITE_C + ", Test: " + SUITE_C_TEST_B + ", Test classes: " +
+                TestClassJFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+                TestClassKFiveMethodsWithNoDepsSample.class + ". Thread count: 5");
+
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
+//                new Object[]{SUITE_C,SUITE_C_TEST_C,
+//                        TestClassLThreeMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+//                                TestClassMFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+//                                TestClassNFiveMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+//                                TestClassOSixMethodsWithNoDepsSample.class.getCanonicalName(),
+//                        12});
+
+        System.out.println("Suite: " + SUITE_C + ", Test: " + SUITE_C_TEST_C + ", Test classes: " +
+                TestClassLThreeMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+                TestClassMFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+                TestClassNFiveMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+                TestClassOSixMethodsWithNoDepsSample.class.getCanonicalName() + ". Thread count: 12.");
 
         tng.run();
 

--- a/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase3Scenario1.java
+++ b/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase3Scenario1.java
@@ -10,7 +10,6 @@ import org.testng.xml.XmlSuite;
 
 import test.thread.parallelization.TestNgRunStateTracker.EventLog;
 import test.thread.parallelization.sample.TestClassAFiveMethodsWithDataProviderOnAllMethodsAndNoDepsSample;
-import test.thread.parallelization.sample.TestClassAFiveMethodsWithNoDepsSample;
 
 import java.util.HashMap;
 import java.util.List;
@@ -115,13 +114,21 @@ public class ParallelByMethodsTestCase3Scenario1 extends BaseParallelizationTest
 
         tng.addListener((ITestNGListener)new TestNgRunStateListener());
 
-        logger.log(Level.INFO, "Beginning ParallelByMethodsTestCase3Scenario1. This test scenario consists of a " +
+//        logger.log(Level.INFO, "Beginning ParallelByMethodsTestCase3Scenario1. This test scenario consists of a " +
+//                "single suite with a single test consisting of a single test class with five methods with a data " +
+//                "provider specifying 3 sets of data. There are no dependencies or factories.");
+
+        System.out.println("Beginning ParallelByMethodsTestCase3Scenario1. This test scenario consists of a " +
                 "single suite with a single test consisting of a single test class with five methods with a data " +
                 "provider specifying 3 sets of data. There are no dependencies or factories.");
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test class: {2}. Thread count: {3}",
-                new Object[]{SUITE,TEST,
-                        TestClassAFiveMethodsWithDataProviderOnAllMethodsAndNoDepsSample.class.getCanonicalName(), 15});
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test class: {2}. Thread count: {3}",
+//                new Object[]{SUITE,TEST,
+//                        TestClassAFiveMethodsWithDataProviderOnAllMethodsAndNoDepsSample.class.getCanonicalName(), 15});
+
+        System.out.println("Suite: " + SUITE + ", Test: " + TEST + ", Test class: "
+                + TestClassAFiveMethodsWithDataProviderOnAllMethodsAndNoDepsSample.class.getCanonicalName() +
+                ". Thread count: 15");
 
         tng.run();
 

--- a/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase3Scenario1.java
+++ b/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase3Scenario1.java
@@ -54,12 +54,6 @@ import static test.thread.parallelization.TestNgRunStateTracker.reset;
  */
 public class ParallelByMethodsTestCase3Scenario1 extends BaseParallelizationTest {
 
-    private static final Logger logger = Logger.getLogger(ParallelByMethodsTestCase3Scenario1.class.getCanonicalName());
-
-    {
-        logger.setLevel(Level.INFO);
-    }
-
     private static final String SUITE = "SingleTestSuite";
     private static final String TEST = "SingleTestClassTest";
 
@@ -114,17 +108,9 @@ public class ParallelByMethodsTestCase3Scenario1 extends BaseParallelizationTest
 
         tng.addListener((ITestNGListener)new TestNgRunStateListener());
 
-//        logger.log(Level.INFO, "Beginning ParallelByMethodsTestCase3Scenario1. This test scenario consists of a " +
-//                "single suite with a single test consisting of a single test class with five methods with a data " +
-//                "provider specifying 3 sets of data. There are no dependencies or factories.");
-
         System.out.println("Beginning ParallelByMethodsTestCase3Scenario1. This test scenario consists of a " +
                 "single suite with a single test consisting of a single test class with five methods with a data " +
                 "provider specifying 3 sets of data. There are no dependencies or factories.");
-
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test class: {2}. Thread count: {3}",
-//                new Object[]{SUITE,TEST,
-//                        TestClassAFiveMethodsWithDataProviderOnAllMethodsAndNoDepsSample.class.getCanonicalName(), 15});
 
         System.out.println("Suite: " + SUITE + ", Test: " + TEST + ", Test class: "
                 + TestClassAFiveMethodsWithDataProviderOnAllMethodsAndNoDepsSample.class.getCanonicalName() +
@@ -218,13 +204,10 @@ public class ParallelByMethodsTestCase3Scenario1 extends BaseParallelizationTest
     //Verifies that the test methods execute in different threads in parallel fashion.
     @Test
     public void verifyThatTestMethodsRunInParallelThreads() {
-
         verifyParallelTestMethodsWithNonParallelDataProvider(
                 getTestMethodLevelEventLogsForTest(SUITE, TEST), TEST, expectedInvocationCounts,
                 5, 5
         );
-
-        //verifySimultaneousTestMethods(testMethodLevelEventLogs, TEST, 5);
     }
 
     //Verifies that all the test method level events for any given test method run in the same thread.

--- a/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase3Scenario2.java
+++ b/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase3Scenario2.java
@@ -62,12 +62,6 @@ import static test.thread.parallelization.TestNgRunStateTracker.reset;
  */
 public class ParallelByMethodsTestCase3Scenario2 extends BaseParallelizationTest {
 
-    private static final Logger logger = Logger.getLogger(ParallelByMethodsTestCase3Scenario2.class.getCanonicalName());
-
-    {
-        logger.setLevel(Level.INFO);
-    }
-
     private static final String SUITE_A = "TestSuiteA";
     private static final String SUITE_B = "TestSuiteB";
 
@@ -145,41 +139,20 @@ public class ParallelByMethodsTestCase3Scenario2 extends BaseParallelizationTest
         TestNG tng = create(suiteOne, suiteTwo);
         tng.addListener((ITestNGListener) new TestNgRunStateListener());
 
-//        logger.log(Level.INFO, "Beginning ParallelByMethodsTestCase3Scenario2. This test scenario consists of two " +
-//                "suites with 1 and 2 tests respectively. One test for a suite shall consist of a single test class " +
-//                "while the rest shall consist of more than one test class. Each test class has some methods with use " +
-//                "a data provider and some which do not. Two data providers are used: one which provides two sets of " +
-//                "data, one which provide three sets of data. There are no dependencies or factories.");
-
         System.out.println("Beginning ParallelByMethodsTestCase3Scenario2. This test scenario consists of two " +
                 "suites with 1 and 2 tests respectively. One test for a suite shall consist of a single test class " +
                 "while the rest shall consist of more than one test class. Each test class has some methods with use " +
                 "a data provider and some which do not. Two data providers are used: one which provides two sets of " +
                 "data, one which provide three sets of data. There are no dependencies or factories.");
 
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-//                new Object[]{SUITE_A,SUITE_A_TEST_A,
-//                        TestClassAFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() +
-//                        ", " + TestClassBSixMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName(), 3});
-
         System.out.println("Suite: " + SUITE_A + ", Test: " + SUITE_A_TEST_A + ", Test classes: " +
                 TestClassAFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() + ", " +
                 TestClassBSixMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() +
                 ". Thread count: 3");
 
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test class: {2}. Thread count: {3}",
-//                new Object[]{SUITE_B,SUITE_B_TEST_A,
-//                        TestClassCFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName(), 4});
-
         System.out.println("Suite: " + SUITE_B + ", Test: " + SUITE_B_TEST_A + ", Test class: " +
                 TestClassCFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() +
                 ". Thread count: 4");
-
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-//                new Object[]{SUITE_B,SUITE_B_TEST_B,
-//                        TestClassDThreeMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() + ", " +
-//                                TestClassEFourMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() + ", " +
-//                                TestClassFSixMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName(), 4});
 
         System.out.println("Suite: " + SUITE_B + ", Test: " + SUITE_B_TEST_B + ", Test classes: " +
                 TestClassDThreeMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class + ", " +

--- a/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase3Scenario2.java
+++ b/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase3Scenario2.java
@@ -145,26 +145,46 @@ public class ParallelByMethodsTestCase3Scenario2 extends BaseParallelizationTest
         TestNG tng = create(suiteOne, suiteTwo);
         tng.addListener((ITestNGListener) new TestNgRunStateListener());
 
-        logger.log(Level.INFO, "Beginning ParallelByMethodsTestCase3Scenario2. This test scenario consists of two " +
+//        logger.log(Level.INFO, "Beginning ParallelByMethodsTestCase3Scenario2. This test scenario consists of two " +
+//                "suites with 1 and 2 tests respectively. One test for a suite shall consist of a single test class " +
+//                "while the rest shall consist of more than one test class. Each test class has some methods with use " +
+//                "a data provider and some which do not. Two data providers are used: one which provides two sets of " +
+//                "data, one which provide three sets of data. There are no dependencies or factories.");
+
+        System.out.println("Beginning ParallelByMethodsTestCase3Scenario2. This test scenario consists of two " +
                 "suites with 1 and 2 tests respectively. One test for a suite shall consist of a single test class " +
                 "while the rest shall consist of more than one test class. Each test class has some methods with use " +
                 "a data provider and some which do not. Two data providers are used: one which provides two sets of " +
                 "data, one which provide three sets of data. There are no dependencies or factories.");
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-                new Object[]{SUITE_A,SUITE_A_TEST_A,
-                        TestClassAFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() +
-                        ", " + TestClassBSixMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName(), 3});
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
+//                new Object[]{SUITE_A,SUITE_A_TEST_A,
+//                        TestClassAFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() +
+//                        ", " + TestClassBSixMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName(), 3});
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test class: {2}. Thread count: {3}",
-                new Object[]{SUITE_B,SUITE_B_TEST_A,
-                        TestClassCFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName(), 4});
+        System.out.println("Suite: " + SUITE_A + ", Test: " + SUITE_A_TEST_A + ", Test classes: " +
+                TestClassAFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() + ", " +
+                TestClassBSixMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() +
+                ". Thread count: 3");
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-                new Object[]{SUITE_B,SUITE_B_TEST_B,
-                        TestClassDThreeMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() + ", " +
-                                TestClassEFourMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() + ", " +
-                                TestClassFSixMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName(), 4});
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test class: {2}. Thread count: {3}",
+//                new Object[]{SUITE_B,SUITE_B_TEST_A,
+//                        TestClassCFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName(), 4});
+
+        System.out.println("Suite: " + SUITE_B + ", Test: " + SUITE_B_TEST_A + ", Test class: " +
+                TestClassCFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() +
+                ". Thread count: 4");
+
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
+//                new Object[]{SUITE_B,SUITE_B_TEST_B,
+//                        TestClassDThreeMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() + ", " +
+//                                TestClassEFourMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() + ", " +
+//                                TestClassFSixMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName(), 4});
+
+        System.out.println("Suite: " + SUITE_B + ", Test: " + SUITE_B_TEST_B + ", Test classes: " +
+                TestClassDThreeMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class + ", " +
+                TestClassEFourMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class + ", " +
+                TestClassFSixMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class + ". Thread count: 4");
 
         tng.run();
 

--- a/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase4Scenario1.java
+++ b/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase4Scenario1.java
@@ -233,49 +233,87 @@ public class ParallelByMethodsTestCase4Scenario1 extends BaseParallelizationTest
         tng.setSuiteThreadPoolSize(2);
         tng.addListener((ITestNGListener) new TestNgRunStateListener());
 
-        logger.log(Level.INFO, "Beginning ParallelByMethodsTestCase4Scenario1. This test scenario consists of three " +
+//        logger.log(Level.INFO, "Beginning ParallelByMethodsTestCase4Scenario1. This test scenario consists of three " +
+//                "suites with 1, 2 and 3 tests respectively. The suites run in parallel and the thread pool size is " +
+//                "2. One test for a suite shall consist of a single test class while the rest shall consist of more " +
+//                "han one test class. Some test classes have a mixture of some methods that use a data provider and " +
+//                "some which do not. The data providers provide data sets of varying sizes. There are no " +
+//                "dependencies or factories.");
+
+        System.out.println("Beginning ParallelByMethodsTestCase4Scenario1. This test scenario consists of three " +
                 "suites with 1, 2 and 3 tests respectively. The suites run in parallel and the thread pool size is " +
                 "2. One test for a suite shall consist of a single test class while the rest shall consist of more " +
                 "han one test class. Some test classes have a mixture of some methods that use a data provider and " +
                 "some which do not. The data providers provide data sets of varying sizes. There are no " +
                 "dependencies or factories.");
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-                new Object[]{SUITE_A,SUITE_A_TEST_A,
-                        TestClassAFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() +
-                                ", " + TestClassBSixMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName(), 3});
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
+//                new Object[]{SUITE_A,SUITE_A_TEST_A,
+//                        TestClassAFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() +
+//                                ", " + TestClassBSixMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName(), 3});
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test class: {2}. Thread count: {3}",
-                new Object[]{SUITE_B,SUITE_B_TEST_A,
-                        TestClassCFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName(), 6});
+        System.out.println("Suite: " + SUITE_A + ", Test: " + SUITE_A_TEST_A + ", Test classes: " +
+                TestClassAFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() + ", " +
+                TestClassBSixMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() +
+                ". Thread count: 3");
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-                new Object[]{SUITE_B,SUITE_B_TEST_B,
-                        TestClassDThreeMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class + ", " +
-                                TestClassEFourMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class + ", " +
-                                TestClassFSixMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class,
-                        20});
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test class: {2}. Thread count: {3}",
+//                new Object[]{SUITE_B,SUITE_B_TEST_A,
+//                        TestClassCFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName(), 6});
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-                new Object[]{SUITE_C,SUITE_C_TEST_A,
-                        TestClassDThreeMethodsWithDataProviderOnAllMethodsAndNoDepsSample.class.getCanonicalName() + ", " +
-                                TestClassGFourMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() + ", " +
-                                TestClassAFiveMethodsWithDataProviderOnAllMethodsAndNoDepsSample.class,
-                        10});
+        System.out.println("Suite: " + SUITE_B + ", Test: " + SUITE_B_TEST_A + ", Test class: " +
+                TestClassCFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() +
+                ". Thread count: 6");
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-                new Object[]{SUITE_C,SUITE_C_TEST_B,
-                        TestClassBFourMethodsWithDataProviderOnAllMethodsAndNoDepsSample.class.getCanonicalName() + ", " +
-                                TestClassHFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class,
-                        5});
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
+//                new Object[]{SUITE_B,SUITE_B_TEST_B,
+//                        TestClassDThreeMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class + ", " +
+//                                TestClassEFourMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class + ", " +
+//                                TestClassFSixMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class,
+//                        20});
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-                new Object[]{SUITE_C,SUITE_C_TEST_C,
-                        TestClassIThreeMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() + ", " +
-                                TestClassJFourMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() + ", " +
-                                TestClassKFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() + ", " +
-                                TestClassBSixMethodsWithDataProviderOnAllMethodsAndNoDepsSample.class.getCanonicalName(),
-                        12});
+        System.out.println("Suite: " + SUITE_B + ", Test: " + SUITE_B_TEST_B + ", Test classes: " +
+                TestClassDThreeMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class + ", " +
+                TestClassEFourMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class + ", " +
+                TestClassFSixMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class + ". Thread count: 20");
+
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
+//                new Object[]{SUITE_C,SUITE_C_TEST_A,
+//                        TestClassDThreeMethodsWithDataProviderOnAllMethodsAndNoDepsSample.class.getCanonicalName() + ", " +
+//                                TestClassGFourMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() + ", " +
+//                                TestClassAFiveMethodsWithDataProviderOnAllMethodsAndNoDepsSample.class,
+//                        10});
+
+        System.out.println("Suite: " + SUITE_C + ", Test: " + SUITE_C_TEST_A + ", Test classes: " +
+                TestClassDThreeMethodsWithDataProviderOnAllMethodsAndNoDepsSample.class.getCanonicalName() + ", " +
+                TestClassGFourMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() + ", " +
+                TestClassAFiveMethodsWithDataProviderOnAllMethodsAndNoDepsSample.class + ". Thread count: 10");
+
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
+//                new Object[]{SUITE_C,SUITE_C_TEST_B,
+//                        TestClassBFourMethodsWithDataProviderOnAllMethodsAndNoDepsSample.class.getCanonicalName() + ", " +
+//                                TestClassHFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class,
+//                        5});
+
+        System.out.println("Suite: " + SUITE_C + ", Test: " + SUITE_C_TEST_B + ", Test classes: " +
+                TestClassBFourMethodsWithDataProviderOnAllMethodsAndNoDepsSample.class.getCanonicalName() + ", " +
+                TestClassHFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class + ". Thread count: 5");
+
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
+//                new Object[]{SUITE_C,SUITE_C_TEST_C,
+//                        TestClassIThreeMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() + ", " +
+//                                TestClassJFourMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() + ", " +
+//                                TestClassKFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() + ", " +
+//                                TestClassBSixMethodsWithDataProviderOnAllMethodsAndNoDepsSample.class.getCanonicalName(),
+//                        12});
+
+        System.out.println("Suite: " + SUITE_C + ", Test: " + SUITE_C_TEST_C + ", Test classes: " +
+                TestClassIThreeMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() + ", " +
+                TestClassJFourMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() + ", " +
+                TestClassKFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() + ", " +
+                TestClassBSixMethodsWithDataProviderOnAllMethodsAndNoDepsSample.class.getCanonicalName() +
+                ". Thread count: 12.");
+
 
         tng.run();
 

--- a/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase4Scenario1.java
+++ b/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase4Scenario1.java
@@ -81,12 +81,6 @@ import static test.thread.parallelization.TestNgRunStateTracker.reset;
  */
 public class ParallelByMethodsTestCase4Scenario1 extends BaseParallelizationTest {
 
-    private static final Logger logger = Logger.getLogger(ParallelByMethodsTestCase4Scenario1.class.getCanonicalName());
-
-    {
-        logger.setLevel(Level.INFO);
-    }
-
     private static final String SUITE_A = "TestSuiteA";
     private static final String SUITE_B = "TestSuiteB";
     private static final String SUITE_C = "TestSuiteC";
@@ -233,13 +227,6 @@ public class ParallelByMethodsTestCase4Scenario1 extends BaseParallelizationTest
         tng.setSuiteThreadPoolSize(2);
         tng.addListener((ITestNGListener) new TestNgRunStateListener());
 
-//        logger.log(Level.INFO, "Beginning ParallelByMethodsTestCase4Scenario1. This test scenario consists of three " +
-//                "suites with 1, 2 and 3 tests respectively. The suites run in parallel and the thread pool size is " +
-//                "2. One test for a suite shall consist of a single test class while the rest shall consist of more " +
-//                "han one test class. Some test classes have a mixture of some methods that use a data provider and " +
-//                "some which do not. The data providers provide data sets of varying sizes. There are no " +
-//                "dependencies or factories.");
-
         System.out.println("Beginning ParallelByMethodsTestCase4Scenario1. This test scenario consists of three " +
                 "suites with 1, 2 and 3 tests respectively. The suites run in parallel and the thread pool size is " +
                 "2. One test for a suite shall consist of a single test class while the rest shall consist of more " +
@@ -247,65 +234,28 @@ public class ParallelByMethodsTestCase4Scenario1 extends BaseParallelizationTest
                 "some which do not. The data providers provide data sets of varying sizes. There are no " +
                 "dependencies or factories.");
 
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-//                new Object[]{SUITE_A,SUITE_A_TEST_A,
-//                        TestClassAFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() +
-//                                ", " + TestClassBSixMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName(), 3});
-
         System.out.println("Suite: " + SUITE_A + ", Test: " + SUITE_A_TEST_A + ", Test classes: " +
                 TestClassAFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() + ", " +
                 TestClassBSixMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() +
                 ". Thread count: 3");
 
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test class: {2}. Thread count: {3}",
-//                new Object[]{SUITE_B,SUITE_B_TEST_A,
-//                        TestClassCFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName(), 6});
-
         System.out.println("Suite: " + SUITE_B + ", Test: " + SUITE_B_TEST_A + ", Test class: " +
                 TestClassCFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() +
                 ". Thread count: 6");
-
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-//                new Object[]{SUITE_B,SUITE_B_TEST_B,
-//                        TestClassDThreeMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class + ", " +
-//                                TestClassEFourMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class + ", " +
-//                                TestClassFSixMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class,
-//                        20});
 
         System.out.println("Suite: " + SUITE_B + ", Test: " + SUITE_B_TEST_B + ", Test classes: " +
                 TestClassDThreeMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class + ", " +
                 TestClassEFourMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class + ", " +
                 TestClassFSixMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class + ". Thread count: 20");
 
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-//                new Object[]{SUITE_C,SUITE_C_TEST_A,
-//                        TestClassDThreeMethodsWithDataProviderOnAllMethodsAndNoDepsSample.class.getCanonicalName() + ", " +
-//                                TestClassGFourMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() + ", " +
-//                                TestClassAFiveMethodsWithDataProviderOnAllMethodsAndNoDepsSample.class,
-//                        10});
-
         System.out.println("Suite: " + SUITE_C + ", Test: " + SUITE_C_TEST_A + ", Test classes: " +
                 TestClassDThreeMethodsWithDataProviderOnAllMethodsAndNoDepsSample.class.getCanonicalName() + ", " +
                 TestClassGFourMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() + ", " +
                 TestClassAFiveMethodsWithDataProviderOnAllMethodsAndNoDepsSample.class + ". Thread count: 10");
 
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-//                new Object[]{SUITE_C,SUITE_C_TEST_B,
-//                        TestClassBFourMethodsWithDataProviderOnAllMethodsAndNoDepsSample.class.getCanonicalName() + ", " +
-//                                TestClassHFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class,
-//                        5});
-
         System.out.println("Suite: " + SUITE_C + ", Test: " + SUITE_C_TEST_B + ", Test classes: " +
                 TestClassBFourMethodsWithDataProviderOnAllMethodsAndNoDepsSample.class.getCanonicalName() + ", " +
                 TestClassHFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class + ". Thread count: 5");
-
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-//                new Object[]{SUITE_C,SUITE_C_TEST_C,
-//                        TestClassIThreeMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() + ", " +
-//                                TestClassJFourMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() + ", " +
-//                                TestClassKFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() + ", " +
-//                                TestClassBSixMethodsWithDataProviderOnAllMethodsAndNoDepsSample.class.getCanonicalName(),
-//                        12});
 
         System.out.println("Suite: " + SUITE_C + ", Test: " + SUITE_C_TEST_C + ", Test classes: " +
                 TestClassIThreeMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.class.getCanonicalName() + ", " +

--- a/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase5Scenario1.java
+++ b/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase5Scenario1.java
@@ -51,12 +51,6 @@ import static test.thread.parallelization.TestNgRunStateTracker.reset;
  */
 public class ParallelByMethodsTestCase5Scenario1 extends BaseParallelizationTest {
 
-    private static final Logger logger = Logger.getLogger(ParallelByMethodsTestCase5Scenario1.class.getCanonicalName());
-
-    {
-        logger.setLevel(Level.INFO);
-    }
-
     private static final String SUITE = "SingleTestSuite";
     private static final String TEST = "SingleTestClassTest";
 
@@ -89,16 +83,9 @@ public class ParallelByMethodsTestCase5Scenario1 extends BaseParallelizationTest
 
         tng.addListener((ITestNGListener)new TestNgRunStateListener());
 
-//        logger.log(Level.INFO, "Beginning ParallelByMethodsTestCase5Scenario1. This test scenario consists of a " +
-//                "single suite with a single test consisting of a factory that provides two instances of a single\n" +
-//                "test class with five methods. There are no dependencies or data providers.");
-
         System.out.println("Beginning ParallelByMethodsTestCase5Scenario1. This test scenario consists of a " +
                 "single suite with a single test consisting of a factory that provides two instances of a single" +
                 "test class with five methods. There are no dependencies or data providers.");
-
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test class: {2}. Thread count: {3}",
-//                new Object[]{SUITE,TEST, TestClassAFiveMethodsWithNoDepsSample.class.getCanonicalName(), 15});
 
         System.out.println("Suite: " + SUITE + ", Test: " + TEST + ", Test class: "
                 + TestClassAFiveMethodsWithNoDepsSample.class.getCanonicalName() +". Thread count: 15");

--- a/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase5Scenario1.java
+++ b/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase5Scenario1.java
@@ -89,12 +89,19 @@ public class ParallelByMethodsTestCase5Scenario1 extends BaseParallelizationTest
 
         tng.addListener((ITestNGListener)new TestNgRunStateListener());
 
-        logger.log(Level.INFO, "Beginning ParallelByMethodsTestCase5Scenario1. This test scenario consists of a " +
-                "single suite with a single test consisting of a factory that provides two instances of a single\n" +
+//        logger.log(Level.INFO, "Beginning ParallelByMethodsTestCase5Scenario1. This test scenario consists of a " +
+//                "single suite with a single test consisting of a factory that provides two instances of a single\n" +
+//                "test class with five methods. There are no dependencies or data providers.");
+
+        System.out.println("Beginning ParallelByMethodsTestCase5Scenario1. This test scenario consists of a " +
+                "single suite with a single test consisting of a factory that provides two instances of a single" +
                 "test class with five methods. There are no dependencies or data providers.");
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test class: {2}. Thread count: {3}",
-                new Object[]{SUITE,TEST, TestClassAFiveMethodsWithNoDepsSample.class.getCanonicalName(), 15});
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test class: {2}. Thread count: {3}",
+//                new Object[]{SUITE,TEST, TestClassAFiveMethodsWithNoDepsSample.class.getCanonicalName(), 15});
+
+        System.out.println("Suite: " + SUITE + ", Test: " + TEST + ", Test class: "
+                + TestClassAFiveMethodsWithNoDepsSample.class.getCanonicalName() +". Thread count: 15");
 
         tng.run();
 

--- a/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase5Scenario2.java
+++ b/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase5Scenario2.java
@@ -69,12 +69,6 @@ import static test.thread.parallelization.TestNgRunStateTracker.reset;
  */
 public class ParallelByMethodsTestCase5Scenario2 extends BaseParallelizationTest {
 
-    private static final Logger logger = Logger.getLogger(ParallelByMethodsTestCase5Scenario2.class.getCanonicalName());
-
-    {
-        logger.setLevel(Level.INFO);
-    }
-
     private static final String SUITE_A = "TestSuiteA";
     private static final String SUITE_B = "TestSuiteB";
 
@@ -154,38 +148,18 @@ public class ParallelByMethodsTestCase5Scenario2 extends BaseParallelizationTest
         TestNG tng = create(suiteOne, suiteTwo);
         tng.addListener((ITestNGListener) new TestNgRunStateListener());
 
-//        logger.log(Level.INFO, "Beginning ParallelByMethodsTestCase5Scenario2. This test scenario consists of two " +
-//                "suites with 1 and 2 tests respectively. One suite with two tests has a test consisting of a single " +
-//                "test class without a factory while the other consists of factories which provide multiple instances " +
-//                "of multiple test classes. One suite shall consist of a single test with multiple test classes which " +
-//                "uses factories. There are no dependencies or data providers.");
-
         System.out.println("Beginning ParallelByMethodsTestCase5Scenario2. This test scenario consists of two " +
                 "suites with 1 and 2 tests respectively. One suite with two tests has a test consisting of a single " +
                 "test class without a factory while the other consists of factories which provide multiple instances " +
                 "of multiple test classes. One suite shall consist of a single test with multiple test classes which " +
                 "uses factories. There are no dependencies or data providers.");
 
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-//                new Object[]{SUITE_A,SUITE_A_TEST_A,TestClassAFiveMethodsWithNoDepsSample.class.getCanonicalName() +
-//                        ", " + TestClassCSixMethodsWithNoDepsSample.class.getCanonicalName(), 10});
-
         System.out.println("Suite: " + SUITE_A + ", Test: " + SUITE_A_TEST_A + ", Test classes: " +
                 TestClassAFiveMethodsWithNoDepsSample.class.getCanonicalName() +
                 ", " + TestClassCSixMethodsWithNoDepsSample.class.getCanonicalName() + ". Thread count: 10");
 
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test class: {2}. Thread count: {3}",
-//                new Object[]{SUITE_B,SUITE_B_TEST_A,TestClassEFiveMethodsWithNoDepsSample.class.getCanonicalName(), 3});
-
         System.out.println("Suite: " + SUITE_B + ", Test: " + SUITE_B_TEST_A + ", Test class: " +
                 TestClassEFiveMethodsWithNoDepsSample.class.getCanonicalName() + ". Thread count: 3");
-
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-//                new Object[]{SUITE_B,SUITE_B_TEST_B,
-//                        TestClassDThreeMethodsWithNoDepsSample.class + ", " +
-//                                TestClassBFourMethodsWithNoDepsSample.class + ", " +
-//                                TestClassFSixMethodsWithNoDepsSample.class,
-//                        20});
 
         System.out.println("Suite " + SUITE_B + ", Test: " + SUITE_B_TEST_B + ", Test classes: " +
                 TestClassDThreeMethodsWithNoDepsSample.class + ", " +

--- a/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase5Scenario2.java
+++ b/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase5Scenario2.java
@@ -13,17 +13,11 @@ import test.thread.parallelization.sample.FactoryForTestClassCSixMethodsWithNoDe
 import test.thread.parallelization.sample.FactoryForTestClassDThreeMethodsWithNoDepsFourInstancesSample;
 import test.thread.parallelization.sample.FactoryForTestClassFSixMethodsWithNoDepsSixInstancesSample;
 
-import test.thread.parallelization.sample.TestClassAFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample;
 import test.thread.parallelization.sample.TestClassAFiveMethodsWithNoDepsSample;
 import test.thread.parallelization.sample.TestClassBFourMethodsWithNoDepsSample;
-import test.thread.parallelization.sample.TestClassBSixMethodsWithDataProviderOnSomeMethodsAndNoDepsSample;
-import test.thread.parallelization.sample.TestClassCFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample;
 import test.thread.parallelization.sample.TestClassCSixMethodsWithNoDepsSample;
-import test.thread.parallelization.sample.TestClassDThreeMethodsWithDataProviderOnSomeMethodsAndNoDepsSample;
 import test.thread.parallelization.sample.TestClassDThreeMethodsWithNoDepsSample;
 import test.thread.parallelization.sample.TestClassEFiveMethodsWithNoDepsSample;
-import test.thread.parallelization.sample.TestClassEFourMethodsWithDataProviderOnSomeMethodsAndNoDepsSample;
-import test.thread.parallelization.sample.TestClassFSixMethodsWithDataProviderOnSomeMethodsAndNoDepsSample;
 import test.thread.parallelization.sample.TestClassFSixMethodsWithNoDepsSample;
 
 import java.util.Arrays;
@@ -160,25 +154,43 @@ public class ParallelByMethodsTestCase5Scenario2 extends BaseParallelizationTest
         TestNG tng = create(suiteOne, suiteTwo);
         tng.addListener((ITestNGListener) new TestNgRunStateListener());
 
-        logger.log(Level.INFO, "Beginning ParallelByMethodsTestCase5Scenario2. This test scenario consists of two " +
+//        logger.log(Level.INFO, "Beginning ParallelByMethodsTestCase5Scenario2. This test scenario consists of two " +
+//                "suites with 1 and 2 tests respectively. One suite with two tests has a test consisting of a single " +
+//                "test class without a factory while the other consists of factories which provide multiple instances " +
+//                "of multiple test classes. One suite shall consist of a single test with multiple test classes which " +
+//                "uses factories. There are no dependencies or data providers.");
+
+        System.out.println("Beginning ParallelByMethodsTestCase5Scenario2. This test scenario consists of two " +
                 "suites with 1 and 2 tests respectively. One suite with two tests has a test consisting of a single " +
                 "test class without a factory while the other consists of factories which provide multiple instances " +
                 "of multiple test classes. One suite shall consist of a single test with multiple test classes which " +
                 "uses factories. There are no dependencies or data providers.");
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-                new Object[]{SUITE_A,SUITE_A_TEST_A,TestClassAFiveMethodsWithNoDepsSample.class.getCanonicalName() +
-                        ", " + TestClassCSixMethodsWithNoDepsSample.class.getCanonicalName(), 10});
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
+//                new Object[]{SUITE_A,SUITE_A_TEST_A,TestClassAFiveMethodsWithNoDepsSample.class.getCanonicalName() +
+//                        ", " + TestClassCSixMethodsWithNoDepsSample.class.getCanonicalName(), 10});
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test class: {2}. Thread count: {3}",
-                new Object[]{SUITE_B,SUITE_B_TEST_A,TestClassEFiveMethodsWithNoDepsSample.class.getCanonicalName(), 3});
+        System.out.println("Suite: " + SUITE_A + ", Test: " + SUITE_A_TEST_A + ", Test classes: " +
+                TestClassAFiveMethodsWithNoDepsSample.class.getCanonicalName() +
+                ", " + TestClassCSixMethodsWithNoDepsSample.class.getCanonicalName() + ". Thread count: 10");
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-                new Object[]{SUITE_B,SUITE_B_TEST_B,
-                        TestClassDThreeMethodsWithNoDepsSample.class + ", " +
-                                TestClassBFourMethodsWithNoDepsSample.class + ", " +
-                                TestClassFSixMethodsWithNoDepsSample.class,
-                        20});
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test class: {2}. Thread count: {3}",
+//                new Object[]{SUITE_B,SUITE_B_TEST_A,TestClassEFiveMethodsWithNoDepsSample.class.getCanonicalName(), 3});
+
+        System.out.println("Suite: " + SUITE_B + ", Test: " + SUITE_B_TEST_A + ", Test class: " +
+                TestClassEFiveMethodsWithNoDepsSample.class.getCanonicalName() + ". Thread count: 3");
+
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
+//                new Object[]{SUITE_B,SUITE_B_TEST_B,
+//                        TestClassDThreeMethodsWithNoDepsSample.class + ", " +
+//                                TestClassBFourMethodsWithNoDepsSample.class + ", " +
+//                                TestClassFSixMethodsWithNoDepsSample.class,
+//                        20});
+
+        System.out.println("Suite " + SUITE_B + ", Test: " + SUITE_B_TEST_B + ", Test classes: " +
+                TestClassDThreeMethodsWithNoDepsSample.class + ", " +
+                TestClassBFourMethodsWithNoDepsSample.class + ", " +
+                TestClassFSixMethodsWithNoDepsSample.class + ". Thread count: 20");
 
         tng.run();
 

--- a/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase6Scenario1.java
+++ b/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase6Scenario1.java
@@ -84,12 +84,6 @@ import static test.thread.parallelization.TestNgRunStateTracker.reset;
  */
 public class ParallelByMethodsTestCase6Scenario1 extends BaseParallelizationTest {
 
-    private static final Logger logger = Logger.getLogger(ParallelByMethodsTestCase6Scenario1.class.getCanonicalName());
-
-    {
-        logger.setLevel(Level.INFO);
-    }
-
     private static final String SUITE_A = "TestSuiteA";
     private static final String SUITE_B = "TestSuiteB";
     private static final String SUITE_C = "TestSuiteC";
@@ -224,14 +218,6 @@ public class ParallelByMethodsTestCase6Scenario1 extends BaseParallelizationTest
         tng.setSuiteThreadPoolSize(2);
         tng.addListener((ITestNGListener) new TestNgRunStateListener());
 
-//        logger.log(Level.INFO, "Beginning ParallelByMethodsTestCase6Scenario1. This test scenario consists of three " +
-//                "suites with 1, 2 and 3 tests respectively. The suites run in parallel and the thread pool size is " +
-//                "2. One suite with two tests has a test consisting of a single test class without a factory while " +
-//                "the other shall consist of factories which provide multiple instances of multiple test classes. One " +
-//                "suite shall consist of a single test with multiple test classes which uses factories. One suite " +
-//                "shall have multiple tests with multiple classes, none of which use a factory. There are no " +
-//                "dependencies.");
-
         System.out.println("Beginning ParallelByMethodsTestCase6Scenario1. This test scenario consists of three " +
                 "suites with 1, 2 and 3 tests respectively. The suites run in parallel and the thread pool size is " +
                 "2. One suite with two tests has a test consisting of a single test class without a factory while " +
@@ -240,61 +226,26 @@ public class ParallelByMethodsTestCase6Scenario1 extends BaseParallelizationTest
                 "shall have multiple tests with multiple classes, none of which use a factory. There are no " +
                 "dependencies.");
 
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-//                new Object[]{SUITE_A,SUITE_A_TEST_A,TestClassAFiveMethodsWithNoDepsSample.class.getCanonicalName() +
-//                        ", " + TestClassCSixMethodsWithNoDepsSample.class.getCanonicalName(), 10});
-
         System.out.println("Suite: " + SUITE_A + ", Test: " + SUITE_A_TEST_A + ", Test classes: " +
                 TestClassAFiveMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
                 TestClassCSixMethodsWithNoDepsSample.class.getCanonicalName() + ". Thread count: 10");
 
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test class: {2}. Thread count: {3}",
-//                new Object[]{SUITE_B,SUITE_B_TEST_A,TestClassEFiveMethodsWithNoDepsSample.class.getCanonicalName(), 3});
-
         System.out.println("Suite: " + SUITE_B + ", Test: " + SUITE_B_TEST_A + ", Test class: " +
                 TestClassEFiveMethodsWithNoDepsSample.class.getCanonicalName() + ". Thread count: 3");
-
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-//                new Object[]{SUITE_B,SUITE_B_TEST_B,
-//                        TestClassDThreeMethodsWithNoDepsSample.class + ", " +
-//                                TestClassBFourMethodsWithNoDepsSample.class + ", " +
-//                                TestClassFSixMethodsWithNoDepsSample.class,
-//                        20});
 
         System.out.println("Suite " + SUITE_B + ", Test: " + SUITE_B_TEST_B + ", Test classes: " +
                 TestClassDThreeMethodsWithNoDepsSample.class + ", " +
                 TestClassBFourMethodsWithNoDepsSample.class + ", " +
                 TestClassFSixMethodsWithNoDepsSample.class + ". Thread count: 20");
 
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-//                new Object[]{SUITE_C,SUITE_C_TEST_A,
-//                        TestClassGThreeMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-//                                TestClassHFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-//                                TestClassIFiveMethodsWithNoDepsSample.class,
-//                        10});
-
         System.out.println("Suite: " + SUITE_C + ", Test: " + SUITE_C_TEST_A + ", Test classes: " +
                 TestClassGThreeMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
                 TestClassHFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
                 TestClassIFiveMethodsWithNoDepsSample.class + ". Thread count: 10");
 
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-//                new Object[]{SUITE_C,SUITE_C_TEST_B,
-//                        TestClassJFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-//                                TestClassKFiveMethodsWithNoDepsSample.class,
-//                        5});
-
         System.out.println("Suite: " + SUITE_C + ", Test: " + SUITE_C_TEST_B + ", Test classes: " +
                 TestClassJFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
                 TestClassKFiveMethodsWithNoDepsSample.class + ". Thread count: 5");
-
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-//                new Object[]{SUITE_C,SUITE_C_TEST_C,
-//                        TestClassLThreeMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-//                                TestClassMFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-//                                TestClassNFiveMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-//                                TestClassOSixMethodsWithNoDepsSample.class.getCanonicalName(),
-//                        12});
 
         System.out.println("Suite: " + SUITE_C + ", Test: " + SUITE_C_TEST_C + ", Test classes: " +
                 TestClassLThreeMethodsWithNoDepsSample.class.getCanonicalName() + ", " +

--- a/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase6Scenario1.java
+++ b/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase6Scenario1.java
@@ -6,6 +6,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.testng.xml.XmlSuite;
 import org.testng.xml.XmlTest;
+
 import test.thread.parallelization.sample.FactoryForTestClassAFiveMethodsWithNoDepsTwoInstancesSample;
 import test.thread.parallelization.sample.FactoryForTestClassBFourMethodsWithNoDepsFiveInstancesSample;
 import test.thread.parallelization.sample.FactoryForTestClassCSixMethodsWithNoDepsThreeInstancesSample;
@@ -223,7 +224,15 @@ public class ParallelByMethodsTestCase6Scenario1 extends BaseParallelizationTest
         tng.setSuiteThreadPoolSize(2);
         tng.addListener((ITestNGListener) new TestNgRunStateListener());
 
-        logger.log(Level.INFO, "Beginning ParallelByMethodsTestCase6Scenario1. This test scenario consists of three " +
+//        logger.log(Level.INFO, "Beginning ParallelByMethodsTestCase6Scenario1. This test scenario consists of three " +
+//                "suites with 1, 2 and 3 tests respectively. The suites run in parallel and the thread pool size is " +
+//                "2. One suite with two tests has a test consisting of a single test class without a factory while " +
+//                "the other shall consist of factories which provide multiple instances of multiple test classes. One " +
+//                "suite shall consist of a single test with multiple test classes which uses factories. One suite " +
+//                "shall have multiple tests with multiple classes, none of which use a factory. There are no " +
+//                "dependencies.");
+
+        System.out.println("Beginning ParallelByMethodsTestCase6Scenario1. This test scenario consists of three " +
                 "suites with 1, 2 and 3 tests respectively. The suites run in parallel and the thread pool size is " +
                 "2. One suite with two tests has a test consisting of a single test class without a factory while " +
                 "the other shall consist of factories which provide multiple instances of multiple test classes. One " +
@@ -231,40 +240,68 @@ public class ParallelByMethodsTestCase6Scenario1 extends BaseParallelizationTest
                 "shall have multiple tests with multiple classes, none of which use a factory. There are no " +
                 "dependencies.");
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-                new Object[]{SUITE_A,SUITE_A_TEST_A,TestClassAFiveMethodsWithNoDepsSample.class.getCanonicalName() +
-                        ", " + TestClassCSixMethodsWithNoDepsSample.class.getCanonicalName(), 10});
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
+//                new Object[]{SUITE_A,SUITE_A_TEST_A,TestClassAFiveMethodsWithNoDepsSample.class.getCanonicalName() +
+//                        ", " + TestClassCSixMethodsWithNoDepsSample.class.getCanonicalName(), 10});
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test class: {2}. Thread count: {3}",
-                new Object[]{SUITE_B,SUITE_B_TEST_A,TestClassEFiveMethodsWithNoDepsSample.class.getCanonicalName(), 3});
+        System.out.println("Suite: " + SUITE_A + ", Test: " + SUITE_A_TEST_A + ", Test classes: " +
+                TestClassAFiveMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+                TestClassCSixMethodsWithNoDepsSample.class.getCanonicalName() + ". Thread count: 10");
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-                new Object[]{SUITE_B,SUITE_B_TEST_B,
-                        TestClassDThreeMethodsWithNoDepsSample.class + ", " +
-                                TestClassBFourMethodsWithNoDepsSample.class + ", " +
-                                TestClassFSixMethodsWithNoDepsSample.class,
-                        20});
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test class: {2}. Thread count: {3}",
+//                new Object[]{SUITE_B,SUITE_B_TEST_A,TestClassEFiveMethodsWithNoDepsSample.class.getCanonicalName(), 3});
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-                new Object[]{SUITE_C,SUITE_C_TEST_A,
-                        TestClassGThreeMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-                                TestClassHFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-                                TestClassIFiveMethodsWithNoDepsSample.class,
-                        10});
+        System.out.println("Suite: " + SUITE_B + ", Test: " + SUITE_B_TEST_A + ", Test class: " +
+                TestClassEFiveMethodsWithNoDepsSample.class.getCanonicalName() + ". Thread count: 3");
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-                new Object[]{SUITE_C,SUITE_C_TEST_B,
-                        TestClassJFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-                                TestClassKFiveMethodsWithNoDepsSample.class,
-                        5});
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
+//                new Object[]{SUITE_B,SUITE_B_TEST_B,
+//                        TestClassDThreeMethodsWithNoDepsSample.class + ", " +
+//                                TestClassBFourMethodsWithNoDepsSample.class + ", " +
+//                                TestClassFSixMethodsWithNoDepsSample.class,
+//                        20});
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-                new Object[]{SUITE_C,SUITE_C_TEST_C,
-                        TestClassLThreeMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-                                TestClassMFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-                                TestClassNFiveMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-                                TestClassOSixMethodsWithNoDepsSample.class.getCanonicalName(),
-                        12});
+        System.out.println("Suite " + SUITE_B + ", Test: " + SUITE_B_TEST_B + ", Test classes: " +
+                TestClassDThreeMethodsWithNoDepsSample.class + ", " +
+                TestClassBFourMethodsWithNoDepsSample.class + ", " +
+                TestClassFSixMethodsWithNoDepsSample.class + ". Thread count: 20");
+
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
+//                new Object[]{SUITE_C,SUITE_C_TEST_A,
+//                        TestClassGThreeMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+//                                TestClassHFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+//                                TestClassIFiveMethodsWithNoDepsSample.class,
+//                        10});
+
+        System.out.println("Suite: " + SUITE_C + ", Test: " + SUITE_C_TEST_A + ", Test classes: " +
+                TestClassGThreeMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+                TestClassHFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+                TestClassIFiveMethodsWithNoDepsSample.class + ". Thread count: 10");
+
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
+//                new Object[]{SUITE_C,SUITE_C_TEST_B,
+//                        TestClassJFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+//                                TestClassKFiveMethodsWithNoDepsSample.class,
+//                        5});
+
+        System.out.println("Suite: " + SUITE_C + ", Test: " + SUITE_C_TEST_B + ", Test classes: " +
+                TestClassJFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+                TestClassKFiveMethodsWithNoDepsSample.class + ". Thread count: 5");
+
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
+//                new Object[]{SUITE_C,SUITE_C_TEST_C,
+//                        TestClassLThreeMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+//                                TestClassMFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+//                                TestClassNFiveMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+//                                TestClassOSixMethodsWithNoDepsSample.class.getCanonicalName(),
+//                        12});
+
+        System.out.println("Suite: " + SUITE_C + ", Test: " + SUITE_C_TEST_C + ", Test classes: " +
+                TestClassLThreeMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+                TestClassMFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+                TestClassNFiveMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+                TestClassOSixMethodsWithNoDepsSample.class.getCanonicalName() + ". Thread count: 12.");
+
         tng.run();
 
         suiteLevelEventLogs = getAllSuiteLevelEventLogs();

--- a/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase7Scenario1.java
+++ b/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase7Scenario1.java
@@ -32,7 +32,7 @@ import static test.thread.parallelization.TestNgRunStateTracker.reset;
 
 /** This class covers PTP_TC_7, Scenario 1 in the Parallelization Test Plan.
  *
- * Test Case Summary: Parallel by methods mode with sequential test suites using a factory with uses a non-parallel
+ * Test Case Summary: Parallel by methods mode with sequential test suites using a factory which uses a non-parallel
  *                    data provider and there are no dependencies.
  *
  * Scenario Description: Single suite with a single test consisting of a single test class with five methods with a
@@ -52,12 +52,6 @@ import static test.thread.parallelization.TestNgRunStateTracker.reset;
  * 8) There are no method exclusions
  */
 public class ParallelByMethodsTestCase7Scenario1 extends BaseParallelizationTest {
-
-    private static final Logger logger = Logger.getLogger(ParallelByMethodsTestCase7Scenario1.class.getCanonicalName());
-
-    {
-        logger.setLevel(Level.INFO);
-    }
 
     private static final String SUITE = "SingleTestSuite";
     private static final String TEST = "SingleTestClassTest";
@@ -91,17 +85,9 @@ public class ParallelByMethodsTestCase7Scenario1 extends BaseParallelizationTest
 
         tng.addListener((ITestNGListener)new TestNgRunStateListener());
 
-//        logger.log(Level.INFO, "Beginning ParallelByMethodsTestCase7Scenario1. This test scenario consists of a " +
-//                "single suite with a single test consisting of a single test class with five methods with a " +
-//                "factory method using a data provider specifying 3 sets of data. There are no dependencies.");
-
         System.out.println("Beginning ParallelByMethodsTestCase7Scenario1. This test scenario consists of a " +
                 "single suite with a single test consisting of a single test class with five methods with a " +
                 "factory method using a data provider specifying 3 sets of data. There are no dependencies.");
-
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test class: {2}. Thread count: {3}",
-//                new Object[]{SUITE,TEST,
-//                        TestClassAFiveMethodsWithFactoryUsingDataProviderAndNoDepsSample.class.getCanonicalName(), 15});
 
         System.out.println("Suite: " + SUITE + ", Test: " + TEST + ", Test class: "
                 + TestClassAFiveMethodsWithFactoryUsingDataProviderAndNoDepsSample.class.getCanonicalName() +

--- a/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase7Scenario1.java
+++ b/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase7Scenario1.java
@@ -91,13 +91,21 @@ public class ParallelByMethodsTestCase7Scenario1 extends BaseParallelizationTest
 
         tng.addListener((ITestNGListener)new TestNgRunStateListener());
 
-        logger.log(Level.INFO, "Beginning ParallelByMethodsTestCase7Scenario1. This test scenario consists of a " +
+//        logger.log(Level.INFO, "Beginning ParallelByMethodsTestCase7Scenario1. This test scenario consists of a " +
+//                "single suite with a single test consisting of a single test class with five methods with a " +
+//                "factory method using a data provider specifying 3 sets of data. There are no dependencies.");
+
+        System.out.println("Beginning ParallelByMethodsTestCase7Scenario1. This test scenario consists of a " +
                 "single suite with a single test consisting of a single test class with five methods with a " +
                 "factory method using a data provider specifying 3 sets of data. There are no dependencies.");
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test class: {2}. Thread count: {3}",
-                new Object[]{SUITE,TEST,
-                        TestClassAFiveMethodsWithFactoryUsingDataProviderAndNoDepsSample.class.getCanonicalName(), 15});
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test class: {2}. Thread count: {3}",
+//                new Object[]{SUITE,TEST,
+//                        TestClassAFiveMethodsWithFactoryUsingDataProviderAndNoDepsSample.class.getCanonicalName(), 15});
+
+        System.out.println("Suite: " + SUITE + ", Test: " + TEST + ", Test class: "
+                + TestClassAFiveMethodsWithFactoryUsingDataProviderAndNoDepsSample.class.getCanonicalName() +
+                ". Thread count: 15");
 
         tng.run();
 

--- a/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase7Scenario2.java
+++ b/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase7Scenario2.java
@@ -8,16 +8,11 @@ import org.testng.xml.XmlSuite;
 import org.testng.xml.XmlTest;
 
 import test.thread.parallelization.sample.TestClassAFiveMethodsWithFactoryUsingDataProviderAndNoDepsSample;
-import test.thread.parallelization.sample.TestClassAFiveMethodsWithNoDepsSample;
 import test.thread.parallelization.sample.TestClassBFourMethodsWithFactoryUsingDataProviderAndNoDepsSample;
-import test.thread.parallelization.sample.TestClassBFourMethodsWithNoDepsSample;
 import test.thread.parallelization.sample.TestClassCSixMethodsWithFactoryUsingDataProviderAndNoDepsSample;
-import test.thread.parallelization.sample.TestClassCSixMethodsWithNoDepsSample;
 import test.thread.parallelization.sample.TestClassDThreeMethodsWithFactoryUsingDataProviderAndNoDepsSample;
-import test.thread.parallelization.sample.TestClassDThreeMethodsWithNoDepsSample;
 import test.thread.parallelization.sample.TestClassEFiveMethodsWithNoDepsSample;
 import test.thread.parallelization.sample.TestClassFSixMethodsWithFactoryUsingDataProviderAndNoDepsSample;
-import test.thread.parallelization.sample.TestClassFSixMethodsWithNoDepsSample;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -168,27 +163,47 @@ public class ParallelByMethodsTestCase7Scenario2 extends BaseParallelizationTest
         TestNG tng = create(suiteOne, suiteTwo);
         tng.addListener((ITestNGListener) new TestNgRunStateListener());
 
-        logger.log(Level.INFO, "Beginning ParallelByMethodsTestCase7Scenario2. This test scenario consists of two " +
+//        logger.log(Level.INFO, "Beginning ParallelByMethodsTestCase7Scenario2. This test scenario consists of two " +
+//                "suites with 1 and 2 tests respectively. One suite with two tests has a test consisting of a single " +
+//                "test class without a factory while the other consists of factories using data providers with " +
+//                "varying numbers of data sets which provide multiple instances of multiple test classes. One suite " +
+//                "shall consist of a single test with multiple test classes which use factories with data providers " +
+//                "with varying numbers of data sets. There are no dependencies.");
+
+        System.out.println("Beginning ParallelByMethodsTestCase7Scenario2. This test scenario consists of two " +
                 "suites with 1 and 2 tests respectively. One suite with two tests has a test consisting of a single " +
                 "test class without a factory while the other consists of factories using data providers with " +
                 "varying numbers of data sets which provide multiple instances of multiple test classes. One suite " +
                 "shall consist of a single test with multiple test classes which use factories with data providers " +
                 "with varying numbers of data sets. There are no dependencies.");
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-                new Object[]{SUITE_A,SUITE_A_TEST_A,
-                        TestClassAFiveMethodsWithFactoryUsingDataProviderAndNoDepsSample.class.getCanonicalName() +
-                        ", " + TestClassCSixMethodsWithFactoryUsingDataProviderAndNoDepsSample.class.getCanonicalName(), 25});
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
+//                new Object[]{SUITE_A,SUITE_A_TEST_A,
+//                        TestClassAFiveMethodsWithFactoryUsingDataProviderAndNoDepsSample.class.getCanonicalName() +
+//                        ", " + TestClassCSixMethodsWithFactoryUsingDataProviderAndNoDepsSample.class.getCanonicalName(), 25});
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test class: {2}. Thread count: {3}",
-                new Object[]{SUITE_B,SUITE_B_TEST_A,TestClassEFiveMethodsWithNoDepsSample.class.getCanonicalName(), 3});
+        System.out.println("Suite: " + SUITE_A + ", Test: " + SUITE_A_TEST_A + ", Test classes: " +
+                TestClassAFiveMethodsWithFactoryUsingDataProviderAndNoDepsSample.class.getCanonicalName() + ", " +
+                TestClassCSixMethodsWithFactoryUsingDataProviderAndNoDepsSample.class.getCanonicalName() +
+                ". Thread count: 25");
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-                new Object[]{SUITE_B,SUITE_B_TEST_B,
-                        TestClassDThreeMethodsWithFactoryUsingDataProviderAndNoDepsSample.class + ", " +
-                                TestClassBFourMethodsWithFactoryUsingDataProviderAndNoDepsSample.class + ", " +
-                                TestClassFSixMethodsWithFactoryUsingDataProviderAndNoDepsSample.class,
-                        40});
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test class: {2}. Thread count: {3}",
+//                new Object[]{SUITE_B,SUITE_B_TEST_A,TestClassEFiveMethodsWithNoDepsSample.class.getCanonicalName(), 3});
+
+        System.out.println("Suite: " + SUITE_B + ", Test: " + SUITE_B_TEST_A + ", Test class: " +
+                TestClassEFiveMethodsWithNoDepsSample.class.getCanonicalName() + ". Thread count: 3");
+
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
+//                new Object[]{SUITE_B,SUITE_B_TEST_B,
+//                        TestClassDThreeMethodsWithFactoryUsingDataProviderAndNoDepsSample.class + ", " +
+//                                TestClassBFourMethodsWithFactoryUsingDataProviderAndNoDepsSample.class + ", " +
+//                                TestClassFSixMethodsWithFactoryUsingDataProviderAndNoDepsSample.class,
+//                        40});
+
+        System.out.println("Suite " + SUITE_B + ", Test: " + SUITE_B_TEST_B + ", Test classes: " +
+                TestClassDThreeMethodsWithFactoryUsingDataProviderAndNoDepsSample.class + ", " +
+                TestClassBFourMethodsWithFactoryUsingDataProviderAndNoDepsSample.class + ", " +
+                TestClassFSixMethodsWithFactoryUsingDataProviderAndNoDepsSample.class + ". Thread count: 40");
 
         tng.run();
 
@@ -320,16 +335,6 @@ public class ParallelByMethodsTestCase7Scenario2 extends BaseParallelizationTest
                         TestClassFSixMethodsWithFactoryUsingDataProviderAndNoDepsSample.class
                 ),
                 3, 4, 5
-        );
-
-        verifySameInstancesOfTestClassesAssociatedWithMethods(
-                SUITE_B,
-                SUITE_B_TEST_B,
-                Arrays.asList(
-                        TestClassDThreeMethodsWithNoDepsSample.class,
-                        TestClassBFourMethodsWithNoDepsSample.class,
-                        TestClassFSixMethodsWithNoDepsSample.class
-                )
         );
     }
 

--- a/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase7Scenario2.java
+++ b/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase7Scenario2.java
@@ -42,7 +42,7 @@ import static test.thread.parallelization.TestNgRunStateTracker.reset;
 
 /** This class covers PTP_TC_7, Scenario 2 in the Parallelization Test Plan.
  *
- * Test Case Summary:  Parallel by methods mode with sequential test suites using a factory with uses a non-parallel
+ * Test Case Summary:  Parallel by methods mode with sequential test suites using a factory with a non-parallel
  *                     data provider and there are no dependencies.
  *
  * Scenario Description: Two suites with 1 and 2 tests respectively. One suite with two tests has a test consisting of
@@ -64,12 +64,6 @@ import static test.thread.parallelization.TestNgRunStateTracker.reset;
  * 7) There are no method exclusions
  */
 public class ParallelByMethodsTestCase7Scenario2 extends BaseParallelizationTest {
-
-    private static final Logger logger = Logger.getLogger(ParallelByMethodsTestCase7Scenario2.class.getCanonicalName());
-
-    {
-        logger.setLevel(Level.INFO);
-    }
 
     private static final String SUITE_A = "TestSuiteA";
     private static final String SUITE_B = "TestSuiteB";
@@ -163,13 +157,6 @@ public class ParallelByMethodsTestCase7Scenario2 extends BaseParallelizationTest
         TestNG tng = create(suiteOne, suiteTwo);
         tng.addListener((ITestNGListener) new TestNgRunStateListener());
 
-//        logger.log(Level.INFO, "Beginning ParallelByMethodsTestCase7Scenario2. This test scenario consists of two " +
-//                "suites with 1 and 2 tests respectively. One suite with two tests has a test consisting of a single " +
-//                "test class without a factory while the other consists of factories using data providers with " +
-//                "varying numbers of data sets which provide multiple instances of multiple test classes. One suite " +
-//                "shall consist of a single test with multiple test classes which use factories with data providers " +
-//                "with varying numbers of data sets. There are no dependencies.");
-
         System.out.println("Beginning ParallelByMethodsTestCase7Scenario2. This test scenario consists of two " +
                 "suites with 1 and 2 tests respectively. One suite with two tests has a test consisting of a single " +
                 "test class without a factory while the other consists of factories using data providers with " +
@@ -177,28 +164,13 @@ public class ParallelByMethodsTestCase7Scenario2 extends BaseParallelizationTest
                 "shall consist of a single test with multiple test classes which use factories with data providers " +
                 "with varying numbers of data sets. There are no dependencies.");
 
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-//                new Object[]{SUITE_A,SUITE_A_TEST_A,
-//                        TestClassAFiveMethodsWithFactoryUsingDataProviderAndNoDepsSample.class.getCanonicalName() +
-//                        ", " + TestClassCSixMethodsWithFactoryUsingDataProviderAndNoDepsSample.class.getCanonicalName(), 25});
-
         System.out.println("Suite: " + SUITE_A + ", Test: " + SUITE_A_TEST_A + ", Test classes: " +
                 TestClassAFiveMethodsWithFactoryUsingDataProviderAndNoDepsSample.class.getCanonicalName() + ", " +
                 TestClassCSixMethodsWithFactoryUsingDataProviderAndNoDepsSample.class.getCanonicalName() +
                 ". Thread count: 25");
 
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test class: {2}. Thread count: {3}",
-//                new Object[]{SUITE_B,SUITE_B_TEST_A,TestClassEFiveMethodsWithNoDepsSample.class.getCanonicalName(), 3});
-
         System.out.println("Suite: " + SUITE_B + ", Test: " + SUITE_B_TEST_A + ", Test class: " +
                 TestClassEFiveMethodsWithNoDepsSample.class.getCanonicalName() + ". Thread count: 3");
-
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-//                new Object[]{SUITE_B,SUITE_B_TEST_B,
-//                        TestClassDThreeMethodsWithFactoryUsingDataProviderAndNoDepsSample.class + ", " +
-//                                TestClassBFourMethodsWithFactoryUsingDataProviderAndNoDepsSample.class + ", " +
-//                                TestClassFSixMethodsWithFactoryUsingDataProviderAndNoDepsSample.class,
-//                        40});
 
         System.out.println("Suite " + SUITE_B + ", Test: " + SUITE_B_TEST_B + ", Test classes: " +
                 TestClassDThreeMethodsWithFactoryUsingDataProviderAndNoDepsSample.class + ", " +

--- a/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase8Scenario1.java
+++ b/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase8Scenario1.java
@@ -1,6 +1,5 @@
 package test.thread.parallelization;
 
-import com.google.common.collect.Multimap;
 import org.testng.ITestNGListener;
 import org.testng.TestNG;
 import org.testng.annotations.BeforeClass;
@@ -8,18 +7,12 @@ import org.testng.annotations.Test;
 import org.testng.xml.XmlSuite;
 import org.testng.xml.XmlTest;
 
-import test.thread.parallelization.sample.FactoryForTestClassFSixMethodsWithNoDepsSixInstancesSample;
 import test.thread.parallelization.sample.TestClassAFiveMethodsWithFactoryUsingDataProviderAndNoDepsSample;
-import test.thread.parallelization.sample.TestClassAFiveMethodsWithNoDepsSample;
 import test.thread.parallelization.sample.TestClassBFourMethodsWithFactoryUsingDataProviderAndNoDepsSample;
-import test.thread.parallelization.sample.TestClassBFourMethodsWithNoDepsSample;
 import test.thread.parallelization.sample.TestClassCSixMethodsWithFactoryUsingDataProviderAndNoDepsSample;
-import test.thread.parallelization.sample.TestClassCSixMethodsWithNoDepsSample;
 import test.thread.parallelization.sample.TestClassDThreeMethodsWithFactoryUsingDataProviderAndNoDepsSample;
-import test.thread.parallelization.sample.TestClassDThreeMethodsWithNoDepsSample;
 import test.thread.parallelization.sample.TestClassEFiveMethodsWithNoDepsSample;
 import test.thread.parallelization.sample.TestClassFSixMethodsWithFactoryUsingDataProviderAndNoDepsSample;
-import test.thread.parallelization.sample.TestClassFSixMethodsWithNoDepsSample;
 import test.thread.parallelization.sample.TestClassGThreeMethodsWithNoDepsSample;
 import test.thread.parallelization.sample.TestClassHFourMethodsWithNoDepsSample;
 import test.thread.parallelization.sample.TestClassIFiveMethodsWithNoDepsSample;
@@ -30,7 +23,6 @@ import test.thread.parallelization.sample.TestClassMFourMethodsWithNoDepsSample;
 import test.thread.parallelization.sample.TestClassNFiveMethodsWithNoDepsSample;
 import test.thread.parallelization.sample.TestClassOSixMethodsWithNoDepsSample;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -51,7 +43,6 @@ import static test.thread.parallelization.TestNgRunStateTracker.getTestLevelEven
 import static test.thread.parallelization.TestNgRunStateTracker.getTestLevelEventLogsForTest;
 import static test.thread.parallelization.TestNgRunStateTracker.getTestListenerFinishEventLog;
 import static test.thread.parallelization.TestNgRunStateTracker.getTestListenerStartEventLog;
-import static test.thread.parallelization.TestNgRunStateTracker.getTestMethodEventLogsForMethod;
 import static test.thread.parallelization.TestNgRunStateTracker.getTestMethodLevelEventLogsForSuite;
 import static test.thread.parallelization.TestNgRunStateTracker.getTestMethodLevelEventLogsForTest;
 import static test.thread.parallelization.TestNgRunStateTracker.reset;
@@ -236,48 +227,85 @@ public class ParallelByMethodsTestCase8Scenario1 extends BaseParallelizationTest
         tng.setSuiteThreadPoolSize(2);
         tng.addListener((ITestNGListener) new TestNgRunStateListener());
 
-        logger.log(Level.INFO, "Beginning ParallelByMethodsTestCase8Scenario1. This test scenario consists of three " +
+//        logger.log(Level.INFO, "Beginning ParallelByMethodsTestCase8Scenario1. This test scenario consists of three " +
+//                "suites with 1, 2 and 3 tests respectively. One suite with two tests has a test consisting of a " +
+//                "single test class without a factory while the other shall consist of test classes with factories " +
+//                "using data providers with varying numbers of data sets. One suite shall consist of a single test " +
+//                "with multiple test classes with factories using data providers with varying numbers of data sets. " +
+//                "One suite shall have multiple tests with multiple classes, none of which use a factory.");
+
+        System.out.println("Beginning ParallelByMethodsTestCase8Scenario1. This test scenario consists of three " +
                 "suites with 1, 2 and 3 tests respectively. One suite with two tests has a test consisting of a " +
                 "single test class without a factory while the other shall consist of test classes with factories " +
                 "using data providers with varying numbers of data sets. One suite shall consist of a single test " +
                 "with multiple test classes with factories using data providers with varying numbers of data sets. " +
                 "One suite shall have multiple tests with multiple classes, none of which use a factory.");
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-                new Object[]{SUITE_A,SUITE_A_TEST_A,
-                        TestClassAFiveMethodsWithFactoryUsingDataProviderAndNoDepsSample.class.getCanonicalName() +
-                        ", " + TestClassCSixMethodsWithFactoryUsingDataProviderAndNoDepsSample.class.getCanonicalName(), 10});
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
+//                new Object[]{SUITE_A,SUITE_A_TEST_A,
+//                        TestClassAFiveMethodsWithFactoryUsingDataProviderAndNoDepsSample.class.getCanonicalName() +
+//                        ", " + TestClassCSixMethodsWithFactoryUsingDataProviderAndNoDepsSample.class.getCanonicalName(), 10});
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test class: {2}. Thread count: {3}",
-                new Object[]{SUITE_B,SUITE_B_TEST_A,TestClassEFiveMethodsWithNoDepsSample.class.getCanonicalName(), 3});
+        System.out.println("Suite: " + SUITE_A + ", Test: " + SUITE_A_TEST_A + ", Test classes: " +
+                TestClassAFiveMethodsWithFactoryUsingDataProviderAndNoDepsSample.class.getCanonicalName() + ", " +
+                TestClassCSixMethodsWithFactoryUsingDataProviderAndNoDepsSample.class.getCanonicalName() +
+                ". Thread count: 10");
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-                new Object[]{SUITE_B,SUITE_B_TEST_B,
-                        TestClassDThreeMethodsWithFactoryUsingDataProviderAndNoDepsSample.class + ", " +
-                                TestClassBFourMethodsWithFactoryUsingDataProviderAndNoDepsSample.class + ", " +
-                                TestClassFSixMethodsWithFactoryUsingDataProviderAndNoDepsSample.class,
-                        20});
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test class: {2}. Thread count: {3}",
+//                new Object[]{SUITE_B,SUITE_B_TEST_A,TestClassEFiveMethodsWithNoDepsSample.class.getCanonicalName(), 3});
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-                new Object[]{SUITE_C,SUITE_C_TEST_A,
-                        TestClassGThreeMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-                                TestClassHFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-                                TestClassIFiveMethodsWithNoDepsSample.class,
-                        10});
+        System.out.println("Suite: " + SUITE_B + ", Test: " + SUITE_B_TEST_A + ", Test class: " +
+                TestClassEFiveMethodsWithNoDepsSample.class.getCanonicalName() + ". Thread count: 3");
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-                new Object[]{SUITE_C,SUITE_C_TEST_B,
-                        TestClassJFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-                                TestClassKFiveMethodsWithNoDepsSample.class,
-                        5});
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
+//                new Object[]{SUITE_B,SUITE_B_TEST_B,
+//                        TestClassDThreeMethodsWithFactoryUsingDataProviderAndNoDepsSample.class + ", " +
+//                                TestClassBFourMethodsWithFactoryUsingDataProviderAndNoDepsSample.class + ", " +
+//                                TestClassFSixMethodsWithFactoryUsingDataProviderAndNoDepsSample.class,
+//                        20});
 
-        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-                new Object[]{SUITE_C,SUITE_C_TEST_C,
-                        TestClassLThreeMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-                                TestClassMFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-                                TestClassNFiveMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-                                TestClassOSixMethodsWithNoDepsSample.class.getCanonicalName(),
-                        12});
+        System.out.println("Suite " + SUITE_B + ", Test: " + SUITE_B_TEST_B + ", Test classes: " +
+                TestClassDThreeMethodsWithFactoryUsingDataProviderAndNoDepsSample.class + ", " +
+                TestClassBFourMethodsWithFactoryUsingDataProviderAndNoDepsSample.class + ", " +
+                TestClassFSixMethodsWithFactoryUsingDataProviderAndNoDepsSample.class + ". Thread count: 20");
+
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
+//                new Object[]{SUITE_C,SUITE_C_TEST_A,
+//                        TestClassGThreeMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+//                                TestClassHFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+//                                TestClassIFiveMethodsWithNoDepsSample.class,
+//                        10});
+
+        System.out.println("Suite: " + SUITE_C + ", Test: " + SUITE_C_TEST_A + ", Test classes: " +
+                TestClassGThreeMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+                TestClassHFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+                TestClassIFiveMethodsWithNoDepsSample.class + ". Thread count: 10");
+
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
+//                new Object[]{SUITE_C,SUITE_C_TEST_B,
+//                        TestClassJFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+//                                TestClassKFiveMethodsWithNoDepsSample.class,
+//                        5});
+
+        System.out.println("Suite: " + SUITE_C + ", Test: " + SUITE_C_TEST_B + ", Test classes: " +
+                TestClassJFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+                TestClassKFiveMethodsWithNoDepsSample.class + ". Thread count: 5");
+
+
+//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
+//                new Object[]{SUITE_C,SUITE_C_TEST_C,
+//                        TestClassLThreeMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+//                                TestClassMFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+//                                TestClassNFiveMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+//                                TestClassOSixMethodsWithNoDepsSample.class.getCanonicalName(),
+//                        12});
+
+        System.out.println("Suite: " + SUITE_C + ", Test: " + SUITE_C_TEST_C + ", Test classes: " +
+                TestClassLThreeMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+                TestClassMFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+                TestClassNFiveMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
+                TestClassOSixMethodsWithNoDepsSample.class.getCanonicalName() + ". Thread count: 12.");
+
         tng.run();
 
         expectedInvocationCounts.put(

--- a/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase8Scenario1.java
+++ b/src/test/java/test/thread/parallelization/ParallelByMethodsTestCase8Scenario1.java
@@ -80,12 +80,6 @@ import static test.thread.parallelization.TestNgRunStateTracker.reset;
  */
 public class ParallelByMethodsTestCase8Scenario1 extends BaseParallelizationTest {
 
-    private static final Logger logger = Logger.getLogger(ParallelByMethodsTestCase8Scenario1.class.getCanonicalName());
-
-    {
-        logger.setLevel(Level.INFO);
-    }
-
     private static final String SUITE_A = "TestSuiteA";
     private static final String SUITE_B = "TestSuiteB";
     private static final String SUITE_C = "TestSuiteC";
@@ -227,13 +221,6 @@ public class ParallelByMethodsTestCase8Scenario1 extends BaseParallelizationTest
         tng.setSuiteThreadPoolSize(2);
         tng.addListener((ITestNGListener) new TestNgRunStateListener());
 
-//        logger.log(Level.INFO, "Beginning ParallelByMethodsTestCase8Scenario1. This test scenario consists of three " +
-//                "suites with 1, 2 and 3 tests respectively. One suite with two tests has a test consisting of a " +
-//                "single test class without a factory while the other shall consist of test classes with factories " +
-//                "using data providers with varying numbers of data sets. One suite shall consist of a single test " +
-//                "with multiple test classes with factories using data providers with varying numbers of data sets. " +
-//                "One suite shall have multiple tests with multiple classes, none of which use a factory.");
-
         System.out.println("Beginning ParallelByMethodsTestCase8Scenario1. This test scenario consists of three " +
                 "suites with 1, 2 and 3 tests respectively. One suite with two tests has a test consisting of a " +
                 "single test class without a factory while the other shall consist of test classes with factories " +
@@ -241,64 +228,27 @@ public class ParallelByMethodsTestCase8Scenario1 extends BaseParallelizationTest
                 "with multiple test classes with factories using data providers with varying numbers of data sets. " +
                 "One suite shall have multiple tests with multiple classes, none of which use a factory.");
 
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-//                new Object[]{SUITE_A,SUITE_A_TEST_A,
-//                        TestClassAFiveMethodsWithFactoryUsingDataProviderAndNoDepsSample.class.getCanonicalName() +
-//                        ", " + TestClassCSixMethodsWithFactoryUsingDataProviderAndNoDepsSample.class.getCanonicalName(), 10});
-
         System.out.println("Suite: " + SUITE_A + ", Test: " + SUITE_A_TEST_A + ", Test classes: " +
                 TestClassAFiveMethodsWithFactoryUsingDataProviderAndNoDepsSample.class.getCanonicalName() + ", " +
                 TestClassCSixMethodsWithFactoryUsingDataProviderAndNoDepsSample.class.getCanonicalName() +
                 ". Thread count: 10");
 
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test class: {2}. Thread count: {3}",
-//                new Object[]{SUITE_B,SUITE_B_TEST_A,TestClassEFiveMethodsWithNoDepsSample.class.getCanonicalName(), 3});
-
         System.out.println("Suite: " + SUITE_B + ", Test: " + SUITE_B_TEST_A + ", Test class: " +
                 TestClassEFiveMethodsWithNoDepsSample.class.getCanonicalName() + ". Thread count: 3");
-
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-//                new Object[]{SUITE_B,SUITE_B_TEST_B,
-//                        TestClassDThreeMethodsWithFactoryUsingDataProviderAndNoDepsSample.class + ", " +
-//                                TestClassBFourMethodsWithFactoryUsingDataProviderAndNoDepsSample.class + ", " +
-//                                TestClassFSixMethodsWithFactoryUsingDataProviderAndNoDepsSample.class,
-//                        20});
 
         System.out.println("Suite " + SUITE_B + ", Test: " + SUITE_B_TEST_B + ", Test classes: " +
                 TestClassDThreeMethodsWithFactoryUsingDataProviderAndNoDepsSample.class + ", " +
                 TestClassBFourMethodsWithFactoryUsingDataProviderAndNoDepsSample.class + ", " +
                 TestClassFSixMethodsWithFactoryUsingDataProviderAndNoDepsSample.class + ". Thread count: 20");
 
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-//                new Object[]{SUITE_C,SUITE_C_TEST_A,
-//                        TestClassGThreeMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-//                                TestClassHFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-//                                TestClassIFiveMethodsWithNoDepsSample.class,
-//                        10});
-
         System.out.println("Suite: " + SUITE_C + ", Test: " + SUITE_C_TEST_A + ", Test classes: " +
                 TestClassGThreeMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
                 TestClassHFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
                 TestClassIFiveMethodsWithNoDepsSample.class + ". Thread count: 10");
 
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-//                new Object[]{SUITE_C,SUITE_C_TEST_B,
-//                        TestClassJFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-//                                TestClassKFiveMethodsWithNoDepsSample.class,
-//                        5});
-
         System.out.println("Suite: " + SUITE_C + ", Test: " + SUITE_C_TEST_B + ", Test classes: " +
                 TestClassJFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
                 TestClassKFiveMethodsWithNoDepsSample.class + ". Thread count: 5");
-
-
-//        logger.log(Level.INFO, "Suite: {0}, Test: {1}, Test classes: {2}. Thread count: {3}",
-//                new Object[]{SUITE_C,SUITE_C_TEST_C,
-//                        TestClassLThreeMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-//                                TestClassMFourMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-//                                TestClassNFiveMethodsWithNoDepsSample.class.getCanonicalName() + ", " +
-//                                TestClassOSixMethodsWithNoDepsSample.class.getCanonicalName(),
-//                        12});
 
         System.out.println("Suite: " + SUITE_C + ", Test: " + SUITE_C_TEST_C + ", Test classes: " +
                 TestClassLThreeMethodsWithNoDepsSample.class.getCanonicalName() + ", " +

--- a/src/test/java/test/thread/parallelization/TestNgRunStateListener.java
+++ b/src/test/java/test/thread/parallelization/TestNgRunStateListener.java
@@ -13,6 +13,9 @@ import java.util.concurrent.TimeUnit;
 
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_INSTANCE;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_NAME;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_BELONGING_TO;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_DEPENDED_ON;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHODS_DEPENDED_ON;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHOD_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.SUITE_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.TEST_NAME;
@@ -104,10 +107,14 @@ public class TestNgRunStateListener implements ISuiteListener, ITestListener {
     }
 
     private TestNgRunStateTracker.EventLogBuilder buildEventLog(ITestResult result, TestNgRunEvent event) {
+
         return(buildEventLog(result.getTestContext(), event))
                 .addData(METHOD_NAME, result.getMethod().getMethodName())
                 .addData(CLASS_NAME, result.getMethod().getRealClass().getCanonicalName())
-                .addData(CLASS_INSTANCE, result.getMethod().getInstance());
+                .addData(CLASS_INSTANCE, result.getMethod().getInstance())
+                .addData(GROUPS_DEPENDED_ON, result.getMethod().getGroupsDependedUpon())
+                .addData(METHODS_DEPENDED_ON, result.getMethod().getMethodsDependedUpon())
+                .addData(GROUPS_BELONGING_TO, result.getMethod().getGroups());
     }
 
     private void delayAfterEvent(TestNgRunEvent event) {

--- a/src/test/java/test/thread/parallelization/TestNgRunStateListener.java
+++ b/src/test/java/test/thread/parallelization/TestNgRunStateListener.java
@@ -9,7 +9,6 @@ import org.testng.ITestContext;
 import org.testng.ITestListener;
 import org.testng.ITestResult;
 
-import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_INSTANCE;

--- a/src/test/java/test/thread/parallelization/TestNgRunStateListener.java
+++ b/src/test/java/test/thread/parallelization/TestNgRunStateListener.java
@@ -9,6 +9,7 @@ import org.testng.ITestContext;
 import org.testng.ITestListener;
 import org.testng.ITestResult;
 
+import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_INSTANCE;

--- a/src/test/java/test/thread/parallelization/TestNgRunStateTracker.java
+++ b/src/test/java/test/thread/parallelization/TestNgRunStateTracker.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -428,6 +429,60 @@ public class TestNgRunStateTracker {
         return testMethodEventLogs;
     }
 
+    public static Multimap<Object, EventLog> getTestMethodEventLogsForMethodsBelongingToGroup(String groupName) {
+        Multimap<Object,EventLog> testMethodEventLogs = ArrayListMultimap.create();
+
+        for(EventLog eventLog : getAllTestMethodLevelEventLogs()) {
+            String[] groupsBelongingTo = (String[])eventLog.getData(EventInfo.GROUPS_BELONGING_TO);
+
+            if(Arrays.asList(groupsBelongingTo).contains(groupName)) {
+                testMethodEventLogs.put(eventLog.getData(EventInfo.CLASS_INSTANCE), eventLog);
+            }
+        }
+        return testMethodEventLogs;
+    }
+
+    public static Multimap<Object, EventLog> getTestMethodEventLogsForMethodsDependedOn(String suiteName, String
+            testName, String className, String methodName) {
+        //System.out.println("\nProcessing " + className + ", " + methodName);
+
+        Multimap<Object,EventLog> testMethodEventLogs = ArrayListMultimap.create();
+        Map<Object,EventLog> startEventLogs = getTestMethodListenerStartEventLogsForMethod(suiteName, testName,
+                className, methodName);
+
+        EventLog eventLog = new ArrayList<>(startEventLogs.values()).get(0);
+
+        String[] methodsDependedOn =  (String[])eventLog.getData(EventInfo.METHODS_DEPENDED_ON);
+
+        //System.out.println("Methods depended on(" + className + ", " + methodName + "):" +
+        //        Arrays.toString(methodsDependedOn));
+
+        for(String methodDependOn : methodsDependedOn) {
+            testMethodEventLogs.putAll(getTestMethodEventLogsForMethod(suiteName, testName, className,
+                    methodDependOn));
+        }
+
+        return testMethodEventLogs;
+    }
+
+    public static Multimap<Object, EventLog> getTestMethodEventLogsForMethodsBelongingToGroupsDependedOn(String
+            suiteName, String testName, String className, String methodName) {
+
+        Multimap<Object,EventLog> testMethodEventLogs = ArrayListMultimap.create();
+        Map<Object,EventLog> startEventLogs = getTestMethodListenerStartEventLogsForMethod(suiteName, testName,
+                className, methodName);
+
+        EventLog eventLog = new ArrayList<>(startEventLogs.values()).get(0);
+
+        String[] groupsDependedOn =  (String[])eventLog.getData(EventInfo.GROUPS_DEPENDED_ON);
+
+        for(String groupDependedOn : groupsDependedOn) {
+            testMethodEventLogs.putAll(getTestMethodEventLogsForMethodsBelongingToGroup(groupDependedOn));
+        }
+
+        return testMethodEventLogs;
+    }
+
     //Get the test method event logs of the specified type for the specified test class from the specified suite and
     //test in a multimap where the keys are the class instances for the test class
     public static Multimap<Object, EventLog> getTestMethodEventLogsByEventTypeForClass(String suiteName, String
@@ -658,7 +713,7 @@ public class TestNgRunStateTracker {
     //suite, test and test class separated out in a map where the keys are the class instances on which the method was
     //run.
     public static Map<Object, Long> getTestMethodListenerStartThreadIds(String suiteName, String testName,
-            String className, String methodName) {
+                String className, String methodName) {
         Map<Object,Long> testMethodEventThreadIds = new HashMap<>();
         Map<Object,EventLog> testMethodEventLogs = getTestMethodListenerStartEventLogsForMethod(suiteName, testName,
                 className, methodName);
@@ -751,8 +806,6 @@ public class TestNgRunStateTracker {
         return testMethodEventThreadIds;
     }
 
-
-
     public static void reset() {
         eventLogs.clear();
     }
@@ -818,7 +871,10 @@ public class TestNgRunStateTracker {
         CLASS_NAME,
         METHOD_NAME,
         CLASS_INSTANCE,
-        DATA_PROVIDER_PARAM
+        DATA_PROVIDER_PARAM,
+        GROUPS_DEPENDED_ON,
+        METHODS_DEPENDED_ON,
+        GROUPS_BELONGING_TO
     }
 
     public static class EventLog {

--- a/src/test/java/test/thread/parallelization/TestNgRunStateTracker.java
+++ b/src/test/java/test/thread/parallelization/TestNgRunStateTracker.java
@@ -444,7 +444,6 @@ public class TestNgRunStateTracker {
 
     public static Multimap<Object, EventLog> getTestMethodEventLogsForMethodsDependedOn(String suiteName, String
             testName, String className, String methodName) {
-        //System.out.println("\nProcessing " + className + ", " + methodName);
 
         Multimap<Object,EventLog> testMethodEventLogs = ArrayListMultimap.create();
         Map<Object,EventLog> startEventLogs = getTestMethodListenerStartEventLogsForMethod(suiteName, testName,
@@ -453,9 +452,6 @@ public class TestNgRunStateTracker {
         EventLog eventLog = new ArrayList<>(startEventLogs.values()).get(0);
 
         String[] methodsDependedOn =  (String[])eventLog.getData(EventInfo.METHODS_DEPENDED_ON);
-
-        //System.out.println("Methods depended on(" + className + ", " + methodName + "):" +
-        //        Arrays.toString(methodsDependedOn));
 
         for(String methodDependOn : methodsDependedOn) {
             testMethodEventLogs.putAll(getTestMethodEventLogsForMethod(suiteName, testName, className,

--- a/src/test/java/test/thread/parallelization/TestNgRunStateTracker.java
+++ b/src/test/java/test/thread/parallelization/TestNgRunStateTracker.java
@@ -3,8 +3,10 @@ package test.thread.parallelization;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -949,7 +951,10 @@ public class TestNgRunStateTracker {
                 sb.append(", Data provider param: ").append(getData(EventInfo.DATA_PROVIDER_PARAM));
             }
 
-            sb.append(", Time of event: ").append(timeOfEvent);
+            Date now = new Date(timeOfEvent);
+            SimpleDateFormat sdfDate = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+
+            sb.append(", Time of event: ").append(sdfDate.format(timeOfEvent));
             sb.append(", Thread ID: ").append(threadId);
             sb.append("}");
             return sb.toString();

--- a/src/test/java/test/thread/parallelization/sample/TestClassAFiveMethodsWithDataProviderOnAllMethodsAndNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/sample/TestClassAFiveMethodsWithDataProviderOnAllMethodsAndNoDepsSample.java
@@ -11,6 +11,9 @@ import java.util.concurrent.TimeUnit;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_INSTANCE;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.DATA_PROVIDER_PARAM;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_BELONGING_TO;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_DEPENDED_ON;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHODS_DEPENDED_ON;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHOD_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.SUITE_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.TEST_NAME;
@@ -34,6 +37,9 @@ public class TestClassAFiveMethodsWithDataProviderOnAllMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -56,6 +62,9 @@ public class TestClassAFiveMethodsWithDataProviderOnAllMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -78,6 +87,9 @@ public class TestClassAFiveMethodsWithDataProviderOnAllMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -100,6 +112,9 @@ public class TestClassAFiveMethodsWithDataProviderOnAllMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -122,6 +137,9 @@ public class TestClassAFiveMethodsWithDataProviderOnAllMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 

--- a/src/test/java/test/thread/parallelization/sample/TestClassAFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/sample/TestClassAFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.java
@@ -12,6 +12,9 @@ import java.util.concurrent.TimeUnit;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_INSTANCE;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.DATA_PROVIDER_PARAM;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_BELONGING_TO;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_DEPENDED_ON;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHODS_DEPENDED_ON;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHOD_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.SUITE_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.TEST_NAME;
@@ -35,6 +38,9 @@ public class TestClassAFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -57,6 +63,9 @@ public class TestClassAFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -79,6 +88,9 @@ public class TestClassAFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -101,6 +113,9 @@ public class TestClassAFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -123,6 +138,9 @@ public class TestClassAFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 

--- a/src/test/java/test/thread/parallelization/sample/TestClassAFiveMethodsWithFactoryUsingDataProviderAndNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/sample/TestClassAFiveMethodsWithFactoryUsingDataProviderAndNoDepsSample.java
@@ -12,6 +12,9 @@ import java.util.concurrent.TimeUnit;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_INSTANCE;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.DATA_PROVIDER_PARAM;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_BELONGING_TO;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_DEPENDED_ON;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHODS_DEPENDED_ON;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHOD_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.SUITE_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.TEST_NAME;
@@ -50,6 +53,9 @@ public class TestClassAFiveMethodsWithFactoryUsingDataProviderAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -72,6 +78,9 @@ public class TestClassAFiveMethodsWithFactoryUsingDataProviderAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -94,6 +103,9 @@ public class TestClassAFiveMethodsWithFactoryUsingDataProviderAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -116,6 +128,9 @@ public class TestClassAFiveMethodsWithFactoryUsingDataProviderAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -138,6 +153,9 @@ public class TestClassAFiveMethodsWithFactoryUsingDataProviderAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 

--- a/src/test/java/test/thread/parallelization/sample/TestClassAFiveMethodsWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/sample/TestClassAFiveMethodsWithNoDepsSample.java
@@ -8,6 +8,9 @@ import java.util.concurrent.TimeUnit;
 
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_INSTANCE;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_NAME;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_BELONGING_TO;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_DEPENDED_ON;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHODS_DEPENDED_ON;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHOD_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.SUITE_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.TEST_NAME;
@@ -30,6 +33,9 @@ public class TestClassAFiveMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -51,6 +57,9 @@ public class TestClassAFiveMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -72,6 +81,9 @@ public class TestClassAFiveMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -93,6 +105,9 @@ public class TestClassAFiveMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -114,6 +129,9 @@ public class TestClassAFiveMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 

--- a/src/test/java/test/thread/parallelization/sample/TestClassBFourMethodsWithDataProviderOnAllMethodsAndNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/sample/TestClassBFourMethodsWithDataProviderOnAllMethodsAndNoDepsSample.java
@@ -11,6 +11,9 @@ import java.util.concurrent.TimeUnit;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_INSTANCE;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.DATA_PROVIDER_PARAM;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_BELONGING_TO;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_DEPENDED_ON;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHODS_DEPENDED_ON;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHOD_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.SUITE_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.TEST_NAME;
@@ -33,6 +36,9 @@ public class TestClassBFourMethodsWithDataProviderOnAllMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -55,6 +61,9 @@ public class TestClassBFourMethodsWithDataProviderOnAllMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -77,6 +86,9 @@ public class TestClassBFourMethodsWithDataProviderOnAllMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -99,6 +111,9 @@ public class TestClassBFourMethodsWithDataProviderOnAllMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 

--- a/src/test/java/test/thread/parallelization/sample/TestClassBFourMethodsWithFactoryUsingDataProviderAndNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/sample/TestClassBFourMethodsWithFactoryUsingDataProviderAndNoDepsSample.java
@@ -12,6 +12,9 @@ import java.util.concurrent.TimeUnit;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_INSTANCE;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.DATA_PROVIDER_PARAM;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_BELONGING_TO;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_DEPENDED_ON;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHODS_DEPENDED_ON;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHOD_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.SUITE_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.TEST_NAME;
@@ -50,6 +53,9 @@ public class TestClassBFourMethodsWithFactoryUsingDataProviderAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -72,6 +78,9 @@ public class TestClassBFourMethodsWithFactoryUsingDataProviderAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -94,6 +103,9 @@ public class TestClassBFourMethodsWithFactoryUsingDataProviderAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -116,6 +128,9 @@ public class TestClassBFourMethodsWithFactoryUsingDataProviderAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 

--- a/src/test/java/test/thread/parallelization/sample/TestClassBFourMethodsWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/sample/TestClassBFourMethodsWithNoDepsSample.java
@@ -8,6 +8,9 @@ import java.util.concurrent.TimeUnit;
 
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_INSTANCE;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_NAME;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_BELONGING_TO;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_DEPENDED_ON;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHODS_DEPENDED_ON;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHOD_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.SUITE_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.TEST_NAME;
@@ -30,6 +33,9 @@ public class TestClassBFourMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -51,6 +57,9 @@ public class TestClassBFourMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -72,6 +81,9 @@ public class TestClassBFourMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -93,6 +105,9 @@ public class TestClassBFourMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 

--- a/src/test/java/test/thread/parallelization/sample/TestClassBSixMethodsWithDataProviderOnAllMethodsAndNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/sample/TestClassBSixMethodsWithDataProviderOnAllMethodsAndNoDepsSample.java
@@ -11,6 +11,9 @@ import java.util.concurrent.TimeUnit;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_INSTANCE;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.DATA_PROVIDER_PARAM;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_BELONGING_TO;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_DEPENDED_ON;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHODS_DEPENDED_ON;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHOD_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.SUITE_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.TEST_NAME;
@@ -34,6 +37,9 @@ public class TestClassBSixMethodsWithDataProviderOnAllMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -56,6 +62,9 @@ public class TestClassBSixMethodsWithDataProviderOnAllMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -78,6 +87,9 @@ public class TestClassBSixMethodsWithDataProviderOnAllMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -100,6 +112,9 @@ public class TestClassBSixMethodsWithDataProviderOnAllMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -122,6 +137,9 @@ public class TestClassBSixMethodsWithDataProviderOnAllMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -144,6 +162,9 @@ public class TestClassBSixMethodsWithDataProviderOnAllMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 

--- a/src/test/java/test/thread/parallelization/sample/TestClassBSixMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/sample/TestClassBSixMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.java
@@ -10,6 +10,9 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.DATA_PROVIDER_PARAM;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_BELONGING_TO;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_DEPENDED_ON;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHODS_DEPENDED_ON;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHOD_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_INSTANCE;
@@ -34,6 +37,9 @@ public class TestClassBSixMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -56,6 +62,9 @@ public class TestClassBSixMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -77,6 +86,9 @@ public class TestClassBSixMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -99,6 +111,9 @@ public class TestClassBSixMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -120,6 +135,9 @@ public class TestClassBSixMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -142,6 +160,9 @@ public class TestClassBSixMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 

--- a/src/test/java/test/thread/parallelization/sample/TestClassCFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/sample/TestClassCFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.java
@@ -12,6 +12,9 @@ import java.util.concurrent.TimeUnit;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_INSTANCE;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.DATA_PROVIDER_PARAM;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_BELONGING_TO;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_DEPENDED_ON;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHODS_DEPENDED_ON;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHOD_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.SUITE_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.TEST_NAME;
@@ -35,6 +38,9 @@ public class TestClassCFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -57,6 +63,9 @@ public class TestClassCFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -79,6 +88,9 @@ public class TestClassCFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -101,6 +113,9 @@ public class TestClassCFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -123,6 +138,9 @@ public class TestClassCFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 

--- a/src/test/java/test/thread/parallelization/sample/TestClassCSixMethodsWithFactoryUsingDataProviderAndNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/sample/TestClassCSixMethodsWithFactoryUsingDataProviderAndNoDepsSample.java
@@ -12,6 +12,9 @@ import java.util.concurrent.TimeUnit;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_INSTANCE;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.DATA_PROVIDER_PARAM;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_BELONGING_TO;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_DEPENDED_ON;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHODS_DEPENDED_ON;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHOD_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.SUITE_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.TEST_NAME;
@@ -50,6 +53,9 @@ public class TestClassCSixMethodsWithFactoryUsingDataProviderAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -72,6 +78,9 @@ public class TestClassCSixMethodsWithFactoryUsingDataProviderAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -94,6 +103,9 @@ public class TestClassCSixMethodsWithFactoryUsingDataProviderAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -116,6 +128,9 @@ public class TestClassCSixMethodsWithFactoryUsingDataProviderAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -138,6 +153,9 @@ public class TestClassCSixMethodsWithFactoryUsingDataProviderAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -160,6 +178,9 @@ public class TestClassCSixMethodsWithFactoryUsingDataProviderAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 

--- a/src/test/java/test/thread/parallelization/sample/TestClassCSixMethodsWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/sample/TestClassCSixMethodsWithNoDepsSample.java
@@ -8,6 +8,9 @@ import java.util.concurrent.TimeUnit;
 
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_INSTANCE;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_NAME;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_BELONGING_TO;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_DEPENDED_ON;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHODS_DEPENDED_ON;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHOD_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.SUITE_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.TEST_NAME;
@@ -30,6 +33,9 @@ public class TestClassCSixMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -51,6 +57,9 @@ public class TestClassCSixMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -72,6 +81,9 @@ public class TestClassCSixMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -93,6 +105,9 @@ public class TestClassCSixMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -114,6 +129,9 @@ public class TestClassCSixMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -135,6 +153,9 @@ public class TestClassCSixMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 

--- a/src/test/java/test/thread/parallelization/sample/TestClassDThreeMethodsWithDataProviderOnAllMethodsAndNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/sample/TestClassDThreeMethodsWithDataProviderOnAllMethodsAndNoDepsSample.java
@@ -11,6 +11,9 @@ import java.util.concurrent.TimeUnit;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_INSTANCE;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.DATA_PROVIDER_PARAM;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_BELONGING_TO;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_DEPENDED_ON;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHODS_DEPENDED_ON;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHOD_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.SUITE_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.TEST_NAME;
@@ -33,6 +36,9 @@ public class TestClassDThreeMethodsWithDataProviderOnAllMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -55,6 +61,9 @@ public class TestClassDThreeMethodsWithDataProviderOnAllMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -77,6 +86,9 @@ public class TestClassDThreeMethodsWithDataProviderOnAllMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 

--- a/src/test/java/test/thread/parallelization/sample/TestClassDThreeMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/sample/TestClassDThreeMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.java
@@ -10,6 +10,9 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.DATA_PROVIDER_PARAM;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_BELONGING_TO;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_DEPENDED_ON;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHODS_DEPENDED_ON;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHOD_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_INSTANCE;
@@ -34,6 +37,9 @@ public class TestClassDThreeMethodsWithDataProviderOnSomeMethodsAndNoDepsSample 
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -56,6 +62,9 @@ public class TestClassDThreeMethodsWithDataProviderOnSomeMethodsAndNoDepsSample 
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -77,6 +86,9 @@ public class TestClassDThreeMethodsWithDataProviderOnSomeMethodsAndNoDepsSample 
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 

--- a/src/test/java/test/thread/parallelization/sample/TestClassDThreeMethodsWithFactoryUsingDataProviderAndNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/sample/TestClassDThreeMethodsWithFactoryUsingDataProviderAndNoDepsSample.java
@@ -12,6 +12,9 @@ import java.util.concurrent.TimeUnit;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_INSTANCE;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.DATA_PROVIDER_PARAM;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_BELONGING_TO;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_DEPENDED_ON;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHODS_DEPENDED_ON;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHOD_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.SUITE_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.TEST_NAME;
@@ -50,6 +53,9 @@ public class TestClassDThreeMethodsWithFactoryUsingDataProviderAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -72,6 +78,9 @@ public class TestClassDThreeMethodsWithFactoryUsingDataProviderAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -94,6 +103,9 @@ public class TestClassDThreeMethodsWithFactoryUsingDataProviderAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 

--- a/src/test/java/test/thread/parallelization/sample/TestClassDThreeMethodsWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/sample/TestClassDThreeMethodsWithNoDepsSample.java
@@ -6,6 +6,9 @@ import test.thread.parallelization.TestNgRunStateTracker;
 
 import java.util.concurrent.TimeUnit;
 
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_BELONGING_TO;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_DEPENDED_ON;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHODS_DEPENDED_ON;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHOD_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_INSTANCE;
@@ -30,6 +33,9 @@ public class TestClassDThreeMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -51,6 +57,9 @@ public class TestClassDThreeMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -72,6 +81,9 @@ public class TestClassDThreeMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 

--- a/src/test/java/test/thread/parallelization/sample/TestClassEFiveMethodsWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/sample/TestClassEFiveMethodsWithNoDepsSample.java
@@ -6,6 +6,9 @@ import test.thread.parallelization.TestNgRunStateTracker;
 
 import java.util.concurrent.TimeUnit;
 
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_BELONGING_TO;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_DEPENDED_ON;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHODS_DEPENDED_ON;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHOD_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_INSTANCE;
@@ -30,6 +33,9 @@ public class TestClassEFiveMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -51,6 +57,9 @@ public class TestClassEFiveMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -72,6 +81,9 @@ public class TestClassEFiveMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -93,6 +105,9 @@ public class TestClassEFiveMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -114,6 +129,9 @@ public class TestClassEFiveMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 

--- a/src/test/java/test/thread/parallelization/sample/TestClassEFourMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/sample/TestClassEFourMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.java
@@ -12,6 +12,9 @@ import java.util.concurrent.TimeUnit;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_INSTANCE;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.DATA_PROVIDER_PARAM;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_BELONGING_TO;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_DEPENDED_ON;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHODS_DEPENDED_ON;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHOD_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.SUITE_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.TEST_NAME;
@@ -35,6 +38,9 @@ public class TestClassEFourMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -57,6 +63,9 @@ public class TestClassEFourMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -78,6 +87,9 @@ public class TestClassEFourMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -99,6 +111,9 @@ public class TestClassEFourMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 

--- a/src/test/java/test/thread/parallelization/sample/TestClassFSixMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/sample/TestClassFSixMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.java
@@ -12,6 +12,9 @@ import java.util.concurrent.TimeUnit;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_INSTANCE;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.DATA_PROVIDER_PARAM;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_BELONGING_TO;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_DEPENDED_ON;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHODS_DEPENDED_ON;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHOD_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.SUITE_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.TEST_NAME;
@@ -34,6 +37,9 @@ public class TestClassFSixMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -56,6 +62,9 @@ public class TestClassFSixMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -77,6 +86,9 @@ public class TestClassFSixMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -99,6 +111,9 @@ public class TestClassFSixMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -120,6 +135,9 @@ public class TestClassFSixMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -142,6 +160,9 @@ public class TestClassFSixMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 

--- a/src/test/java/test/thread/parallelization/sample/TestClassFSixMethodsWithFactoryUsingDataProviderAndNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/sample/TestClassFSixMethodsWithFactoryUsingDataProviderAndNoDepsSample.java
@@ -12,6 +12,9 @@ import java.util.concurrent.TimeUnit;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_INSTANCE;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.DATA_PROVIDER_PARAM;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_BELONGING_TO;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_DEPENDED_ON;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHODS_DEPENDED_ON;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHOD_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.SUITE_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.TEST_NAME;
@@ -50,6 +53,9 @@ public class TestClassFSixMethodsWithFactoryUsingDataProviderAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -72,6 +78,9 @@ public class TestClassFSixMethodsWithFactoryUsingDataProviderAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -94,6 +103,9 @@ public class TestClassFSixMethodsWithFactoryUsingDataProviderAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -116,6 +128,9 @@ public class TestClassFSixMethodsWithFactoryUsingDataProviderAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -138,6 +153,9 @@ public class TestClassFSixMethodsWithFactoryUsingDataProviderAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -160,6 +178,9 @@ public class TestClassFSixMethodsWithFactoryUsingDataProviderAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 

--- a/src/test/java/test/thread/parallelization/sample/TestClassFSixMethodsWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/sample/TestClassFSixMethodsWithNoDepsSample.java
@@ -8,6 +8,9 @@ import java.util.concurrent.TimeUnit;
 
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_INSTANCE;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_NAME;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_BELONGING_TO;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_DEPENDED_ON;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHODS_DEPENDED_ON;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHOD_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.SUITE_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.TEST_NAME;
@@ -29,6 +32,9 @@ public class TestClassFSixMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -50,6 +56,9 @@ public class TestClassFSixMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -71,6 +80,9 @@ public class TestClassFSixMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -92,6 +104,9 @@ public class TestClassFSixMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -113,6 +128,9 @@ public class TestClassFSixMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -134,6 +152,9 @@ public class TestClassFSixMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 

--- a/src/test/java/test/thread/parallelization/sample/TestClassGFourMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/sample/TestClassGFourMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.java
@@ -12,6 +12,9 @@ import java.util.concurrent.TimeUnit;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_INSTANCE;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.DATA_PROVIDER_PARAM;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_BELONGING_TO;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_DEPENDED_ON;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHODS_DEPENDED_ON;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHOD_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.SUITE_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.TEST_NAME;
@@ -35,6 +38,9 @@ public class TestClassGFourMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -57,6 +63,9 @@ public class TestClassGFourMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -78,6 +87,9 @@ public class TestClassGFourMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -99,6 +111,9 @@ public class TestClassGFourMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 

--- a/src/test/java/test/thread/parallelization/sample/TestClassGThreeMethodsWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/sample/TestClassGThreeMethodsWithNoDepsSample.java
@@ -8,6 +8,9 @@ import java.util.concurrent.TimeUnit;
 
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_INSTANCE;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_NAME;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_BELONGING_TO;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_DEPENDED_ON;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHODS_DEPENDED_ON;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHOD_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.SUITE_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.TEST_NAME;
@@ -30,6 +33,9 @@ public class TestClassGThreeMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -51,6 +57,9 @@ public class TestClassGThreeMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -72,6 +81,9 @@ public class TestClassGThreeMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 

--- a/src/test/java/test/thread/parallelization/sample/TestClassHFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/sample/TestClassHFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.java
@@ -12,6 +12,9 @@ import java.util.concurrent.TimeUnit;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_INSTANCE;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.DATA_PROVIDER_PARAM;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_BELONGING_TO;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_DEPENDED_ON;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHODS_DEPENDED_ON;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHOD_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.SUITE_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.TEST_NAME;
@@ -35,6 +38,9 @@ public class TestClassHFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -57,6 +63,9 @@ public class TestClassHFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -79,6 +88,9 @@ public class TestClassHFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -101,6 +113,9 @@ public class TestClassHFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -123,6 +138,9 @@ public class TestClassHFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 

--- a/src/test/java/test/thread/parallelization/sample/TestClassHFourMethodsWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/sample/TestClassHFourMethodsWithNoDepsSample.java
@@ -8,6 +8,9 @@ import java.util.concurrent.TimeUnit;
 
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_INSTANCE;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_NAME;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_BELONGING_TO;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_DEPENDED_ON;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHODS_DEPENDED_ON;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHOD_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.SUITE_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.TEST_NAME;
@@ -29,6 +32,9 @@ public class TestClassHFourMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -50,6 +56,9 @@ public class TestClassHFourMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -71,6 +80,9 @@ public class TestClassHFourMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -92,6 +104,9 @@ public class TestClassHFourMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 

--- a/src/test/java/test/thread/parallelization/sample/TestClassIFiveMethodsWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/sample/TestClassIFiveMethodsWithNoDepsSample.java
@@ -8,6 +8,9 @@ import java.util.concurrent.TimeUnit;
 
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_INSTANCE;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_NAME;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_BELONGING_TO;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_DEPENDED_ON;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHODS_DEPENDED_ON;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHOD_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.SUITE_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.TEST_NAME;
@@ -30,6 +33,9 @@ public class TestClassIFiveMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -51,6 +57,9 @@ public class TestClassIFiveMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -72,6 +81,9 @@ public class TestClassIFiveMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -93,6 +105,9 @@ public class TestClassIFiveMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -114,6 +129,9 @@ public class TestClassIFiveMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 

--- a/src/test/java/test/thread/parallelization/sample/TestClassIThreeMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/sample/TestClassIThreeMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.java
@@ -12,6 +12,9 @@ import java.util.concurrent.TimeUnit;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_INSTANCE;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.DATA_PROVIDER_PARAM;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_BELONGING_TO;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_DEPENDED_ON;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHODS_DEPENDED_ON;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHOD_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.SUITE_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.TEST_NAME;
@@ -34,6 +37,9 @@ public class TestClassIThreeMethodsWithDataProviderOnSomeMethodsAndNoDepsSample 
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -56,6 +62,9 @@ public class TestClassIThreeMethodsWithDataProviderOnSomeMethodsAndNoDepsSample 
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -77,6 +86,9 @@ public class TestClassIThreeMethodsWithDataProviderOnSomeMethodsAndNoDepsSample 
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 

--- a/src/test/java/test/thread/parallelization/sample/TestClassJFourMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/sample/TestClassJFourMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.java
@@ -12,6 +12,9 @@ import java.util.concurrent.TimeUnit;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_INSTANCE;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.DATA_PROVIDER_PARAM;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_BELONGING_TO;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_DEPENDED_ON;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHODS_DEPENDED_ON;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHOD_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.SUITE_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.TEST_NAME;
@@ -35,6 +38,9 @@ public class TestClassJFourMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                     .addData(TEST_NAME, testName)
                     .addData(SUITE_NAME, suiteName)
                     .addData(DATA_PROVIDER_PARAM, dpVal)
+                    .addData(GROUPS_DEPENDED_ON, new String[0])
+                    .addData(METHODS_DEPENDED_ON, new String[0])
+                    .addData(GROUPS_BELONGING_TO, new String[0])
                     .build()
         );
 
@@ -57,6 +63,9 @@ public class TestClassJFourMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -78,6 +87,9 @@ public class TestClassJFourMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -99,6 +111,9 @@ public class TestClassJFourMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 

--- a/src/test/java/test/thread/parallelization/sample/TestClassJFourMethodsWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/sample/TestClassJFourMethodsWithNoDepsSample.java
@@ -8,6 +8,9 @@ import java.util.concurrent.TimeUnit;
 
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_INSTANCE;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_NAME;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_BELONGING_TO;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_DEPENDED_ON;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHODS_DEPENDED_ON;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHOD_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.SUITE_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.TEST_NAME;
@@ -29,6 +32,9 @@ public class TestClassJFourMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -50,6 +56,9 @@ public class TestClassJFourMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -71,6 +80,9 @@ public class TestClassJFourMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -92,6 +104,9 @@ public class TestClassJFourMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 

--- a/src/test/java/test/thread/parallelization/sample/TestClassKFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/sample/TestClassKFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample.java
@@ -12,6 +12,9 @@ import java.util.concurrent.TimeUnit;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_INSTANCE;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.DATA_PROVIDER_PARAM;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_BELONGING_TO;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_DEPENDED_ON;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHODS_DEPENDED_ON;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHOD_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.SUITE_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.TEST_NAME;
@@ -35,6 +38,9 @@ public class TestClassKFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -57,6 +63,9 @@ public class TestClassKFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -79,6 +88,9 @@ public class TestClassKFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -101,6 +113,9 @@ public class TestClassKFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -123,6 +138,9 @@ public class TestClassKFiveMethodsWithDataProviderOnSomeMethodsAndNoDepsSample {
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
                         .addData(DATA_PROVIDER_PARAM, dpVal)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 

--- a/src/test/java/test/thread/parallelization/sample/TestClassKFiveMethodsWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/sample/TestClassKFiveMethodsWithNoDepsSample.java
@@ -8,6 +8,9 @@ import java.util.concurrent.TimeUnit;
 
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_INSTANCE;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_NAME;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_BELONGING_TO;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_DEPENDED_ON;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHODS_DEPENDED_ON;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHOD_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.SUITE_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.TEST_NAME;
@@ -30,6 +33,9 @@ public class TestClassKFiveMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -51,6 +57,9 @@ public class TestClassKFiveMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -72,6 +81,9 @@ public class TestClassKFiveMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -93,6 +105,9 @@ public class TestClassKFiveMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -114,6 +129,9 @@ public class TestClassKFiveMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 

--- a/src/test/java/test/thread/parallelization/sample/TestClassLThreeMethodsWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/sample/TestClassLThreeMethodsWithNoDepsSample.java
@@ -8,6 +8,9 @@ import java.util.concurrent.TimeUnit;
 
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_INSTANCE;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_NAME;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_BELONGING_TO;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_DEPENDED_ON;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHODS_DEPENDED_ON;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHOD_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.SUITE_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.TEST_NAME;
@@ -30,6 +33,9 @@ public class TestClassLThreeMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -51,6 +57,9 @@ public class TestClassLThreeMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -72,6 +81,9 @@ public class TestClassLThreeMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 

--- a/src/test/java/test/thread/parallelization/sample/TestClassMFourMethodsWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/sample/TestClassMFourMethodsWithNoDepsSample.java
@@ -8,6 +8,9 @@ import java.util.concurrent.TimeUnit;
 
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_INSTANCE;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_NAME;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_BELONGING_TO;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_DEPENDED_ON;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHODS_DEPENDED_ON;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHOD_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.SUITE_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.TEST_NAME;
@@ -29,6 +32,9 @@ public class TestClassMFourMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -50,6 +56,9 @@ public class TestClassMFourMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -71,6 +80,9 @@ public class TestClassMFourMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -92,6 +104,9 @@ public class TestClassMFourMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 

--- a/src/test/java/test/thread/parallelization/sample/TestClassNFiveMethodsWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/sample/TestClassNFiveMethodsWithNoDepsSample.java
@@ -8,6 +8,9 @@ import java.util.concurrent.TimeUnit;
 
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_INSTANCE;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_NAME;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_BELONGING_TO;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_DEPENDED_ON;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHODS_DEPENDED_ON;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHOD_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.SUITE_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.TEST_NAME;
@@ -30,6 +33,9 @@ public class TestClassNFiveMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -51,6 +57,9 @@ public class TestClassNFiveMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -72,6 +81,9 @@ public class TestClassNFiveMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -93,6 +105,9 @@ public class TestClassNFiveMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -114,6 +129,9 @@ public class TestClassNFiveMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 

--- a/src/test/java/test/thread/parallelization/sample/TestClassOSixMethodsWithNoDepsSample.java
+++ b/src/test/java/test/thread/parallelization/sample/TestClassOSixMethodsWithNoDepsSample.java
@@ -8,6 +8,9 @@ import java.util.concurrent.TimeUnit;
 
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_INSTANCE;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.CLASS_NAME;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_BELONGING_TO;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.GROUPS_DEPENDED_ON;
+import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHODS_DEPENDED_ON;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.METHOD_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.SUITE_NAME;
 import static test.thread.parallelization.TestNgRunStateTracker.EventInfo.TEST_NAME;
@@ -29,6 +32,9 @@ public class TestClassOSixMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -50,6 +56,9 @@ public class TestClassOSixMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -71,6 +80,9 @@ public class TestClassOSixMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -92,6 +104,9 @@ public class TestClassOSixMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -113,6 +128,9 @@ public class TestClassOSixMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 
@@ -134,6 +152,9 @@ public class TestClassOSixMethodsWithNoDepsSample {
                         .addData(CLASS_INSTANCE, this)
                         .addData(TEST_NAME, testName)
                         .addData(SUITE_NAME, suiteName)
+                        .addData(GROUPS_DEPENDED_ON, new String[0])
+                        .addData(METHODS_DEPENDED_ON, new String[0])
+                        .addData(GROUPS_BELONGING_TO, new String[0])
                         .build()
         );
 


### PR DESCRIPTION
Reverted to System.out.print for logging until we come up with a better solution for debugging failures on the CI builds.

Relaxed the parallelization verification.

Removed unused methods as a result of refactoring.