### PR TITLE
Refactor DynamicGraph to use more efficient algorithms and data structures.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-1710: Inefficient DynamicGraph causes hang with only 100 tests. (Steve Prentice)
 Fixed: GITHUB-1716: Potential NPE in jq.Main reporter (Krishnan Mahadevan)
 Fixed: GITHUB-1709: @Ignore doesn't work when used on child class, and parent has @Test methods (Krishnan Mahadevan)
 Fixed: GITHUB-1706: Retrying of methods fail when test method involves native injection (Krishnan Mahadevan)

--- a/src/main/java/org/testng/collections/Sets.java
+++ b/src/main/java/org/testng/collections/Sets.java
@@ -20,4 +20,8 @@ public final class Sets {
   public static <V> Set<V> newLinkedHashSet() {
     return new LinkedHashSet<>();
   }
+
+  public static <V> Set<V> newLinkedHashSet(Collection<V> c) {
+    return new LinkedHashSet<>(c);
+  }
 }

--- a/src/main/java/org/testng/internal/DynamicGraphHelper.java
+++ b/src/main/java/org/testng/internal/DynamicGraphHelper.java
@@ -109,7 +109,7 @@ public final class DynamicGraphHelper {
         if (xmlTest.getGroupByInstances()) {
             ListMultiMap<ITestNGMethod, ITestNGMethod> instanceDependencies = createInstanceDependencies(methods);
             for (Map.Entry<ITestNGMethod, List<ITestNGMethod>> es : instanceDependencies.entrySet()) {
-                result.addEdge(TestRunner.PriorityWeight.groupByInstance.ordinal(), es.getKey(), es.getValue());
+                result.addEdges(TestRunner.PriorityWeight.groupByInstance.ordinal(), es.getKey(), es.getValue());
             }
         }
 

--- a/src/main/java/org/testng/internal/thread/graph/GraphThreadPoolExecutor.java
+++ b/src/main/java/org/testng/internal/thread/graph/GraphThreadPoolExecutor.java
@@ -30,7 +30,7 @@ public class GraphThreadPoolExecutor<T> extends ThreadPoolExecutor {
     m_factory = factory;
 
     if (m_graph.getFreeNodes().isEmpty()) {
-      throw new TestNGException("The graph of methods contains a cycle:" + graph.getEdges());
+      throw new TestNGException("The graph of methods contains a cycle:" + graph);
     }
   }
 

--- a/src/test/java/org/testng/internal/DynamicGraphHelperTest.java
+++ b/src/test/java/org/testng/internal/DynamicGraphHelperTest.java
@@ -41,7 +41,7 @@ public class DynamicGraphHelperTest extends SimpleBaseTest {
     public void testCreateDynamicGraphAllIndependent() {
         DynamicGraph<ITestNGMethod> graph = newGraph(IndependentTestClassSample.class);
         assertThat(graph.getFreeNodes()).hasSize(2);
-        assertThat(graph.getEdges().isEmpty());
+        assertThat(graph.getEdges()).isEmpty();
     }
 
     @Test(dataProvider = "getDependencyData")

--- a/src/test/java/org/testng/internal/dynamicgraph/LotsOfEdgesTest.java
+++ b/src/test/java/org/testng/internal/dynamicgraph/LotsOfEdgesTest.java
@@ -1,0 +1,406 @@
+package org.testng.internal.dynamicgraph;
+
+import org.testng.annotations.Test;
+
+// https://github.com/cbeust/testng/issues/1710
+public class LotsOfEdgesTest {
+  @Test(priority = 1, groups = {"group1"})
+  void test_1_1() {
+  }
+
+  @Test(priority = 2, groups = {"group1"})
+  void test_1_2() {
+  }
+
+  @Test(priority = 3, groups = {"group1"})
+  void test_1_3() {
+  }
+
+  @Test(priority = 1, groups = {"group1"})
+  void test_1_4() {
+  }
+
+  @Test(priority = 2, groups = {"group1"})
+  void test_1_5() {
+  }
+
+  @Test(priority = 6, groups = {"group1"})
+  void test_1_6() {
+  }
+
+  @Test(priority = 7, groups = {"group1"})
+  void test_1_7() {
+  }
+
+  @Test(priority = 8, groups = {"group1"})
+  void test_1_8() {
+  }
+
+  @Test(priority = 9, groups = {"group1"})
+  void test_1_9() {
+  }
+
+  @Test(priority = 10, groups = {"group1"})
+  void test_1_10() {
+  }
+
+  @Test(priority = 1, groups = {"group1"})
+  void test_2_1() {
+  }
+
+  @Test(priority = 2, groups = {"group1"})
+  void test_2_2() {
+  }
+
+  @Test(priority = 3, groups = {"group1"})
+  void test_2_3() {
+  }
+
+  @Test(priority = 1, groups = {"group1"})
+  void test_2_4() {
+  }
+
+  @Test(priority = 2, groups = {"group1"})
+  void test_2_5() {
+  }
+
+  @Test(priority = 6, groups = {"group1"})
+  void test_2_6() {
+  }
+
+  @Test(priority = 7, groups = {"group1"})
+  void test_2_7() {
+  }
+
+  @Test(priority = 8, groups = {"group1"})
+  void test_2_8() {
+  }
+
+  @Test(priority = 9, dependsOnGroups = {"group1"})
+  void test_3_9() {
+  }
+
+  @Test(priority = 10, dependsOnGroups = {"group1"})
+  void test_3_10() {
+  }
+
+  @Test(priority = 1, dependsOnGroups = {"group1"})
+  void test_4_1() {
+  }
+
+  @Test(priority = 2, dependsOnGroups = {"group1"})
+  void test_4_2() {
+  }
+
+  @Test(priority = 3, dependsOnGroups = {"group1"})
+  void test_4_3() {
+  }
+
+  @Test(priority = 1, dependsOnGroups = {"group1"})
+  void test_4_4() {
+  }
+
+  @Test(priority = 2, dependsOnGroups = {"group1"})
+  void test_4_5() {
+  }
+
+  @Test(priority = 6, dependsOnGroups = {"group1"})
+  void test_4_6() {
+  }
+
+  @Test(priority = 7, dependsOnGroups = {"group1"})
+  void test_4_7() {
+  }
+
+  @Test(priority = 8, dependsOnGroups = {"group1"})
+  void test_4_8() {
+  }
+
+  @Test(priority = 9, dependsOnGroups = {"group1"})
+  void test_4_9() {
+  }
+
+  @Test(priority = 10, dependsOnGroups = {"group1"})
+  void test_4_10() {
+  }
+
+  @Test(priority = 1, dependsOnGroups = {"group1"})
+  void test_5_1() {
+  }
+
+  @Test(priority = 2, dependsOnGroups = {"group1"})
+  void test_5_2() {
+  }
+
+  @Test(priority = 3, dependsOnGroups = {"group1"})
+  void test_5_3() {
+  }
+
+  @Test(priority = 1, dependsOnGroups = {"group1"})
+  void test_5_4() {
+  }
+
+  @Test(priority = 2, dependsOnGroups = {"group1"})
+  void test_5_5() {
+  }
+
+  @Test(priority = 6, dependsOnGroups = {"group1"})
+  void test_5_6() {
+  }
+
+  @Test(priority = 7, dependsOnGroups = {"group1"})
+  void test_5_7() {
+  }
+
+  @Test(priority = 8, dependsOnGroups = {"group1"})
+  void test_5_8() {
+  }
+
+  @Test(priority = 9, dependsOnGroups = {"group1"})
+  void test_5_9() {
+  }
+
+  @Test(priority = 10, dependsOnGroups = {"group1"})
+  void test_5_10() {
+  }
+
+  @Test(priority = 9)
+  void test_2_9() {
+  }
+
+  @Test(priority = 10)
+  void test_2_10() {
+  }
+
+  @Test(priority = 1)
+  void test_3_1() {
+  }
+
+  @Test(priority = 2)
+  void test_3_2() {
+  }
+
+  @Test(priority = 3)
+  void test_3_3() {
+  }
+
+  @Test(priority = 1)
+  void test_3_4() {
+  }
+
+  @Test(priority = 2)
+  void test_3_5() {
+  }
+
+  @Test(priority = 6)
+  void test_3_6() {
+  }
+
+  @Test(priority = 7)
+  void test_3_7() {
+  }
+
+  @Test(priority = 8)
+  void test_3_8() {
+  }
+
+  @Test(priority = 1)
+  void test_6_1() {
+  }
+
+  @Test(priority = 2)
+  void test_6_2() {
+  }
+
+  @Test(priority = 3)
+  void test_6_3() {
+  }
+
+  @Test(priority = 1)
+  void test_6_4() {
+  }
+
+  @Test(priority = 2)
+  void test_6_5() {
+  }
+
+  @Test(priority = 6)
+  void test_6_6() {
+  }
+
+  @Test(priority = 7)
+  void test_6_7() {
+  }
+
+  @Test(priority = 8)
+  void test_6_8() {
+  }
+
+  @Test(priority = 9)
+  void test_6_9() {
+  }
+
+  @Test(priority = 10)
+  void test_6_10() {
+  }
+
+  @Test(priority = 1)
+  void test_7_1() {
+  }
+
+  @Test(priority = 2)
+  void test_7_2() {
+  }
+
+  @Test(priority = 3)
+  void test_7_3() {
+  }
+
+  @Test(priority = 1)
+  void test_7_4() {
+  }
+
+  @Test(priority = 2)
+  void test_7_5() {
+  }
+
+  @Test(priority = 6)
+  void test_7_6() {
+  }
+
+  @Test(priority = 7)
+  void test_7_7() {
+  }
+
+  @Test(priority = 8)
+  void test_7_8() {
+  }
+
+  @Test(priority = 9)
+  void test_7_9() {
+  }
+
+  @Test(priority = 10)
+  void test_7_10() {
+  }
+
+  @Test(priority = 1)
+  void test_8_1() {
+  }
+
+  @Test(priority = 2)
+  void test_8_2() {
+  }
+
+  @Test(priority = 3)
+  void test_8_3() {
+  }
+
+  @Test(priority = 1)
+  void test_8_4() {
+  }
+
+  @Test(priority = 2)
+  void test_8_5() {
+  }
+
+  @Test(priority = 6)
+  void test_8_6() {
+  }
+
+  @Test(priority = 7)
+  void test_8_7() {
+  }
+
+  @Test(priority = 8)
+  void test_8_8() {
+  }
+
+  @Test(priority = 9)
+  void test_8_9() {
+  }
+
+  @Test(priority = 10)
+  void test_8_10() {
+  }
+
+  @Test(priority = 1)
+  void test_9_1() {
+  }
+
+  @Test(priority = 2)
+  void test_9_2() {
+  }
+
+  @Test(priority = 3)
+  void test_9_3() {
+  }
+
+  @Test(priority = 1)
+  void test_9_4() {
+  }
+
+  @Test(priority = 2)
+  void test_9_5() {
+  }
+
+  @Test(priority = 6)
+  void test_9_6() {
+  }
+
+  @Test(priority = 7)
+  void test_9_7() {
+  }
+
+  @Test(priority = 8)
+  void test_9_8() {
+  }
+
+  @Test(priority = 9)
+  void test_9_9() {
+  }
+
+  @Test(priority = 10)
+  void test_9_10() {
+  }
+
+  @Test(priority = 1)
+  void test_10_1() {
+  }
+
+  @Test(priority = 2)
+  void test_10_2() {
+  }
+
+  @Test(priority = 3)
+  void test_10_3() {
+  }
+
+  @Test(priority = 1)
+  void test_10_4() {
+  }
+
+  @Test(priority = 2)
+  void test_10_5() {
+  }
+
+  @Test(priority = 6)
+  void test_10_6() {
+  }
+
+  @Test(priority = 7)
+  void test_10_7() {
+  }
+
+  @Test(priority = 8)
+  void test_10_8() {
+  }
+
+  @Test(priority = 9)
+  void test_10_9() {
+  }
+
+  @Test(priority = 10)
+  void test_10_10() {
+  }
+}


### PR DESCRIPTION
DynamicGraph now organizes its edges in two maps of maps so it can quickly
lookup edges to or from any node to any other node. Previously, finding
edges, especially when searching by the "to" node, would require iterating
over all nodes. This caused an exponential performance curve resulting in
the LotsOfEdgesTest not being able to finish in any practical length of time.

Fixes #1710 

In #1710, we talked about taking a different approach to solving this problem, but in the end, I decided not to take that approach and keep DynamicGraph working pretty much the same way as before. The changes to DynamicGraph are mostly geared toward using a different data structure to manage the edges and adapting the code to take advantage of those data structures. The result is a massive performance boost without any additional memory usage (because the old code also kept two copies of the edges – m_edges and m_allEdges).

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`