### PR TITLE
Revert test runner constructor

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-1613: The constructor removed from TestRunner would stop Eclipse working.(Yehui Wang)
 Fixed: GITHUB-1598: Injected types parameter and optional parameters cannot be used together. (Yehui Wang)
 Fixed: GITHUB-1594: Cannot filter by "testnames" when suite xml is a suite of suites (Krishnan Mahadevan)
 Fixed: GITHUB-1584: Can't run tests from IDEA (Krishnan Mahadevan)

--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,0 +1,8 @@
+/com/
+/org/
+/ConverterSample2.class
+/ConverterSample4.class
+/NoPackageTest.class
+/test/
+/test_result/
+/testhelper/

--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,8 +1,0 @@
-/com/
-/org/
-/ConverterSample2.class
-/ConverterSample4.class
-/NoPackageTest.class
-/test/
-/test_result/
-/testhelper/

--- a/src/main/java/org/testng/TestRunner.java
+++ b/src/main/java/org/testng/TestRunner.java
@@ -180,6 +180,9 @@ public class TestRunner
         skipFailedInvocationCounts, invokedMethodListeners, classListeners);
   }
   
+  /**
+   * This constructor is used by testng-remote, any changes related to it please contact with testng-team.
+   */
   public TestRunner(IConfiguration configuration, ISuite suite, XmlTest test,
       boolean skipFailedInvocationCounts,
       Collection<IInvokedMethodListener> invokedMethodListeners,

--- a/src/main/java/org/testng/TestRunner.java
+++ b/src/main/java/org/testng/TestRunner.java
@@ -36,6 +36,7 @@ import org.testng.internal.MethodGroupsHelper;
 import org.testng.internal.MethodHelper;
 import org.testng.internal.ResultMap;
 import org.testng.internal.RunInfo;
+import org.testng.internal.Systematiser;
 import org.testng.internal.TestListenerHelper;
 import org.testng.internal.TestMethodWorker;
 import org.testng.internal.TestNGClassFinder;
@@ -173,6 +174,17 @@ public class TestRunner
       Collection<IInvokedMethodListener> invokedMethodListeners,
       List<IClassListener> classListeners, Comparator<ITestNGMethod> comparator) {
     this.comparator = comparator;
+    this.m_dataProviderListeners = Collections.emptyMap();
+    init(configuration, suite, test, suite.getOutputDirectory(),
+        suite.getAnnotationFinder(),
+        skipFailedInvocationCounts, invokedMethodListeners, classListeners);
+  }
+  
+  public TestRunner(IConfiguration configuration, ISuite suite, XmlTest test,
+      boolean skipFailedInvocationCounts,
+      Collection<IInvokedMethodListener> invokedMethodListeners,
+      List<IClassListener> classListeners) {
+    this.comparator = Systematiser.getComparator();
     this.m_dataProviderListeners = Collections.emptyMap();
     init(configuration, suite, test, suite.getOutputDirectory(),
         suite.getAnnotationFinder(),


### PR DESCRIPTION
Fixes #1613.
Removed constructor would introduce non-backward compatible issue in `testng-remote::RemoteTestNG6_*` , all the Eclipse TestNG version would be stop working.

