### PR TITLE
Prevent circular dependency

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-1874: Prevent circular dependency error when suite includes different methods from same class (Krishnan Mahadevan)
 Fixed: GITHUB-1863: IMethodInterceptor will be invoked twice when listener implements both ITestListener and IMethodInterceptor via eclipse execution way.(Bin Wu)
 Fixed: GITHUB-1865: testngXmlPathInJar- cannot be cleared when vm terminate(Yehui Wang)
 Fixed: GITHUB-1850: Parser returns a wrong structure when parent suite has duplicate child suites (Chao Qin)

--- a/src/main/java/org/testng/xml/XmlClass.java
+++ b/src/main/java/org/testng/xml/XmlClass.java
@@ -203,8 +203,6 @@ public class XmlClass implements Cloneable {
     int result = 1;
     result = prime * result + ((m_class == null) ? 0 : m_class.hashCode());
     result = prime * result + (m_loadClasses ? 1 : 0);
-    result = prime * result + ((m_excludedMethods == null) ? 0 : m_excludedMethods.hashCode());
-    result = prime * result + ((m_includedMethods == null) ? 0 : m_includedMethods.hashCode());
     result = prime * result + m_index;
     result = prime * result + ((m_name == null) ? 0 : m_name.hashCode());
     return result;
@@ -218,15 +216,9 @@ public class XmlClass implements Cloneable {
     if (obj == null) return XmlSuite.f();
     if (getClass() != obj.getClass()) return XmlSuite.f();
     XmlClass other = (XmlClass) obj;
-    if (other.m_loadClasses != m_loadClasses
-        || !m_excludedMethods.equals(other.m_excludedMethods)) {
+    if (other.m_loadClasses != m_loadClasses) {
       return XmlSuite.f();
     }
-    if (m_includedMethods == null) {
-      if (other.m_includedMethods != null) return XmlSuite.f();
-    } else if (!m_includedMethods.equals(other.m_includedMethods)) return XmlSuite.f();
-    //    if (m_index != other.m_index)
-    //      return XmlSuite.f();
     if (m_name == null) {
       if (other.m_name != null) return XmlSuite.f();
     } else if (!m_name.equals(other.m_name)) return XmlSuite.f();

--- a/src/test/java/test/suites/github1874/IssueTest.java
+++ b/src/test/java/test/suites/github1874/IssueTest.java
@@ -1,0 +1,28 @@
+package test.suites.github1874;
+
+import org.testng.TestNG;
+import org.testng.annotations.Test;
+import org.testng.xml.XmlClass;
+import org.testng.xml.XmlSuite;
+import org.testng.xml.XmlTest;
+import test.SimpleBaseTest;
+
+public class IssueTest extends SimpleBaseTest {
+
+  @Test
+  //We are explicitly not including any assertions here because the intent of this test is to
+  //ensure that there are no exceptions triggered related to circular dependency.
+  public void testEnsureNoCyclicDependencyTriggered() {
+    XmlSuite suite = createXmlSuite("sample_suite");
+    XmlTest test = createXmlTest(suite, "sample_test");
+    XmlClass entryOne = new XmlClass(TestClassSample.class);
+    createXmlInclude(entryOne, "testMethodTwo");
+    test.getClasses().add(entryOne);
+    XmlClass entryTwo = new XmlClass(TestClassSample.class);
+    createXmlInclude(entryTwo, "testMethodOne");
+    test.getClasses().add(entryTwo);
+    TestNG testng = create(suite);
+    testng.run();
+  }
+
+}

--- a/src/test/java/test/suites/github1874/TestClassSample.java
+++ b/src/test/java/test/suites/github1874/TestClassSample.java
@@ -1,0 +1,12 @@
+package test.suites.github1874;
+
+import org.testng.annotations.Test;
+
+public class TestClassSample {
+  @Test
+  public void testMethodOne() {}
+
+  @Test
+  public void testMethodTwo() {}
+
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -870,6 +870,7 @@
     <classes>
       <class name="test.suites.github1533.Github1533Test"/>
       <class name="test.suites.github1850.DuplicateChildSuitesInitializationTest"/>
+      <class name="test.suites.github1874.IssueTest"/>
     </classes>
   </test>
 


### PR DESCRIPTION
Closes #1874

Currently XmlClass includes both “included” and 
“excluded” methods as part of its equals() and 
hashCode() calculation. 

So in scenarios which involve two XmlClass objects
for the same Class but with different included and 
excluded methods, TestNG seems the two XmlClass
objects as different. 

So when users basically add the same class twice 
but with different methods, TestNG ends up looking
at this as if there’s a cyclic dependency (which is
incorrect).

Fixes #1874  .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
