### PR TITLE
Re-order to ensure built-in interceptor added first

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,7 @@
 Current
+Fixed: GITHUB-1726: Allow user-defined method interceptors to have the last say in method re-ordering (Krishnan Mahadevan)
 Fixed: GITHUB-564: Support using @Optional on @Test method parameters to use null values (Krishnan Mahadevan)
+New: Upgrade TestNG to start needing at-least JDK8 (Krishnan Mahadevan)
 Fixed: GITHUB-1637: Remove dependency on a pre-created jar for running unit tests for JarFileUtils (Krishnan Mahadevan)
 Fixed: GITHUB-1710: Inefficient DynamicGraph causes hang with only 100 tests. (Steve Prentice)
 Fixed: GITHUB-1716: Potential NPE in jq.Main reporter (Krishnan Mahadevan)

--- a/src/main/java/org/testng/TestRunner.java
+++ b/src/main/java/org/testng/TestRunner.java
@@ -212,8 +212,11 @@ public class TestRunner
     setVerbose(test.getVerbose());
 
     boolean preserveOrder = test.getPreserveOrder();
-    m_methodInterceptors = new ArrayList<>();
     builtinInterceptor = preserveOrder ? new PreserveOrderMethodInterceptor() : new InstanceOrderingMethodInterceptor();
+    m_methodInterceptors = new ArrayList<>();
+    //Add the built in interceptor as the first interceptor. That way we let our users determine the final order
+    //by plugging in their own custom interceptors as well.
+    m_methodInterceptors.add(builtinInterceptor);
 
     List<XmlPackage> m_packageNamesFromXml = test.getXmlPackages();
     if(null != m_packageNamesFromXml) {
@@ -661,8 +664,6 @@ public class TestRunner
 
     List<IMethodInstance> methodInstances = MethodHelper.methodsToMethodInstances(Arrays.asList(methods));
 
-    // add built-in interceptor (PreserveOrderMethodInterceptor or InstanceOrderingMethodInterceptor at the end of the list
-    m_methodInterceptors.add(builtinInterceptor);
     for (IMethodInterceptor m_methodInterceptor : m_methodInterceptors) {
       methodInstances = m_methodInterceptor.intercept(methodInstances, this);
     }

--- a/src/test/java/test/methodinterceptors/issue1726/CustomInterceptorTest.java
+++ b/src/test/java/test/methodinterceptors/issue1726/CustomInterceptorTest.java
@@ -1,0 +1,54 @@
+package test.methodinterceptors.issue1726;
+
+import org.testng.IInvokedMethod;
+import org.testng.IInvokedMethodListener;
+import org.testng.ITestNGListener;
+import org.testng.ITestResult;
+import org.testng.TestNG;
+import org.testng.annotations.Test;
+import org.testng.xml.XmlSuite;
+import org.testng.xml.XmlTest;
+import test.SimpleBaseTest;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CustomInterceptorTest extends SimpleBaseTest {
+
+    @Test
+    public void testOrderingWhenInvolvingCustomInterceptors() {
+        XmlSuite suite = createXmlSuite("suite");
+        suite.setPreserveOrder(false);
+        XmlTest xmlTest = createXmlTest(suite, "test", TestClassSample1.class, TestClassSample2.class);
+        xmlTest.setPreserveOrder(false);
+        TestNG testng = create(suite);
+        testng.addListener(new PriorityInterceptor());
+        testng.addListener((ITestNGListener) new MethodOrderTracker());
+        testng.run();
+        List<String> expected = Arrays.asList(
+                "TestClassSample2.Test3",
+                "TestClassSample1.Test1",
+                "TestClassSample1.Test2",
+                "TestClassSample2.Test4"
+        );
+        assertThat(MethodOrderTracker.ordered).containsExactlyElementsOf(expected);
+    }
+
+    public static class MethodOrderTracker implements IInvokedMethodListener {
+        static List<String> ordered = new ArrayList<>();
+
+        @Override
+        public void beforeInvocation(IInvokedMethod method, ITestResult testResult) {
+
+        }
+
+        @Override
+        public void afterInvocation(IInvokedMethod method, ITestResult testResult) {
+            String clazz = method.getTestMethod().getRealClass().getSimpleName() + ".";
+            ordered.add(clazz + method.getTestMethod().getMethodName());
+        }
+    }
+}

--- a/src/test/java/test/methodinterceptors/issue1726/Priority.java
+++ b/src/test/java/test/methodinterceptors/issue1726/Priority.java
@@ -1,0 +1,11 @@
+package test.methodinterceptors.issue1726;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface Priority {
+    int value() default 0;
+}

--- a/src/test/java/test/methodinterceptors/issue1726/PriorityInterceptor.java
+++ b/src/test/java/test/methodinterceptors/issue1726/PriorityInterceptor.java
@@ -1,0 +1,35 @@
+package test.methodinterceptors.issue1726;
+
+import org.testng.IMethodInstance;
+import org.testng.IMethodInterceptor;
+import org.testng.ITestContext;
+
+import java.lang.reflect.Method;
+import java.util.Comparator;
+import java.util.List;
+
+public class PriorityInterceptor implements IMethodInterceptor {
+
+    public List<IMethodInstance> intercept(List<IMethodInstance> methods,
+                                           ITestContext context) {
+        Comparator<IMethodInstance> comparator = Comparator.comparingInt(PriorityInterceptor::getPriority);
+        methods.sort(comparator);
+        return methods;
+    }
+
+    private static int getPriority(IMethodInstance mi) {
+        int result = 0;
+        Method method = mi.getMethod().getConstructorOrMethod().getMethod();
+        Priority a1 = method.getAnnotation(Priority.class);
+        if (a1 != null) {
+            return a1.value();
+        }
+        Class<?> cls = method.getDeclaringClass();
+        Priority classPriority = cls.getAnnotation(Priority.class);
+        if (classPriority != null) {
+            result = classPriority.value();
+        }
+        return result;
+    }
+
+}

--- a/src/test/java/test/methodinterceptors/issue1726/TestClassSample1.java
+++ b/src/test/java/test/methodinterceptors/issue1726/TestClassSample1.java
@@ -1,0 +1,19 @@
+package test.methodinterceptors.issue1726;
+
+import org.testng.Reporter;
+import org.testng.annotations.Test;
+
+public class TestClassSample1 {
+
+    @Priority(4)
+    @Test(description = "Test Multiple Day Absence Request flow", groups = "Test")
+    public void Test1() {
+        Reporter.log(getClass().getName() + ".Test1", true);
+    }
+
+    @Priority(8)
+    @Test(description = "Test Single Day Absence Request Flow", groups = {"Regression", "Test"})
+    public void Test2() {
+        Reporter.log(getClass().getName() + ".Test2", true);
+    }
+}

--- a/src/test/java/test/methodinterceptors/issue1726/TestClassSample2.java
+++ b/src/test/java/test/methodinterceptors/issue1726/TestClassSample2.java
@@ -1,0 +1,19 @@
+package test.methodinterceptors.issue1726;
+
+import org.testng.Reporter;
+import org.testng.annotations.Test;
+
+public class TestClassSample2 {
+
+    @Priority(3)
+    @Test(description = "Test Multiple Day Absence Request flow", groups = "Test")
+    public void Test3() {
+        Reporter.log(getClass().getName() + ".Test3", true);
+    }
+
+    @Priority(9)
+    @Test(description = "Test Single Day Absence Request Flow", groups = {"Regression", "Test"})
+    public void Test4() {
+        Reporter.log(getClass().getName() + ".Test4", true);
+    }
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -697,6 +697,7 @@
       <class name="test.methodinterceptors.MethodInterceptorTest" />
       <class name="test.methodinterceptors.Issue392Test" />
       <class name="test.methodinterceptors.multipleinterceptors.MultipleInterceptorsTest" />
+      <class name="test.methodinterceptors.issue1726.CustomInterceptorTest"/>
     </classes>
   </test>
 


### PR DESCRIPTION
Closes #1726

Currently TestNG injects the built in method 
interceptor [order preserving interceptor or the 
instance ordering interceptor] as the last. 
So if a user has their own method interceptor 
which attempts at re-ordering the methods, it still
doesn’t have any effect, because we end up ordering
methods finally based on either instances or order
of occurrence of class in the suite xml.

Fixed this by having the built in injectors added 
at the top rather than at the end.

But for custom interceptors that intend to change
method order to work, one would need to ensure that 
preserve-order is DISABLED (this is enabled by default
at suite and test level)

Fixes #1726  .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
