### PR TITLE
Fix for issue #1668

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 Current
 =======
+Fixed: GITHUB-1668: "Invalid Method Selector" exception triggered when using suite level beanshell methodselectors (Krishnan Mahadevan)
 Fixed: GITHUB-1659: New line characters are removed from stack traces in testng-results.xml (Krishnan Mahadevan)
 Fixed: GITHUB-1503: Consider adding a -n (no execute) option (Krishnan Mahadevan)
 Fixed: GITHUB-1648: Depends on method is not respected on the sequential run on second test that extends same base testClass (Krishnan Mahadevan)

--- a/src/main/java/org/testng/TestNG.java
+++ b/src/main/java/org/testng/TestNG.java
@@ -46,6 +46,7 @@ import org.testng.reporters.SuiteHTMLReporter;
 import org.testng.reporters.VerboseReporter;
 import org.testng.reporters.XMLReporter;
 import org.testng.reporters.jq.Main;
+import org.testng.util.Strings;
 import org.testng.xml.IPostProcessor;
 import org.testng.xml.Parser;
 import org.testng.xml.XmlClass;
@@ -533,7 +534,9 @@ public class TestNG {
   }
 
   public void addMethodSelector(String className, int priority) {
-    m_methodDescriptors.put(className, priority);
+    if (Strings.isNotNullAndNotEmpty(className)) {
+      m_methodDescriptors.put(className, priority);
+    }
   }
 
   /**

--- a/src/test/java/org/testng/xml/XmlSuiteTest.java
+++ b/src/test/java/org/testng/xml/XmlSuiteTest.java
@@ -1,5 +1,6 @@
 package org.testng.xml;
 
+import org.testng.TestNG;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.testng.collections.Lists;
@@ -36,7 +37,7 @@ public class XmlSuiteTest extends SimpleBaseTest {
     }
 
     @Test(dataProvider = "dp", description = "GITHUB-778")
-    public void testTimeOut(String timeout, int size, int lineNumber) throws IOException {
+    public void testTimeOut(String timeout, int size, int lineNumber) {
         XmlSuite suite = new XmlSuite();
         suite.setTimeOut(timeout);
         StringReader stringReader = new StringReader(suite.toXml());
@@ -55,6 +56,19 @@ public class XmlSuiteTest extends SimpleBaseTest {
                 {"1000", 1, 2},
                 {"", 0, 0}
         };
+    }
+
+    @Test(description = "GITHUB-1668")
+    public void ensureNoExceptionsAreRaisedWhenMethodSelectorsDefinedAtSuiteLevel() throws IOException {
+        Parser parser = new Parser("src/test/resources/xml/issue1668.xml");
+        List<XmlSuite> suites = parser.parseToList();
+        XmlSuite xmlsuite = suites.get(0);
+        TestNG testNG = create();
+        testNG.setXmlSuites(suites);
+        testNG.setUseDefaultListeners(false);
+        testNG.run();
+        //Trigger a call to "toXml()" to ensure that there is no exception raised.
+        assertThat(xmlsuite.toXml()).isNotEmpty();
     }
 
 }

--- a/src/test/java/org/testng/xml/issue1668/TestClassSample.java
+++ b/src/test/java/org/testng/xml/issue1668/TestClassSample.java
@@ -1,0 +1,11 @@
+package org.testng.xml.issue1668;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestClassSample {
+    @Test
+    public void testMethod() {
+        Assert.assertTrue(true);
+    }
+}

--- a/src/test/resources/xml/issue1668.xml
+++ b/src/test/resources/xml/issue1668.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+<suite name="1668_Suite" parallel="false" verbose="2">
+    <method-selectors>
+        <method-selector>
+            <script language="beanshell">
+                <![CDATA[
+                whatTest = System.getProperty("testToRun");
+                if (whatTest == null || whatTest.trim().isEmpty()) return true;
+                whatTest.contains(testngMethod.getXmlTest().getName());
+                ]]>
+            </script>
+        </method-selector>
+    </method-selectors>
+    <test name="1668_Test1" verbose="2">
+        <classes>
+            <class name="org.testng.xml.issue1668.TestClassSample"/>
+        </classes>
+    </test>
+</suite>


### PR DESCRIPTION
Fixing “Invalid Method Selector" exception triggered 
when using suite level beanshell methodselectors 

Closes #1668

Fixes #1668  .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
