### PR TITLE
Use concurrent collections

### DIFF
--- a/src/main/java/org/testng/SuiteRunner.java
+++ b/src/main/java/org/testng/SuiteRunner.java
@@ -28,6 +28,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
 import com.google.inject.Injector;
 
 /**
@@ -38,7 +40,7 @@ public class SuiteRunner implements ISuite, IInvokedMethodListener {
 
   private static final String DEFAULT_OUTPUT_DIR = "test-output";
 
-  private Map<String, ISuiteResult> suiteResults = Collections.synchronizedMap(Maps.<String, ISuiteResult>newLinkedHashMap());
+  private Map<String, ISuiteResult> suiteResults = new ConcurrentHashMap<>();
   private List<TestRunner> testRunners = Lists.newArrayList();
   private Map<Class<? extends ISuiteListener>, ISuiteListener> listeners = Maps.newHashMap();
   private TestListenerAdapter textReporter = new TestListenerAdapter();

--- a/src/main/java/org/testng/internal/thread/graph/GraphThreadPoolExecutor.java
+++ b/src/main/java/org/testng/internal/thread/graph/GraphThreadPoolExecutor.java
@@ -1,14 +1,14 @@
 package org.testng.internal.thread.graph;
 
 import org.testng.TestNGException;
-import org.testng.collections.Lists;
 import org.testng.internal.DynamicGraph;
 import org.testng.internal.DynamicGraph.Status;
 import org.testng.internal.thread.TestNGThreadFactory;
 
-import java.util.Collections;
 import java.util.List;
+import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
@@ -20,7 +20,7 @@ import java.util.concurrent.TimeUnit;
 public class GraphThreadPoolExecutor<T> extends ThreadPoolExecutor {
 
   private final DynamicGraph<T> m_graph;
-  private final List<Runnable> m_activeRunnables = Collections.synchronizedList(Lists.<Runnable>newArrayList());
+  private final Queue<Runnable> m_activeRunnables = new ConcurrentLinkedDeque<>();
   private final IThreadWorkerFactory<T> m_factory;
 
   public GraphThreadPoolExecutor(String name, DynamicGraph<T> graph, IThreadWorkerFactory<T> factory, int corePoolSize,

--- a/src/main/java/org/testng/reporters/JUnitXMLReporter.java
+++ b/src/main/java/org/testng/reporters/JUnitXMLReporter.java
@@ -15,11 +15,13 @@ import java.net.UnknownHostException;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Collection;
+import java.util.Queue;
 import java.util.TimeZone;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.regex.Pattern;
 
 import java.text.SimpleDateFormat;
@@ -47,10 +49,8 @@ public class JUnitXMLReporter implements IResultListener2 {
 
 
   private int m_numFailed= 0;
-  private List<ITestResult> m_allTests =
-      Collections.synchronizedList(Lists.<ITestResult>newArrayList());
-  private List<ITestResult> m_configIssues =
-      Collections.synchronizedList(Lists.<ITestResult>newArrayList());
+  private Queue<ITestResult> m_allTests = new ConcurrentLinkedDeque<>();
+  private Queue<ITestResult> m_configIssues = new ConcurrentLinkedDeque<>();
   private Map<String, String> m_fileNameMap = Maps.newHashMap();
   private int m_fileNameIncrementer = 0;
 
@@ -182,7 +182,7 @@ public class JUnitXMLReporter implements IResultListener2 {
     return sdf.format(Calendar.getInstance().getTime());
   }
 
-  private synchronized void createElementFromTestResults(XMLStringBuffer document, List<ITestResult> results) {
+  private synchronized void createElementFromTestResults(XMLStringBuffer document, Collection<ITestResult> results) {
     for(ITestResult tr : results) {
       createElement(document, tr);
     }
@@ -304,8 +304,8 @@ public class JUnitXMLReporter implements IResultListener2 {
 	 * Reset all member variables for next test.
 	 * */
 	private void resetAll() {
-		m_allTests = Collections.synchronizedList(Lists.<ITestResult>newArrayList());
-		m_configIssues = Collections.synchronizedList(Lists.<ITestResult>newArrayList());
+		m_allTests = new ConcurrentLinkedDeque<>();
+		m_configIssues = new ConcurrentLinkedDeque<>();
 		m_numFailed = 0;
     }
 


### PR DESCRIPTION
Switched over to using concurrent linked queue and
concurrent hash maps instead of using synchronized 
lists and maps.

Fixes # .

### Did you remember to?

- [ ] Add test case(s)
- [ ] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
