### PR TITLE
Expose GraphViz visualisation

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+New  : Expose Graph Visualisation representation for users to build real-time debugging tools (Krishnan Mahadevan)
 Fixed: GITHUB-574: String cannot be cast to Integer if log property is set in maven pom.xml (Krishnan Mahadevan)
 Fixed: GITHUB-1402: TestNG reporting - Quickly identify Retry-d Tests (Krishnan Mahadevan)
 Fixed: GITHUB-1697: Need ability to mark "failed but up for retry" tests differently from "skipped" tests (Krishnan Mahadevan)

--- a/src/main/java/org/testng/IExecutionVisualiser.java
+++ b/src/main/java/org/testng/IExecutionVisualiser.java
@@ -1,0 +1,14 @@
+package org.testng;
+
+/**
+ * A TestNG listener that can be used to build graph representations of TestNG methods as and when
+ * they are being executed on a real-time basis.
+ */
+public interface IExecutionVisualiser extends ITestNGListener {
+  /**
+   * @param dotDefinition - A <a href="https://graphviz.gitlab.io/_pages/doc/info/lang.html">DOT</a>
+   *     representation of the Directed Acyclic Graph that TestNG builds internally to represent its
+   *     tests.
+   */
+  void consumeDotDefinition(String dotDefinition);
+}

--- a/src/main/java/org/testng/SuiteRunner.java
+++ b/src/main/java/org/testng/SuiteRunner.java
@@ -4,6 +4,7 @@ import static org.testng.internal.Utils.isStringBlank;
 
 import org.testng.collections.Lists;
 import org.testng.collections.Maps;
+import org.testng.collections.Sets;
 import org.testng.internal.Attributes;
 import org.testng.internal.IConfiguration;
 import org.testng.internal.IInvoker;
@@ -74,6 +75,7 @@ public class SuiteRunner implements ISuite, IInvokedMethodListener {
   private List<ITestNGMethod> allTestMethods = Lists.newArrayList();
   private SuiteRunState suiteState = new SuiteRunState();
   private IAttributes attributes = new Attributes();
+  private final Set<IExecutionVisualiser> visualisers = Sets.newHashSet();
 
   public SuiteRunner(IConfiguration configuration, XmlSuite suite, String outputDir,
       Comparator<ITestNGMethod> comparator) {
@@ -429,6 +431,9 @@ public class SuiteRunner implements ISuite, IInvokedMethodListener {
     }
   }
 
+  private void addVisualiser(IExecutionVisualiser visualiser) {
+    visualisers.add(visualiser);
+  }
 
 
   private void addReporter(IReporter listener) {
@@ -450,6 +455,7 @@ public class SuiteRunner implements ISuite, IInvokedMethodListener {
   }
 
   private void runTest(TestRunner tr) {
+    visualisers.forEach(tr::addListener);
     tr.run();
 
     ISuiteResult sr = new SuiteResult(xmlSuite, tr);
@@ -508,6 +514,9 @@ public class SuiteRunner implements ISuite, IInvokedMethodListener {
     }
     if (listener instanceof ISuiteListener) {
       addListener((ISuiteListener) listener);
+    }
+    if (listener instanceof IExecutionVisualiser) {
+      addVisualiser((IExecutionVisualiser) listener);
     }
     if (listener instanceof IReporter) {
       addReporter((IReporter) listener);

--- a/src/main/java/org/testng/TestNG.java
+++ b/src/main/java/org/testng/TestNG.java
@@ -178,6 +178,7 @@ public class TestNG {
   private boolean isSuiteInitialized = false;
   private final org.testng.internal.ExitCodeListener exitCodeListener = new org.testng.internal.ExitCodeListener();
   private ExitCode exitCode;
+  private final Map<Class<? extends IExecutionVisualiser>, IExecutionVisualiser> m_executionVisualisers = Maps.newHashMap();
 
   /**
    * Default constructor. Setting also usage of default listeners/reporters.
@@ -651,6 +652,10 @@ public class TestNG {
   public void addListener(ITestNGListener listener) {
     if (listener == null) {
       return;
+    }
+    if (listener instanceof IExecutionVisualiser) {
+      IExecutionVisualiser visualiser = (IExecutionVisualiser) listener;
+      maybeAddListener(m_executionVisualisers, visualiser);
     }
     if (listener instanceof ISuiteListener) {
       ISuiteListener suite = (ISuiteListener) listener;
@@ -1229,6 +1234,8 @@ public class TestNG {
     for (IConfigurationListener cl : m_configuration.getConfigurationListeners()) {
       result.addConfigurationListener(cl);
     }
+
+    m_executionVisualisers.values().forEach(result::addListener);
 
     return result;
   }

--- a/src/main/java/org/testng/TestRunner.java
+++ b/src/main/java/org/testng/TestRunner.java
@@ -84,6 +84,7 @@ public class TestRunner
   /** ITestListeners support. */
   private List<ITestListener> m_testListeners = Lists.newArrayList();
   private Set<IConfigurationListener> m_configurationListeners = Sets.newHashSet();
+  private final Set<IExecutionVisualiser> visualisers = Sets.newHashSet();
 
   private IConfigurationListener m_confListener= new ConfigurationListener();
 
@@ -621,6 +622,7 @@ public class TestRunner
       // termination from methods that never get invoked).
       DynamicGraph<ITestNGMethod> graph = DynamicGraphHelper.createDynamicGraph(intercept(m_allTestMethods),
               getCurrentXmlTest());
+      graph.setVisualisers(this.visualisers);
       if (parallel) {
         if (graph.getNodeCount() > 0) {
           GraphThreadPoolExecutor<ITestNGMethod> executor =
@@ -1020,6 +1022,11 @@ public class TestRunner
     if (listener instanceof IDataProviderListener) {
       IDataProviderListener dataProviderListener = (IDataProviderListener) listener;
       m_dataProviderListeners.put(dataProviderListener.getClass(), dataProviderListener);
+    }
+
+    if (listener instanceof IExecutionVisualiser) {
+      IExecutionVisualiser l = (IExecutionVisualiser) listener;
+      visualisers.add(l);
     }
     m_suite.addListener(listener);
   }

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -74,6 +74,7 @@
       </run>
     </groups>
     <classes>
+      <class name="test.graph.GraphVisualiserTest"/>
       <class name="test.Test1" />
       <class name="test.MethodTest" />
       <class name="test.sample.AfterClassCalledAtEnd"/>


### PR DESCRIPTION
TestNG already has support to transform its 
dynamic graph contents into a GraphViz representation.

Enabled exposing this capability via a new TestNG
listener so that end-users can build implementations
to render this content for their debugging purposes.

Fixes # .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
