### PR TITLE
Fixed: GITHUB-1865: testngXmlPathInJar- cannot be cleared when vm terminate

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-1865: testngXmlPathInJar- cannot be cleared when vm terminate(Yehui Wang)
 Fixed: GITHUB-1850: Parser returns a wrong structure when parent suite has duplicate child suites (Chao Qin)
 Fixed: GITHUB-1803: Added new methods for comparing float and double arrays with delta (Atul Agrawal)
 Fixed: GITHUB-1661: Fixed Assert logic for two dimensional arrays (Atul Agrawal)

--- a/src/main/java/org/testng/JarFileUtils.java
+++ b/src/main/java/org/testng/JarFileUtils.java
@@ -11,6 +11,7 @@ import org.testng.xml.internal.TestNamesMatcher;
 import org.testng.xml.internal.XmlSuiteUtils;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
@@ -68,7 +69,6 @@ class JarFileUtils {
     try (JarFile jf = new JarFile(jarFile)) {
       Enumeration<JarEntry> entries = jf.entries();
       File file = java.nio.file.Files.createTempDirectory("testngXmlPathInJar-").toFile();
-      file.deleteOnExit();
       String suitePath = null;
       while (entries.hasMoreElements()) {
         JarEntry je = entries.nextElement();
@@ -88,6 +88,7 @@ class JarFileUtils {
         return false;
       }
       Collection<XmlSuite> parsedSuites = Parser.parse(suitePath, processor);
+      delete(file);
       for (XmlSuite suite : parsedSuites) {
         // If test names were specified, only run these test names
         if (testNames != null) {
@@ -104,6 +105,15 @@ class JarFileUtils {
       }
     }
     return false;
+  }
+  
+  private void delete(File f) throws IOException {
+    if (f.isDirectory()) {
+      for (File c : f.listFiles())
+        delete(c);
+    }
+    if (!f.delete())
+      throw new FileNotFoundException("Failed to delete file: " + f);
   }
 
   private boolean matchesXmlPathInJar(JarEntry je) {


### PR DESCRIPTION
Fixes #1865  