### PR TITLE
TestNG Reporting - Identify retried tests

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-1402: TestNG reporting - Quickly identify Retry-d Tests (Krishnan Mahadevan)
 Fixed: GITHUB-1697: Need ability to mark "failed but up for retry" tests differently from "skipped" tests (Krishnan Mahadevan)
 Fixed: GITHUB-1810: Nullpointer exception when running TestNG tests from CMD (Krishnan Mahadevan)
 Fixed: GITHUB-1590: Started configuration method has wrong status and end time during execution (Krishnan Mahadevan)

--- a/src/main/java/org/testng/reporters/XMLReporterConfig.java
+++ b/src/main/java/org/testng/reporters/XMLReporterConfig.java
@@ -30,6 +30,7 @@ public class XMLReporterConfig {
   public static final String ATTR_URL = "url";
   public static final String ATTR_NAME = "name";
   public static final String ATTR_STATUS = "status";
+  public static final String ATTR_RETRIED = "retried";
   public static final String ATTR_DESC = "description";
   public static final String ATTR_METHOD_SIG = "signature";
   public static final String ATTR_GROUPS = "groups";

--- a/src/main/java/org/testng/reporters/XMLSuiteResultWriter.java
+++ b/src/main/java/org/testng/reporters/XMLSuiteResultWriter.java
@@ -152,6 +152,9 @@ public class XMLSuiteResultWriter {
   private void addTestResult(XMLStringBuffer xmlBuffer, ITestResult testResult) {
     Properties attribs = getTestResultAttributes(testResult);
     attribs.setProperty(XMLReporterConfig.ATTR_STATUS, getStatusString(testResult.getStatus()));
+    if (testResult.wasRetried()) {
+      attribs.setProperty(XMLReporterConfig.ATTR_RETRIED, Boolean.TRUE.toString());
+    }
     xmlBuffer.push(XMLReporterConfig.TAG_TEST_METHOD, attribs);
     addTestMethodParams(xmlBuffer, testResult);
     addTestResultException(xmlBuffer, testResult);


### PR DESCRIPTION
Closes #1402

Enriched the following to distinctly show retried
tests:
* xml reporter.
* console reporter
* text reporter
* mailable reporter
* html reporter.

Fixes #1402 .

### Did you remember to?

- [ ] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
