### PR TITLE
Enable URI format for suite location.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-212: Enable support for providing a URI as suite file location (Krishnan Mahadevan)
 Fixed: GITHUB-161 : Provide a way to customize SAXParserFactory implementation (Krishnan Mahadevan)
 Fixed: GITHUB-1455: Configure XML output of XmlSuite (Krishnan Mahadevan)
 Fixed: GITHUB-1465: Failure policy CONTINUE handling is broken for tests that are skipped in @BeforeMethod method (Krishnan Mahadevan)

--- a/src/main/java/org/testng/internal/YamlParser.java
+++ b/src/main/java/org/testng/internal/YamlParser.java
@@ -2,6 +2,7 @@ package org.testng.internal;
 
 import org.testng.TestNGException;
 import org.testng.xml.ISuiteParser;
+import org.testng.xml.Parser;
 import org.testng.xml.XmlSuite;
 
 import java.io.FileNotFoundException;
@@ -21,7 +22,7 @@ public class YamlParser implements ISuiteParser {
 
   @Override
   public boolean accept(String fileName) {
-    return fileName.endsWith(".yaml");
+    return Parser.hasFileScheme(fileName) && fileName.endsWith(".yaml");
   }
 
 }

--- a/src/main/java/org/testng/xml/Parser.java
+++ b/src/main/java/org/testng/xml/Parser.java
@@ -150,7 +150,7 @@ public class Parser {
     if (m_fileName != null) {
       URI uri = URI.create(m_fileName);
       if (uri.getScheme() == null) {
-        uri =new File(m_fileName).toURI();
+        uri = new File(m_fileName).toURI();
       }
       if ("file".equalsIgnoreCase(uri.getScheme())) {
         File mainFile = new File(uri);
@@ -169,11 +169,8 @@ public class Parser {
       for (String currentFile : toBeParsed) {
         File parentFile = null;
         InputStream inputStream = null;
-        String scheme = URI.create(currentFile).getScheme();
-        if (scheme == null) { //scheme would be null if the currentFile was just a file path.
-          scheme = new File(currentFile).toURI().getScheme();
-        }
-        if ("file".equalsIgnoreCase(scheme)) {
+
+        if (hasFileScheme(currentFile)) {
           File currFile = new File(currentFile);
           parentFile = currFile.getParentFile();
           inputStream = m_inputStream != null ? m_inputStream : new FileInputStream(currFile);
@@ -201,13 +198,7 @@ public class Parser {
         if (!suiteFiles.isEmpty()) {
           for (String path : suiteFiles) {
             String canonicalPath = path;
-            //Resort to files only if the scheme is "file"
-            scheme = URI.create(path).getScheme();
-            if (scheme == null) {
-              scheme = new File(path).toURI().getScheme();
-            }
-
-            if ("file".equalsIgnoreCase(scheme)) {
+            if (hasFileScheme(path)) {
               if (parentFile != null && new File(parentFile, path).exists()) {
                 canonicalPath = new File(parentFile, path).getCanonicalPath();
               } else {
@@ -249,6 +240,18 @@ public class Parser {
       return resultList;
     }
 
+  }
+
+  /**
+   *
+   * @param uri - The uri to be verified.
+   * @return - <code>true</code> if the uri has "file:" as its scheme.
+   */
+  public static boolean hasFileScheme(String uri) {
+    String scheme = URI.create(uri).getScheme();
+    //A URI is regarded as having a file scheme if it either has its scheme as "file"
+    //(or) if the scheme is null (which is true when uri's represent local file system path.)
+    return scheme == null || "file".equalsIgnoreCase(scheme);
   }
 
   public List<XmlSuite> parseToList()

--- a/src/main/java/org/testng/xml/SuiteXmlParser.java
+++ b/src/main/java/org/testng/xml/SuiteXmlParser.java
@@ -23,6 +23,6 @@ public class SuiteXmlParser extends XMLParser<XmlSuite> implements ISuiteParser 
 
   @Override
   public boolean accept(String fileName) {
-    return fileName.endsWith(".xml");
+    return Parser.hasFileScheme(fileName) && fileName.endsWith(".xml");
   }
 }

--- a/src/main/java/org/testng/xml/dom/DomXmlParser.java
+++ b/src/main/java/org/testng/xml/dom/DomXmlParser.java
@@ -1,6 +1,7 @@
 package org.testng.xml.dom;
 
 import org.testng.xml.ISuiteParser;
+import org.testng.xml.Parser;
 import org.testng.xml.XMLParser;
 import org.testng.xml.XmlSuite;
 import org.w3c.dom.Document;
@@ -29,7 +30,7 @@ public class DomXmlParser extends XMLParser<XmlSuite> implements ISuiteParser {
 
   @Override
   public boolean accept(String fileName) {
-    return fileName.endsWith(".xml");
+    return Parser.hasFileScheme(fileName) && fileName.endsWith(".xml");
   }
 
   public XmlSuite parse2(String currentFile, InputStream inputStream,

--- a/src/test/java/org/testng/xml/FakeHttpXmlParser.java
+++ b/src/test/java/org/testng/xml/FakeHttpXmlParser.java
@@ -1,0 +1,19 @@
+package org.testng.xml;
+
+import org.testng.TestNGException;
+
+import java.io.InputStream;
+
+public class FakeHttpXmlParser implements ISuiteParser {
+    @Override
+    public boolean accept(String fileName) {
+        return fileName.startsWith("https") || fileName.startsWith("http");
+    }
+
+    @Override
+    public XmlSuite parse(String filePath, InputStream is, boolean loadClasses) throws TestNGException {
+        XmlSuite suite = new XmlSuite();
+        suite.setName("fake_suite");
+        return suite;
+    }
+}

--- a/src/test/java/org/testng/xml/ParserTest.java
+++ b/src/test/java/org/testng/xml/ParserTest.java
@@ -23,7 +23,9 @@ public class ParserTest {
     public Object[][] getData() {
         return new Object[][]{
                 {XML_FILE_NAME},
-                {new File(XML_FILE_NAME).toURI().toString()}
+                {new File(XML_FILE_NAME).toURI().toString()},
+                {"http://localhost:4444/testng.xml"},
+                {"https://localhost:4444/testng.xml"}
         };
     }
 }

--- a/src/test/java/org/testng/xml/ParserTest.java
+++ b/src/test/java/org/testng/xml/ParserTest.java
@@ -1,0 +1,29 @@
+package org.testng.xml;
+
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.List;
+
+public class ParserTest {
+
+    private static final String XML_FILE_NAME = "src/test/resources/a.xml";
+
+    @Test(dataProvider = "dp")
+    public void testParsing(String file) throws Exception {
+        Parser parser = new Parser(file);
+        List<XmlSuite> suites = parser.parseToList();
+        assertEquals(suites.size(), 1);
+    }
+
+    @DataProvider(name = "dp")
+    public Object[][] getData() {
+        return new Object[][]{
+                {XML_FILE_NAME},
+                {new File(XML_FILE_NAME).toURI().toString()}
+        };
+    }
+}

--- a/src/test/resources/META-INF/services/org.testng.xml.ISuiteParser
+++ b/src/test/resources/META-INF/services/org.testng.xml.ISuiteParser
@@ -1,0 +1,1 @@
+org.testng.xml.FakeHttpXmlParser

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -744,6 +744,7 @@
     <classes>
       <class name="org.testng.xml.SuiteXmlParserTest" />
       <class name="org.testng.xml.XmlSuiteTest"/>
+      <class name="org.testng.xml.ParserTest"/>
     </classes>
   </test>
 


### PR DESCRIPTION
Closes #212

Till now TestNG provided support only for local  file system paths as suite file locations.

Now enabling the location to be specified as a URI.
TestNG will still support only `file:` URI and regular local file system locations, but if one wants
to work with a `http` URI as the suite file locationthen one can provide the location as a URL and then
plug-in an implementation of `org.testng.xml.ISuiteParser` via service loaders and wire in their support for the same.

Fixes #212  .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
