### PR TITLE
Remove JVM argument "experimental"

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,7 @@ Current
 Fixed: GITHUB-1649: @Test annotated methods cannot inject java.lang.reflect.Method (Krishnan Mahadevan)
 Fixed: GITHUB-1625: Null fields in parallel method tests (Krishnan Mahadevan)
 New  : GITHUB-1631: data provider class name injection into Factory meta-data (Sergey Korol)
+Fixed: GITHUB-1605: Research the usefulness of the JVM argument "experimental" (Krishnan Mahadevan)
 
 6.13.1
 No functional changes. Released with newer version JCommander (1.72.0)

--- a/src/main/java/org/testng/internal/ClassBasedParallelWorker.java
+++ b/src/main/java/org/testng/internal/ClassBasedParallelWorker.java
@@ -4,13 +4,11 @@ import org.testng.IMethodInstance;
 import org.testng.ITestClass;
 import org.testng.ITestNGMethod;
 import org.testng.collections.Lists;
-import org.testng.collections.Maps;
 import org.testng.collections.Sets;
 import org.testng.internal.thread.graph.IWorker;
 import org.testng.xml.XmlSuite;
 import org.testng.xml.XmlTest;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -53,18 +51,9 @@ class ClassBasedParallelWorker extends AbstractParallelWorker {
             if (sequentialClasses.contains(c)) {
                 if (!processedClasses.contains(c)) {
                     processedClasses.add(c);
-                    if (System.getProperty("experimental") != null) {
-                        Collection<List<IMethodInstance>> instances = createInstances(methodInstances);
-                        for (List<IMethodInstance> inst : instances) {
-                            TestMethodWorker worker = createTestMethodWorker(arguments, inst, params, c);
-                            result.add(worker);
-                        }
-                    }
-                    else {
-                        // Sequential class: all methods in one worker
-                        TestMethodWorker worker = createTestMethodWorker(arguments, methodInstances, params, c);
-                        result.add(worker);
-                    }
+                    // Sequential class: all methods in one worker
+                    TestMethodWorker worker = createTestMethodWorker(arguments, methodInstances, params, c);
+                    result.add(worker);
                 }
             }
             else {
@@ -107,20 +96,6 @@ class ClassBasedParallelWorker extends AbstractParallelWorker {
         }
 
         return vResult;
-    }
-
-    private static Collection<List<IMethodInstance>> createInstances(List<IMethodInstance> methodInstances) {
-        Map<Object, List<IMethodInstance>> map = Maps.newHashMap();
-        for (IMethodInstance imi : methodInstances) {
-            Object o = imi.getInstance();
-            List<IMethodInstance> l = map.get(o);
-            if (l == null) {
-                l = Lists.newArrayList();
-                map.put(o, l);
-            }
-            l.add(imi);
-        }
-        return map.values();
     }
 
     private static boolean isSequential(org.testng.annotations.ITestAnnotation test, XmlTest xmlTest) {


### PR DESCRIPTION
Closes #1605

Introduced by SHA1: 8a1684f3d04225aa0f0ffed507d382a684014386

The JVM argument “experimental” was supposed to 
distribute test methods within a same class across
multiple workers and thus behave as if it was 
providing parallelism across multiple test methods
for a given test class, when user specifies one of 
the following : 

* “singleThreaded” is set to “true” (or)
* “parallel” = “classes” at <test>|<suite> level

But this flag is merely adding dummy test workers
who don’t have any test methods to run at all, because
when we attempt at creating a test worker, we feed it
methods that all belong to the same test class.

So if user has 3 test classes (each class has 2 methods), 
ideally there would be  only 3 test workers. 
But this flag causes empty 6 additional test 
workers to be added up.

The original intend behind this flag seems to be 
around providing a distinct new execution mechanism
apart from “Sequential On instances” (which is what
parallel=“classes” currently does). 

Removing off this flag’s support in TestNG.

Fixes #1605 .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
