### PR TITLE
After methods should be skipped when exclusion used

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-1574: Before/After methods are not running when groups "include" in suite (Krishnan Mahadevan)
 Fixed: GITHUB-217: exception in DataProvider doesn't fail test run (Krishnan Mahadevan)
 Fixed: GITHUB-987: Parameters threadCount and parallel doesn't work with maven (Krishnan Mahadevan)
 Fixed: GITHUB-1472: Optimize DynamicGraph.getUnfinishedNodes (Krishnan Mahadevan & Nathan Reynolds)

--- a/src/main/java/org/testng/internal/XmlMethodSelector.java
+++ b/src/main/java/org/testng/internal/XmlMethodSelector.java
@@ -275,6 +275,9 @@ public class XmlMethodSelector implements IMethodSelector {
   }
 
   private static boolean isExcluded(Collection<String> excludedGroups, String... groups) {
+    if (!excludedGroups.isEmpty() && groups.length == 0) {
+      return true;
+    }
     return isMemberOf(excludedGroups, groups);
   }
 

--- a/src/test/java/test/groupinvocation/GroupSuiteTest.java
+++ b/src/test/java/test/groupinvocation/GroupSuiteTest.java
@@ -14,6 +14,7 @@ import test.SimpleBaseTest;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -123,7 +124,7 @@ public class GroupSuiteTest extends SimpleBaseTest {
       test.setExcludedGroups(excludedTestGroups);
     }
 
-    tng.setXmlSuites(Arrays.asList(suite));
+    tng.setXmlSuites(Collections.singletonList(suite));
 
     InvokedMethodNameListener listener = new InvokedMethodNameListener();
     tng.addListener((ITestNGListener) listener);
@@ -131,6 +132,18 @@ public class GroupSuiteTest extends SimpleBaseTest {
     tng.run();
 
     assertThat(listener.getInvokedMethodNames()).containsExactly(methods);
+  }
+
+  @Test(description = "GITHUB-1574")
+  public void testToCheckNoConfigurationsAreExecuted() {
+    XmlSuite suite = createXmlSuite("suite");
+    XmlTest test = createXmlTest(suite, "test", Issue1574TestclassSample.class);
+    test.addExcludedGroup("sometest");
+    TestNG testng = create(suite);
+    InvokedMethodNameListener listener = new InvokedMethodNameListener();
+    testng.addListener((ITestNGListener) listener);
+    testng.run();
+    assertThat(listener.getInvokedMethodNames()).containsExactly("anothertest", "tearDownSuite");
   }
 
   private static List<String> g(String... groups) {

--- a/src/test/java/test/groupinvocation/Issue1574TestclassSample.java
+++ b/src/test/java/test/groupinvocation/Issue1574TestclassSample.java
@@ -1,0 +1,43 @@
+package test.groupinvocation;
+
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterSuite;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+public class Issue1574TestclassSample {
+    @BeforeSuite
+    public void setupSuite() {
+    }
+
+    @BeforeTest
+    public void setUpTest() {
+    }
+
+    @BeforeMethod
+    public void setUpMethod() {
+    }
+
+    @AfterMethod
+    public void tearDownMethod() {
+    }
+
+    @AfterTest
+    public void tearDownTest() {
+    }
+
+    @AfterSuite(alwaysRun = true)
+    public void tearDownSuite() {
+    }
+
+    @Test(groups = {"sometest"})
+    public void someTest() {
+    }
+
+    @Test(groups = {"anothertest"})
+    public void anothertest() {
+    }
+}


### PR DESCRIPTION
Closes #1574

Suppose there are one or more configuration methods
which don’t belong to any group and for which “alwaysRun”
attribute is not set, and when the user specifies 
a valid exclusion list for groups, TestNG would still
execute those configuration methods.

Fixed this anomaly.

Fixes #1574  .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
