### PR TITLE
Standardize timezone reference in reports.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-466: JUnitReportReporter always converts the system time into GMT (Krishnan Mahadevan)
 Fixed: GITHUB-1723: Standardize timezone reference in XML reports (Krishnan Mahadevan)
 Fixed: GITHUB-489: Incorrect timezone info in <test-method> element of testng-results.xml (Krishnan Mahadevan)
 Fixed: GITHUB-1735: IExecutionListener.onStart() running twice when used as annotation (Krishnan Mahadevan)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,6 @@
 Current
+Fixed: GITHUB-1723: Standardize timezone reference in XML reports (Krishnan Mahadevan)
+Fixed: GITHUB-489: Incorrect timezone info in <test-method> element of testng-results.xml (Krishnan Mahadevan)
 Fixed: GITHUB-1735: IExecutionListener.onStart() running twice when used as annotation (Krishnan Mahadevan)
 New  : Removed deprecated methods across TestNG (Krishnan Mahadevan)
 Fixed: GITHUB-1726: Allow user-defined method interceptors to have the last say in method re-ordering (Krishnan Mahadevan)

--- a/src/main/java/org/testng/internal/RuntimeBehavior.java
+++ b/src/main/java/org/testng/internal/RuntimeBehavior.java
@@ -1,5 +1,7 @@
 package org.testng.internal;
 
+import java.util.TimeZone;
+
 /**
  * This class houses handling all JVM arguments by TestNG
  */
@@ -15,5 +17,17 @@ public final class RuntimeBehavior {
     public static boolean isDryRun() {
         String value = System.getProperty("testng.mode.dryrun", "false");
         return Boolean.parseBoolean(value);
+    }
+
+    /**
+     * @return - returns the {@link TimeZone} corresponding to the JVM argument
+     * <code>-Dtestng.timezone</code> if it was set. If not set, it returns the default
+     * timezone pertaining to the user property <code>user.timezone</code>
+     */
+    public static TimeZone getTimeZone() {
+        if (System.getProperty("testng.timezone", "").trim().isEmpty()) {
+            return TimeZone.getDefault();
+        }
+        return TimeZone.getTimeZone(System.getProperty("testng.timezone"));
     }
 }

--- a/src/main/java/org/testng/internal/RuntimeBehavior.java
+++ b/src/main/java/org/testng/internal/RuntimeBehavior.java
@@ -25,9 +25,10 @@ public final class RuntimeBehavior {
      * timezone pertaining to the user property <code>user.timezone</code>
      */
     public static TimeZone getTimeZone() {
-        if (System.getProperty("testng.timezone", "").trim().isEmpty()) {
+        String timeZone = System.getProperty("testng.timezone", "");
+        if (timeZone.trim().isEmpty()) {
             return TimeZone.getDefault();
         }
-        return TimeZone.getTimeZone(System.getProperty("testng.timezone"));
+        return TimeZone.getTimeZone(timeZone);
     }
 }

--- a/src/main/java/org/testng/reporters/JUnitReportReporter.java
+++ b/src/main/java/org/testng/reporters/JUnitReportReporter.java
@@ -90,7 +90,7 @@ public class JUnitReportReporter implements IReporter {
       Class<?> cls = entry.getKey();
       Properties p1 = new Properties();
       p1.setProperty(XMLConstants.ATTR_NAME, cls.getName());
-      p1.setProperty(XMLConstants.ATTR_TIMESTAMP, JUnitXMLReporter.timeAsGmt());
+      p1.setProperty(XMLConstants.ATTR_TIMESTAMP, JUnitXMLReporter.formattedTime());
 
       List<TestTag> testCases = Lists.newArrayList();
       int failures = 0;

--- a/src/main/java/org/testng/reporters/JUnitXMLReporter.java
+++ b/src/main/java/org/testng/reporters/JUnitXMLReporter.java
@@ -4,27 +4,21 @@ package org.testng.reporters;
 import org.testng.ITestContext;
 import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
-import org.testng.collections.Lists;
 import org.testng.collections.Maps;
 import org.testng.collections.Sets;
 import org.testng.internal.IResultListener2;
 import org.testng.internal.Utils;
+import org.testng.util.TimeUtils;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.Calendar;
-import java.util.Collections;
 import java.util.Collection;
 import java.util.Queue;
-import java.util.TimeZone;
-import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.regex.Pattern;
-
-import java.text.SimpleDateFormat;
 
 /**
  * A JUnit XML report generator (replacing the original JUnitXMLReporter that was
@@ -163,7 +157,7 @@ public class JUnitXMLReporter implements IResultListener2 {
       attrs.setProperty(XMLConstants.ATTR_TIME,
           Double.toString((context.getEndDate().getTime() - context.getStartDate().getTime()) / 1000.0));
 
-      attrs.setProperty(XMLConstants.ATTR_TIMESTAMP, timeAsGmt());
+      attrs.setProperty(XMLConstants.ATTR_TIMESTAMP, formattedTime());
 
       document.push(XMLConstants.TESTSUITE, attrs);
 
@@ -175,11 +169,8 @@ public class JUnitXMLReporter implements IResultListener2 {
       Utils.writeUtf8File(context.getOutputDirectory(),generateFileName(context) + ".xml", document.toXML());
   }
 
-  static String timeAsGmt() {
-    SimpleDateFormat sdf = new SimpleDateFormat();
-    sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
-    sdf.applyPattern("dd MMM yyyy HH:mm:ss z");
-    return sdf.format(Calendar.getInstance().getTime());
+  static String formattedTime() {
+    return TimeUtils.formatTimeInLocalOrSpecifiedTimeZone(System.currentTimeMillis(), XMLReporterConfig.FMT_DEFAULT);
   }
 
   private synchronized void createElementFromTestResults(XMLStringBuffer document, Collection<ITestResult> results) {

--- a/src/main/java/org/testng/reporters/XMLReporter.java
+++ b/src/main/java/org/testng/reporters/XMLReporter.java
@@ -191,8 +191,8 @@ public class XMLReporter implements IReporter {
   public static void addDurationAttributes(XMLReporterConfig config, Properties attributes,
       Date minStartDate, Date maxEndDate) {
 
-    String startTime = TimeUtils.timeInUTC(minStartDate.getTime(), config.getTimestampFormat());
-    String endTime = TimeUtils.timeInUTC(maxEndDate.getTime(), config.getTimestampFormat());
+    String startTime = TimeUtils.formatTimeInLocalOrSpecifiedTimeZone(minStartDate.getTime(), config.getTimestampFormat());
+    String endTime = TimeUtils.formatTimeInLocalOrSpecifiedTimeZone(maxEndDate.getTime(), config.getTimestampFormat());
     long duration = maxEndDate.getTime() - minStartDate.getTime();
 
     attributes.setProperty(XMLReporterConfig.ATTR_STARTED_AT, startTime);

--- a/src/main/java/org/testng/reporters/XMLReporterConfig.java
+++ b/src/main/java/org/testng/reporters/XMLReporterConfig.java
@@ -81,9 +81,7 @@ public class XMLReporterConfig {
    */
   public static final int FF_LEVEL_SUITE_RESULT = 3;
 
-  // note: We're hardcoding the 'Z' because Java doesn't support all the
-  // intricacies of ISO-8601.
-  static final String FMT_DEFAULT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+  static final String FMT_DEFAULT = "yyyy-MM-dd'T'HH:mm:ss z";
 
   /**
    * Indicates the way that the file fragmentation should be performed. Set this

--- a/src/main/java/org/testng/reporters/XMLSuiteResultWriter.java
+++ b/src/main/java/org/testng/reporters/XMLSuiteResultWriter.java
@@ -194,8 +194,8 @@ public class XMLSuiteResultWriter {
 
     attributes.setProperty(XMLReporterConfig.ATTR_METHOD_SIG, removeClassName(testResult.getMethod().toString()));
 
-    String startTime = TimeUtils.timeInUTC(testResult.getStartMillis(), config.getTimestampFormat());
-    String endTime = TimeUtils.timeInUTC(testResult.getEndMillis(), config.getTimestampFormat());
+    String startTime = TimeUtils.formatTimeInLocalOrSpecifiedTimeZone(testResult.getStartMillis(), config.getTimestampFormat());
+    String endTime = TimeUtils.formatTimeInLocalOrSpecifiedTimeZone(testResult.getEndMillis(), config.getTimestampFormat());
     attributes.setProperty(XMLReporterConfig.ATTR_STARTED_AT, startTime);
     attributes.setProperty(XMLReporterConfig.ATTR_FINISHED_AT, endTime);
     long duration = testResult.getEndMillis() - testResult.getStartMillis();

--- a/src/main/java/org/testng/util/TimeUtils.java
+++ b/src/main/java/org/testng/util/TimeUtils.java
@@ -1,5 +1,7 @@
 package org.testng.util;
 
+import org.testng.internal.RuntimeBehavior;
+
 import java.text.SimpleDateFormat;
 import java.util.TimeZone;
 
@@ -14,11 +16,26 @@ public final class TimeUtils {
      * @param timeInMilliSeconds - The time in milliseconds
      * @param format             - A format that can be used by {@link SimpleDateFormat}
      * @return - A formatted string representation of the time in UTC/GMT timezone.
+     * @deprecated - Method stands deprecated as of TestNG 7.0.0
      */
+    @Deprecated
     public static String timeInUTC(long timeInMilliSeconds, String format) {
         SimpleDateFormat sdf = new SimpleDateFormat(format);
         TimeZone utc = TimeZone.getTimeZone("UTC");
         sdf.setTimeZone(utc);
+        return sdf.format(timeInMilliSeconds);
+    }
+
+    /**
+     * @param timeInMilliSeconds - The time in milliseconds
+     * @param format             - A format that can be used by {@link SimpleDateFormat}
+     * @return - A formatted string representation of the time in the timezone as obtained via
+     * {@link RuntimeBehavior#getTimeZone()}
+     */
+    public static String formatTimeInLocalOrSpecifiedTimeZone(long timeInMilliSeconds, String format) {
+        SimpleDateFormat sdf = new SimpleDateFormat(format);
+        TimeZone timeZone = RuntimeBehavior.getTimeZone();
+        sdf.setTimeZone(timeZone);
         return sdf.format(timeInMilliSeconds);
     }
 }


### PR DESCRIPTION
Closes #1723  and #489

As part of fixing this, introduced a standard 
mechanism of accepting the timezone.

We now read the timezone via the custom JVM argument
-Dtestng.timezone. If its not set, then we fall 
back to the default timezone which is read via 
the JVM property -Duser.timezone

Fixes #1723  and #489

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.