### PR TITLE
Data provider class injection into Factory meta-data (fixes #1631)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 Current
 =======
 Fixed: GITHUB-1625: Null fields in parallel method tests (Krishnan Mahadevan)
+New: GITHUB-1631: data provider class name injection into Factory meta-data (Sergey Korol)
 
 6.13.1
 No functional changes. Released with newer version JCommander (1.72.0)

--- a/src/main/java/org/testng/internal/annotations/JDK15TagFactory.java
+++ b/src/main/java/org/testng/internal/annotations/JDK15TagFactory.java
@@ -304,11 +304,10 @@ public class JDK15TagFactory {
   private IAnnotation createFactoryTag(Class<?> cls, Annotation a) {
     FactoryAnnotation result = new FactoryAnnotation();
     Factory c = (Factory) a;
+    Class<?> dpc = findInherited(c.dataProviderClass(), cls, Factory.class, "dataProviderClass", DEFAULT_CLASS);
     result.setParameters(c.parameters());
     result.setDataProvider(c.dataProvider());
-    result.setDataProviderClass(
-        findInherited(c.dataProviderClass(), cls, Factory.class, "dataProviderClass",
-            DEFAULT_CLASS));
+    result.setDataProviderClass(dpc == null || dpc == Object.class ? cls : dpc);
     result.setEnabled(c.enabled());
     result.setIndices(Ints.asList(c.indices()));
 

--- a/src/test/java/test/factory/github1631/DataProviderTransformer.java
+++ b/src/test/java/test/factory/github1631/DataProviderTransformer.java
@@ -1,0 +1,41 @@
+package test.factory.github1631;
+
+import org.testng.IAnnotationTransformer2;
+import org.testng.annotations.IConfigurationAnnotation;
+import org.testng.annotations.IDataProviderAnnotation;
+import org.testng.annotations.IFactoryAnnotation;
+import org.testng.annotations.ITestAnnotation;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
+public class DataProviderTransformer implements IAnnotationTransformer2 {
+
+    private Class<?> dataProviderClass;
+
+    @Override
+    public void transform(final IConfigurationAnnotation annotation, final Class testClass,
+                          final Constructor testConstructor, final Method testMethod) {
+        // not implemented
+    }
+
+    @Override
+    public void transform(final IDataProviderAnnotation annotation, final Method testMethod) {
+        // not implemented
+    }
+
+    @Override
+    public void transform(final ITestAnnotation annotation, final Class testClass,
+                          final Constructor testConstructor, final Method testMethod) {
+        // not implemented
+    }
+
+    @Override
+    public void transform(final IFactoryAnnotation annotation, final Method testMethod) {
+        dataProviderClass = annotation.getDataProviderClass();
+    }
+
+    public Class<?> getDataProviderClass() {
+        return dataProviderClass;
+    }
+}

--- a/src/test/java/test/factory/github1631/ExternalDataProviders.java
+++ b/src/test/java/test/factory/github1631/ExternalDataProviders.java
@@ -1,0 +1,11 @@
+package test.factory.github1631;
+
+import org.testng.annotations.DataProvider;
+
+public class ExternalDataProviders {
+
+    @DataProvider
+    public Object[] data() {
+        return new Object[]{1, 2, 3};
+    }
+}

--- a/src/test/java/test/factory/github1631/FactoryWithExternalDataProviderTests.java
+++ b/src/test/java/test/factory/github1631/FactoryWithExternalDataProviderTests.java
@@ -1,0 +1,20 @@
+package test.factory.github1631;
+
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+
+public class FactoryWithExternalDataProviderTests {
+
+    public FactoryWithExternalDataProviderTests() {
+    }
+
+    @Factory(dataProvider = "data", dataProviderClass = ExternalDataProviders.class)
+    public FactoryWithExternalDataProviderTests(final int i) {
+        // not important
+    }
+
+    @Test
+    public void fakeTest() {
+        // not important
+    }
+}

--- a/src/test/java/test/factory/github1631/FactoryWithLocalDataProviderTests.java
+++ b/src/test/java/test/factory/github1631/FactoryWithLocalDataProviderTests.java
@@ -1,0 +1,26 @@
+package test.factory.github1631;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+
+public class FactoryWithLocalDataProviderTests {
+
+    public FactoryWithLocalDataProviderTests() {
+    }
+
+    @Factory(dataProvider = "data")
+    public FactoryWithLocalDataProviderTests(final int i) {
+        // not important
+    }
+
+    @DataProvider
+    public Object[] data() {
+        return new Object[]{1, 2, 3};
+    }
+
+    @Test
+    public void fakeTest() {
+        // not important
+    }
+}

--- a/src/test/java/test/factory/github1631/GitHub1631Tests.java
+++ b/src/test/java/test/factory/github1631/GitHub1631Tests.java
@@ -1,0 +1,29 @@
+package test.factory.github1631;
+
+import org.testng.*;
+import org.testng.annotations.Test;
+import test.SimpleBaseTest;
+
+public class GitHub1631Tests extends SimpleBaseTest {
+
+    @Test(description = "Test @Factory(dataProvider) should implicitly inject data provider class name")
+    public void factoryWithLocalDataProviderShouldUseHostClassName() {
+        final DataProviderTransformer transformer = runTest(FactoryWithLocalDataProviderTests.class);
+        Assert.assertEquals(transformer.getDataProviderClass(), FactoryWithLocalDataProviderTests.class);
+    }
+
+    @Test(description = "Test @Factory(dataProvider) should explicitly set data provider class name")
+    public void factoryWithExplicitDataProviderShouldUseExternalClassName() {
+        final DataProviderTransformer transformer = runTest(FactoryWithExternalDataProviderTests.class);
+        Assert.assertEquals(transformer.getDataProviderClass(), ExternalDataProviders.class);
+    }
+
+    private DataProviderTransformer runTest(final Class<?> cls) {
+        final TestNG tng = create(cls);
+        final DataProviderTransformer dpt = new DataProviderTransformer();
+        tng.addListener(dpt);
+        tng.run();
+
+        return dpt;
+    }
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -379,6 +379,7 @@
       <class name="test.factory.classconf.XClassOrderWithFactoryTest" />
       <class name="test.factory.FactoryInterleavingTest"/>
       <class name="test.factory.FactoryDataProviderTest"/>
+      <class name="test.factory.github1631.GitHub1631Tests"/>
 
       <class name="test.factory.DisabledFactoryTest"/>
       <class name="test.factory.FactoryAndTestMethodTest" />


### PR DESCRIPTION
There was no way to extract data provider class name from `IAnnotationTransformer2` listener's meta-data, used for constructor-level `Factory` interception with missing `dataProviderClass` arg. See #1631 for details.

To fix this issue, host class name was explicitly set if `null` or `Object.class` values were returned by `findInherited` API.

### Did you remember to?

- [x] Add test case(s)
- [x] Update `CHANGES.txt`