### PR TITLE
Cannot filter by "testnames" when suite xml is a suite of suites

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-1594: Cannot filter by "testnames" when suite xml is a suite of suites (Krishnan Mahadevan)
 Fixed: GITHUB-1584: Can't run tests from IDEA (Krishnan Mahadevan)
 Fixed: GITHUB-1589: TestNGAntTask should be consistently using the Ant Log API for writing log messages (Krishnan Mahadevan)
 Fixed: GITHUB-1587: TestNG can not guarantee the ExecutionListener Instance as singleton(Yehui Wang)

--- a/src/main/java/org/testng/collections/Lists.java
+++ b/src/main/java/org/testng/collections/Lists.java
@@ -3,6 +3,7 @@ package org.testng.collections;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 
 public final class Lists {
@@ -11,6 +12,10 @@ public final class Lists {
 
   public static <K> List<K> newArrayList() {
     return new ArrayList<>();
+  }
+
+  public static <K> List<K> newLinkedList() {
+    return new LinkedList<>();
   }
 
   public static <K> List<K> newArrayList(Collection<K> c) {

--- a/src/main/java/org/testng/xml/XmlTest.java
+++ b/src/main/java/org/testng/xml/XmlTest.java
@@ -752,4 +752,12 @@ public class XmlTest implements Cloneable {
   public XmlGroups getXmlGroups() {
     return m_xmlGroups;
   }
+
+  /**
+   * @param names The list of names to check.
+   * @return <code>true</code> if the current test's name matches with any of the given names.
+   */
+  public boolean nameMatchesAny(List<String> names) {
+    return names.contains(getName());
+  }
 }

--- a/src/main/java/org/testng/xml/internal/XmlSuiteUtils.java
+++ b/src/main/java/org/testng/xml/internal/XmlSuiteUtils.java
@@ -1,0 +1,131 @@
+package org.testng.xml.internal;
+
+import org.testng.TestNGException;
+import org.testng.collections.Lists;
+import org.testng.collections.Sets;
+import org.testng.xml.XmlSuite;
+import org.testng.xml.XmlTest;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A utility class that exposes helper methods to work with {@link XmlSuite}
+ */
+public final class XmlSuiteUtils {
+
+    private XmlSuiteUtils() {
+        //Utility class. Defeat instantiation.
+    }
+
+    /**
+     * Creates a cloned copy of the current {@link XmlSuite} if the current suite
+     * contains at-least on &lt;test&gt; whose name matches with the provided names.
+     *
+     * @param xmlSuite  The {@link XmlSuite} to work with.
+     * @param testNames The list of testnames to iterate through
+     * @return - A {@link XmlSuite} that contains all the tests whose name matched with the provided names.
+     * that was passed. If there were no &lt;test&gt; match that was found throws a {@link TestNGException}
+     */
+    public static XmlSuite cloneIfContainsTestsWithNamesMatchingAny(XmlSuite xmlSuite, List<String> testNames) {
+        if (testNames == null || testNames.isEmpty()) {
+            throw new TestNGException("Please provide a valid list of names to check.");
+        }
+
+        //Search through all the child suites.
+        for (XmlSuite suite : xmlSuite.getChildSuites()) {
+            XmlSuite clonedSuite = cloneIfSuiteContainTestsWithNamesMatchingAny(suite, testNames);
+            if (clonedSuite != null) {
+                return clonedSuite;
+            }
+        }
+
+        //Tests weren't found in child suites. Lets search in the current suite.
+        XmlSuite clonedSuite = cloneIfSuiteContainTestsWithNamesMatchingAny(xmlSuite, testNames);
+
+        if (clonedSuite == null) {
+            throw new TestNGException("The test(s) <" + testNames.toString() + "> cannot be found.");
+        }
+        return clonedSuite;
+    }
+
+    /**
+     * A validator that runs through the list of suites and checks if each of the suites contains
+     * any {@link XmlTest} with the same name. If found, then a {@link TestNGException} is raised.
+     *
+     * @param suites - The list of {@link XmlSuite} to validate.
+     */
+    public static void validateIfSuitesContainDuplicateTests(List<XmlSuite> suites) {
+        for (XmlSuite suite : suites) {
+            ensureNoDuplicateTestsArePresent(suite);
+            validateIfSuitesContainDuplicateTests(suite.getChildSuites());
+        }
+    }
+
+    /**
+     * Ensure that two XmlSuite don't have the same name
+     *
+     * @param suites - The List of {@link XmlSuite} that are to be tested and names updated if duplicate
+     *               names found.
+     */
+    public static void adjustSuiteNamesToEnsureUniqueness(List<XmlSuite> suites) {
+        adjustSuiteNamesToEnsureUniqueness(suites, Sets.<String>newHashSet());
+    }
+
+    /**
+     * Ensures that the current suite doesn't contain any duplicate {@link XmlTest} instances.
+     * If duplicates are found, then a {@link TestNGException} is raised.
+     *
+     * @param xmlSuite - The {@link XmlSuite} to work with.
+     */
+    static void ensureNoDuplicateTestsArePresent(XmlSuite xmlSuite) {
+        Set<String> testNames = Sets.newHashSet();
+        for (XmlTest test : xmlSuite.getTests()) {
+            if (!testNames.add(test.getName())) {
+                throw new TestNGException("Two tests in the same suite [" + xmlSuite.getName() + "] "
+                        + "cannot have the same name: " + test.getName());
+            }
+        }
+    }
+
+    private static XmlSuite cloneIfSuiteContainTestsWithNamesMatchingAny(XmlSuite suite, List<String> testNames) {
+        List<XmlTest> tests = Lists.newLinkedList();
+        for (XmlTest xt : suite.getTests()) {
+            if (xt.nameMatchesAny(testNames)) {
+                tests.add(xt);
+            }
+        }
+        if (tests.isEmpty()) {
+            return null;
+        }
+        return cleanClone(suite, tests);
+    }
+
+    private static XmlSuite cleanClone(XmlSuite xmlSuite, List<XmlTest> tests) {
+        XmlSuite result = (XmlSuite) xmlSuite.clone();
+        result.getTests().clear();
+        result.getTests().addAll(tests);
+        return result;
+    }
+
+    private static void adjustSuiteNamesToEnsureUniqueness(List<XmlSuite> suites, Set<String> names) {
+        for (XmlSuite suite : suites) {
+            String name = suite.getName();
+
+            int count = 0;
+            String tmpName = name;
+            while (names.contains(tmpName)) {
+                tmpName = name + " (" + count++ + ")";
+            }
+
+            if (count > 0) {
+                suite.setName(tmpName);
+                names.add(tmpName);
+            } else {
+                names.add(name);
+            }
+
+            adjustSuiteNamesToEnsureUniqueness(suite.getChildSuites(), names);
+        }
+    }
+}

--- a/src/test/java/org/testng/xml/XmlSuiteTest.java
+++ b/src/test/java/org/testng/xml/XmlSuiteTest.java
@@ -1,6 +1,5 @@
 package org.testng.xml;
 
-import static org.testng.Assert.assertEquals;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.testng.collections.Lists;
@@ -8,8 +7,9 @@ import test.SimpleBaseTest;
 
 import java.io.IOException;
 import java.io.StringReader;
-import java.util.Collections;
 import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class XmlSuiteTest extends SimpleBaseTest {
 
@@ -18,8 +18,8 @@ public class XmlSuiteTest extends SimpleBaseTest {
         XmlSuite suite = new XmlSuite();
         suite.addIncludedGroup("foo");
         suite.addExcludedGroup("bar");
-        assertEquals(Collections.singletonList("foo"), suite.getIncludedGroups());
-        assertEquals(Collections.singletonList("bar"), suite.getExcludedGroups());
+        assertThat(suite.getIncludedGroups()).containsExactly("foo");
+        assertThat(suite.getExcludedGroups()).containsExactly("bar");
     }
 
     @Test
@@ -31,8 +31,8 @@ public class XmlSuiteTest extends SimpleBaseTest {
         groups.setRun(xmlRun);
         XmlSuite suite = new XmlSuite();
         suite.setGroups(groups);
-        assertEquals(Collections.singletonList("foo"), suite.getIncludedGroups());
-        assertEquals(Collections.singletonList("bar"), suite.getExcludedGroups());
+        assertThat(suite.getIncludedGroups()).containsExactly("foo");
+        assertThat(suite.getExcludedGroups()).containsExactly("bar");
     }
 
     @Test(dataProvider = "dp", description = "GITHUB-778")
@@ -42,10 +42,10 @@ public class XmlSuiteTest extends SimpleBaseTest {
         StringReader stringReader = new StringReader(suite.toXml());
         List<String> resultLines = Lists.newArrayList();
         List<Integer> lineNumbers = grep(stringReader, "time-out=\"1000\"", resultLines);
-        assertEquals(lineNumbers.size(), size);
-        assertEquals(resultLines.size(), size);
+        assertThat(lineNumbers).size().isEqualTo(size);
+        assertThat(resultLines).size().isEqualTo(size);
         if (size > 0) {
-            assertEquals(lineNumbers.get(size - 1).intValue(), lineNumber);
+            assertThat(lineNumbers.get(size-1)).isEqualTo(lineNumber);
         }
     }
 

--- a/src/test/java/org/testng/xml/XmlTestTest.java
+++ b/src/test/java/org/testng/xml/XmlTestTest.java
@@ -1,0 +1,18 @@
+package org.testng.xml;
+
+import org.testng.annotations.Test;
+import test.SimpleBaseTest;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class XmlTestTest extends SimpleBaseTest {
+    @Test
+    public void testNameMatchesAny() {
+        XmlSuite xmlSuite = createDummySuiteWithTestNamesAs("test1");
+        XmlTest xmlTest = xmlSuite.getTests().get(0);
+        assertThat(xmlTest.nameMatchesAny(Collections.singletonList("test1"))).isTrue();
+        assertThat(xmlTest.nameMatchesAny(Collections.singletonList("test2"))).isFalse();
+    }
+}

--- a/src/test/java/org/testng/xml/internal/XmlSuiteUtilsTest.java
+++ b/src/test/java/org/testng/xml/internal/XmlSuiteUtilsTest.java
@@ -1,0 +1,80 @@
+package org.testng.xml.internal;
+
+import org.testng.TestNGException;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.testng.xml.XmlSuite;
+import test.SimpleBaseTest;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class XmlSuiteUtilsTest extends SimpleBaseTest {
+
+    @Test(expectedExceptions = TestNGException.class,
+            expectedExceptionsMessageRegExp = "\nTwo tests in the same suite \\[random_suite\\] cannot have the same name: test1")
+    public void testEnsureNoDuplicateTestsArePresentNegativeCondition() {
+        XmlSuite suite = createDummySuiteWithTestNamesAs("test1", "test1");
+        XmlSuiteUtils.ensureNoDuplicateTestsArePresent(suite);
+    }
+
+    @Test
+    public void testEnsureNoDuplicateTestsArePresent() {
+        XmlSuite suite = createDummySuiteWithTestNamesAs("test1", "test2");
+        XmlSuiteUtils.ensureNoDuplicateTestsArePresent(suite);
+    }
+
+    @Test
+    public void testCloneIfContainsTestsWithNamesMatchingAny() {
+        XmlSuite suite = createDummySuiteWithTestNamesAs("test1", "test2");
+        XmlSuite clonedSuite = XmlSuiteUtils.cloneIfContainsTestsWithNamesMatchingAny(suite, Collections.singletonList("test2"));
+        assertThat(suite.getTests()).hasSameElementsAs(clonedSuite.getTests());
+    }
+
+    @Test(description = "GITHUB-1594", dataProvider = "getTestnames")
+    public void testCloneIfContainsTestsWithNamesMatchingAnyChildSuites(String testname, boolean foundInParent) {
+        XmlSuite parentSuite = createDummySuiteWithTestNamesAs("test1", "test2");
+        parentSuite.setName("parent_suite");
+        XmlSuite childSuite = createDummySuiteWithTestNamesAs("test3", "test4");
+        childSuite.setName("child_suite");
+        parentSuite.getChildSuites().add(childSuite);
+        XmlSuite clonedSuite = XmlSuiteUtils.cloneIfContainsTestsWithNamesMatchingAny(parentSuite, Collections.singletonList(testname));
+        if (foundInParent) {
+            assertThat(clonedSuite.getTests()).hasSameElementsAs(parentSuite.getTests());
+        } else {
+            assertThat(clonedSuite.getTests()).hasSameElementsAs(childSuite.getTests());
+        }
+    }
+
+    @Test(expectedExceptions = TestNGException.class,
+            expectedExceptionsMessageRegExp = "\nPlease provide a valid list of names to check.",
+            dataProvider = "getData")
+    public void testCloneIfContainsTestsWithNamesMatchingAnyNegativeCondition(XmlSuite xmlSuite, List<String> names) {
+        XmlSuiteUtils.cloneIfContainsTestsWithNamesMatchingAny(xmlSuite, names);
+    }
+
+    @Test(expectedExceptions = TestNGException.class,
+            expectedExceptionsMessageRegExp = "\nThe test\\(s\\) \\<\\[test3\\]\\> cannot be found.")
+    public void testCloneIfContainsTestsWithNamesMatchingAnyWithoutMatch() {
+        XmlSuite xmlSuite = createDummySuiteWithTestNamesAs("test1", "test2");
+        XmlSuiteUtils.cloneIfContainsTestsWithNamesMatchingAny(xmlSuite, Collections.singletonList("test3"));
+    }
+
+    @DataProvider(name = "getTestnames")
+    public Object[][] getTestnameToSearchFor() {
+        return new Object[][]{
+                {"test4", false},
+                {"test1", true}
+        };
+    }
+
+    @DataProvider(name = "getData")
+    public Object[][] getTestData() {
+        return new Object[][]{
+                {new XmlSuite(), null},
+                {new XmlSuite(), Collections.<String>emptyList()}
+        };
+    }
+}

--- a/src/test/java/test/SimpleBaseTest.java
+++ b/src/test/java/test/SimpleBaseTest.java
@@ -120,8 +120,16 @@ public class SimpleBaseTest {
       return create(suite);
     }
     return create(outDir, suite);
+  }
 
-
+  protected static XmlSuite createDummySuiteWithTestNamesAs(String... tests) {
+    XmlSuite suite = new XmlSuite();
+    suite.setName("random_suite");
+    for (String test : tests) {
+      XmlTest xmlTest = new XmlTest(suite);
+      xmlTest.setName(test);
+    }
+    return suite;
   }
 
   protected static XmlSuite createXmlSuite(String name) {

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -748,6 +748,8 @@
     <classes>
       <class name="org.testng.xml.SuiteXmlParserTest" />
       <class name="org.testng.xml.XmlSuiteTest"/>
+      <class name="org.testng.xml.internal.XmlSuiteUtilsTest"/>
+      <class name="org.testng.xml.XmlTestTest"/>
       <class name="org.testng.xml.ParserTest"/>
     </classes>
   </test>


### PR DESCRIPTION
Closes #1594

As part of this changeset, extracted out the 
unrelated xmlsuite manipulation code out of TestNG
class and then added them to XmlSuite

Fixes #1594 .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
