### PR TITLE
Consider adding a -n (no execute) option

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 Current
 =======
+Fixed: GITHUB-1503: Consider adding a -n (no execute) option (Krishnan Mahadevan)
 Fixed: GITHUB-1648: Depends on method is not respected on the sequential run on second test that extends same base testClass (Krishnan Mahadevan)
 Fixed: GITHUB-1636: Parallel test run is not working in 6.13.1 (Krishnan Mahadevan)
 New  : GITHUB-1634: Make "-xmlpathinjar" support <suite-files> (Yehui Wang)

--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -444,6 +444,10 @@ public class Invoker implements IInvoker {
       ConstructorOrMethod method = tm.getConstructorOrMethod();
 
       IConfigurable configurableInstance = computeConfigurableInstance(method, targetInstance);
+      if (RuntimeBehavior.isDryRun()) {
+        testResult.setStatus(ITestResult.SUCCESS);
+        return;
+      }
       if (configurableInstance != null) {
         MethodInvocationHelper.invokeConfigurable(targetInstance, params,
                 configurableInstance, method.getMethod(), testResult);
@@ -558,6 +562,11 @@ public class Invoker implements IInvoker {
       m_notifier.addInvokedMethod(invokedMethod);
 
       Method thisMethod = tm.getConstructorOrMethod().getMethod();
+
+      if (RuntimeBehavior.isDryRun()) {
+        setTestStatus(testResult, ITestResult.SUCCESS);
+        return testResult;
+      }
 
       // If this method is a IHookable, invoke its run() method
       IHookable hookableInstance = IHookable.class.isAssignableFrom(tm.getRealClass()) ? (IHookable) instance : m_configuration.getHookable();

--- a/src/main/java/org/testng/internal/RuntimeBehavior.java
+++ b/src/main/java/org/testng/internal/RuntimeBehavior.java
@@ -1,0 +1,19 @@
+package org.testng.internal;
+
+/**
+ * This class houses handling all JVM arguments by TestNG
+ */
+public final class RuntimeBehavior {
+
+    private RuntimeBehavior() {
+    }
+
+    /**
+     * @return - returns <code>true</code> if we would like to run in the Dry mode and
+     * <code>false</code> otherwise.
+     */
+    public static boolean isDryRun() {
+        String value = System.getProperty("testng.mode.dryrun", "false");
+        return Boolean.parseBoolean(value);
+    }
+}

--- a/src/test/java/org/testng/DryRunSample.java
+++ b/src/test/java/org/testng/DryRunSample.java
@@ -1,0 +1,31 @@
+package org.testng;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class DryRunSample {
+
+    @BeforeSuite
+    public void beforeSuite() {
+        throw new RuntimeException("Error");
+    }
+
+    @BeforeClass
+    public void beforeClass() {
+        throw new RuntimeException("error");
+    }
+
+    @Test(dataProvider = "dp")
+    public void test1(int i) {
+    }
+
+    @DataProvider(name = "dp")
+    public Object[][] getData() {
+        return new Object[][]{
+                {1},
+                {2}
+        };
+    }
+}

--- a/src/test/java/org/testng/DryRunTest.java
+++ b/src/test/java/org/testng/DryRunTest.java
@@ -1,0 +1,23 @@
+package org.testng;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import org.testng.annotations.Test;
+import test.SimpleBaseTest;
+
+public class DryRunTest extends SimpleBaseTest {
+
+    @Test
+    public void testDryRun() {
+        System.setProperty("testng.mode.dryrun", "true");
+        try {
+            TestNG tng = create(DryRunSample.class);
+            TestListenerAdapter listener = new TestListenerAdapter();
+            tng.addListener((ITestNGListener) listener);
+            tng.run();
+            assertThat(listener.getPassedTests()).hasSize(2);
+        } finally {
+            System.setProperty("testng.mode.dryrun", "false");
+        }
+    }
+
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -871,6 +871,12 @@
     </classes>
   </test>
 
+  <test name = "dryRun">
+    <classes>
+      <class name="org.testng.DryRunTest"/>
+    </classes>
+  </test>
+
   <test name="RunOrderingTest">
     <classes>
       <class name="test.github799.EnsureInstancesAreOrderedViaFactories"/>


### PR DESCRIPTION
Closes #1503

Users can now run their tests in a dry run mode 
by passing the JVM argument : `testng.mode.dryrun=true`

Fixes #1503 .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
