### PR TITLE
Fixing improper usage of computeIfAbsent()

### DIFF
--- a/src/main/java/org/testng/internal/BaseTestMethod.java
+++ b/src/main/java/org/testng/internal/BaseTestMethod.java
@@ -456,11 +456,7 @@ public abstract class BaseTestMethod implements ITestNGMethod {
     for (Map.Entry<String, String> e : xmlTest.getXmlDependencyGroups().entrySet()) {
       String name = e.getKey();
       String dependsOn = e.getValue();
-      Set<String> set = result.computeIfAbsent(name, s -> {
-        Set<String> tempSet = Sets.newHashSet();
-        result.put(s, tempSet);
-        return tempSet;
-      });
+      Set<String> set = result.computeIfAbsent(name, s -> Sets.newHashSet());
       set.addAll(Arrays.asList(SPACE_SEPARATOR_PATTERN.split(dependsOn)));
     }
 

--- a/src/main/java/org/testng/internal/TestMethodWorker.java
+++ b/src/main/java/org/testng/internal/TestMethodWorker.java
@@ -161,11 +161,7 @@ public class TestMethodWorker implements IWorker<ITestNGMethod> {
     //DO NOT REMOVE THIS SYNC LOCK.
     synchronized (testClass) { //NOSONAR
       Map<ITestClass, Set<Object>> invokedBeforeClassMethods = m_classMethodMap.getInvokedBeforeClassMethods();
-      Set<Object> instances = invokedBeforeClassMethods.computeIfAbsent(testClass, key -> {
-        Set<Object> set = Sets.newHashSet();
-        invokedBeforeClassMethods.put(key, set);
-        return set;
-      });
+      Set<Object> instances = invokedBeforeClassMethods.computeIfAbsent(testClass, key -> Sets.newHashSet());
       Object instance = mi.getInstance();
       if (!instances.contains(instance)) {
         instances.add(instance);
@@ -202,11 +198,7 @@ public class TestMethodWorker implements IWorker<ITestNGMethod> {
       return;
     }
     Map<ITestClass, Set<Object>> invokedAfterClassMethods = m_classMethodMap.getInvokedAfterClassMethods();
-    Set<Object> instances = invokedAfterClassMethods.computeIfAbsent(testClass, key -> {
-      Set<Object> set = Sets.newHashSet();
-      invokedAfterClassMethods.put(key, set);
-      return set;
-    });
+    Set<Object> instances = invokedAfterClassMethods.computeIfAbsent(testClass, key -> Sets.newHashSet());
     Object inst = mi.getInstance();
     if (!instances.contains(inst)) {
       invokeInstances.add(inst);

--- a/src/main/java/org/testng/internal/TestNGClassFinder.java
+++ b/src/main/java/org/testng/internal/TestNGClassFinder.java
@@ -297,15 +297,7 @@ public class TestNGClassFinder extends BaseClassFinder {
   // Class<S> should be replaced by Class<? extends T> but java doesn't fail as expected
   // See: https://github.com/cbeust/testng/issues/1070
   private <T, S extends T> void addInstance(Class<S> clazz, T instance) {
-    List<Object> instances =
-        m_instanceMap.computeIfAbsent(
-            clazz,
-            key -> {
-              List<Object> list = Lists.newArrayList();
-              m_instanceMap.put(key, list);
-              return list;
-            });
-
+    List<Object> instances = m_instanceMap.computeIfAbsent(clazz, key -> Lists.newArrayList());
     instances.add(instance);
   }
 }


### PR DESCRIPTION
JDK9 is throwing a ConcurrentModificationException
when computeIfAbsent() is incorrectly used.
Fixed all those discrepancies.

Fixes # .

### Did you remember to?

- [ ] Add test case(s)
- [ ] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
