### PR TITLE
Making sure TestNG only contains singleton ExecutionListener Instance

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-1587: TestNG can not guarantee the ExecutionListener Instance as singleton(Yehui Wang)
 Fixed: GITHUB-217: exception in DataProvider doesn't fail test run (Krishnan Mahadevan)
 Fixed: GITHUB-987: Parameters threadCount and parallel doesn't work with maven (Krishnan Mahadevan)
 Fixed: GITHUB-1472: Optimize DynamicGraph.getUnfinishedNodes (Krishnan Mahadevan & Nathan Reynolds)

--- a/src/main/java/org/testng/internal/Configuration.java
+++ b/src/main/java/org/testng/internal/Configuration.java
@@ -78,7 +78,9 @@ public class Configuration implements IConfiguration {
 
   @Override
   public void addExecutionListener(IExecutionListener l) {
-    m_executionListeners.put(l.getClass(), l);
+      if (!m_executionListeners.keySet().contains(l.getClass())) {
+          m_executionListeners.put(l.getClass(), l);
+        }
   }
 
   @Override

--- a/src/main/java/org/testng/internal/Configuration.java
+++ b/src/main/java/org/testng/internal/Configuration.java
@@ -78,9 +78,9 @@ public class Configuration implements IConfiguration {
 
   @Override
   public void addExecutionListener(IExecutionListener l) {
-      if (!m_executionListeners.keySet().contains(l.getClass())) {
-          m_executionListeners.put(l.getClass(), l);
-        }
+    if (!m_executionListeners.keySet().contains(l.getClass())) {
+        m_executionListeners.put(l.getClass(), l);
+    }
   }
 
   @Override

--- a/src/test/java/test/SimpleBaseTest.java
+++ b/src/test/java/test/SimpleBaseTest.java
@@ -5,12 +5,14 @@ import org.testng.ITestNGListener;
 import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
 import org.testng.TestNG;
+import org.testng.TestNGException;
 import org.testng.annotations.ITestAnnotation;
 import org.testng.collections.Lists;
 import org.testng.internal.annotations.AnnotationHelper;
 import org.testng.internal.annotations.DefaultAnnotationTransformer;
 import org.testng.internal.annotations.IAnnotationFinder;
 import org.testng.internal.annotations.JDK15AnnotationFinder;
+import org.testng.xml.Parser;
 import org.testng.xml.XmlClass;
 import org.testng.xml.XmlGroups;
 import org.testng.xml.XmlInclude;
@@ -18,6 +20,7 @@ import org.testng.xml.XmlPackage;
 import org.testng.xml.XmlRun;
 import org.testng.xml.XmlSuite;
 import org.testng.xml.XmlTest;
+import org.xml.sax.SAXException;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -35,6 +38,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.regex.Pattern;
+
+import javax.xml.parsers.ParserConfigurationException;
 
 public class SimpleBaseTest {
   // System property specifying where the resources (e.g. xml files) can be found
@@ -371,6 +376,18 @@ public class SimpleBaseTest {
       e.printStackTrace();
     }
     return resultLineNumbers;
+  }
+  
+  protected static List<XmlSuite> getSuites(String... suiteFiles){
+    List<XmlSuite> suites = new ArrayList<>();
+    for (String suiteFile : suiteFiles) {
+        try {
+          suites.addAll(new Parser(suiteFile).parseToList());
+      } catch (ParserConfigurationException | SAXException | IOException e) {
+          throw new TestNGException(e);
+      }
+    }
+    return suites;
   }
 
 }

--- a/src/test/java/test/listeners/ExecutionListener3SampleTest.java
+++ b/src/test/java/test/listeners/ExecutionListener3SampleTest.java
@@ -1,0 +1,9 @@
+package test.listeners;
+
+import org.testng.annotations.Test;
+
+public class ExecutionListener3SampleTest {
+  @Test
+  public void f() {}
+
+}

--- a/src/test/java/test/listeners/ExecutionListenerAndSuiteListener.java
+++ b/src/test/java/test/listeners/ExecutionListenerAndSuiteListener.java
@@ -4,9 +4,6 @@ import org.testng.IExecutionListener;
 import org.testng.ISuite;
 import org.testng.ISuiteListener;
 
-/**
- * @author Yehui Wang
- */
 public class ExecutionListenerAndSuiteListener implements ISuiteListener, IExecutionListener {
 
     private String testString;

--- a/src/test/java/test/listeners/ExecutionListenerAndSuiteListener.java
+++ b/src/test/java/test/listeners/ExecutionListenerAndSuiteListener.java
@@ -19,15 +19,15 @@ public class ExecutionListenerAndSuiteListener implements ISuiteListener, IExecu
 
     @Override
     public void onStart(ISuite suite) {
-        this.tmp = testString.toUpperCase();
+        tmp = testString.toUpperCase();
     }
 
     @Override
     public void onFinish(ISuite suite) {
     }
 
-    public String getTmpString() {
-        return this.tmp;
+    public static String getTmpString() {
+        return tmp;
     }
 
 }

--- a/src/test/java/test/listeners/ExecutionListenerAndSuiteListener.java
+++ b/src/test/java/test/listeners/ExecutionListenerAndSuiteListener.java
@@ -1,0 +1,36 @@
+package test.listeners;
+
+import org.testng.IExecutionListener;
+import org.testng.ISuite;
+import org.testng.ISuiteListener;
+
+/**
+ * @author Yehui Wang
+ */
+public class ExecutionListenerAndSuiteListener implements ISuiteListener, IExecutionListener {
+
+    private String testString;
+    private static String tmp;
+    @Override
+    public void onExecutionStart() {
+        testString = "initialized";
+    }
+
+    @Override
+    public void onExecutionFinish() {
+    }
+
+    @Override
+    public void onStart(ISuite suite) {
+        this.tmp = testString.toUpperCase();
+    }
+
+    @Override
+    public void onFinish(ISuite suite) {
+    }
+
+    public String getTmpString() {
+        return this.tmp;
+    }
+
+}

--- a/src/test/java/test/listeners/ExecutionListenerAndSuiteListenerTest.java
+++ b/src/test/java/test/listeners/ExecutionListenerAndSuiteListenerTest.java
@@ -2,37 +2,23 @@ package test.listeners;
 
 import static org.testng.Assert.assertEquals;
 
-import java.io.IOException;
 import java.util.List;
 
-import javax.xml.parsers.ParserConfigurationException;
-
 import org.testng.TestNG;
-import org.testng.TestNGException;
 import org.testng.annotations.Test;
-import org.testng.xml.Parser;
 import org.testng.xml.XmlSuite;
-import org.xml.sax.SAXException;
+import test.SimpleBaseTest;
 
 
-public class ExecutionListenerAndSuiteListenerTest {
+public class ExecutionListenerAndSuiteListenerTest extends SimpleBaseTest{
 
     @Test
     public void executionListenerAndSuiteListenerTest() {
-        String suiteFile = "src/test/resources/executionlistenersingletoncheck/parent.xml";
-        runTests(suiteFile);
-    }
-
-    private static void runTests(String suiteFile) {
-        List<XmlSuite> suites;
-        try {
-            suites = new Parser(suiteFile).parseToList();
-        } catch (ParserConfigurationException | SAXException | IOException e) {
-            throw new TestNGException(e);
-        }
-        TestNG testng = new TestNG();
-        testng.setXmlSuites(suites);
-        testng.run();
-        assertEquals(ExecutionListenerAndSuiteListener.getTmpString(), "INITIALIZED");
+      String suiteFile = getPathToResource("executionlistenersingletoncheck/parent.xml");
+      List<XmlSuite> suites = getSuites(suiteFile);
+      TestNG testng = new TestNG();
+      testng.setXmlSuites(suites);
+      testng.run();
+      assertEquals(ExecutionListenerAndSuiteListener.getTmpString(), "INITIALIZED");
     }
 }

--- a/src/test/java/test/listeners/ExecutionListenerAndSuiteListenerTest.java
+++ b/src/test/java/test/listeners/ExecutionListenerAndSuiteListenerTest.java
@@ -23,7 +23,7 @@ public class ExecutionListenerAndSuiteListenerTest {
         runTests(suiteFile);
     }
 
-    private void runTests(String suiteFile) {
+    private static void runTests(String suiteFile) {
         List<XmlSuite> suites;
         try {
             suites = new Parser(suiteFile).parseToList();
@@ -32,8 +32,7 @@ public class ExecutionListenerAndSuiteListenerTest {
         }
         TestNG testng = new TestNG();
         testng.setXmlSuites(suites);
-        ExecutionListenerAndSuiteListener listener = new ExecutionListenerAndSuiteListener();
         testng.run();
-        assertEquals(listener.getTmpString(), "INITIALIZED");
+        assertEquals(ExecutionListenerAndSuiteListener.getTmpString(), "INITIALIZED");
     }
 }

--- a/src/test/java/test/listeners/ExecutionListenerAndSuiteListenerTest.java
+++ b/src/test/java/test/listeners/ExecutionListenerAndSuiteListenerTest.java
@@ -1,0 +1,39 @@
+package test.listeners;
+
+import static org.testng.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.List;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.testng.TestNG;
+import org.testng.TestNGException;
+import org.testng.annotations.Test;
+import org.testng.xml.Parser;
+import org.testng.xml.XmlSuite;
+import org.xml.sax.SAXException;
+
+
+public class ExecutionListenerAndSuiteListenerTest {
+
+    @Test
+    public void executionListenerAndSuiteListenerTest() {
+        String suiteFile = "src/test/resources/executionlistenersingletoncheck/parent.xml";
+        runTests(suiteFile);
+    }
+
+    private void runTests(String suiteFile) {
+        List<XmlSuite> suites;
+        try {
+            suites = new Parser(suiteFile).parseToList();
+        } catch (ParserConfigurationException | SAXException | IOException e) {
+            throw new TestNGException(e);
+        }
+        TestNG testng = new TestNG();
+        testng.setXmlSuites(suites);
+        ExecutionListenerAndSuiteListener listener = new ExecutionListenerAndSuiteListener();
+        testng.run();
+        assertEquals(listener.getTmpString(), "INITIALIZED");
+    }
+}

--- a/src/test/resources/executionlistenersingletoncheck/child.xml
+++ b/src/test/resources/executionlistenersingletoncheck/child.xml
@@ -1,0 +1,11 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<suite name="Child Suite">
+    <listeners>
+        <listener class-name="test.listeners.ExecutionListenerAndSuiteListener" />
+    </listeners>    
+   <test name="Child Test">
+        <classes>
+            <class name="test.listeners.ExecutionListener3SampleTest"/>
+        </classes>
+    </test>
+</suite>

--- a/src/test/resources/executionlistenersingletoncheck/parent.xml
+++ b/src/test/resources/executionlistenersingletoncheck/parent.xml
@@ -1,0 +1,14 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<suite name="Parent Suite" >
+   <listeners>
+      <listener class-name="test.listeners.ExecutionListenerAndSuiteListener" />
+   </listeners>
+   <suite-files>
+      <suite-file path="child.xml"/>
+   </suite-files> 
+   <test name="Parent Test">
+        <classes>
+            <class name="test.listeners.ExecutionListener1SampleTest"/>
+        </classes>
+    </test>
+</suite>

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -193,6 +193,7 @@
       <class name="test.listeners.SuiteAndConfigurationListenerTest" />
       <class name="test.listeners.ListenerInXmlTest" />
       <class name="test.listeners.ExecutionListenerTest" />
+      <class name="test.listeners.ExecutionListenerAndSuiteListenerTest" />
       <class name="test.listeners.ConfigurationListenerTest" />
       <class name="test.multiplelisteners.TestMaker" />
       <class name="test.listeners.github1130.GitHub1130Test"/>


### PR DESCRIPTION
Fixes 1586:
Current solution for adding instance of ExecutionListener only guarantee one instance, but there is no guarantee on singleton which is necessary indeed.
When the same ExecutionListener is added multiple times by like child suites, the latest one always repalce the last one.  The issue would be introduced then. Test case below shows the an  issue from it. 

My proposal is to making sure ExecutionListener singleton instance. 