### PR TITLE
TestNG doesn't use the searchable loaders for JUnit tests

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: TestNG doesn't use the searchable loaders for JUnit tests
 Fixed: GITHUB-1880: @AfterGroups(alwaysRun = true) is not called if there is an exception in @BeforeGroups (Krishnan Mahadevan)
 Fixed: GITHUB-1874: Prevent circular dependency error when suite includes different methods from same class (Krishnan Mahadevan)
 Fixed: GITHUB-1863: IMethodInterceptor will be invoked twice when listener implements both ITestListener and IMethodInterceptor via eclipse execution way.(Bin Wu)

--- a/src/main/java/org/testng/junit/JUnit4TestClass.java
+++ b/src/main/java/org/testng/junit/JUnit4TestClass.java
@@ -6,6 +6,14 @@ import org.junit.runner.Description;
 public class JUnit4TestClass extends JUnitTestClass {
 
   public JUnit4TestClass(Description test) {
-    super(test.getTestClass());
+    super(descriptionToClass(test));
+  }
+
+  private static Class<?> descriptionToClass(Description test) {
+    Class<?> result = test.getTestClass();
+    if (result == null) {
+        result = org.testng.internal.ClassHelper.forName(test.getClassName());
+    }
+    return result;
   }
 }

--- a/src/main/java/org/testng/junit/JUnit4TestMethod.java
+++ b/src/main/java/org/testng/junit/JUnit4TestMethod.java
@@ -8,11 +8,10 @@ import org.testng.internal.Utils;
 public class JUnit4TestMethod extends JUnitTestMethod {
 
   public JUnit4TestMethod(JUnitTestClass owner, Description desc) {
-    super(owner, desc.getMethodName(), getMethod(desc), desc);
+    super(owner, desc.getMethodName(), getMethod(owner.getRealClass(), desc), desc);
   }
 
-  private static ConstructorOrMethod getMethod(Description desc) {
-    Class<?> c = desc.getTestClass();
+  private static ConstructorOrMethod getMethod(Class<?> c, Description desc) {
     String method = desc.getMethodName();
     if (JUnit4SpockMethod.isSpockClass(c)) {
       return new JUnit4SpockMethod(desc);

--- a/src/test/java/test/JUnitTestClassLoader.java
+++ b/src/test/java/test/JUnitTestClassLoader.java
@@ -1,0 +1,135 @@
+package test;
+
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import javax.tools.JavaCompiler;
+import javax.tools.ToolProvider;
+
+import org.testng.*;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+public class JUnitTestClassLoader extends ClassLoader {
+  private final File tmpDir;
+  public JUnitTestClassLoader() {
+    try {
+      File tmp = File.createTempFile("aaa", null);
+      tmp.delete();
+      tmpDir = tmp.getParentFile();
+    } catch (Exception e) {
+      throw new Error(e);
+    }
+  }
+
+  @Test
+  public void testPassAndFail() throws Exception {
+    String src = "import org.junit.Test;\n"
+               + "import static org.junit.Assert.*;\n"
+               + "public class SimpleTest1 {\n"
+               + "    @Test\n"
+               + "    public void test1() {\n"
+               + "        assertEquals(42, 42);\n"
+               + "    }\n"
+               + "    @Test\n"
+               + "    public void test2() {\n"
+               + "        assertEquals(42, 0);\n"
+               + "    }\n"
+               + "}\n";
+    Listener listener = runJunitTest(src, "SimpleTest1");
+    assertEquals(1, listener.success);
+    assertEquals(1, listener.failure);
+  }
+
+  @Test
+  public void testFail() throws Exception {
+    String src = "import org.junit.Test;\n"
+               + "import static org.junit.Assert.*;\n"
+               + "public class SimpleTest2 {\n"
+               + "    @Test\n"
+               + "    public void test() {\n"
+               + "        assertEquals(42, 0);\n"
+               + "    }\n"
+               + "}\n";
+    Listener listener = runJunitTest(src, "SimpleTest2");
+    assertEquals(0, listener.success);
+    assertEquals(1, listener.failure);
+  }
+
+  @Test
+  public void testPass() throws Exception {
+    String src = "import org.junit.Test;\n"
+               + "import static org.junit.Assert.*;\n"
+               + "public class SimpleTest3 {\n"
+               + "    @Test\n"
+               + "    public void test() {\n"
+               + "        assertEquals(42, 42);\n"
+               + "    }\n"
+               + "}\n";
+    Listener listener = runJunitTest(src, "SimpleTest3");
+    assertEquals(1, listener.success);
+    assertEquals(0, listener.failure);
+  }
+
+  private Listener runJunitTest(String src, String name) throws Exception {
+    TestNG tng = new TestNG(false);
+    Class<?> testClass = compile(src, name);
+    Listener listener = new Listener();
+    tng.setJUnit(true);
+    tng.addClassLoader(testClass.getClassLoader());
+    assertNotEquals(testClass.getClassLoader(), this.getClass().getClassLoader(),
+                    "JUnit test must be loaded by a different classloader");
+    try {
+        this.getClass().getClassLoader().loadClass(testClass.getName());
+        fail("it must be imposiible to load JUnit test by current classloader");
+    } catch (ClassNotFoundException c) {
+    }
+
+    tng.setTestClasses(new Class<?>[]{testClass});
+    tng.addListener(listener);
+    tng.run();
+    return listener;
+  }
+
+  private Class<?> compile(String src, String name) throws Exception {
+    // compile class and load it into by a custom classloader
+    File srcFile = new File(tmpDir, name + ".java");
+    try (PrintWriter pw = new PrintWriter(new FileWriter(srcFile))) {
+      pw.append(src);
+    }
+    JavaCompiler javac = ToolProvider.getSystemJavaCompiler();
+    assertEquals(0, javac.run(null, null, null, srcFile.getCanonicalPath()));
+    srcFile.delete();
+    File classFile = new File(tmpDir, name + ".class");
+    byte[] bytes;
+    try (DataInputStream dis = new DataInputStream(new FileInputStream(classFile))) {
+      bytes = new byte[dis.available()];
+      dis.readFully(bytes);
+    }
+    classFile.delete();
+    return defineClass(name, bytes, 0, bytes.length);
+  }
+
+  private static class Listener implements ITestListener {
+    public int success = 0;
+    public int failure = 0;
+
+    public void onTestSuccess(ITestResult result) {
+      success++;
+    }
+
+    public void onTestFailure(ITestResult result) {
+      failure++;
+    }
+
+    public void onTestStart(ITestResult result) { }
+    public void onTestSkipped(ITestResult result) { }
+    public void onTestFailedButWithinSuccessPercentage(ITestResult result) { }
+    public void onStart(ITestContext context) { }
+    public void onFinish(ITestContext context) { }
+  }
+
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -644,6 +644,7 @@
       <class name="test.JUnit4Test" />
       <class name="test.junit4.listeners.Issue323TestRunner"/>
       <class name="test.groovy.GroovyTest" />
+      <class name="test.JUnitTestClassLoader" />
     </classes>
   </test>
 


### PR DESCRIPTION
working on [CODETOOLS-7901875]( https://bugs.openjdk.java.net/browse/CODETOOLS-7901875), I noticed that TestNG doesn't use classloaders added by TestNG::addClassLoader to load JUnit test classes and always uses the current classloader to load them. This makes usage of TestNG in jtreg test harness a bit cumbersome.

here is the excerpt from jtreg bug w/ more details:
-- JUnit uses o.j.runner.Description as a description for a test or test suite, this class doesn’t store a reference to a test class, but has getTestClass method to return it. getTestClass assumes that the test class is accessible for JUnit’s classloader 
 -- if Description::getTestClass does not found a class, it returns null 
 -- from what I see, there is no code in JUnit which depends result of on Description::getTestClass 
 -- the guy who creates Description has a reference to the test class, so it’s possible to pass that reference to Description and it looks like it’s fixed in new version of junit[1] 
 - for all o.j.r.notification.RunNotifier method which gets o.j.runner.Description instance, o.t.j.JUnit4TestRunner$RL uses it to create o.testng.ITestResult in createTestResult method and then passes ITestResult to actual listeners 
 -- o.t.j.JUnit4TestRunner$RL::createTestResult creates o.t.junit.JUnit4TestClass and JUnit4TestMethod instances using o.j.runner.Description 
 -- c-tor of both classes assume that o.j.runner.Description::getTestClass returns a reference, if it returns null, NPE will be thrown 
 -- TestNG has an aux class to deal w/ classloaders related problems — o.t.internal.ClassHelper, but o.t.junit.JUnit4TestClass / JUnit4TestMethod don't use it
 - when we run tests in agentvm mode, TestNG/JUnit and the runner(c.s.j.regtest.agent.TestNGRunner) are available for Application classloader and loaded by it, but tests are loaded by a classloader created in c.s.j.regtest.agent.MainActionHelper::runClass. thus test classes are unavailable for TestNG/JUnit classes, we get NPE at the very first invocation of o.t.j.JUnit4TestRunner$RL