### PR TITLE
XmlTest is null when read via IInvokedMethodListener

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-1029: Issue with getting XmlTest from test method (Krishnan Mahadevan)
 Fixed: GITHUB-212: Enable support for providing a URI as suite file location (Krishnan Mahadevan)
 Fixed: GITHUB-161 : Provide a way to customize SAXParserFactory implementation (Krishnan Mahadevan)
 Fixed: GITHUB-1455: Configure XML output of XmlSuite (Krishnan Mahadevan)

--- a/src/main/java/org/testng/internal/TestNGMethod.java
+++ b/src/main/java/org/testng/internal/TestNGMethod.java
@@ -36,6 +36,7 @@ public class TestNGMethod extends BaseTestMethod {
   private TestNGMethod(Method method, IAnnotationFinder finder, boolean initialize,
       XmlTest xmlTest, Object instance) {
     super(method.getName(), method, finder, instance);
+    setXmlTest(xmlTest);
 
     if(initialize) {
       init(xmlTest);

--- a/src/test/java/test/listeners/ListenerTest.java
+++ b/src/test/java/test/listeners/ListenerTest.java
@@ -2,16 +2,23 @@ package test.listeners;
 
 import org.testng.*;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.testng.collections.Lists;
 
 import org.testng.xml.XmlSuite;
 import test.SimpleBaseTest;
+import test.listeners.github1029.Issue1029InvokedMethodListener;
+import test.listeners.github1029.Issue1029SampleTestClassWithDataDrivenMethod;
+import test.listeners.github1029.Issue1029SampleTestClassWithFiveInstances;
+import test.listeners.github1029.Issue1029SampleTestClassWithFiveMethods;
+import test.listeners.github1029.Issue1029SampleTestClassWithOneMethod;
 import test.listeners.github1393.Listener1393;
 import test.listeners.github956.ListenerFor956;
 import test.listeners.github956.TestClassContainer;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -259,5 +266,32 @@ public class ListenerTest extends SimpleBaseTest {
     tng.run();
     Assert.assertEquals(adapter.getPassedTests().size(), 0);
     Assert.assertEquals(adapter.getFailedTests().size(), 1);
+  }
+
+  @Test(dataProvider = "dp", description ="GITHUB-1029" )
+  public void ensureXmlTestIsNotNull(Class<?> clazz, XmlSuite.ParallelMode mode) {
+    XmlSuite xmlSuite = createXmlSuite("Suite");
+    createXmlTest(xmlSuite, "GITHUB-1029-Test", clazz);
+    xmlSuite.setParallel(mode);
+    Issue1029InvokedMethodListener listener = new Issue1029InvokedMethodListener();
+    TestNG testng = create(xmlSuite);
+    testng.addListener((ITestNGListener) listener);
+    testng.setThreadCount(10);
+    testng.setDataProviderThreadCount(10);
+    testng.run();
+    List<String> expected = Collections.nCopies(5, "GITHUB-1029-Test");
+    assertThat(listener.getBeforeInvocation()).containsExactlyElementsOf(expected);
+    assertThat(listener.getAfterInvocation()).containsExactlyElementsOf(expected);
+  }
+
+  @DataProvider(name = "dp")
+  public Object[][] getData() {
+    return new Object[][]{
+            {Issue1029SampleTestClassWithFiveMethods.class, XmlSuite.ParallelMode.METHODS},
+            {Issue1029SampleTestClassWithOneMethod.class, XmlSuite.ParallelMode.METHODS},
+            {Issue1029SampleTestClassWithDataDrivenMethod.class, XmlSuite.ParallelMode.METHODS},
+            {Issue1029SampleTestClassWithFiveInstances.class, XmlSuite.ParallelMode.INSTANCES}
+
+    };
   }
 }

--- a/src/test/java/test/listeners/github1029/Issue1029InvokedMethodListener.java
+++ b/src/test/java/test/listeners/github1029/Issue1029InvokedMethodListener.java
@@ -1,0 +1,35 @@
+package test.listeners.github1029;
+
+import org.testng.IInvokedMethod;
+import org.testng.IInvokedMethodListener;
+import org.testng.ITestResult;
+import org.testng.xml.XmlTest;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class Issue1029InvokedMethodListener implements IInvokedMethodListener {
+    private List<String> beforeInvocation = Collections.synchronizedList(new ArrayList<String>());
+    private List<String> afterInvocation = Collections.synchronizedList(new ArrayList<String>());
+
+    @Override
+    public void beforeInvocation(IInvokedMethod method, ITestResult testResult) {
+        XmlTest xmlTest = method.getTestMethod().getXmlTest();
+        beforeInvocation.add(xmlTest.getName());
+    }
+
+    @Override
+    public void afterInvocation(IInvokedMethod method, ITestResult testResult) {
+        XmlTest xmlTest = method.getTestMethod().getXmlTest();
+        afterInvocation.add(xmlTest.getName());
+    }
+
+    public List<String> getAfterInvocation() {
+        return afterInvocation;
+    }
+
+    public List<String> getBeforeInvocation() {
+        return beforeInvocation;
+    }
+}

--- a/src/test/java/test/listeners/github1029/Issue1029SampleTestClassWithDataDrivenMethod.java
+++ b/src/test/java/test/listeners/github1029/Issue1029SampleTestClassWithDataDrivenMethod.java
@@ -1,0 +1,24 @@
+package test.listeners.github1029;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class Issue1029SampleTestClassWithDataDrivenMethod {
+    @Test(dataProvider = "dp")
+    public void a(int i) {
+        Assert.assertTrue(i > 0);
+    }
+
+    @DataProvider(name = "dp", parallel = true)
+    public Object[][] getData() {
+        return new Object[][]{
+                {1},
+                {2},
+                {3},
+                {4},
+                {5}
+        };
+    }
+
+}

--- a/src/test/java/test/listeners/github1029/Issue1029SampleTestClassWithFiveInstances.java
+++ b/src/test/java/test/listeners/github1029/Issue1029SampleTestClassWithFiveInstances.java
@@ -1,0 +1,32 @@
+package test.listeners.github1029;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+
+public class Issue1029SampleTestClassWithFiveInstances {
+
+    private int i;
+
+    @Factory(dataProvider = "dp")
+    public Issue1029SampleTestClassWithFiveInstances(int i) {
+        this.i = i;
+    }
+
+    @Test
+    public void a() {
+        Assert.assertTrue(i > 0);
+    }
+
+    @DataProvider(name = "dp")
+    public static Object[][] getData() {
+        return new Object[][]{
+                {1},
+                {2},
+                {3},
+                {4},
+                {5}
+        };
+    }
+}

--- a/src/test/java/test/listeners/github1029/Issue1029SampleTestClassWithFiveMethods.java
+++ b/src/test/java/test/listeners/github1029/Issue1029SampleTestClassWithFiveMethods.java
@@ -1,0 +1,29 @@
+package test.listeners.github1029;
+
+import org.testng.Assert;
+import org.testng.Reporter;
+import org.testng.annotations.Test;
+
+public class Issue1029SampleTestClassWithFiveMethods {
+    @Test
+    public void a() {
+        Assert.assertTrue(true);
+    }
+    @Test
+    public void b() {
+        Assert.assertTrue(true);
+    }
+    @Test
+    public void c() {
+        Assert.assertTrue(true);
+    }
+    @Test
+    public void d() {
+        Assert.assertTrue(true);
+    }
+    @Test
+    public void e() {
+        Assert.assertTrue(true);
+    }
+
+}

--- a/src/test/java/test/listeners/github1029/Issue1029SampleTestClassWithOneMethod.java
+++ b/src/test/java/test/listeners/github1029/Issue1029SampleTestClassWithOneMethod.java
@@ -1,0 +1,12 @@
+package test.listeners.github1029;
+
+import org.testng.Assert;
+import org.testng.Reporter;
+import org.testng.annotations.Test;
+
+public class Issue1029SampleTestClassWithOneMethod {
+    @Test(invocationCount = 5, threadPoolSize = 10)
+    public void a() {
+        Assert.assertTrue(true);
+    }
+}


### PR DESCRIPTION
Closes #1029

Fixes #1029  .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
