### PR TITLE
Fixing #1700

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-1700: Test ignored if @BeforeMethod in base class fails for another test class (Krishnan Mahadevan)
 Fixed: GITHUB-1694: @BeforeGroups executed multiple times when tests run in parallel, once if not parallel (Krishnan Mahadevan)
 Fixed: GITHUB-1688: @Ignore annotation on base class doesn't ignore tests in child classes (Krishnan Mahadevan)
 Fixed: GITHUB-1687: NullPointerException is thrown when beanshell evaluates to null (Krishnan Mahadevan)

--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -337,14 +337,17 @@ public class Invoker implements IInvoker {
   /**
    * @return true if this class or a parent class failed to initialize.
    */
-  private boolean classConfigurationFailed(Class<?> cls) {
+  private boolean classConfigurationFailed(Class<?> cls, Object instance) {
     for (Class<?> c : m_classInvocationResults.keySet()) {
-      if (c == cls || c.isAssignableFrom(cls)) {
+      Set<Object> obj = m_classInvocationResults.get(c);
+      boolean containsBeforeTestOrBeforeSuiteFailure = obj.contains(null);
+      if (c == cls || c.isAssignableFrom(cls) && (obj.contains(instance) || containsBeforeTestOrBeforeSuiteFailure)) {
         return true;
       }
     }
     return false;
   }
+
 
   /**
    * @return true if this class has successfully run all its @Configuration
@@ -359,7 +362,7 @@ public class Invoker implements IInvoker {
     if(m_suiteState.isFailed()) {
       result = false;
     } else {
-      boolean hasConfigurationFailures = classConfigurationFailed(cls);
+      boolean hasConfigurationFailures = classConfigurationFailed(cls, instance);
       if (hasConfigurationFailures) {
         if (! m_continueOnFailedConfiguration) {
           result = false;
@@ -376,7 +379,7 @@ public class Invoker implements IInvoker {
       }
       else if (! m_continueOnFailedConfiguration) {
         for (Class<?> clazz : m_classInvocationResults.keySet()) {
-          if (clazz.isAssignableFrom(cls)) {
+          if (clazz.isAssignableFrom(cls) && m_classInvocationResults.get(clazz).contains(instance)) {
             result = false;
             break;
           }

--- a/src/test/java/test/configuration/github1700/BaseClassSample.java
+++ b/src/test/java/test/configuration/github1700/BaseClassSample.java
@@ -1,0 +1,20 @@
+package test.configuration.github1700;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.collections.Lists;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+public class BaseClassSample {
+
+    public static List<String> messages = Lists.newArrayList();
+    @BeforeMethod(alwaysRun = true)
+    public void setUp(Method method) {
+        if (method.getName().endsWith("test1")) {
+            Assert.assertEquals(2, 1);
+        }
+        messages.add(getClass().getCanonicalName() + ".setup()");
+    }
+}

--- a/src/test/java/test/configuration/github1700/ChildClassTestSample1.java
+++ b/src/test/java/test/configuration/github1700/ChildClassTestSample1.java
@@ -1,0 +1,10 @@
+package test.configuration.github1700;
+
+import org.testng.annotations.Test;
+
+public class ChildClassTestSample1 extends BaseClassSample {
+    @Test
+    public void test1() {
+        messages.add(getClass().getCanonicalName() + ".test1()");
+    }
+}

--- a/src/test/java/test/configuration/github1700/ChildClassTestSample2.java
+++ b/src/test/java/test/configuration/github1700/ChildClassTestSample2.java
@@ -1,0 +1,10 @@
+package test.configuration.github1700;
+
+import org.testng.annotations.Test;
+
+public class ChildClassTestSample2 extends BaseClassSample {
+    @Test
+    public void test2() {
+        messages.add(getClass().getCanonicalName() + ".test2()");
+    }
+}

--- a/src/test/java/test/configuration/github1700/RunTest.java
+++ b/src/test/java/test/configuration/github1700/RunTest.java
@@ -1,0 +1,19 @@
+package test.configuration.github1700;
+
+import org.testng.TestNG;
+import org.testng.annotations.Test;
+import test.SimpleBaseTest;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+public class RunTest extends SimpleBaseTest {
+
+    @Test(description = "GITHUB-1700")
+    public void testMethod() {
+        TestNG tng = create();
+        tng.setTestClasses(new Class[]{ChildClassTestSample1.class, ChildClassTestSample2.class});
+        tng.run();
+        assertThat(BaseClassSample.messages).containsOnly(ChildClassTestSample2.class.getCanonicalName() + ".setup()",
+                ChildClassTestSample2.class.getCanonicalName() + ".test2()");
+    }
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -119,6 +119,7 @@
       <class name="test.testng249.VerifyTest"/>
       <class name="test.testng195.AfterMethodTest" />
       <class name="test.regression.BeforeTestFailingTest"/>
+      <class name="test.configuration.github1700.RunTest"/>
       <class name="test.testng285.TestNG285Test" />
       <class name="test.failedreporter.FailedReporterTest" />
       <class name="test.attributes.AttributeTest"/>


### PR DESCRIPTION
Closes #1700

Fix for: Test ignored if @BeforeMethod in base 
class fails for another test class.

Fixes #1700 .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
