### PR TITLE
@beforeGroups executed multiple times in Parallel mode

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-1694: @BeforeGroups executed multiple times when tests run in parallel, once if not parallel (Krishnan Mahadevan)
 Fixed: GITHUB-1688: @Ignore annotation on base class doesn't ignore tests in child classes (Krishnan Mahadevan)
 Fixed: GITHUB-1687: NullPointerException is thrown when beanshell evaluates to null (Krishnan Mahadevan)
 

--- a/src/main/java/org/testng/annotations/Ignore.java
+++ b/src/main/java/org/testng/annotations/Ignore.java
@@ -18,7 +18,7 @@ import static java.lang.annotation.ElementType.TYPE;
  *
  * A package annotation is done in {@code package-info.java}. For example:
  * <pre>
- * @Ignore
+ * {@literal @}Ignore
  * package test.ignorePackage;
  *
  * import org.testng.annotations.Ignore;

--- a/src/main/java/org/testng/internal/ConfigurationMethod.java
+++ b/src/main/java/org/testng/internal/ConfigurationMethod.java
@@ -355,10 +355,10 @@ public class ConfigurationMethod extends BaseTestMethod {
       initGroups(IAfterTest.class);
     }
      if (annotation.getBeforeGroups().length != 0) {
-      initGroups(IBeforeGroups.class);
+      initBeforeAfterGroups(IBeforeGroups.class, annotation.getBeforeGroups());
     }
      if (annotation.getAfterGroups().length != 0) {
-      initGroups(IAfterGroups.class);
+       initBeforeAfterGroups(IAfterGroups.class, annotation.getAfterGroups());
     }
      if (annotation.getBeforeTestClass()) {
       initGroups(IBeforeClass.class);

--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -730,10 +730,9 @@ public class Invoker implements IInvoker {
   {
     List<ITestNGMethod> filteredMethods = Lists.newArrayList();
     String[] groups = currentTestMethod.getGroups();
-    Map<String, List<ITestNGMethod>> beforeGroupMap = groupMethods.getBeforeGroupsMap();
 
     for (String group : groups) {
-      List<ITestNGMethod> methods = beforeGroupMap.get(group);
+      List<ITestNGMethod> methods = groupMethods.getBeforeGroupMethodsForGroup(group);
       if (methods != null) {
         filteredMethods.addAll(methods);
       }
@@ -788,9 +787,8 @@ public class Invoker implements IInvoker {
 
     // Now filteredGroups contains all the groups for which we need to run the afterGroups
     // method.  Find all the methods that correspond to these groups and invoke them.
-    Map<String, List<ITestNGMethod>> map = groupMethods.getAfterGroupsMap();
     for (String g : filteredGroups.values()) {
-      List<ITestNGMethod> methods = map.get(g);
+      List<ITestNGMethod> methods = groupMethods.getAfterGroupMethodsForGroup(g);
       // Note:  should put them in a map if we want to make sure the same afterGroups
       // doesn't get run twice
       if (methods != null) {

--- a/src/test/java/test/beforegroups/BeforeGroupsTest.java
+++ b/src/test/java/test/beforegroups/BeforeGroupsTest.java
@@ -1,0 +1,65 @@
+package test.beforegroups;
+
+import org.testng.ITestNGListener;
+import org.testng.TestNG;
+import org.testng.annotations.Test;
+import org.testng.collections.Lists;
+import org.testng.internal.ClassHelper;
+import org.testng.internal.PackageUtils;
+import org.testng.xml.XmlSuite;
+import org.testng.xml.XmlTest;
+import test.InvokedMethodNameListener;
+import test.SimpleBaseTest;
+import test.beforegroups.issue1694.BaseClassWithBeforeGroups;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BeforeGroupsTest extends SimpleBaseTest {
+    @Test
+    public void testInSequentialMode() throws IOException {
+        runTest(XmlSuite.ParallelMode.NONE);
+    }
+
+    @Test
+    public void testParallelMode() throws IOException {
+        runTest(XmlSuite.ParallelMode.CLASSES);
+    }
+
+    private static void runTest(XmlSuite.ParallelMode mode) throws IOException {
+        XmlSuite suite = createXmlSuite("sample_suite");
+        String pkg = BaseClassWithBeforeGroups.class.getPackage().getName();
+        Class<?>[] classes = findClassesInPackage(pkg);
+        XmlTest xmlTest = createXmlTestWithPackages(suite, "sample_test", classes);
+        xmlTest.addIncludedGroup("regression");
+        xmlTest.setParallel(mode);
+        TestNG tng = create(suite);
+        InvokedMethodNameListener listener = new InvokedMethodNameListener();
+        tng.addListener((ITestNGListener) listener);
+        tng.run();
+        List<String> beforeGroups = Lists.newArrayList();
+        List<String> afterGroups = Lists.newArrayList();
+        for (String name : listener.getInvokedMethodNames()) {
+            if (name.equalsIgnoreCase(BaseClassWithBeforeGroups.BEFORE_GROUPS)) {
+                beforeGroups.add(name);
+            }
+            if (name.equalsIgnoreCase(BaseClassWithBeforeGroups.AFTER_GROUPS)) {
+                afterGroups.add(name);
+            }
+        }
+        assertThat(beforeGroups).containsOnly(BaseClassWithBeforeGroups.BEFORE_GROUPS);
+        assertThat(afterGroups).containsOnly(BaseClassWithBeforeGroups.AFTER_GROUPS);
+    }
+
+    private static Class<?>[] findClassesInPackage(String packageName) throws IOException {
+        String[] classes = PackageUtils.findClassesInPackage(packageName, new ArrayList<String>(), new ArrayList<String>());
+        List<Class<?>> loadedClasses = new ArrayList<>();
+        for (String clazz : classes) {
+            loadedClasses.add(ClassHelper.forName(clazz));
+        }
+        return loadedClasses.toArray(new Class<?>[loadedClasses.size()]);
+    }
+}

--- a/src/test/java/test/beforegroups/issue1694/BaseClassWithBeforeGroups.java
+++ b/src/test/java/test/beforegroups/issue1694/BaseClassWithBeforeGroups.java
@@ -1,0 +1,18 @@
+package test.beforegroups.issue1694;
+
+import org.testng.annotations.AfterGroups;
+import org.testng.annotations.BeforeGroups;
+
+public class BaseClassWithBeforeGroups {
+    public static final String BEFORE_GROUPS = "beforeGroups";
+    public static final String AFTER_GROUPS = "afterGroups";
+
+    @BeforeGroups(value = "regression")
+    public void beforeGroups() {
+    }
+
+    @AfterGroups(value = "regression")
+    public void afterGroups() {
+    }
+
+}

--- a/src/test/java/test/beforegroups/issue1694/ChildClassA.java
+++ b/src/test/java/test/beforegroups/issue1694/ChildClassA.java
@@ -1,0 +1,9 @@
+package test.beforegroups.issue1694;
+
+import org.testng.annotations.Test;
+
+public class ChildClassA extends BaseClassWithBeforeGroups {
+    @Test(groups = "regression")
+    public void testMethodA() {
+    }
+}

--- a/src/test/java/test/beforegroups/issue1694/ChildClassB.java
+++ b/src/test/java/test/beforegroups/issue1694/ChildClassB.java
@@ -1,0 +1,9 @@
+package test.beforegroups.issue1694;
+
+import org.testng.annotations.Test;
+
+public class ChildClassB extends BaseClassWithBeforeGroups {
+    @Test(groups = "regression")
+    public void testMethodB() {
+    }
+}

--- a/src/test/java/test/beforegroups/issue1694/ChildClassC.java
+++ b/src/test/java/test/beforegroups/issue1694/ChildClassC.java
@@ -1,0 +1,9 @@
+package test.beforegroups.issue1694;
+
+import org.testng.annotations.Test;
+
+public class ChildClassC extends BaseClassWithBeforeGroups {
+    @Test(groups = "regression")
+    public void testMethodC() {
+    }
+}

--- a/src/test/java/test/beforegroups/issue1694/ChildClassD.java
+++ b/src/test/java/test/beforegroups/issue1694/ChildClassD.java
@@ -1,0 +1,9 @@
+package test.beforegroups.issue1694;
+
+import org.testng.annotations.Test;
+
+public class ChildClassD extends BaseClassWithBeforeGroups {
+    @Test(groups = "regression")
+    public void testMethodD() {
+    }
+}

--- a/src/test/java/test/beforegroups/issue1694/ChildClassE.java
+++ b/src/test/java/test/beforegroups/issue1694/ChildClassE.java
@@ -1,0 +1,9 @@
+package test.beforegroups.issue1694;
+
+import org.testng.annotations.Test;
+
+public class ChildClassE extends BaseClassWithBeforeGroups {
+    @Test(groups = "regression")
+    public void testMethodE() {
+    }
+}

--- a/src/test/java/test/beforegroups/issue1694/ChildClassF.java
+++ b/src/test/java/test/beforegroups/issue1694/ChildClassF.java
@@ -1,0 +1,9 @@
+package test.beforegroups.issue1694;
+
+import org.testng.annotations.Test;
+
+public class ChildClassF extends BaseClassWithBeforeGroups {
+    @Test(groups = "regression")
+    public void testMethodF() {
+    }
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -174,6 +174,7 @@
       <class name="test.factory.github328.GitHub328Test" />
       <class name="test.github1490.VerifyDataProviderListener"/>      
       <class name="test.methodselection.MethodSelectionTest"/>
+      <class name="test.beforegroups.BeforeGroupsTest"/>
     </classes>
   </test>
 


### PR DESCRIPTION
Closes #1694

There are two issues that have been fixed:

1. As per java docs, the “values” attribute for 
@BeforeGroups and @AfterGroups should have precedence
when provided and should override the value specified
via “groups” attribute. But “values” is completely
ignored.
2. In Parallel mode, @BeforeGroups gets executed
multiple times.

Fixes #1694  .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
