### PR TITLE
Assure thread affinity

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,10 @@
 Current
+New  : TestNG now guarantees thread-affinity for methods that use either preserve-order (or) dependsOnMethods (Krishnan Mahadevan) 
+Fixed: GITHUB-1185: DependsOnMethods made parallel class use several threads (Krishnan Mahadevan)
+Fixed: GITHUB-1173: Parallel="classes" executes methods of test class in different threads (Krishnan Mahadevan)
+Fixed: GITHUB-1066: Regression is in priority. It broke parallel mode (Krishnan Mahadevan)
+Fixed: GITHUB-1050: Parallel classes runs methods from one class in different threads, interleaves two classes in one thread (Krishnan Mahadevan)
+Fixed: GITHUB-89: parallel="classes" is not forcing test methods from the same testClass to be run in the same thread as it is suposed to (Krishnan Mahadevan)
 Fixed: GITHUB-1719: successPercentage does not work correctly for tests with dataProvider (Krishnan Mahadevan)
 Fixed: GITHUB-1241: Streamline Retry Analyzer usage when same test is run multiple times (Krishnan Mahadevan)
 Fixed: GITHUB-1777: ITestListener.onTestStart() not called after fail or skip from @BeforeMethod (Krishnan Mahadevan)

--- a/src/main/java/org/testng/TestRunner.java
+++ b/src/main/java/org/testng/TestRunner.java
@@ -57,6 +57,8 @@ import org.testng.xml.XmlTest;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 
+import javax.annotation.Nonnull;
+
 import static org.testng.internal.MethodHelper.fixMethodsWithClass;
 
 /**
@@ -147,7 +149,6 @@ public class TestRunner
   private ClassMethodMap m_classMethodMap;
   private TestNGClassFinder m_testClassFinder;
   private IConfiguration m_configuration;
-  private IMethodInterceptor builtinInterceptor;
 
   public enum PriorityWeight {
     groupByInstance, preserveOrder, priority, dependsOnGroups, dependsOnMethods
@@ -212,7 +213,7 @@ public class TestRunner
     setVerbose(test.getVerbose());
 
     boolean preserveOrder = test.getPreserveOrder();
-    builtinInterceptor = preserveOrder ? new PreserveOrderMethodInterceptor() : new InstanceOrderingMethodInterceptor();
+    IMethodInterceptor builtinInterceptor = preserveOrder ? new PreserveOrderMethodInterceptor() : new InstanceOrderingMethodInterceptor();
     m_methodInterceptors = new ArrayList<>();
     //Add the built in interceptor as the first interceptor. That way we let our users determine the final order
     //by plugging in their own custom interceptors as well.
@@ -370,7 +371,7 @@ public class TestRunner
     List<ITestNGMethod> afterXmlTestMethods = Lists.newArrayList();
 
     ClassInfoMap classMap = new ClassInfoMap(m_testClassesFromXml);
-    m_testClassFinder= new TestNGClassFinder(classMap,Maps.<Class<?>, List<Object>>newHashMap(),
+    m_testClassFinder= new TestNGClassFinder(classMap,Maps.newHashMap(),
                                              m_configuration, this, m_dataProviderListeners);
     ITestMethodFinder testMethodFinder = new TestNGMethodFinder(m_runInfo, m_annotationFinder, comparator);
 
@@ -570,7 +571,7 @@ public class TestRunner
           IJUnitTestRunner tr= ClassHelper.createTestRunner(TestRunner.this);
           tr.setInvokedMethodListeners(m_invokedMethodListeners);
           try {
-            tr.run(tc, methods.toArray(new String[methods.size()]));
+            tr.run(tc, methods.toArray(new String[0]));
           }
           catch(Exception ex) {
             ex.printStackTrace();
@@ -596,13 +597,13 @@ public class TestRunner
       }
 
       @Override
-      public int compareTo(IWorker<ITestNGMethod> other) {
+      public int compareTo(@Nonnull IWorker<ITestNGMethod> other) {
         return getPriority() - other.getPriority();
       }
     });
 
     runJUnitWorkers(workers);
-    m_allTestMethods= runMethods.toArray(new ITestNGMethod[runMethods.size()]);
+    m_allTestMethods= runMethods.toArray(new ITestNGMethod[0]);
   }
 
   /**
@@ -625,7 +626,7 @@ public class TestRunner
           GraphThreadPoolExecutor<ITestNGMethod> executor =
                   new GraphThreadPoolExecutor<>("test=" + xmlTest.getName(), graph, this,
                           threadCount, threadCount, 0, TimeUnit.MILLISECONDS,
-                          new LinkedBlockingQueue<Runnable>());
+                          new LinkedBlockingQueue<>());
           executor.run();
           try {
             long timeOut = m_xmlTest.getTimeOut(XmlTest.DEFAULT_TIMEOUT_MS);
@@ -675,7 +676,7 @@ public class TestRunner
     //so let's update the current classMethodMap object with the list of methods obtained from the interceptor.
     this.m_classMethodMap = new ClassMethodMap(result, null);
 
-    ITestNGMethod[] resultArray = result.toArray(new ITestNGMethod[result.size()]);
+    ITestNGMethod[] resultArray = result.toArray(new ITestNGMethod[0]);
 
     //Check if an interceptor had altered the effective test method count. If yes, then we need to
     //update our configurationGroupMethod object with that information.
@@ -822,13 +823,13 @@ public class TestRunner
   @Override
   public String[] getIncludedGroups() {
     Map<String, String> ig= m_xmlMethodSelector.getIncludedGroups();
-    return ig.values().toArray(new String[ig.size()]);
+    return ig.values().toArray(new String[0]);
   }
 
   @Override
   public String[] getExcludedGroups() {
     Map<String, String> eg= m_xmlMethodSelector.getExcludedGroups();
-    return eg.values().toArray(new String[eg.size()]);
+    return eg.values().toArray(new String[0]);
   }
 
   @Override

--- a/src/main/java/org/testng/internal/RuntimeBehavior.java
+++ b/src/main/java/org/testng/internal/RuntimeBehavior.java
@@ -8,6 +8,8 @@ import java.util.TimeZone;
 public final class RuntimeBehavior {
 
     public static final String TESTNG_LISTENERS_ALWAYSRUN = "testng.listeners.alwaysrun";
+    public static final String TESTNG_THREAD_AFFINITY = "testng.thread.affinity";
+    public static final String TESTNG_MODE_DRYRUN = "testng.mode.dryrun";
 
     private RuntimeBehavior() {
     }
@@ -17,7 +19,7 @@ public final class RuntimeBehavior {
      * <code>false</code> otherwise.
      */
     public static boolean isDryRun() {
-        String value = System.getProperty("testng.mode.dryrun", "false");
+        String value = System.getProperty(TESTNG_MODE_DRYRUN, "false");
         return Boolean.parseBoolean(value);
     }
 
@@ -41,5 +43,17 @@ public final class RuntimeBehavior {
    */
   public static boolean invokeListenersForSkippedTests() {
     return Boolean.parseBoolean(System.getProperty(TESTNG_LISTENERS_ALWAYSRUN, "false"));
+  }
+
+  /**
+   * @return - <code>true</code> if we would like to enforce Thread affinity when dealing with the
+   *     below two variants of execution models:
+   *     <ul>
+   *       <li>Ordering priority
+   *       <li>Ordering by dependsOnMethods (will not work with dependency on multiple methods)
+   *     </ul>
+   */
+  public static boolean enforceThreadAffinity() {
+    return Boolean.parseBoolean(System.getProperty(TESTNG_THREAD_AFFINITY, "false"));
   }
 }

--- a/src/main/java/org/testng/internal/thread/graph/GraphThreadPoolExecutor.java
+++ b/src/main/java/org/testng/internal/thread/graph/GraphThreadPoolExecutor.java
@@ -1,14 +1,16 @@
 package org.testng.internal.thread.graph;
 
 import org.testng.TestNGException;
+import org.testng.collections.Maps;
 import org.testng.internal.DynamicGraph;
 import org.testng.internal.DynamicGraph.Status;
+import org.testng.internal.RuntimeBehavior;
 import org.testng.internal.thread.TestNGThreadFactory;
 
+import javax.annotation.Nonnull;
 import java.util.List;
-import java.util.Queue;
+import java.util.Map;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
@@ -20,8 +22,9 @@ import java.util.concurrent.TimeUnit;
 public class GraphThreadPoolExecutor<T> extends ThreadPoolExecutor {
 
   private final DynamicGraph<T> m_graph;
-  private final Queue<Runnable> m_activeRunnables = new ConcurrentLinkedDeque<>();
   private final IThreadWorkerFactory<T> m_factory;
+  private final Map<T, IWorker<T>> mapping = Maps.newConcurrentMap();
+  private final Map<T, T> upstream = Maps.newConcurrentMap();
 
   public GraphThreadPoolExecutor(String name, DynamicGraph<T> graph, IThreadWorkerFactory<T> factory, int corePoolSize,
       int maximumPoolSize, long keepAliveTime, TimeUnit unit, BlockingQueue<Runnable> workQueue) {
@@ -45,12 +48,15 @@ public class GraphThreadPoolExecutor<T> extends ThreadPoolExecutor {
    * Create one worker per node and execute them.
    */
   private void runNodes(List<T> freeNodes) {
-    List<IWorker<T>> runnables = m_factory.createWorkers(freeNodes);
-    for (IWorker<T> r : runnables) {
-      m_activeRunnables.add(r);
-      setStatus(r, Status.RUNNING);
+    List<IWorker<T>> workers = m_factory.createWorkers(freeNodes);
+    mapNodeToWorker(workers, freeNodes);
+
+    for (int ix = 0; ix < workers.size(); ix++) {
+      IWorker<T> worker = workers.get(ix);
+      mapNodeToParent(freeNodes, ix);
+      setStatus(worker, Status.RUNNING);
       try {
-        execute(r);
+        execute(worker);
       }
       catch(Exception ex) {
         ex.printStackTrace();
@@ -58,10 +64,22 @@ public class GraphThreadPoolExecutor<T> extends ThreadPoolExecutor {
     }
   }
 
-  private void setStatus(IWorker<T> worker, Status status) {
-    if (status == Status.FINISHED) {
-      m_activeRunnables.remove(worker);
+  @Override
+  @SuppressWarnings("unchecked")
+  public void afterExecute(Runnable r, Throwable t) {
+    synchronized (m_graph) {
+      setStatus((IWorker<T>) r, computeStatus(r));
+      if (m_graph.getNodeCount() == m_graph.getNodeCountWithStatus(Status.FINISHED)) {
+        shutdown();
+      } else {
+        List<T> freeNodes = m_graph.getFreeNodes();
+        handleThreadAffinity(freeNodes);
+        runNodes(freeNodes);
+      }
     }
+  }
+
+  private void setStatus(IWorker<T> worker, Status status) {
     synchronized(m_graph) {
       for (T m : worker.getTasks()) {
         m_graph.setStatus(m, status);
@@ -69,16 +87,85 @@ public class GraphThreadPoolExecutor<T> extends ThreadPoolExecutor {
     }
   }
 
-  @Override
-  public void afterExecute(Runnable r, Throwable t) {
-    setStatus((IWorker<T>) r, Status.FINISHED);
-    synchronized(m_graph) {
-      if (m_graph.getNodeCount() == m_graph.getNodeCountWithStatus(Status.FINISHED)) {
-        shutdown();
-      } else {
-        List<T> freeNodes = m_graph.getFreeNodes();
-        runNodes(freeNodes);
-      }
+  @SuppressWarnings("unchecked")
+  private Status computeStatus(Runnable r) {
+    IWorker<T> worker = (IWorker<T>) r;
+    Status status = Status.FINISHED;
+    if (RuntimeBehavior.enforceThreadAffinity() && !worker.completed()) {
+      status = Status.READY;
     }
+    return status;
+  }
+
+  private void mapNodeToWorker(List<IWorker<T>> runnables, List<T> freeNodes) {
+    if (!RuntimeBehavior.enforceThreadAffinity()) {
+      return;
+    }
+    int index = 0;
+    for (IWorker<T> runnable : runnables) {
+      T freeNode = freeNodes.get(index++);
+      IWorker<T> w = mapping.get(freeNode);
+      if (w != null) {
+        long current = w.getThreadIdToRunOn();
+        runnable.setThreadIdToRunOn(current);
+      }
+      mapping.put(freeNode, runnable);
+    }
+  }
+
+  private void mapNodeToParent(List<T> freeNodes, int ix) {
+    if (!RuntimeBehavior.enforceThreadAffinity()) {
+      return;
+    }
+    T key = freeNodes.get(ix);
+    List<T> nodes = m_graph.getDependenciesFor(key);
+    nodes.forEach(eachNode -> upstream.put(eachNode, key));
+  }
+
+  private void handleThreadAffinity(List<T> freeNodes) {
+    if (!RuntimeBehavior.enforceThreadAffinity()) {
+      return;
+    }
+    for (T node : freeNodes) {
+      IWorker<T> w = mapping.get(upstream.get(node));
+      long threadId = w.getCurrentThreadId();
+      mapping.put(node, new PhoneyWorker(threadId));
+    }
+  }
+
+  private class PhoneyWorker implements IWorker<T> {
+      private long threadId;
+
+      public PhoneyWorker(long threadId) {
+          this.threadId = threadId;
+      }
+
+      @Override
+      public List<T> getTasks() {
+          return null;
+      }
+
+      @Override
+      public long getTimeOut() {
+          return 0;
+      }
+
+      @Override
+      public int getPriority() {
+          return 0;
+      }
+
+      @Override
+      public int compareTo(@Nonnull IWorker<T> o) {
+          return 0;
+      }
+
+      @Override
+      public void run() {}
+
+      @Override
+      public long getThreadIdToRunOn() {
+          return threadId;
+      }
   }
 }

--- a/src/main/java/org/testng/internal/thread/graph/IThreadWorkerFactory.java
+++ b/src/main/java/org/testng/internal/thread/graph/IThreadWorkerFactory.java
@@ -1,7 +1,6 @@
 package org.testng.internal.thread.graph;
 
 import java.util.List;
-import java.util.Set;
 
 
 /**

--- a/src/main/java/org/testng/internal/thread/graph/IWorker.java
+++ b/src/main/java/org/testng/internal/thread/graph/IWorker.java
@@ -22,4 +22,20 @@ public interface IWorker<T> extends Runnable, Comparable<IWorker<T>> {
    * @return the priority of this task.
    */
   int getPriority();
+
+  default long getCurrentThreadId() {
+    return -1;
+  }
+
+  default void setThreadIdToRunOn(long threadIdToRunOn) {
+  }
+
+  default long getThreadIdToRunOn() {
+    return -1;
+  }
+
+  default boolean completed() {
+    return true;
+  }
+
 }

--- a/src/test/java/org/testng/DryRunTest.java
+++ b/src/test/java/org/testng/DryRunTest.java
@@ -2,21 +2,22 @@ package org.testng;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import org.testng.annotations.Test;
+import org.testng.internal.RuntimeBehavior;
 import test.SimpleBaseTest;
 
 public class DryRunTest extends SimpleBaseTest {
 
     @Test
     public void testDryRun() {
-        System.setProperty("testng.mode.dryrun", "true");
+        System.setProperty(RuntimeBehavior.TESTNG_MODE_DRYRUN, "true");
         try {
             TestNG tng = create(DryRunSample.class);
             TestListenerAdapter listener = new TestListenerAdapter();
-            tng.addListener((ITestNGListener) listener);
+            tng.addListener(listener);
             tng.run();
             assertThat(listener.getPassedTests()).hasSize(2);
         } finally {
-            System.setProperty("testng.mode.dryrun", "false");
+            System.setProperty(RuntimeBehavior.TESTNG_MODE_DRYRUN, "false");
         }
     }
 

--- a/src/test/java/test/thread/parallelization/issue1773/IssueTest.java
+++ b/src/test/java/test/thread/parallelization/issue1773/IssueTest.java
@@ -1,0 +1,69 @@
+package test.thread.parallelization.issue1773;
+
+import org.testng.TestNG;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.testng.internal.RuntimeBehavior;
+import org.testng.xml.XmlSuite;
+import test.SimpleBaseTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class IssueTest extends SimpleBaseTest {
+  @BeforeClass
+  public void setup() {
+    System.setProperty(RuntimeBehavior.TESTNG_THREAD_AFFINITY, "true");
+  }
+
+  @Test(dataProvider = "dp1")
+  public void testThreadAffinity(Class<?>... classes) {
+    XmlSuite xmlsuite = createXmlSuite("test_suite");
+    xmlsuite.setParallel(XmlSuite.ParallelMode.CLASSES);
+    xmlsuite.setThreadCount(6);
+    createXmlTest(xmlsuite, "Test 1", classes);
+    TestNG testng = create(xmlsuite);
+    testng.setVerbose(2);
+    LogGatheringListener listener = new LogGatheringListener();
+    testng.addListener(listener);
+    testng.run();
+    assertThat(listener.log).hasSize(2);
+  }
+
+  @Test(dataProvider = "dp2")
+  public void testThreadAffinityAcrossTests(XmlSuite.ParallelMode mode, int size) {
+    XmlSuite xmlsuite = createXmlSuite("test_suite");
+    xmlsuite.setParallel(XmlSuite.ParallelMode.TESTS);
+    xmlsuite.setThreadCount(6);
+    createXmlTest(xmlsuite, "Test_1", PriorityTestSample1.class,PriorityTestSample2.class).setParallel(mode);
+    createXmlTest(xmlsuite, "Test_2", PriorityTestSample1.class,PriorityTestSample2.class).setParallel(mode);
+    TestNG testng = create(xmlsuite);
+    testng.setVerbose(2);
+    LogGatheringListener listener = new LogGatheringListener();
+    testng.addListener(listener);
+    testng.run();
+    assertThat(listener.log).hasSize(size);
+  }
+
+  @DataProvider(name = "dp2")
+  public Object[][] createTestData() {
+    return new Object[][] {
+            {XmlSuite.ParallelMode.NONE, 2},
+            {XmlSuite.ParallelMode.CLASSES, 4}
+    };
+  }
+
+  @DataProvider(name = "dp1")
+  public Object[][] getData() {
+    return new Object[][] {
+      {PriorityTestSample1.class, PriorityTestSample2.class},
+      {MethodDependenciesSample1.class, MethodDependenciesSample2.class}
+    };
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void teardown() {
+    System.setProperty(RuntimeBehavior.TESTNG_THREAD_AFFINITY, "false");
+  }
+}

--- a/src/test/java/test/thread/parallelization/issue1773/LogGatheringListener.java
+++ b/src/test/java/test/thread/parallelization/issue1773/LogGatheringListener.java
@@ -1,0 +1,19 @@
+package test.thread.parallelization.issue1773;
+
+import org.testng.IInvokedMethod;
+import org.testng.IInvokedMethodListener;
+import org.testng.ITestResult;
+import org.testng.Reporter;
+import org.testng.collections.Sets;
+
+import java.util.Set;
+
+public class LogGatheringListener implements IInvokedMethodListener {
+
+    Set<String> log = Sets.newHashSet();
+
+    @Override
+    public void afterInvocation(IInvokedMethod method, ITestResult testResult) {
+        log.addAll(Reporter.getOutput(testResult));
+    }
+}

--- a/src/test/java/test/thread/parallelization/issue1773/MethodDependenciesSample1.java
+++ b/src/test/java/test/thread/parallelization/issue1773/MethodDependenciesSample1.java
@@ -1,0 +1,21 @@
+package test.thread.parallelization.issue1773;
+
+import org.testng.Reporter;
+import org.testng.annotations.Test;
+
+public class MethodDependenciesSample1 {
+
+  @Test
+  public void parentMethod() {
+    log();
+  }
+
+  @Test(dependsOnMethods = "parentMethod")
+  public void childMethod() {
+    log();
+  }
+
+  private void log() {
+    Reporter.log(Long.toString(Thread.currentThread().getId()));
+  }
+}

--- a/src/test/java/test/thread/parallelization/issue1773/MethodDependenciesSample2.java
+++ b/src/test/java/test/thread/parallelization/issue1773/MethodDependenciesSample2.java
@@ -1,0 +1,21 @@
+package test.thread.parallelization.issue1773;
+
+import org.testng.Reporter;
+import org.testng.annotations.Test;
+
+public class MethodDependenciesSample2 {
+
+  @Test
+  public void parentMethod() {
+    log();
+  }
+
+  @Test(dependsOnMethods = "parentMethod")
+  public void childMethod() {
+    log();
+  }
+
+  private void log() {
+    Reporter.log(Long.toString(Thread.currentThread().getId()));
+  }
+}

--- a/src/test/java/test/thread/parallelization/issue1773/PriorityTestSample1.java
+++ b/src/test/java/test/thread/parallelization/issue1773/PriorityTestSample1.java
@@ -1,0 +1,26 @@
+package test.thread.parallelization.issue1773;
+
+import org.testng.Reporter;
+import org.testng.annotations.Test;
+
+public class PriorityTestSample1 {
+
+  @Test(priority = 1)
+  public void FirstTest() {
+    log();
+  }
+
+  @Test(priority = 2)
+  public void SecondTest() {
+    log();
+  }
+
+  @Test(priority = 3)
+  public void ThridTest() {
+    log();
+  }
+
+  private void log(){
+    Reporter.log(Long.toString(Thread.currentThread().getId()));
+  }
+}

--- a/src/test/java/test/thread/parallelization/issue1773/PriorityTestSample2.java
+++ b/src/test/java/test/thread/parallelization/issue1773/PriorityTestSample2.java
@@ -1,0 +1,27 @@
+package test.thread.parallelization.issue1773;
+
+import org.testng.Reporter;
+import org.testng.annotations.Test;
+
+public class PriorityTestSample2 {
+
+  @Test(priority = 1)
+  public void FirstTest() {
+    log();
+  }
+
+  @Test(priority = 2)
+  public void SecondTest() {
+    log();
+  }
+
+  @Test(priority = 3)
+  public void ThridTest() {
+    log();
+  }
+
+  private void log(){
+    Reporter.log(Long.toString(Thread.currentThread().getId()));
+  }
+
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -894,5 +894,11 @@
     </classes>
   </test>
 
+  <test name="threadAffinity">
+    <classes>
+      <class name="test.thread.parallelization.issue1773.IssueTest"/>
+    </classes>
+  </test>
+
 </suite>
 


### PR DESCRIPTION
Closes #89, #1050, #1066, #1173, #1185

This PR aims at assuring that methods that fall
under the below two use cases, all run on the 
same thread when classes are being run in parallel:

* @Test methods in a class are ordered by priority
* @Test methods have a single dependency on 
another method using “dependsOnMethods” attribute.

The thread affinity feature is supposed to be 
“experimental” and it can be turned on via the
JVM argument : `-Dtestng.thread.affinity=true`

This feature is turned off by default just to 
ensure that we don’t have any users experiencing
un-usual behavior.

Fixes #89, #1050, #1066, #1173, #1185

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.