### PR TITLE
Fix #1863 IMethodInterceptor will be invoked twice when listener implements both ITestListener and IMethodInterceptor via eclipse execution way

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-1863: IMethodInterceptor will be invoked twice when listener implements both ITestListener and IMethodInterceptor via eclipse execution way.(Bin Wu)
 Fixed: GITHUB-1865: testngXmlPathInJar- cannot be cleared when vm terminate(Yehui Wang)
 Fixed: GITHUB-1850: Parser returns a wrong structure when parent suite has duplicate child suites (Chao Qin)
 Fixed: GITHUB-1803: Added new methods for comparing float and double arrays with delta (Atul Agrawal)

--- a/src/main/java/org/testng/TestRunner.java
+++ b/src/main/java/org/testng/TestRunner.java
@@ -1139,7 +1139,10 @@ public class TestRunner
   }
 
   void addMethodInterceptor(IMethodInterceptor methodInterceptor) {
-    m_methodInterceptors.add(methodInterceptor);
+      //avoid to add interceptor twice when the defined listeners implements both ITestListener and IMethodInterceptor.
+      if (!m_methodInterceptors.contains(methodInterceptor)) {
+          m_methodInterceptors.add(methodInterceptor);
+    }
   }
 
   @Override

--- a/src/test/java/test/listeners/InterceptorInvokeTwiceSimulateListener.java
+++ b/src/test/java/test/listeners/InterceptorInvokeTwiceSimulateListener.java
@@ -1,0 +1,29 @@
+package test.listeners;
+
+import java.util.List;
+import org.testng.IMethodInstance;
+import org.testng.IMethodInterceptor;
+import org.testng.ITestContext;
+import org.testng.ITestListener;
+import org.testng.ITestResult;
+
+/**
+ * This listener is used to trigger the bug 1863: IMethodInterceptor will be invoked twice when
+ * listener implements both ITestListener and IMethodInterceptor via eclipse execution way
+ */
+public class InterceptorInvokeTwiceSimulateListener implements
+        ITestListener, IMethodInterceptor {
+
+    private int count = 0;
+
+    @Override
+    public List<IMethodInstance> intercept(List<IMethodInstance> methods, ITestContext context) {
+        count++;
+        return methods;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+}

--- a/src/test/java/test/listeners/ListenerTest.java
+++ b/src/test/java/test/listeners/ListenerTest.java
@@ -124,6 +124,15 @@ public class ListenerTest extends SimpleBaseTest {
     tng.run();
     Assert.assertEquals(interceptor.getCount(), 1);
   }
+  
+  @Test(description = "GITHUB-1863:IMethodInterceptor will be invoked twice when listener implements both ITestListener and IMethodInterceptor via eclipse execution way")
+  public void methodInterceptorShouldBeRunOnceWhenCustomisedListenerImplementsITestListenerAndIMethodInterceptor() {
+    TestNG tng = create(LSampleTest.class);
+    InterceptorInvokeTwiceSimulateListener interceptor = new InterceptorInvokeTwiceSimulateListener();
+    tng.addListener(interceptor);
+    tng.run();
+    Assert.assertEquals(interceptor.getCount(), 1);
+}
 
   @Test(description = "GITHUB-356: Add listeners for @BeforeClass/@AfterClass")
   public void classListenerShouldWork() {


### PR DESCRIPTION
IMethodInterceptor will be invoked twice when listener implements both
ITestListener and IMethodInterceptor via eclipse execution way.

The root cause is when using ITestRunnerFactory2 to create a new
testRunner, all listeners which implements ITestListener will be added, if this listener is also implements IMethodInterceptor, then it will be added to m_methodInterceptors, however, the implemented IMethodInterceptor will be added to m_methodInterceptors again.

in the second time of adding implemented IMethodInterceptor to
m_methodInterceptors, we add statement to check if this interceptor already exist or not could solve this issue.

Fixes # 1863.

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
