### PR TITLE
Problem of combination dependsOnMethods & RetryAnalyzer

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-1538: Dependent methods don't get invoked when a failed test method is retried via a RetryAnalyser (Krishnan Mahadevan)
 Fixed: GITHUB-426: firstTimeOnly ignored for threadPoolSize > 1 (Krishnan Mahadevan)
 Fixed: GITHUB-466: JUnitReportReporter always converts the system time into GMT (Krishnan Mahadevan)
 Fixed: GITHUB-1723: Standardize timezone reference in XML reports (Krishnan Mahadevan)

--- a/src/test/java/test/retryAnalyzer/issue1538/RetryForIssue1538.java
+++ b/src/test/java/test/retryAnalyzer/issue1538/RetryForIssue1538.java
@@ -1,0 +1,11 @@
+package test.retryAnalyzer.issue1538;
+
+import org.testng.IRetryAnalyzer;
+import org.testng.ITestResult;
+
+public class RetryForIssue1538 implements IRetryAnalyzer {
+    @Override
+    public boolean retry(ITestResult result) {
+        return true;
+    }
+}

--- a/src/test/java/test/retryAnalyzer/issue1538/TestClassSampleWithTestMethodDependencies.java
+++ b/src/test/java/test/retryAnalyzer/issue1538/TestClassSampleWithTestMethodDependencies.java
@@ -1,0 +1,18 @@
+package test.retryAnalyzer.issue1538;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestClassSampleWithTestMethodDependencies {
+    private int i = 0;
+
+    @Test(retryAnalyzer = RetryForIssue1538.class)
+    public void a() {
+        Assert.assertEquals(i++, 1);
+    }
+
+    @Test(dependsOnMethods = "a", retryAnalyzer = RetryForIssue1538.class)
+    public void b() {
+        Assert.assertEquals(i++, 2);
+    }
+}


### PR DESCRIPTION
Closes #1538

Un-related change:
Updated the Invoker class to start using some
of the JDK8 features

Fixes #1538  .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
