### PR TITLE
Fix #1850

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-1850: Parser returns a wrong structure when parent suite has duplicate child suites (Chao Qin)
 Fixed: GITHUB-1803: Added new methods for comparing float and double arrays with delta (Atul Agrawal)
 Fixed: GITHUB-1661: Fixed Assert logic for two dimensional arrays (Atul Agrawal)
 Fixed: GITHUB-1734: Added unit tests for NaN, Max, Min, Positive and Negative infinity (Atul Agrawal)

--- a/src/main/java/org/testng/xml/Parser.java
+++ b/src/main/java/org/testng/xml/Parser.java
@@ -12,6 +12,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
+import java.util.Queue;
+import java.util.ArrayDeque;
 
 /** <code>Parser</code> is a parser for a TestNG XML test suite file. */
 public class Parser {
@@ -127,7 +129,7 @@ public class Parser {
     /*
      * Keeps a track of parent XmlSuite for each child suite
      */
-    Map<String, XmlSuite> childToParentMap = Maps.newHashMap();
+    Map<String, Queue<XmlSuite>> childToParentMap = Maps.newHashMap();
     while (!toBeParsed.isEmpty()) {
 
       for (String currentFile : toBeParsed) {
@@ -147,7 +149,7 @@ public class Parser {
         toBeRemoved.add(currentFile);
 
         if (childToParentMap.containsKey(currentFile)) {
-          XmlSuite parentSuite = childToParentMap.get(currentFile);
+          XmlSuite parentSuite = childToParentMap.get(currentFile).remove();
           // Set parent
           currentXmlSuite.setParentSuite(parentSuite);
           // append children
@@ -171,7 +173,13 @@ public class Parser {
             }
             if (!processedSuites.contains(canonicalPath)) {
               toBeAdded.add(canonicalPath);
-              childToParentMap.put(canonicalPath, currentXmlSuite);
+              if (childToParentMap.containsKey(canonicalPath)) {
+                childToParentMap.get(canonicalPath).add(currentXmlSuite);
+              } else {
+                Queue<XmlSuite> parentQueue = new ArrayDeque<>();
+                parentQueue.add(currentXmlSuite);
+                childToParentMap.put(canonicalPath, parentQueue);
+              }
             }
           }
         }

--- a/src/test/java/test/suites/github1850/DuplicateChildSuitesInitializationTest.java
+++ b/src/test/java/test/suites/github1850/DuplicateChildSuitesInitializationTest.java
@@ -1,0 +1,74 @@
+package test.suites.github1850;
+
+import org.testng.annotations.Test;
+import org.testng.xml.Parser;
+import org.testng.xml.XmlSuite;
+import test.SimpleBaseTest;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * This test checks that TestNG can handle duplicate child suites when we have the following set of files:
+ * <p>
+ * - parent-suite-with-duplicate-child -> [child-suite-1, children/child-suite-3, child-suite1, children/child-suite-3]
+ * - children/child-suite-3 -> [../child-suite-2, child-suite-4, morechildren/child-suite-5]
+ * <p>
+ * SHOULD return a XmlSuite object with following structure:
+ * <p>
+ * parent-suite-with-duplicate-child
+ * ├───child-suite-1
+ * ├───child-suite-3
+ * │   ├───child-suite-2
+ * │   ├───child-suite-4
+ * │   └───child-suite-5
+ * ├───child-suite-1(0)
+ * └───child-suite-3(0)
+ * ├───child-suite-2(0)
+ * ├───child-suite-4(0)
+ * └───child-suite-5(0)
+ * <p>
+ * but NOT like:
+ * <p>
+ * parent-suite-with-duplicate-child
+ * ├───child-suite-1
+ * ├───child-suite-3
+ * ├───child-suite-1(0)
+ * └───child-suite-3(0)
+ * ├───child-suite-2
+ * ├───child-suite-4
+ * ├───child-suite-5
+ * ├───child-suite-2(0)
+ * ├───child-suite-4(0)
+ * └───child-suite-5(0)
+ * <p>
+ * Check the <code>checksuitesinitialization</code> folder under test resources
+ */
+public class DuplicateChildSuitesInitializationTest extends SimpleBaseTest {
+    @Test
+    public void checkDuplicateChildSuites() throws IOException {
+        String path = getPathToResource("checksuitesinitialization/parent-suite-with-duplicate-child.xml");
+        Parser parser = new Parser(path);
+        List<XmlSuite> suites = parser.parseToList();
+        XmlSuite rootSuite = suites.get(0);
+        assertEquals(rootSuite.getChildSuites().size(), 4);
+
+        XmlSuite suite3 = rootSuite.getChildSuites().get(1);
+        assertEquals(suite3.getName(), "Child Suite 3");
+        assertEquals(suite3.getChildSuites().size(), 3);
+
+        XmlSuite suite3_0 = rootSuite.getChildSuites().get(3);
+        assertEquals(suite3.getName(), "Child Suite 3");
+        assertEquals(suite3_0.getChildSuites().size(), 3);
+
+        XmlSuite suite5 = suite3.getChildSuites().get(2);
+        assertEquals(suite5.getName(), "Child Suite 5");
+        assertEquals(suite5.getTests().size(), 1);
+
+        XmlSuite suite5_0 = suite3_0.getChildSuites().get(2);
+        assertEquals(suite5_0.getName(), "Child Suite 5");
+        assertEquals(suite5_0.getTests().size(), 1);
+    }
+}

--- a/src/test/resources/checksuitesinitialization/parent-suite-with-duplicate-child.xml
+++ b/src/test/resources/checksuitesinitialization/parent-suite-with-duplicate-child.xml
@@ -1,0 +1,10 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<suite name="Parent Suite">
+  <parameter name="foo" value="bar"/>
+  <suite-files>
+    <suite-file path="./child-suite1.xml" />
+    <suite-file path="children/child-suite-3.xml" />
+    <suite-file path="./child-suite1.xml" />
+    <suite-file path="children/child-suite-3.xml" />
+  </suite-files>
+</suite>

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -869,6 +869,7 @@
   <test name="Suite_Related_Tests">
     <classes>
       <class name="test.suites.github1533.Github1533Test"/>
+      <class name="test.suites.github1850.DuplicateChildSuitesInitializationTest"/>
     </classes>
   </test>
 


### PR DESCRIPTION
Fixes #1850  .

Parser returns a XmlSuite with wrong strucutre when the parent suite
has duplicate child suites.

The root cause is during the process, the mapping of child suite's
path and current suite object is overrided by the later one.

Use Map<String, Queue<XmlSuite>> childToParentMap instead of
Map<String, XmlSuite> childToParentMap could solve this issue.
### Did you remember to?

- [x] Add test case(s)
- [x] Update `CHANGES.txt`

