### PR TITLE
Fix memory leak

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-1766: Testng generates a lot of temp folders like testngXmlPathInJar-***
 Fixed: GITHUB-1759: core interfaces refactoring to support default methods (Sergey Korol)
 Fixed: GITHUB-1753: TestResult for an SKIP test lose attributes contributed by @BeforeMethod's or @AfterMethod's (Krishnan Mahadevan)
 Fixed: GITHUB-1756: ITest .getTestName() doesn't return the actual test name for skipped methods (Krishnan Mahadevan)

--- a/src/main/java/org/testng/JarFileUtils.java
+++ b/src/main/java/org/testng/JarFileUtils.java
@@ -57,6 +57,7 @@ class JarFileUtils {
         try (JarFile jf = new JarFile(jarFile)) {
             Enumeration<JarEntry> entries = jf.entries();
             File file = java.nio.file.Files.createTempDirectory("testngXmlPathInJar-").toFile();
+            file.deleteOnExit();
             String suitePath = null;
             while (entries.hasMoreElements()) {
                 JarEntry je = entries.nextElement();


### PR DESCRIPTION
Close #1766

For now testng generates a lot of garbage files in tmp directory. After fix such files will be removed after end of execution

Fixes #
1. Add deleteOnExit option for temp file
