### PR TITLE
Streamline function name in JS from suite name

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-298: Avoid Javascript errors in function name when suite name has special characters (Krishnan Mahadevan)
 Fixed: GITHUB-1048: Fix validation errors in TestNG CSS to adhere to CSS level 3 + SVG (Krishnan Mahadevan)
 Fixed: GITHUB-341: TestNG does not respect "-parallel classes" when running with a jar file (Krishnan Mahadevan)
 Fixed: GITHUB-1790: IAnnotationTransformer transform method is not called for all test classes annotated with @Test (Krishnan Mahadevan)

--- a/src/main/java/org/testng/reporters/jq/BasePanel.java
+++ b/src/main/java/org/testng/reporters/jq/BasePanel.java
@@ -30,7 +30,7 @@ abstract public class BasePanel implements IPanel {
   }
 
   protected static String suiteToTag(ISuite suite) {
-    return suite.getName().replace(" ", "_");
+    return suite.getName().replaceAll("[^A-Za-z0-9]", "_");
   }
 
 }


### PR DESCRIPTION
Closes #298

The html report in TestNG basically relies on the
suite name when it comes to creating a function
name. But there are rules associated with function
names in JS and it cannot contain special characters.

Fixed this discrepancy by removing off all 
non-alphanumeric characters from the suite name
and replacing them with “_”

Fixes #298 .

### Did you remember to?

- [ ] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
