### PR TITLE
Provide ability to distinguish retried tests

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-1697: Need ability to mark "failed but up for retry" tests differently from "skipped" tests (Krishnan Mahadevan)
 Fixed: GITHUB-1810: Nullpointer exception when running TestNG tests from CMD (Krishnan Mahadevan)
 Fixed: GITHUB-1590: Started configuration method has wrong status and end time during execution (Krishnan Mahadevan)
 Fixed: GITHUB-298: Avoid Javascript errors in function name when suite name has special characters (Krishnan Mahadevan)

--- a/src/main/java/org/testng/ITestResult.java
+++ b/src/main/java/org/testng/ITestResult.java
@@ -101,4 +101,15 @@ public interface ITestResult extends IAttributes, Comparable<ITestResult> {
      * @param name - The new name to be used as a test name
      */
     void setTestName(String name);
+
+  /**
+   * @return - <code>true</code> if the test was retried again by an implementation of {@link
+   *     IRetryAnalyzer}
+   */
+  boolean wasRetried();
+
+  /**
+   * @param wasRetried - <code>true</code> if the test was retried and <code>false</code> otherwise.
+   */
+  void setWasRetried(boolean wasRetried);
 }

--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -1216,6 +1216,7 @@ public class Invoker implements IInvoker {
         failure.instances.add(instance);
       }
       testResult.setStatus(ITestResult.SKIP);
+      testResult.setWasRetried(true);
     } else {
       testResult.setStatus(status);
       if (status == ITestResult.FAILURE && !handled) {

--- a/src/main/java/org/testng/internal/TestResult.java
+++ b/src/main/java/org/testng/internal/TestResult.java
@@ -33,6 +33,7 @@ public class TestResult implements ITestResult {
   private String m_instanceName;
   private ITestContext m_context;
   private int parameterIndex;
+  private boolean m_wasRetried;
 
   public TestResult() {
 
@@ -326,5 +327,13 @@ public class TestResult implements ITestResult {
 
   public int getParameterIndex() {
     return parameterIndex;
+  }
+
+  public boolean wasRetried() {
+    return m_wasRetried;
+  }
+
+  public void setWasRetried(boolean wasRetried) {
+    this.m_wasRetried = wasRetried;
   }
 }

--- a/src/test/java/test/reflect/TestResultJustForTesting.java
+++ b/src/test/java/test/reflect/TestResultJustForTesting.java
@@ -99,6 +99,16 @@ public class TestResultJustForTesting implements ITestResult {
   }
 
   @Override
+  public boolean wasRetried() {
+    return false;
+  }
+
+  @Override
+  public void setWasRetried(boolean wasRetried) {
+
+  }
+
+  @Override
   public String getInstanceName() {
     return null;
   }

--- a/src/test/java/test/retryAnalyzer/issue1697/DatadrivenSample.java
+++ b/src/test/java/test/retryAnalyzer/issue1697/DatadrivenSample.java
@@ -1,0 +1,22 @@
+package test.retryAnalyzer.issue1697;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class DatadrivenSample {
+  private boolean flag = true;
+
+  @Test(dataProvider = "dp", retryAnalyzer = RetryForDataDrivenTest.class)
+  public void testMethod(int data) {
+    if (data == 1 && flag) {
+      flag = false;
+      Assert.fail();
+    }
+  }
+
+  @DataProvider(name = "dp")
+  public Object[][] getData() {
+    return new Object[][] {{1}, {2}};
+  }
+}

--- a/src/test/java/test/retryAnalyzer/issue1697/LocalReporter.java
+++ b/src/test/java/test/retryAnalyzer/issue1697/LocalReporter.java
@@ -1,0 +1,55 @@
+package test.retryAnalyzer.issue1697;
+
+import org.testng.IReporter;
+import org.testng.ISuite;
+import org.testng.ISuiteResult;
+import org.testng.ITestResult;
+import org.testng.collections.Maps;
+import org.testng.collections.Sets;
+import org.testng.xml.XmlSuite;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class LocalReporter implements IReporter {
+  private Set<ITestResult> skipped = Collections.newSetFromMap(Maps.newConcurrentMap());
+  private Set<ITestResult> retried = Collections.newSetFromMap(Maps.newConcurrentMap());
+
+  @Override
+  public void generateReport(
+      List<XmlSuite> xmlSuites, List<ISuite> suites, String outputDirectory) {
+    suites
+        .stream()
+        .map(
+            suite -> {
+              Set<ITestResult> results = Sets.newHashSet();
+              Collection<ISuiteResult> values = suite.getResults().values();
+              for (ISuiteResult value : values) {
+                results.addAll(value.getTestContext().getSkippedTests().getAllResults());
+              }
+              return results;
+            })
+        .collect(Collectors.toSet())
+        .forEach(
+            iTestResults -> {
+              for (ITestResult iTestResult : iTestResults) {
+                if (iTestResult.wasRetried()) {
+                  retried.add(iTestResult);
+                } else {
+                  skipped.add(iTestResult);
+                }
+              }
+            });
+  }
+
+    public Set<ITestResult> getRetried() {
+        return retried;
+    }
+
+    public Set<ITestResult> getSkipped() {
+        return skipped;
+    }
+}

--- a/src/test/java/test/retryAnalyzer/issue1697/RetryForDataDrivenTest.java
+++ b/src/test/java/test/retryAnalyzer/issue1697/RetryForDataDrivenTest.java
@@ -1,0 +1,16 @@
+package test.retryAnalyzer.issue1697;
+
+import org.testng.IRetryAnalyzer;
+import org.testng.ITestResult;
+
+public class RetryForDataDrivenTest implements IRetryAnalyzer {
+  private int counter = 0;
+
+  @Override
+  public boolean retry(ITestResult result) {
+    if (counter++ < 2) {
+      return true;
+    }
+    return false;
+  }
+}

--- a/src/test/java/test/retryAnalyzer/issue1697/SampleTestclass.java
+++ b/src/test/java/test/retryAnalyzer/issue1697/SampleTestclass.java
@@ -1,0 +1,23 @@
+package test.retryAnalyzer.issue1697;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class SampleTestclass {
+  public static int counter = 0;
+
+  @Test(retryAnalyzer = SimpleRetrier.class)
+  public void dataDrivenTest() {
+    if (counter++ != 1) {
+      Assert.fail();
+    }
+  }
+
+  @Test
+  public void parent() {
+    Assert.fail();
+  }
+
+  @Test(dependsOnMethods = "parent")
+  public void child() {}
+}

--- a/src/test/java/test/retryAnalyzer/issue1697/SimpleRetrier.java
+++ b/src/test/java/test/retryAnalyzer/issue1697/SimpleRetrier.java
@@ -1,0 +1,11 @@
+package test.retryAnalyzer.issue1697;
+
+import org.testng.IRetryAnalyzer;
+import org.testng.ITestResult;
+
+public class SimpleRetrier implements IRetryAnalyzer {
+    @Override
+    public boolean retry(ITestResult result) {
+        return true;
+    }
+}


### PR DESCRIPTION
Closes #1697

As part of this changeset, TestNG now provides a 
query mechanism using which an ITestResult can be
queried to see if a skipped test was retried or not.

Fixes #1697 .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
