### PR TITLE
Exception in DataProvider doesn't fail test run

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-217: exception in DataProvider doesn't fail test run (Krishnan Mahadevan)
 Fixed: GITHUB-987: Parameters threadCount and parallel doesn't work with maven (Krishnan Mahadevan)
 Fixed: GITHUB-1472: Optimize DynamicGraph.getUnfinishedNodes (Krishnan Mahadevan & Nathan Reynolds)
 Fixed: GITHUB-1566: Invalid XML characters in Params in testng-results.xml (Krishnan Mahadevan)

--- a/src/main/java/org/testng/TestNG.java
+++ b/src/main/java/org/testng/TestNG.java
@@ -143,11 +143,8 @@ public class TestNG {
   private final Map<Class<? extends IReporter>, IReporter> m_reporters = Maps.newHashMap();
   private final Map<Class<? extends IDataProviderListener>, IDataProviderListener> m_dataProviderListeners = Maps.newHashMap();
 
-  protected static final int HAS_NO_TEST = 8;
 
   public static final Integer DEFAULT_VERBOSE = 1;
-
-  private boolean m_hasTests= false;
 
   // Command line suite parameters
   private int m_threadCount = -1;
@@ -210,10 +207,10 @@ public class TestNG {
   }
 
   public int getStatus() {
-    if (m_hasTests) {
-      return exitCode.getExitCode();
+    if (!exitCodeListener.hasTests()) {
+      return ExitCode.HAS_NO_TEST;
     }
-    return HAS_NO_TEST;
+    return exitCode.getExitCode();
   }
 
   /**
@@ -1154,10 +1151,9 @@ public class TestNG {
     }
 
     runExecutionListeners(false /* finish */);
-    m_hasTests = this.exitCodeListener.hasTests();
     exitCode = this.exitCodeListener.getStatus();
 
-    if(!m_hasTests) {
+    if(!exitCodeListener.hasTests()) {
       if (TestRunner.getVerbose() > 1) {
         System.err.println("[TestNG] No tests found. Nothing was run");
         usage();
@@ -1243,7 +1239,6 @@ public class TestNG {
    */
   public List<ISuite> runSuitesLocally() {
     if (m_suites.isEmpty()) {
-      this.m_hasTests = false;
       error("No test suite found. Nothing to run");
       usage();
       return Collections.emptyList();
@@ -2005,7 +2000,6 @@ public class TestNG {
     }
 
     private void setHasRunTests() {
-      m_mainRunner.m_hasTests= true;
     }
 
     /**

--- a/src/main/java/org/testng/TestNG.java
+++ b/src/main/java/org/testng/TestNG.java
@@ -29,6 +29,7 @@ import org.testng.collections.Sets;
 import org.testng.internal.ClassHelper;
 import org.testng.internal.Configuration;
 import org.testng.internal.DynamicGraph;
+import org.testng.internal.ExitCodeListener;
 import org.testng.internal.IConfiguration;
 import org.testng.internal.IResultListener2;
 import org.testng.internal.OverrideProcessor;
@@ -185,6 +186,7 @@ public class TestNG {
   private final Map<Class<? extends IAlterSuiteListener>, IAlterSuiteListener> m_alterSuiteListeners= Maps.newHashMap();
 
   private boolean m_isInitialized = false;
+  private org.testng.internal.ExitCodeListener m_exitCode;
 
   /**
    * Default constructor. Setting also usage of default listeners/reporters.
@@ -215,7 +217,7 @@ public class TestNG {
   }
 
   private void setStatus(int status) {
-    m_status |= status;
+    m_status = status;
   }
 
   /**
@@ -963,7 +965,8 @@ public class TestNG {
   }
 
   private void initializeDefaultListeners() {
-    addListener((ITestNGListener) new ExitCodeListener(this));
+    this.m_exitCode = new org.testng.internal.ExitCodeListener();
+    addListener((ITestNGListener) this.m_exitCode);
     if (m_useDefaultListeners) {
       addReporter(SuiteHTMLReporter.class);
       addReporter(Main.class);
@@ -1155,6 +1158,8 @@ public class TestNG {
     }
 
     runExecutionListeners(false /* finish */);
+    m_hasTests = this.m_exitCode.isHasTests();
+    setStatus(this.m_exitCode.getStatus());
 
     if(!m_hasTests) {
       setStatus(HAS_NO_TEST);
@@ -1975,6 +1980,10 @@ public class TestNG {
     m_status |= HAS_SKIPPED;
   }
 
+  @Deprecated
+  /**
+   * @deprecated - This class stands deprecated as of TestNG v6.13
+   */
   public static class ExitCodeListener implements IResultListener2 {
     private TestNG m_mainRunner;
 

--- a/src/main/java/org/testng/TestNGAntTask.java
+++ b/src/main/java/org/testng/TestNGAntTask.java
@@ -36,6 +36,7 @@ import org.apache.tools.ant.types.ResourceCollection;
 import org.apache.tools.ant.types.resources.FileResource;
 import org.apache.tools.ant.types.selectors.FilenameSelector;
 import org.testng.collections.Lists;
+import org.testng.internal.ExitCode;
 import org.testng.internal.Utils;
 import org.testng.reporters.VerboseReporter;
 
@@ -738,7 +739,7 @@ public class TestNGAntTask extends Task {
       }
     }
 
-    boolean failed= ((exitValue & TestNG.HAS_FAILURE) == TestNG.HAS_FAILURE) || wasKilled;
+    boolean failed= (ExitCode.hasFailure(exitValue)) || wasKilled;
     if(failed) {
       final String msg= wasKilled ? "The tests timed out and were killed." : "The tests failed.";
       if(m_haltOnFailure) {
@@ -754,7 +755,7 @@ public class TestNGAntTask extends Task {
       }
     }
 
-    if((exitValue & TestNG.HAS_SKIPPED) == TestNG.HAS_SKIPPED) {
+    if(ExitCode.hasSkipped(exitValue)) {
       if(m_haltOnSkipped) {
         executeHaltTarget(exitValue);
         throw new BuildException("There are TestNG SKIPPED tests");
@@ -768,7 +769,7 @@ public class TestNGAntTask extends Task {
       }
     }
 
-    if((exitValue & TestNG.HAS_FSP) == TestNG.HAS_FSP) {
+    if(ExitCode.hasFailureWithinSuccessPercentage(exitValue)) {
       if(m_haltOnFSP) {
         executeHaltTarget(exitValue);
         throw new BuildException("There are TestNG FAILED WITHIN SUCCESS PERCENTAGE tests");

--- a/src/main/java/org/testng/TestNGAntTask.java
+++ b/src/main/java/org/testng/TestNGAntTask.java
@@ -722,10 +722,10 @@ public class TestNGAntTask extends Task {
   protected void actOnResult(int exitValue, boolean wasKilled) {
     if(exitValue == -1) {
       executeHaltTarget(exitValue);
-      throw new BuildException("an error occured when running TestNG tests");
+      throw new BuildException("an error occurred when running TestNG tests");
     }
 
-    if((exitValue & TestNG.HAS_NO_TEST) == TestNG.HAS_NO_TEST) {
+    if((exitValue & ExitCode.HAS_NO_TEST) == ExitCode.HAS_NO_TEST) {
       if(m_haltOnFailure) {
         executeHaltTarget(exitValue);
         throw new BuildException("No tests were run");

--- a/src/main/java/org/testng/internal/ExitCode.java
+++ b/src/main/java/org/testng/internal/ExitCode.java
@@ -21,26 +21,32 @@ import java.util.BitSet;
  */
 public class ExitCode {
 
+    public static final int HAS_NO_TEST = 8;
+    private static final int FAILED_WITHIN_SUCCESS = 4;
+    private static final int SKIPPED = 2;
+    private static final int FAILED = 1;
+    private static final int SIZE = 3;
+
     private final BitSet exitCodeBits;
 
     ExitCode() {
-        this(new BitSet(3));
+        this(new BitSet(SIZE));
     }
 
     public static boolean hasFailureWithinSuccessPercentage(int returnCode) {
-        return (returnCode >= 4 && returnCode <= 7);
+        return (returnCode & FAILED_WITHIN_SUCCESS) == FAILED_WITHIN_SUCCESS;
     }
 
     public static boolean hasSkipped(int returnCode) {
-        return (returnCode == 2 || returnCode == 3 || returnCode == 6 || returnCode == 7);
+        return (returnCode & SKIPPED) == SKIPPED;
     }
 
     public static boolean hasFailure(int returnCode) {
-        return (returnCode == 1 || returnCode == 3);
+        return (returnCode & FAILED) == FAILED;
     }
 
     public static ExitCode newExitCodeRepresentingFailure() {
-        BitSet bitSet = new BitSet(3);
+        BitSet bitSet = new BitSet(SIZE);
         bitSet.set(0, true);
         bitSet.set(1, false);
         bitSet.set(2, false);

--- a/src/main/java/org/testng/internal/ExitCode.java
+++ b/src/main/java/org/testng/internal/ExitCode.java
@@ -1,0 +1,93 @@
+package org.testng.internal;
+
+import org.testng.IResultMap;
+import org.testng.ITestContext;
+
+import java.util.BitSet;
+
+/**
+ * |---------------------|---------|--------|-------------|------------------------------------------|
+ * | FailedWithinSuccess | Skipped | Failed | Status Code | Remarks                                  |
+ * |---------------------|---------|--------|-------------|------------------------------------------|
+ * | 0                   | 0       | 0      | 0           | Passed tests                             |
+ * | 0                   | 0       | 1      | 1           | Failed tests                             |
+ * | 0                   | 1       | 0      | 2           | Skipped tests                            |
+ * | 0                   | 1       | 1      | 3           | Skipped/Failed tests                     |
+ * | 1                   | 0       | 0      | 4           | FailedWithinSuccess tests                |
+ * | 1                   | 0       | 1      | 5           | FailedWithinSuccess/Failed tests         |
+ * | 1                   | 1       | 0      | 6           | FailedWithinSuccess/Skipped tests        |
+ * | 1                   | 1       | 1      | 7           | FailedWithinSuccess/Skipped/Failed tests |
+ * |---------------------|---------|--------|-------------|------------------------------------------|
+ */
+public class ExitCode {
+
+    private final BitSet exitCodeBits;
+
+    ExitCode() {
+        this(new BitSet(3));
+    }
+
+    public static boolean hasFailureWithinSuccessPercentage(int returnCode) {
+        return (returnCode >= 4 && returnCode <= 7);
+    }
+
+    public static boolean hasSkipped(int returnCode) {
+        return (returnCode == 2 || returnCode == 3 || returnCode == 6 || returnCode == 7);
+    }
+
+    public static boolean hasFailure(int returnCode) {
+        return (returnCode == 1 || returnCode == 3);
+    }
+
+    public static ExitCode newExitCodeRepresentingFailure() {
+        BitSet bitSet = new BitSet(3);
+        bitSet.set(0, true);
+        bitSet.set(1, false);
+        bitSet.set(2, false);
+
+        return new ExitCode(bitSet);
+    }
+
+    private ExitCode(BitSet exitCodeBits) {
+        this.exitCodeBits = exitCodeBits;
+    }
+
+    void computeAndUpdate(ITestContext context) {
+        computeAndUpdate(0, context.getFailedTests(), context.getFailedConfigurations());
+        computeAndUpdate(1, context.getSkippedTests(), context.getSkippedConfigurations());
+        computeAndUpdate(2, context.getFailedButWithinSuccessPercentageTests(), null);
+    }
+
+    private void computeAndUpdate(int index, IResultMap testResults, IResultMap configResults) {
+        boolean containsResults = testResults.size() != 0;
+        if (configResults != null) {
+            containsResults = containsResults || configResults.size() != 0;
+        }
+        if (containsResults) {
+            this.exitCodeBits.set(index);
+        }
+    }
+
+    public boolean hasFailure() {
+        return exitCodeBits.get(0);
+    }
+
+    public boolean hasSkip() {
+        return exitCodeBits.get(1);
+    }
+
+    public boolean hasFailureWithinSuccessPercentage() {
+        return exitCodeBits.get(2);
+    }
+
+    public int getExitCode() {
+        int exitCode = 0;
+        for (int i = 0; i < exitCodeBits.length(); i++) {
+            if (exitCodeBits.get(i)) {
+                exitCode = exitCode | (1 << i);
+            }
+        }
+
+        return exitCode;
+    }
+}

--- a/src/main/java/org/testng/internal/ExitCodeListener.java
+++ b/src/main/java/org/testng/internal/ExitCodeListener.java
@@ -1,0 +1,106 @@
+package org.testng.internal;
+
+import org.testng.IReporter;
+import org.testng.ISuite;
+import org.testng.ISuiteResult;
+import org.testng.ITestContext;
+import org.testng.ITestListener;
+import org.testng.ITestResult;
+import org.testng.xml.XmlSuite;
+
+import java.util.BitSet;
+import java.util.List;
+
+public class ExitCodeListener implements ITestListener, IReporter {
+    private boolean hasTests = false;
+    private int status;
+
+    public int getStatus() {
+        return status;
+    }
+
+    public boolean isHasTests() {
+        return hasTests;
+    }
+
+    @Override
+    public void generateReport(List<XmlSuite> xmlSuites, List<ISuite> suites, String outputDirectory) {
+        BitSet initial = new BitSet(3);
+        initial.set(0, false); // Success bit
+        initial.set(1, false); // failed bit
+        initial.set(2, false); // skipped bit
+        for (ISuite suite : suites) {
+            for (ISuiteResult suiteResult : suite.getResults().values()) {
+                ITestContext context = suiteResult.getTestContext();
+                boolean passed = (context.getPassedTests().size() != 0) ||
+                        (context.getPassedConfigurations().size() != 0);
+                initial.set(0, passed);
+                boolean failed = (context.getFailedTests().size() != 0) ||
+                        (context.getFailedConfigurations().size() != 0) ||
+                        (context.getFailedButWithinSuccessPercentageTests().size() !=0);
+                initial.set(1, failed);
+                boolean skipped = (context.getSkippedTests().size() != 0) ||
+                        (context.getSkippedConfigurations().size() != 0);
+                initial.set(2, skipped);
+
+            }
+        }
+        status = convert(initial);
+    }
+
+    private static int convert(BitSet set) {
+        int size = set.length() - 1;
+        int value = 0;
+        for (int i= size;i >=0;i--) {
+            int prefix = 0;
+            if (set.get(i)) {
+                prefix = 1;
+            }
+            value += Math.pow(2, i) * prefix;
+        }
+        return transform(value);
+    }
+
+
+    private static int transform(int value) {
+        if (value ==0 || value == 1) {
+            return 0;
+        }
+        return value;
+    }
+
+    @Override
+    public void onTestStart(ITestResult result) {
+        this.hasTests = true;
+    }
+
+    @Override
+    public void onTestSuccess(ITestResult result) {
+        this.hasTests = true;
+    }
+
+    @Override
+    public void onTestFailure(ITestResult result) {
+        this.hasTests = true;
+    }
+
+    @Override
+    public void onTestSkipped(ITestResult result) {
+        this.hasTests = true;
+    }
+
+    @Override
+    public void onTestFailedButWithinSuccessPercentage(ITestResult result) {
+        this.hasTests = true;
+    }
+
+    @Override
+    public void onStart(ITestContext context) {
+
+    }
+
+    @Override
+    public void onFinish(ITestContext context) {
+
+    }
+}

--- a/src/main/java/org/testng/internal/ExitCodeListener.java
+++ b/src/main/java/org/testng/internal/ExitCodeListener.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 public class ExitCodeListener implements ITestListener, IReporter {
     private boolean hasTests = false;
-    private ExitCode status = new ExitCode();
+    private final ExitCode status = new ExitCode();
 
     public ExitCode getStatus() {
         return status;

--- a/src/main/java/org/testng/internal/ExitCodeListener.java
+++ b/src/main/java/org/testng/internal/ExitCodeListener.java
@@ -8,65 +8,28 @@ import org.testng.ITestListener;
 import org.testng.ITestResult;
 import org.testng.xml.XmlSuite;
 
-import java.util.BitSet;
 import java.util.List;
 
 public class ExitCodeListener implements ITestListener, IReporter {
     private boolean hasTests = false;
-    private int status;
+    private ExitCode status = new ExitCode();
 
-    public int getStatus() {
+    public ExitCode getStatus() {
         return status;
     }
 
-    public boolean isHasTests() {
+    public boolean hasTests() {
         return hasTests;
     }
 
     @Override
     public void generateReport(List<XmlSuite> xmlSuites, List<ISuite> suites, String outputDirectory) {
-        BitSet initial = new BitSet(3);
-        initial.set(0, false); // Success bit
-        initial.set(1, false); // failed bit
-        initial.set(2, false); // skipped bit
         for (ISuite suite : suites) {
             for (ISuiteResult suiteResult : suite.getResults().values()) {
                 ITestContext context = suiteResult.getTestContext();
-                boolean passed = (context.getPassedTests().size() != 0) ||
-                        (context.getPassedConfigurations().size() != 0);
-                initial.set(0, passed);
-                boolean failed = (context.getFailedTests().size() != 0) ||
-                        (context.getFailedConfigurations().size() != 0) ||
-                        (context.getFailedButWithinSuccessPercentageTests().size() !=0);
-                initial.set(1, failed);
-                boolean skipped = (context.getSkippedTests().size() != 0) ||
-                        (context.getSkippedConfigurations().size() != 0);
-                initial.set(2, skipped);
-
+                status.computeAndUpdate(context);
             }
         }
-        status = convert(initial);
-    }
-
-    private static int convert(BitSet set) {
-        int size = set.length() - 1;
-        int value = 0;
-        for (int i= size;i >=0;i--) {
-            int prefix = 0;
-            if (set.get(i)) {
-                prefix = 1;
-            }
-            value += Math.pow(2, i) * prefix;
-        }
-        return transform(value);
-    }
-
-
-    private static int transform(int value) {
-        if (value ==0 || value == 1) {
-            return 0;
-        }
-        return value;
     }
 
     @Override

--- a/src/main/java/org/testng/junit/JUnit4TestRunner.java
+++ b/src/main/java/org/testng/junit/JUnit4TestRunner.java
@@ -123,6 +123,7 @@ public class JUnit4TestRunner implements IJUnitTestRunner {
         public void testAssumptionFailure(Failure failure) {
             notified.add(failure.getDescription());
             ITestResult tr = m_findedMethods.get(failure.getDescription());
+            validate(tr, failure.getDescription());
             runAfterInvocationListeners(tr);
             tr.setStatus(TestResult.SKIP);
             tr.setEndMillis(Calendar.getInstance().getTimeInMillis());
@@ -172,6 +173,7 @@ public class JUnit4TestRunner implements IJUnitTestRunner {
         @Override
         public void testFinished(Description description) throws Exception {
             ITestResult tr = m_findedMethods.get(description);
+            validate(tr, description);
             runAfterInvocationListeners(tr);
             if (!notified.contains(description)) {
                 tr.setStatus(TestResult.SUCCESS);
@@ -189,6 +191,7 @@ public class JUnit4TestRunner implements IJUnitTestRunner {
             if (!notified.contains(description)) {
                 notified.add(description);
                 ITestResult tr = m_findedMethods.get(description);
+                validate(tr, description);
                 runAfterInvocationListeners(tr);
                 tr.setStatus(TestResult.SKIP);
                 tr.setEndMillis(tr.getStartMillis());
@@ -206,11 +209,13 @@ public class JUnit4TestRunner implements IJUnitTestRunner {
 
         @Override
         public void testRunStarted(Description description) throws Exception {
+
         }
 
         @Override
         public void testStarted(Description description) throws Exception {
             ITestResult tr = m_findedMethods.get(description);
+            validate(tr, description);
             for (ITestListener l : m_listeners) {
                 l.onTestStart(tr);
             }
@@ -221,6 +226,16 @@ public class JUnit4TestRunner implements IJUnitTestRunner {
             for (IInvokedMethodListener l: m_invokeListeners) {
                 l.afterInvocation(im, tr);
             }
+        }
+
+        private void validate(ITestResult tr, Description description) {
+            if (tr == null) {
+                throw new TestNGException(stringify(description));
+            }
+        }
+
+        private String stringify(Description description) {
+            return description.getClassName() + "." + description.getMethodName() + "()";
         }
     }
 

--- a/src/test/java/test/cli/github1517/ExitCodeListenerBehaviorTest.java
+++ b/src/test/java/test/cli/github1517/ExitCodeListenerBehaviorTest.java
@@ -18,9 +18,9 @@ public class ExitCodeListenerBehaviorTest extends SimpleBaseTest {
     @DataProvider
     public Object[][] getData() {
         return new Object[][]{
-                {TestClassWithConfigFailureSample.class, 6},
-                {TestClassWithConfigSkipSample.class, 4},
-                {TestClassWithConfigSkipAndFailureSample.class, 6}
+                {TestClassWithConfigFailureSample.class, 3},
+                {TestClassWithConfigSkipSample.class, 2},
+                {TestClassWithConfigSkipAndFailureSample.class, 3}
         };
     }
 

--- a/src/test/java/test/cli/github1517/ExitCodeListenerBehaviorTest.java
+++ b/src/test/java/test/cli/github1517/ExitCodeListenerBehaviorTest.java
@@ -18,9 +18,9 @@ public class ExitCodeListenerBehaviorTest extends SimpleBaseTest {
     @DataProvider
     public Object[][] getData() {
         return new Object[][]{
-                {TestClassWithConfigFailureSample.class, 3},
-                {TestClassWithConfigSkipSample.class, 2},
-                {TestClassWithConfigSkipAndFailureSample.class, 3},
+                {TestClassWithConfigFailureSample.class, 6},
+                {TestClassWithConfigSkipSample.class, 4},
+                {TestClassWithConfigSkipAndFailureSample.class, 6}
         };
     }
 

--- a/src/test/java/test/github1405/JUnitTestClassSample.java
+++ b/src/test/java/test/github1405/JUnitTestClassSample.java
@@ -5,8 +5,4 @@ import org.junit.Test;
 public class JUnitTestClassSample {
     @Test
     public void testMethod() {}
-    @Test
-    public static void main(String[] args) {
-
-    }
 }

--- a/src/test/java/test/reports/UniqueReporterInjectionTest.java
+++ b/src/test/java/test/reports/UniqueReporterInjectionTest.java
@@ -20,8 +20,8 @@ public class UniqueReporterInjectionTest extends SimpleBaseTest {
         tng.addListener((ITestNGListener) new ReporterListenerForIssue1227());
         tng.run();
         //Since we have another reporting listener that is injected via the service loader file
-        //reporting listeners size will now have to be two.
-        Assert.assertEquals(tng.getReporters().size(),2);
+        //reporting listeners size will now have to be three (because the ExitCodeListener is also a reporter backed listener).
+        Assert.assertEquals(tng.getReporters().size(),3);
         Assert.assertEquals(ReporterListenerForIssue1227.counter, 1);
     }
 

--- a/src/test/java/test/retryAnalyzer/ExitCodeTest.java
+++ b/src/test/java/test/retryAnalyzer/ExitCodeTest.java
@@ -35,14 +35,14 @@ public class ExitCodeTest extends SimpleBaseTest {
   public void exitWithNonzeroOnSkips() {
     TestNG tng = create(Issue217TestClassSample.class);
     tng.run();
-    assertEquals(tng.getStatus(), 5);
+    assertEquals(tng.getStatus(), 2);
   }
 
   @Test(description = "GITHUB-217")
   public void exitWithNonzeroOnSkips1() {
     TestNG tng = create(Issue217TestClassSampleWithOneDataProvider.class);
     tng.run();
-    assertEquals(tng.getStatus(), 4);
+    assertEquals(tng.getStatus(), 2);
   }
 
 }

--- a/src/test/java/test/retryAnalyzer/ExitCodeTest.java
+++ b/src/test/java/test/retryAnalyzer/ExitCodeTest.java
@@ -1,5 +1,6 @@
 package test.retryAnalyzer;
 
+import org.testng.ITestNGListener;
 import org.testng.TestNG;
 import org.testng.annotations.Test;
 import test.SimpleBaseTest;
@@ -25,7 +26,23 @@ public class ExitCodeTest extends SimpleBaseTest {
   @Test
   public void exitsWithZeroAfterSuccessfulRetry() {
     TestNG tng = create(EventualSuccess.class);
+    tng.addListener((ITestNGListener) new TestResultPruner());
     tng.run();
     assertEquals(tng.getStatus(), 0);
   }
+
+  @Test(description = "GITHUB-217")
+  public void exitWithNonzeroOnSkips() {
+    TestNG tng = create(Issue217TestClassSample.class);
+    tng.run();
+    assertEquals(tng.getStatus(), 5);
+  }
+
+  @Test(description = "GITHUB-217")
+  public void exitWithNonzeroOnSkips1() {
+    TestNG tng = create(Issue217TestClassSampleWithOneDataProvider.class);
+    tng.run();
+    assertEquals(tng.getStatus(), 4);
+  }
+
 }

--- a/src/test/java/test/retryAnalyzer/Issue217TestClassSample.java
+++ b/src/test/java/test/retryAnalyzer/Issue217TestClassSample.java
@@ -1,0 +1,21 @@
+package test.retryAnalyzer;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class Issue217TestClassSample {
+    @Test
+    public void a() {
+    }
+
+    @Test(dataProvider = "dp")
+    public void testMethod(int i) {
+        Assert.assertTrue(i > 0);
+    }
+
+    @DataProvider(name = "dp")
+    public Object[][] getData() {
+        throw new RuntimeException("Simulating a failure");
+    }
+}

--- a/src/test/java/test/retryAnalyzer/Issue217TestClassSampleWithOneDataProvider.java
+++ b/src/test/java/test/retryAnalyzer/Issue217TestClassSampleWithOneDataProvider.java
@@ -1,0 +1,17 @@
+package test.retryAnalyzer;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class Issue217TestClassSampleWithOneDataProvider {
+    @Test(dataProvider = "dp")
+    public void testMethod(int i) {
+        Assert.assertTrue(i > 0);
+    }
+
+    @DataProvider(name = "dp")
+    public Object[][] getData() {
+        throw new RuntimeException("Simulating a failure");
+    }
+}

--- a/src/test/java/test/retryAnalyzer/RetryAnalyzerTest.java
+++ b/src/test/java/test/retryAnalyzer/RetryAnalyzerTest.java
@@ -1,9 +1,6 @@
 package test.retryAnalyzer;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
 
 import java.util.List;
 
@@ -22,21 +19,19 @@ public class RetryAnalyzerTest extends SimpleBaseTest {
     public void testInvocationCounts() {
         TestNG tng = create(InvocationCountTest.class);
         TestListenerAdapter tla = new TestListenerAdapter();
-        tng.addListener(tla);
+        tng.addListener((ITestNGListener) new TestResultPruner());
+        tng.addListener((ITestNGListener) tla);
 
         tng.run();
 
-        assertFalse(tng.hasFailure());
-        assertFalse(tng.hasSkip());
-
-        assertTrue(tla.getFailedTests().isEmpty());
+        assertThat(tla.getFailedTests()).isEmpty();
 
         List<ITestResult> fsp = tla.getFailedButWithinSuccessPercentageTests();
-        assertEquals(fsp.size(), 1);
-        assertEquals(fsp.get(0).getName(), "failAfterThreeRetries");
+        assertThat(fsp).hasSize(1);
+        assertThat(fsp.get(0).getName()).isEqualTo("failAfterThreeRetries");
 
         List<ITestResult> skipped = tla.getSkippedTests();
-        assertEquals(skipped.size(), InvocationCountTest.invocations.size() - fsp.size());
+        assertThat(skipped).hasSize(InvocationCountTest.invocations.size() - fsp.size());
     }
 
     @Test

--- a/src/test/java/test/retryAnalyzer/TestResultPruner.java
+++ b/src/test/java/test/retryAnalyzer/TestResultPruner.java
@@ -1,0 +1,27 @@
+package test.retryAnalyzer;
+
+import org.testng.ITestContext;
+import org.testng.ITestNGMethod;
+import org.testng.ITestResult;
+import org.testng.TestListenerAdapter;
+
+import java.util.Set;
+
+public class TestResultPruner extends TestListenerAdapter {
+
+    @Override
+    public void onFinish(ITestContext context) {
+        for (ITestNGMethod method : context.getAllTestMethods()) {
+            Set<ITestResult> passed = context.getPassedTests().getResults(method);
+            Set<ITestResult> skipped = context.getSkippedTests().getResults(method);
+            Set<ITestResult> failed = context.getFailedTests().getResults(method);
+            Set<ITestResult> failedWithinSuccess = context.getFailedButWithinSuccessPercentageTests().getResults(method);
+            if (!passed.isEmpty() && !skipped.isEmpty()) {
+                context.getSkippedTests().removeResult(method);
+            }
+            if (((!failedWithinSuccess.isEmpty()) || (!failed.isEmpty())) && !skipped.isEmpty()) {
+                context.getSkippedTests().removeResult(method);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #217

Following is the gist of changes done:
* Deprecated the nested ExitCodeListener and added a new one.
* Added null checks to ensure that an ITestResult object created based on a Description object is not
null. Description Object is typically seen to be null when JUnit encounters problems in parsing a method  as a test method.
* The new ExitCodeListener now considers pass/fail/skip methods through-out the entire suite of suites to determine the effective return code (or) status. So altered some tests to now assert on the new status
* Removed an invalid JUnit @Test (annotation on a  static method is not valid in JUnit world)
* Since new ExitCodeListener is a reporter backed listener, altered a test that asserts on the reporter count. (UniqueReporterInjectionTest.java)

Fixes #217.

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
