### PR TITLE
Streamline command line argument passing for TestNG

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-341: TestNG does not respect "-parallel classes" when running with a jar file (Krishnan Mahadevan)
 Fixed: GITHUB-1790: IAnnotationTransformer transform method is not called for all test classes annotated with @Test (Krishnan Mahadevan)
 Fixed: GITHUB-1787: Method level parameters are missing when using Yaml generation utilities (Krishnan Mahadevan)
 New  : TestNG now guarantees thread-affinity for methods that use either preserve-order (or) dependsOnMethods (Krishnan Mahadevan)

--- a/src/main/java/org/testng/JarFileUtils.java
+++ b/src/main/java/org/testng/JarFileUtils.java
@@ -27,12 +27,19 @@ class JarFileUtils {
     private final String xmlPathInJar;
     private final List<String> testNames;
     private final List<XmlSuite> suites = Lists.newLinkedList();
+    private final XmlSuite.ParallelMode mode;
 
     JarFileUtils(IPostProcessor processor, String xmlPathInJar, List<String> testNames) {
+        this(processor, xmlPathInJar, testNames, XmlSuite.ParallelMode.NONE);
+    }
+
+    JarFileUtils(IPostProcessor processor, String xmlPathInJar, List<String> testNames, XmlSuite.ParallelMode mode) {
         this.processor = processor;
         this.xmlPathInJar = xmlPathInJar;
         this.testNames = testNames;
+        this.mode = mode == null ? XmlSuite.ParallelMode.NONE: mode;
     }
+
 
     List<XmlSuite> extractSuitesFrom(File jarFile) {
         try {
@@ -44,7 +51,9 @@ class JarFileUtils {
             if (!foundTestngXml) {
                 Utils.log("TestNG", 1,
                         "Couldn't find the " + xmlPathInJar + " in the jar file, running all the classes");
-                suites.add(XmlSuiteUtils.newXmlSuiteUsing(classes));
+                XmlSuite suite = XmlSuiteUtils.newXmlSuiteUsing(classes);
+                suite.setParallel(this.mode);
+                suites.add(suite);
             }
         } catch (IOException ex) {
             throw new TestNGException(ex);

--- a/src/main/java/org/testng/TestNG.java
+++ b/src/main/java/org/testng/TestNG.java
@@ -365,7 +365,7 @@ public class TestNG {
     // We have a jar file and no XML file was specified: try to find an XML file inside the jar
     File jarFile = new File(m_jarPath);
 
-    JarFileUtils utils = new JarFileUtils(getProcessor(),m_xmlPathInJar, m_testNames);
+    JarFileUtils utils = new JarFileUtils(getProcessor(),m_xmlPathInJar, m_testNames, m_parallelMode);
 
     m_suites.addAll(utils.extractSuitesFrom(jarFile));
   }

--- a/src/main/java/org/testng/xml/XmlSuite.java
+++ b/src/main/java/org/testng/xml/XmlSuite.java
@@ -680,7 +680,9 @@ public class XmlSuite implements Cloneable {
   public int getDataProviderThreadCount() {
     String s = RuntimeBehavior.getDefaultDataProviderThreadCount();
     try {
-      return Integer.parseInt(s);
+      if (!s.trim().isEmpty()) {
+        return Integer.parseInt(s);
+      }
     } catch (NumberFormatException nfe) {
       System.err.println("Parsing System property 'dataproviderthreadcount': " + nfe);
     }

--- a/src/test/java/org/testng/jarfileutils/JarCreator.java
+++ b/src/test/java/org/testng/jarfileutils/JarCreator.java
@@ -13,16 +13,25 @@ import java.io.File;
 import java.io.IOException;
 
 public class JarCreator {
-    public static File generateJar() throws IOException {
-        File jarFile = File.createTempFile("testng", ".jar");
-        JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "testng-tests.jar")
-                .addClasses(getTestClasses())
-                .addAsResource("jarfileutils/testng-tests.xml")
-                .addAsResource("jarfileutils/child.xml")
-                .addAsResource("jarfileutils/child/child.xml")
-                .addAsResource("jarfileutils/child/childofchild/childofchild.xml")
-                .addAsResource("jarfileutils/childofchild/childofchild.xml");
 
+    private static final String PREFIX = "testng";
+    private static final String ARCHIVE_NAME = "testng-tests.jar";
+
+    public static File generateJar() throws IOException {
+        return generateJar(getTestClasses(), getResources(), PREFIX, ARCHIVE_NAME);
+    }
+
+    public static File generateJar(Class<?>[] classes) throws IOException {
+        return generateJar(classes, new String[] {}, PREFIX, ARCHIVE_NAME);
+    }
+
+    public static File generateJar(Class<?>[] classes, String[] resources, String prefix, String archiveName) throws IOException {
+        File jarFile = File.createTempFile(prefix, ".jar");
+        JavaArchive archive = ShrinkWrap.create(JavaArchive.class, archiveName)
+                .addClasses(classes);
+        for (String resource : resources) {
+            archive = archive.addAsResource(resource);
+        }
         archive.as(ZipExporter.class).exportTo(jarFile, true);
         return jarFile;
     }
@@ -34,6 +43,16 @@ public class JarCreator {
                 SampleTest3.class,
                 SampleTest4.class,
                 SampleTest5.class
+        };
+    }
+
+    private static String[] getResources() {
+        return new String[] {
+                "jarfileutils/testng-tests.xml",
+                "jarfileutils/child.xml",
+                "jarfileutils/child/child.xml",
+                "jarfileutils/child/childofchild/childofchild.xml",
+                "jarfileutils/childofchild/childofchild.xml"
         };
     }
 }

--- a/src/test/java/test/commandline/issue341/LocalLogAggregator.java
+++ b/src/test/java/test/commandline/issue341/LocalLogAggregator.java
@@ -1,0 +1,26 @@
+package test.commandline.issue341;
+
+import org.testng.IInvokedMethod;
+import org.testng.IInvokedMethodListener;
+import org.testng.ITestResult;
+import org.testng.Reporter;
+import org.testng.collections.Lists;
+import org.testng.collections.Maps;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class LocalLogAggregator implements IInvokedMethodListener {
+  private static final Set<String> logs = Collections.newSetFromMap(Maps.newConcurrentMap());
+
+  @Override
+  public void afterInvocation(IInvokedMethod method, ITestResult testResult) {
+    logs.addAll(Reporter.getOutput(testResult));
+  }
+
+  public static Set<String> getLogs() {
+    return logs;
+  }
+}

--- a/src/test/java/test/commandline/issue341/TestSampleA.java
+++ b/src/test/java/test/commandline/issue341/TestSampleA.java
@@ -1,0 +1,11 @@
+package test.commandline.issue341;
+
+import org.testng.Reporter;
+import org.testng.annotations.Test;
+
+public class TestSampleA {
+  @Test
+  public void a() {
+    Reporter.log(Long.toString(Thread.currentThread().getId()));
+  }
+}

--- a/src/test/java/test/commandline/issue341/TestSampleB.java
+++ b/src/test/java/test/commandline/issue341/TestSampleB.java
@@ -1,0 +1,11 @@
+package test.commandline.issue341;
+
+import org.testng.Reporter;
+import org.testng.annotations.Test;
+
+public class TestSampleB {
+  @Test
+  public void aa() {
+    Reporter.log(Long.toString(Thread.currentThread().getId()));
+  }
+}


### PR DESCRIPTION
Closes #341

Fixed the discrepancy:
“testng does not respect "-parallel classes" when 
running with a jar file”

Fixes #341 .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
