### PR TITLE
Add onlyForGroups to @AfterMethod

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-549 and GITHUB-780: Introduce onlyForGroups attribute for @BeforeMethod and @AfterMethod (Sergei Tachenov)
 Fixed: GITHUB-1745: Support native injection for @Factory methods (Krishnan Mahadevan)
 Fixed: GITHUB-1746: Make InvokedMethodNameListener thread-safe, fixing occasional build failures (Sergei Tachenov)
 Fixed: GITHUB-1538: Dependent methods don't get invoked when a failed test method is retried via a RetryAnalyser (Krishnan Mahadevan)

--- a/src/main/java/org/testng/annotations/AfterMethod.java
+++ b/src/main/java/org/testng/annotations/AfterMethod.java
@@ -15,6 +15,12 @@ public @interface AfterMethod {
 
   /**
    * The list of groups this class/method belongs to.
+   * Note that even if the test method that was invoked belongs
+   * to a different group, all @AfterMethod methods will be
+   * invoked after it as long as they belong to groups
+   * that were selected to run at all.  See {@link #onlyForGroups()}
+   * to select test method groups which this method will
+   * be invoked after.
    */
   public String[] groups() default {};
 
@@ -39,6 +45,16 @@ public @interface AfterMethod {
    *  versions will be run.
    */
   public String[] dependsOnMethods() default {};
+
+  /**
+   * Causes this method to be invoked only if the test method belongs to a listed group.
+   * It can be used if different cleanups are needed for different groups.  Omitting
+   * this or setting it to an empty list will cause this method to run after every
+   * test method, regardless of which group it belongs to.  Otherwise, this method
+   * is only invoked if the test method that was invoked belongs to one of the groups
+   * listed here.
+   */
+  public String[] onlyForGroups() default {};
 
   /**
    *  For before methods (beforeSuite, beforeTest, beforeTestClass and

--- a/src/main/java/org/testng/internal/ConfigurationMethod.java
+++ b/src/main/java/org/testng/internal/ConfigurationMethod.java
@@ -19,6 +19,7 @@ import org.testng.internal.annotations.IAfterMethod;
 import org.testng.internal.annotations.IAfterSuite;
 import org.testng.internal.annotations.IAfterTest;
 import org.testng.internal.annotations.IAnnotationFinder;
+import org.testng.internal.annotations.IBaseBeforeAfterMethod;
 import org.testng.internal.annotations.IBeforeClass;
 import org.testng.internal.annotations.IBeforeGroups;
 import org.testng.internal.annotations.IBeforeMethod;
@@ -456,11 +457,15 @@ public class ConfigurationMethod extends BaseTestMethod {
   }
 
   public String[] getGroupFilters() {
-    IBeforeMethod before = m_annotationFinder.findAnnotation(getConstructorOrMethod(), IBeforeMethod.class);
-    if (before == null) {
+    IBaseBeforeAfterMethod beforeAfter;
+    beforeAfter = m_annotationFinder.findAnnotation(getConstructorOrMethod(), IBeforeMethod.class);
+    if (beforeAfter == null) {
+      beforeAfter = m_annotationFinder.findAnnotation(getConstructorOrMethod(), IAfterMethod.class);
+    }
+    if (beforeAfter == null) {
       return new String[0];
     }
-    return before.getGroupFilters();
+    return beforeAfter.getGroupFilters();
   }
 
 }

--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -546,7 +546,7 @@ public class Invoker implements IInvoker {
       testResult.setMethod(tm);
       runInvokedMethodListeners(BEFORE_INVOCATION, invokedMethod, testResult);
       runInvokedMethodListeners(AFTER_INVOCATION, invokedMethod, testResult);
-      ITestNGMethod[] teardownConfigMethods = TestNgMethodUtils.filterLastTimeRunnableTeardownConfigurationMethods(tm, afterMethods);
+      ITestNGMethod[] teardownConfigMethods = TestNgMethodUtils.filterTeardownConfigurationMethods(tm, afterMethods);
       invokeConfigurations(testClass, tm, teardownConfigMethods, suite, params, parameterValues, instance, testResult);
       invokeAfterGroupsConfigurations(tm, groupMethods, suite, params, instance);
 
@@ -651,12 +651,7 @@ public class Invoker implements IInvoker {
 
       collectResults(tm, testResult);
 
-      //
-      // Invoke afterMethods only if
-      // - lastTimeOnly is not set
-      // - lastTimeOnly is set, and we are reaching the last invocationCount
-      //
-      ITestNGMethod[] tearDownConfigMethods = TestNgMethodUtils.filterLastTimeRunnableTeardownConfigurationMethods(tm, afterMethods);
+      ITestNGMethod[] tearDownConfigMethods = TestNgMethodUtils.filterTeardownConfigurationMethods(tm, afterMethods);
       invokeConfigurations(testClass, tm, tearDownConfigMethods, suite, params, parameterValues, instance, testResult);
 
       //

--- a/src/main/java/org/testng/internal/TestNgMethodUtils.java
+++ b/src/main/java/org/testng/internal/TestNgMethodUtils.java
@@ -85,14 +85,11 @@ class TestNgMethodUtils {
         return vResult.toArray(new ITestNGMethod[vResult.size()]);
     }
 
-    /**
-     * Filters configuration method array, leaving only those methods that should actually run.
-     */
     static ITestNGMethod[] filterSetupConfigurationMethods(ITestNGMethod tm, ITestNGMethod[] methods) {
         List<ITestNGMethod> result = Lists.newArrayList();
         for (ITestNGMethod m : methods) {
             ConfigurationMethod cm = (ConfigurationMethod) m;
-            if (doesConfigMethodPassFirstTimeFilter(cm, tm)
+            if (doesSetupMethodPassFirstTimeFilter(cm, tm)
              && doesConfigMethodPassGroupFilters(cm, tm)) {
                 result.add(m);
             }
@@ -100,11 +97,12 @@ class TestNgMethodUtils {
         return result.toArray(new ITestNGMethod[result.size()]);
     }
 
-    static ITestNGMethod[] filterLastTimeRunnableTeardownConfigurationMethods(ITestNGMethod tm, ITestNGMethod[] methods) {
+    static ITestNGMethod[] filterTeardownConfigurationMethods(ITestNGMethod tm, ITestNGMethod[] methods) {
         List<ITestNGMethod> result = Lists.newArrayList();
         for (ITestNGMethod m : methods) {
             ConfigurationMethod cm = (ConfigurationMethod) m;
-            if (isConfigMethodRunningLastTime(cm, tm)) {
+            if (doesTeardownMethodPassLastTimeFilter(cm, tm)
+             && doesConfigMethodPassGroupFilters(cm, tm)) {
                 result.add(m);
             }
         }
@@ -126,11 +124,11 @@ class TestNgMethodUtils {
         return String.format("%s+%d+%d", instance.toString(), method.getCurrentInvocationCount(), method.getParameterInvocationCount());
     }
 
-    private static boolean doesConfigMethodPassFirstTimeFilter(ConfigurationMethod cm, ITestNGMethod tm) {
+    private static boolean doesSetupMethodPassFirstTimeFilter(ConfigurationMethod cm, ITestNGMethod tm) {
         return !cm.isFirstTimeOnly() || (cm.isFirstTimeOnly() && tm.getCurrentInvocationCount() == 0);
     }
 
-    private static boolean isConfigMethodRunningLastTime(ConfigurationMethod cm, ITestNGMethod tm) {
+    private static boolean doesTeardownMethodPassLastTimeFilter(ConfigurationMethod cm, ITestNGMethod tm) {
         return !cm.isLastTimeOnly() || (cm.isLastTimeOnly() && !tm.hasMoreInvocation());
     }
 

--- a/src/main/java/org/testng/internal/annotations/IAfterMethod.java
+++ b/src/main/java/org/testng/internal/annotations/IAfterMethod.java
@@ -1,5 +1,5 @@
 package org.testng.internal.annotations;
 
-public interface IAfterMethod extends IBaseBeforeAfter {
+public interface IAfterMethod extends IBaseBeforeAfterMethod {
 
 }

--- a/src/main/java/org/testng/internal/annotations/IBaseBeforeAfterMethod.java
+++ b/src/main/java/org/testng/internal/annotations/IBaseBeforeAfterMethod.java
@@ -1,0 +1,8 @@
+package org.testng.internal.annotations;
+
+public interface IBaseBeforeAfterMethod extends IBaseBeforeAfter {
+    /**
+     * The list of groups the test method must belong to one of which.
+     */
+    String[] getGroupFilters();
+}

--- a/src/main/java/org/testng/internal/annotations/IBeforeMethod.java
+++ b/src/main/java/org/testng/internal/annotations/IBeforeMethod.java
@@ -1,10 +1,5 @@
 package org.testng.internal.annotations;
 
-public interface IBeforeMethod extends IBaseBeforeAfter {
-
-    /**
-     * The list of groups the test method must belong to one of which.
-     */
-    public String[] getGroupFilters();
+public interface IBeforeMethod extends IBaseBeforeAfterMethod {
 
 }

--- a/src/main/java/org/testng/internal/annotations/JDK15TagFactory.java
+++ b/src/main/java/org/testng/internal/annotations/JDK15TagFactory.java
@@ -239,7 +239,7 @@ public class JDK15TagFactory {
           bs.description(), bs.enabled(), bs.groups(),
           bs.inheritGroups(), null,
           false, bs.lastTimeOnly(),
-          bs.timeOut(), new String[0]);
+          bs.timeOut(), bs.onlyForGroups());
     }
 
     return result;

--- a/src/test/java/test/configuration/AfterMethodWithGroupFiltersSampleTest.java
+++ b/src/test/java/test/configuration/AfterMethodWithGroupFiltersSampleTest.java
@@ -1,0 +1,39 @@
+package test.configuration;
+
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+public class AfterMethodWithGroupFiltersSampleTest {
+    static final String[] EXPECTED_INVOCATIONS = {
+            "g1m1", "afterGroup1", "g1m2", "afterGroup1",
+            "g2m1", "afterGroup2", "g2m2", "afterGroup2", "g2m3", "afterGroup2",
+    };
+
+    @AfterMethod(onlyForGroups = {"group1"})
+    public void afterGroup1() {
+    }
+
+    @Test(groups = "group1")
+    public void g1m1() {
+    }
+
+    @Test(groups = "group1")
+    public void g1m2() {
+    }
+
+    @AfterMethod(onlyForGroups = {"group2"})
+    public void afterGroup2() {
+    }
+
+    @Test(groups = "group2")
+    public void g2m1() {
+    }
+
+    @Test(groups = "group2")
+    public void g2m2() {
+    }
+
+    @Test(groups = "group2")
+    public void g2m3() {
+    }
+}

--- a/src/test/java/test/configuration/AfterMethodWithGroupFiltersTest.java
+++ b/src/test/java/test/configuration/AfterMethodWithGroupFiltersTest.java
@@ -1,0 +1,18 @@
+package test.configuration;
+
+import org.testng.annotations.Test;
+import test.InvokedMethodNameListener;
+import test.SimpleBaseTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AfterMethodWithGroupFiltersTest extends SimpleBaseTest {
+
+    @Test
+    public void beforeMethodWithBeforeGroupsShouldOnlyRunBeforeGroupMethods() {
+        InvokedMethodNameListener nameListener = run(AfterMethodWithGroupFiltersSampleTest.class);
+        assertThat(nameListener.getInvokedMethodNames())
+                .containsExactly(AfterMethodWithGroupFiltersSampleTest.EXPECTED_INVOCATIONS);
+    }
+
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -791,6 +791,7 @@
       <class name="test.configuration.MethodCallOrderTest"/>
       <class name="test.configuration.MultipleBeforeGroupTest" />
       <class name="test.configuration.BeforeMethodWithGroupFiltersTest" />
+      <class name="test.configuration.AfterMethodWithGroupFiltersTest" />
       <class name="test.configuration.ReflectMethodParametrizedConfigurationMethodTest" />
       <class name="test.configuration.SuiteFactoryOnceTest" />
       <class name="test.configuration.SuiteTest" />


### PR DESCRIPTION
Similar to @BeforeMethod, it allows to invoke @AfterMethod only if the test method that was invoked belongs to one of the listed groups.

Fixes #549 (closed already by my recent PR) and #780 (which is essentially the same, so I think it should be closed too).