### PR TITLE
Ensure TestResult contains proper test method

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-1061: Have a way to change timeout dynamically at runtime (Krishnan Mahadevan)
 Fixed: GITHUB-1029: Issue with getting XmlTest from test method (Krishnan Mahadevan)
 Fixed: GITHUB-212: Enable support for providing a URI as suite file location (Krishnan Mahadevan)
 Fixed: GITHUB-161 : Provide a way to customize SAXParserFactory implementation (Krishnan Mahadevan)

--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -206,6 +206,9 @@ public class Invoker implements IInvoker {
             }
 
             log(3, "Invoking " + Utils.detailedMethodName(tm, true));
+            if (testMethodResult != null) {
+              ((TestResult) testMethodResult).setMethod(currentTestMethod);
+            }
 
             Object[] parameters = Parameters.createConfigurationParameters(tm.getConstructorOrMethod().getMethod(),
                 params,

--- a/src/test/java/test/parameters/Issue1061Sample.java
+++ b/src/test/java/test/parameters/Issue1061Sample.java
@@ -1,0 +1,36 @@
+package test.parameters;
+
+import org.testng.ITestResult;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+
+public class Issue1061Sample {
+    private final long timeout;
+    private final long waitTime;
+
+    @DataProvider
+    public static Object[][] dp() {
+        return new Object[][]{
+                new Object[]{1_000, 2_000},
+                new Object[]{3_000, 6_000}
+        };
+    }
+
+    @Factory(dataProvider = "dp")
+    public Issue1061Sample(long timeout, long waitTime) {
+        this.timeout = timeout;
+        this.waitTime = waitTime;
+    }
+
+    @BeforeMethod
+    public void setup(ITestResult result) {
+        result.getMethod().setTimeOut(timeout);
+    }
+
+    @Test
+    public void test() throws InterruptedException {
+        Thread.sleep(waitTime);
+    }
+}


### PR DESCRIPTION
Closes #1061

When natively injecting a ITestResult for a configuration method
TestNG doesn’t inject the correct test method.
Fixed this, so that user’s can leverage native 
injection of ITestResult and do things such as 
altering timeouts of the method to be executed etc.,

Fixes #1061 .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
