### PR TITLE
Null fields in parallel method tests

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,9 +1,11 @@
 Current
 =======
+Fixed: GITHUB-1625: Null fields in parallel method tests (Krishnan Mahadevan)
+
+6.13.1
+No functional changes. Released with newer version JCommander (1.72.0)
 
 6.13
-====
-
 Fixed: GITHUB-1619: ConcurrentHashMap doesn't secure insertion order.(Yehui Wang)
 Fixed: GITHUB-1616: Test cases with priority and dependsOnGroups dependencies, execution order is chaos. (Yehui Wang)
 Fixed: GITHUB-1613: The constructor removed from TestRunner would stop Eclipse working.(Yehui Wang)

--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,7 @@ dependencies {
     testCompile 'org.assertj:assertj-core:2.5.0'
     testCompile 'org.codehaus.groovy:groovy-all:2.4.7'
     testCompile 'org.spockframework:spock-core:1.0-groovy-2.4'
+    testCompile 'org.mockito:mockito-core:2.12.0'
 }
 
 task sourceJar(type: Jar) {

--- a/kobalt/src/Build.kt
+++ b/kobalt/src/Build.kt
@@ -64,6 +64,7 @@ val p = project {
     dependenciesTest {
         compile("org.assertj:assertj-core:3.5.2",
                 "org.testng:testng:6.9.13.7",
+                "org.mockito:mockito-core:2.12.0",
                 "org.spockframework:spock-core:1.0-groovy-2.4")
     }
 

--- a/src/test/java/test/configuration/BeforeClassThreadTest.java
+++ b/src/test/java/test/configuration/BeforeClassThreadTest.java
@@ -5,16 +5,16 @@ import org.testng.annotations.Test;
 import org.testng.xml.XmlSuite;
 
 import test.SimpleBaseTest;
-import junit.framework.Assert;
 
-public class BeforeClassThreadTest extends SimpleBaseTest{
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BeforeClassThreadTest extends SimpleBaseTest {
 
     @Test
     public void beforeClassMethodsShouldRunInParallel() {
-        TestNG tng = create(new Class[] { BeforeClassThreadA.class, BeforeClassThreadB.class });
+        TestNG tng = create(BeforeClassThreadA.class, BeforeClassThreadB.class);
         tng.setParallel(XmlSuite.ParallelMode.METHODS);
         tng.run();
-
-        Assert.assertTrue(Math.abs(BeforeClassThreadA.WHEN - BeforeClassThreadB.WHEN) < 1000);
+        assertThat(Math.abs(BeforeClassThreadA.WHEN - BeforeClassThreadB.WHEN)).isLessThan(1000);
     }
 }

--- a/src/test/java/test/configuration/github1625/TestRunnerIssue1625.java
+++ b/src/test/java/test/configuration/github1625/TestRunnerIssue1625.java
@@ -1,0 +1,28 @@
+package test.configuration.github1625;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.testng.TestNG;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.testng.xml.XmlSuite;
+import test.SimpleBaseTest;
+
+public class TestRunnerIssue1625 extends SimpleBaseTest {
+
+    @Test(dataProvider = "dp")
+    public void testMethod(Class<?> clazz) {
+        TestNG testNG = create(clazz);
+        testNG.setParallel(XmlSuite.ParallelMode.METHODS);
+        testNG.run();
+        assertThat(testNG.getStatus()).isEqualTo(0);
+    }
+
+    @DataProvider(name = "dp")
+    public Object[][] getData() {
+        return new Object[][]{
+                {TestclassSampleUsingMocks.class},
+                {TestclassSampleWithoutUsingMocks.class}
+        };
+    }
+}

--- a/src/test/java/test/configuration/github1625/TestclassSampleUsingMocks.java
+++ b/src/test/java/test/configuration/github1625/TestclassSampleUsingMocks.java
@@ -1,0 +1,30 @@
+package test.configuration.github1625;
+
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+public class TestclassSampleUsingMocks {
+    @Mock
+    List<String> list;
+
+
+    @BeforeClass
+    public void beforeClass() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void first() {
+        Assert.assertNotNull(list);
+    }
+
+    @Test
+    public void second() {
+        Assert.assertNotNull(list);
+    }
+}

--- a/src/test/java/test/configuration/github1625/TestclassSampleWithoutUsingMocks.java
+++ b/src/test/java/test/configuration/github1625/TestclassSampleWithoutUsingMocks.java
@@ -1,0 +1,28 @@
+package test.configuration.github1625;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestclassSampleWithoutUsingMocks {
+
+    private List<String> list;
+
+    @BeforeClass
+    public void beforeClass() {
+        list = new ArrayList<>();
+    }
+
+    @Test
+    public void first() {
+        Assert.assertNotNull(list);
+    }
+
+    @Test
+    public void second() {
+        Assert.assertNotNull(list);
+    }
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -782,6 +782,7 @@
       <class name="test.configuration.VerifySuiteTest" />
       <class name="test.configuration.SingleConfigurationTest" />
       <class name="test.configuration.BeforeClassWithDisabledTest" />
+      <class name="test.configuration.github1625.TestRunnerIssue1625"/>
     </classes>
   </test>
 


### PR DESCRIPTION
Closes #1625

Caused by 
SHA: f622b85b22a0b9751f4ad125d141f440c87746a4

Un-related changes.
Cleaned up BeforeClassThreadTest to use assertions

Fixes #1625 .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
