### PR TITLE
Streamline listener invocation with config methods

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-1602: beforeInvocation method don't get called for skipped tests (Krishnan Mahadevan)
 Fixed: GITHUB-549 and GITHUB-780: Introduce onlyForGroups attribute for @BeforeMethod and @AfterMethod (Sergei Tachenov)
 Fixed: GITHUB-1745: Support native injection for @Factory methods (Krishnan Mahadevan)
 Fixed: GITHUB-1746: Make InvokedMethodNameListener thread-safe, fixing occasional build failures (Sergei Tachenov)

--- a/src/test/java/test/listeners/github1465/IssueTest.java
+++ b/src/test/java/test/listeners/github1465/IssueTest.java
@@ -16,7 +16,7 @@ public class IssueTest extends SimpleBaseTest {
         TestNG testNG = create(ExampleClassSample.class);
         testNG.setConfigFailurePolicy(policy);
         ExampleClassListener listener = new ExampleClassListener();
-        testNG.addListener((ITestNGListener) listener);
+        testNG.addListener(listener);
         testNG.run();
         String[] expected = new String[]{
                 "beforeInvocation:_test_method: test1", "afterInvocation:_test_method: test1",
@@ -40,7 +40,13 @@ public class IssueTest extends SimpleBaseTest {
         };
         String[] skipFailurePolicyExpected = new String[]{
                 "beforeInvocation:_before_method: beforeMethod[test1]",
-                "afterInvocation:_before_method: beforeMethod[test1]"
+                "afterInvocation:_before_method: beforeMethod[test1]",
+                "beforeInvocation:_after_method: afterMethod",
+                "afterInvocation:_after_method: afterMethod",
+                "beforeInvocation:_before_method: beforeMethod",
+                "afterInvocation:_before_method: beforeMethod",
+                "beforeInvocation:_after_method: afterMethod",
+                "afterInvocation:_after_method: afterMethod"
         };
         return new Object[][]{
                 {XmlSuite.FailurePolicy.CONTINUE, continueFailurePolicyExpected},

--- a/src/test/java/test/listeners/github1602/IssueTest.java
+++ b/src/test/java/test/listeners/github1602/IssueTest.java
@@ -1,0 +1,47 @@
+package test.listeners.github1602;
+
+import org.testng.TestNG;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.testng.collections.Lists;
+import org.testng.xml.XmlSuite;
+import test.SimpleBaseTest;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class IssueTest extends SimpleBaseTest {
+
+    @Test(dataProvider = "dp")
+    public void testListenerInvocation(Class<?> clazz, XmlSuite.FailurePolicy policy, List<String> expected) {
+        TestNG tng = create(clazz);
+        ListenerForIssue1602 listener = new ListenerForIssue1602();
+        tng.setConfigFailurePolicy(policy);
+        tng.setVerbose(2);
+        tng.addListener(listener);
+        tng.run();
+        assertThat(listener.getLogs()).containsExactlyElementsOf(expected);
+    }
+
+    @DataProvider(name = "dp")
+    public Object[][] getData() {
+        List<String> passList = Arrays.asList("BeforeInvocation_beforeMethod_STARTED", "AfterInvocation_beforeMethod_SUCCESS",
+                "BeforeInvocation_testMethod_STARTED", "AfterInvocation_testMethod_SUCCESS",
+                "BeforeInvocation_afterMethod_STARTED", "AfterInvocation_afterMethod_SUCCESS");
+        List<String> baseList = Arrays.asList("BeforeInvocation_beforeMethod_STARTED", "AfterInvocation_beforeMethod_FAILURE",
+                "BeforeInvocation_testMethod_SKIP", "AfterInvocation_testMethod_SKIP",
+                "BeforeInvocation_afterMethod_STARTED");
+        List<String> skipList = Lists.newArrayList(baseList);
+        skipList.add("AfterInvocation_afterMethod_SKIP");
+        List<String> failList = Lists.newArrayList(baseList);
+        failList.add("AfterInvocation_afterMethod_FAILURE");
+        return new Object[][]{
+                {TestClassWithPassingConfigsSample.class, XmlSuite.FailurePolicy.SKIP, passList},
+                {TestClassWithFailingConfigsSample.class, XmlSuite.FailurePolicy.SKIP, skipList},
+                {TestClassWithPassingConfigsSample.class, XmlSuite.FailurePolicy.CONTINUE, passList},
+                {TestClassWithFailingConfigsSample.class, XmlSuite.FailurePolicy.CONTINUE, failList}
+        };
+    }
+}

--- a/src/test/java/test/listeners/github1602/ListenerForIssue1602.java
+++ b/src/test/java/test/listeners/github1602/ListenerForIssue1602.java
@@ -1,0 +1,46 @@
+package test.listeners.github1602;
+
+import org.testng.IInvokedMethod;
+import org.testng.IInvokedMethodListener;
+import org.testng.ITestResult;
+import org.testng.collections.Lists;
+
+import java.util.Collections;
+import java.util.List;
+
+public class ListenerForIssue1602 implements IInvokedMethodListener {
+    private List<String> logs = Collections.synchronizedList(Lists.newArrayList());
+
+    @Override
+    public void beforeInvocation(IInvokedMethod method, ITestResult testResult) {
+        logs.add("BeforeInvocation_" + method.getTestMethod().getMethodName() + "_" + intToStatus(testResult));
+    }
+
+    @Override
+    public void afterInvocation(IInvokedMethod method, ITestResult testResult) {
+        logs.add("AfterInvocation_" + method.getTestMethod().getMethodName() + "_" + intToStatus(testResult));
+    }
+
+    public List<String> getLogs() {
+        return logs;
+    }
+
+    private String intToStatus(ITestResult testResult) {
+        int status = testResult.getStatus();
+        switch (status) {
+            case ITestResult.CREATED:
+                return "CREATED";
+            case ITestResult.SUCCESS:
+                return "SUCCESS";
+            case ITestResult.SKIP:
+                return "SKIP";
+            case ITestResult.FAILURE:
+                return "FAILURE";
+            case ITestResult.STARTED:
+                return "STARTED";
+            case ITestResult.SUCCESS_PERCENTAGE_FAILURE:
+                return "SUCCESS_PERCENTAGE_FAILURE";
+        }
+        return " ??? " + String.valueOf(status);
+    }
+}

--- a/src/test/java/test/listeners/github1602/TestClassWithFailingConfigsSample.java
+++ b/src/test/java/test/listeners/github1602/TestClassWithFailingConfigsSample.java
@@ -1,0 +1,21 @@
+package test.listeners.github1602;
+
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+public class TestClassWithFailingConfigsSample {
+    @BeforeMethod
+    public void beforeMethod() {
+        throw new RuntimeException();
+    }
+
+    @Test
+    public void testMethod() { }
+
+    @AfterMethod
+    public void afterMethod() {
+        throw new RuntimeException();
+    }
+}

--- a/src/test/java/test/listeners/github1602/TestClassWithPassingConfigsSample.java
+++ b/src/test/java/test/listeners/github1602/TestClassWithPassingConfigsSample.java
@@ -1,0 +1,19 @@
+package test.listeners.github1602;
+
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class TestClassWithPassingConfigsSample {
+    @BeforeMethod
+    public void beforeMethod() {
+    }
+
+    @Test
+    public void testMethod() {
+    }
+
+    @AfterMethod
+    public void afterMethod() {
+    }
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -166,6 +166,7 @@
       <class name="test.listeners.github551.Test551"/>
       <class name="test.listeners.github1284.TestListeners"/>
       <class name="test.listeners.github1735.ExecutionListenerTest"/>
+      <class name="test.listeners.github1602.IssueTest"/>
       <class name="test_result.GitHub1197Test"/>
       <class name="test.listeners.github1319.TestResultInstanceCheckTest"/>
       <class name="test.testng1396.ParallelByInstancesInterceptorTest"/>


### PR DESCRIPTION
Closes #1602

* Ensured that before and after invocation are triggered
for Skipped config methods
* Fixed status anomalies when ITestResult is 
passed around before/after invocation methods.
*Altered an existing test to accommodate listener
invocation for skipped config methods as well 
(since now irrespective of whether a config method
gets executed or get skipped, the listeners for it
will always be invoked)

Fixes #1602  .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
