### PR TITLE
Fix Helper.getMap() thread safety issues

### DIFF
--- a/src/test/java/test/thread/Helper.java
+++ b/src/test/java/test/thread/Helper.java
@@ -1,28 +1,16 @@
 package test.thread;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class Helper {
-  private static Map<String, Map<Long, Long>> m_maps = new HashMap<>();
+  private static final Map<String, Map<Long, Long>> m_maps = new ConcurrentHashMap<>();
 
   public static Map<Long, Long> getMap(String className) {
-    synchronized(m_maps) {
-      Map<Long, Long> result = m_maps.get(className);
-      if (result == null) {
-        // TODO a synchronizedMap will break MultiThreadedDependentSampleTest
-        // a not synchronizedMap will __sometimes__ break ParallelITestTest
-        //result = Collections.synchronizedMap(new HashMap<Long, Long>());
-        result = new HashMap<>();
-        m_maps.put(className, result);
-      }
-      return result;
-    }
-//    System.out.println("Putting class:" + className + " result:" + result);
-
+    return m_maps.computeIfAbsent(className, cn -> new ConcurrentHashMap<>());
   }
 
   public static void reset() {
-    m_maps = new HashMap<>();
+    m_maps.clear();
   }
 }


### PR DESCRIPTION
Use of `ConcurrentHashMap` here fixes `ParallelTestTest` thread safety issues,
and doesn't cause deadlock in `MultiThreadedDependentTest`, as `synchronizedMap`
would.

I have also used a `ConcurrentHashMap` for the map of maps as well and made it `final` to prevent possible thread-safety issues on this level, which incidentally lead to shortening the whole thing to one line thanks to the wonderful `computeIfAbsent` method.

Do I need to create an issue for this kind of PR and/or update CHANGES.txt, as only tests are involved?