### PR TITLE
Ignore null message in assertNotEquals methods

### DIFF
--- a/src/main/java/org/testng/Assert.java
+++ b/src/main/java/org/testng/Assert.java
@@ -4,6 +4,7 @@ import static org.testng.internal.EclipseInterface.ASSERT_LEFT;
 import static org.testng.internal.EclipseInterface.ASSERT_LEFT2;
 import static org.testng.internal.EclipseInterface.ASSERT_MIDDLE;
 import static org.testng.internal.EclipseInterface.ASSERT_RIGHT;
+import static org.testng.internal.EclipseInterface.ASSERT_LEFT_INEQUALITY;
 
 import java.lang.reflect.Array;
 import java.util.Arrays;
@@ -777,13 +778,20 @@ public class Assert {
   }
 
   static String format(Object actual, Object expected, String message) {
+    return format(actual, expected, message, false);
+  }
+
+  static String format(Object actual, Object expected, String message, boolean equality) {
     String formatted = "";
     if (null != message) {
       formatted = message + " ";
     }
-
-    return formatted + ASSERT_LEFT + expected + ASSERT_MIDDLE + actual + ASSERT_RIGHT;
+    if (equality) {
+      return formatted + ASSERT_LEFT + expected + ASSERT_MIDDLE + actual + ASSERT_RIGHT;
+    }
+    return formatted + ASSERT_LEFT_INEQUALITY + expected + ASSERT_MIDDLE + actual + ASSERT_RIGHT;
   }
+
 
   /**
    * Asserts that two collections contain the same elements in the same order. If they do not,
@@ -1154,7 +1162,7 @@ public class Assert {
     }
 
     if (fail) {
-      Assert.fail(message);
+      Assert.fail(format(actual1, actual2, message, false));
     }
   }
 

--- a/src/main/java/org/testng/internal/EclipseInterface.java
+++ b/src/main/java/org/testng/internal/EclipseInterface.java
@@ -15,4 +15,5 @@ public class EclipseInterface {
   public static final String ASSERT_LEFT2 = "expected not same " + OPENING_CHARACTER;
   public static final String ASSERT_MIDDLE = CLOSING_CHARACTER + " but found " + OPENING_CHARACTER;
   public static final String ASSERT_RIGHT = Character.toString(CLOSING_CHARACTER);
+  public static final String ASSERT_LEFT_INEQUALITY = "did not expect to find " + OPENING_CHARACTER;
 }


### PR DESCRIPTION
Closes #432

Fixes #432  .

### Did you remember to?

- [ ] Add test case(s)
- [ ] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.

Here's a sample code

```java
public class AssertionTest {
    @Test
    public void testMethod() {
        Assert.assertNotEquals(true, true);
    }
}
```

Execution output
```
java.lang.AssertionError: did not expect to find [true] but found [true]

	at org.testng.Assert.fail(Assert.java:97)
	at org.testng.Assert.assertNotEquals(Assert.java:1165)
	at org.testng.Assert.assertNotEquals(Assert.java:1170)
```