### PR TITLE
IExecutionListener.onStart() running multiple times

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-1735: IExecutionListener.onStart() running twice when used as annotation (Krishnan Mahadevan)
 New  : Removed deprecated methods across TestNG (Krishnan Mahadevan)
 Fixed: GITHUB-1726: Allow user-defined method interceptors to have the last say in method re-ordering (Krishnan Mahadevan)
 Fixed: GITHUB-564: Support using @Optional on @Test method parameters to use null values (Krishnan Mahadevan)

--- a/src/main/java/org/testng/TestNG.java
+++ b/src/main/java/org/testng/TestNG.java
@@ -688,7 +688,7 @@ public class TestNG {
       setConfigurable((IConfigurable) listener);
     }
     if (listener instanceof IExecutionListener) {
-      m_configuration.addExecutionListener((IExecutionListener) listener);
+      m_configuration.addExecutionListenerIfAbsent((IExecutionListener) listener);
     }
     if (listener instanceof IConfigurationListener) {
       m_configuration.addConfigurationListener((IConfigurationListener) listener);

--- a/src/main/java/org/testng/TestRunner.java
+++ b/src/main/java/org/testng/TestRunner.java
@@ -1012,8 +1012,9 @@ public class TestRunner
     }
     if (listener instanceof IExecutionListener) {
       IExecutionListener iel = (IExecutionListener) listener;
-      iel.onExecutionStart();
-      m_configuration.addExecutionListener(iel);
+      if (m_configuration.addExecutionListenerIfAbsent(iel)) {
+        iel.onExecutionStart();
+      }
     }
     if (listener instanceof IDataProviderListener) {
       IDataProviderListener dataProviderListener = (IDataProviderListener) listener;

--- a/src/main/java/org/testng/internal/Configuration.java
+++ b/src/main/java/org/testng/internal/Configuration.java
@@ -77,10 +77,8 @@ public class Configuration implements IConfiguration {
   }
 
   @Override
-  public void addExecutionListener(IExecutionListener l) {
-    if (!m_executionListeners.keySet().contains(l.getClass())) {
-        m_executionListeners.put(l.getClass(), l);
-    }
+  public boolean addExecutionListenerIfAbsent(IExecutionListener l) {
+    return  m_executionListeners.putIfAbsent(l.getClass(), l) == null;
   }
 
   @Override

--- a/src/main/java/org/testng/internal/IConfiguration.java
+++ b/src/main/java/org/testng/internal/IConfiguration.java
@@ -19,7 +19,11 @@ public interface IConfiguration {
   void setConfigurable(IConfigurable c);
 
   List<IExecutionListener> getExecutionListeners();
-  void addExecutionListener(IExecutionListener l);
+  default void addExecutionListener(IExecutionListener l) {}
+
+  default boolean addExecutionListenerIfAbsent(IExecutionListener l) {
+    return false;
+  }
 
   List<IConfigurationListener> getConfigurationListeners();
   void addConfigurationListener(IConfigurationListener cl);

--- a/src/test/java/test/listeners/github1735/ExecutionListenerTest.java
+++ b/src/test/java/test/listeners/github1735/ExecutionListenerTest.java
@@ -1,0 +1,24 @@
+package test.listeners.github1735;
+
+import org.testng.TestNG;
+import org.testng.annotations.Test;
+import org.testng.xml.XmlSuite;
+import test.SimpleBaseTest;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ExecutionListenerTest extends SimpleBaseTest {
+    @Test
+    public void ensureExecutionListenerIsInvokedOnlyOnce() {
+        XmlSuite suite = createXmlSuite("suite");
+        createXmlTest(suite, "test1", TestClassSample.class, TestClassTwoSample.class);
+        createXmlTest(suite, "test2", TestClassSample.class, TestClassTwoSample.class);
+        TestNG testng = create(suite);
+        testng.run();
+        assertThat(LocalExecutionListener.getFinish()).containsExactlyElementsOf(Collections.singletonList("finish"));
+        assertThat(LocalExecutionListener.getStart()).containsExactlyElementsOf(Collections.singletonList("start"));
+    }
+
+}

--- a/src/test/java/test/listeners/github1735/LocalExecutionListener.java
+++ b/src/test/java/test/listeners/github1735/LocalExecutionListener.java
@@ -1,0 +1,29 @@
+package test.listeners.github1735;
+
+import org.testng.IExecutionListener;
+import org.testng.collections.Lists;
+
+import java.util.List;
+
+public class LocalExecutionListener implements IExecutionListener {
+    private static final List<String> start = Lists.newArrayList();
+    private static final List<String>  finish = Lists.newArrayList();
+
+    @Override
+    public void onExecutionStart() {
+        start.add("start");
+    }
+
+    @Override
+    public void onExecutionFinish() {
+        finish.add("finish");
+    }
+
+    public static List<String> getFinish() {
+        return finish;
+    }
+
+    public static List<String> getStart() {
+        return start;
+    }
+}

--- a/src/test/java/test/listeners/github1735/TestClassSample.java
+++ b/src/test/java/test/listeners/github1735/TestClassSample.java
@@ -1,0 +1,10 @@
+package test.listeners.github1735;
+
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+@Listeners(LocalExecutionListener.class)
+public class TestClassSample {
+    @Test
+    public void testMethod(){}
+}

--- a/src/test/java/test/listeners/github1735/TestClassTwoSample.java
+++ b/src/test/java/test/listeners/github1735/TestClassTwoSample.java
@@ -1,0 +1,10 @@
+package test.listeners.github1735;
+
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+@Listeners(LocalExecutionListener.class)
+public class TestClassTwoSample {
+    @Test
+    public void testMethod(){}
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -165,6 +165,7 @@
       <class name="test.testng173.TestNG173Test" />
       <class name="test.listeners.github551.Test551"/>
       <class name="test.listeners.github1284.TestListeners"/>
+      <class name="test.listeners.github1735.ExecutionListenerTest"/>
       <class name="test_result.GitHub1197Test"/>
       <class name="test.listeners.github1319.TestResultInstanceCheckTest"/>
       <class name="test.testng1396.ParallelByInstancesInterceptorTest"/>


### PR DESCRIPTION
Closes #1735

Prevent IExecutionListener.onStart() from 
running more than once when added via the 
@Listeners annotation.

Fixes #1735  .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
