### PR TITLE
Fixed NPE when suite does not contain started tests.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,6 @@
 Current
-Fixed: GITHUB-1931: [NPE] Reporter org.testng.reporters.jq.Main failed (Oleg Shaburov)
 Fixed: GITHUB-1935: Wrong text for assertEquals (Krishnan Mahadevan)
-Fixed: GITHUB-1931: [NPE] Reporter org.testng.reporters.jq.Main failed (Krishnan Mahadevan)
+Fixed: GITHUB-1931: [NPE] Reporter org.testng.reporters.jq.Main failed (Krishnan Mahadevan, Oleg Shaburov)
 New: Remove raw type warnings in ConversionUtils
 Fixed: GITHUB-1480: Parallel=methods not working when tests have different priorities set (Micah Lapping-Carr)
 Fixed: GITHUB-1041: Factory data-provider parameters not displayed in test-result (Krishnan Mahadevan)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-1931: [NPE] Reporter org.testng.reporters.jq.Main failed (Oleg Shaburov)
 Fixed: GITHUB-1931: [NPE] Reporter org.testng.reporters.jq.Main failed (Krishnan Mahadevan)
 New: Remove raw type warnings in ConversionUtils
 Fixed: GITHUB-1480: Parallel=methods not working when tests have different priorities set (Micah Lapping-Carr)

--- a/src/main/java/org/testng/reporters/jq/TimesPanel.java
+++ b/src/main/java/org/testng/reporters/jq/TimesPanel.java
@@ -120,8 +120,13 @@ public class TimesPanel extends BaseMultiSuitePanel {
 
   private long maxTime(ISuite suite) {
     boolean testsInParallel = XmlSuite.ParallelMode.TESTS.equals(suite.getXmlSuite().getParallel());
+    Long result = m_totalTime.get(suite.getName());
+    // there are no running tests in the suite
+    if (result == null) {
+      return 0L;
+    }
     if (! testsInParallel) {
-      return m_totalTime.get(suite.getName());
+      return result;
     }
     Optional<ITestContext> maxValue = suite.getResults().values().stream()
         .map(ISuiteResult::getTestContext)
@@ -129,7 +134,7 @@ public class TimesPanel extends BaseMultiSuitePanel {
     if (maxValue.isPresent()) {
       return time(maxValue.get());
     }
-    return m_totalTime.get(suite.getName());
+    return result;
   }
 
   private static Long time(ITestContext ctx) {

--- a/src/test/java/org/testng/reporters/jq/TimesPanelTest.java
+++ b/src/test/java/org/testng/reporters/jq/TimesPanelTest.java
@@ -4,40 +4,30 @@ import org.testng.ISuite;
 import org.testng.annotations.Test;
 import org.testng.internal.paramhandler.FakeSuite;
 import org.testng.reporters.XMLStringBuffer;
-import org.testng.xml.XmlClass;
-import org.testng.xml.XmlSuite;
 import org.testng.xml.XmlTest;
+import test.SimpleBaseTest;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.testng.AssertJUnit.assertTrue;
 
-/**
- * Created by Oleg Shaburov on 28.10.2018
- * shaburov.o.a@gmail.com
- */
-public class TimesPanelTest {
+public class TimesPanelTest extends SimpleBaseTest {
 
     private static final String GITHUB_1931 = "GITHUB-1931 [NPE] TimesPanel.maxTime(ISuite suite)";
 
     @Test(description = GITHUB_1931)
     public void generateReportTimesPanelContentForSuiteWithoutStartedTests() {
-        XmlSuite xmlSuite = new XmlSuite();
-        xmlSuite.setName("GITHUB_1931");
-        XmlTest xmlTest = new XmlTest(xmlSuite);
-        List<XmlClass> xmlClasses = new ArrayList<>();
-        xmlClasses.add(new XmlClass(Object.class));
-        xmlTest.setXmlClasses(xmlClasses);
+        XmlTest xmlTest = createXmlTest("GITHUB_1931", "NPE", Object.class);
         ISuite iSuite = new FakeSuite(xmlTest);
         List<ISuite> suites = new ArrayList<>();
+        suites.add(iSuite);
         Model model = new Model(suites);
-        XMLStringBuffer buffer = new XMLStringBuffer();
-
         TimesPanel panel = new TimesPanel(model);
+        XMLStringBuffer buffer = new XMLStringBuffer();
         panel.getContent(iSuite, buffer);
-        assertThat(panel.getContent(iSuite, buffer), containsString("Total running time: 0 ms"));
+        assertTrue("TimesPanel contains total running time",
+                panel.getContent(iSuite, buffer).contains("Total running time: 0 ms"));
     }
 
 }

--- a/src/test/java/org/testng/reporters/jq/TimesPanelTest.java
+++ b/src/test/java/org/testng/reporters/jq/TimesPanelTest.java
@@ -1,0 +1,43 @@
+package org.testng.reporters.jq;
+
+import org.testng.ISuite;
+import org.testng.annotations.Test;
+import org.testng.internal.paramhandler.FakeSuite;
+import org.testng.reporters.XMLStringBuffer;
+import org.testng.xml.XmlClass;
+import org.testng.xml.XmlSuite;
+import org.testng.xml.XmlTest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Created by Oleg Shaburov on 28.10.2018
+ * shaburov.o.a@gmail.com
+ */
+public class TimesPanelTest {
+
+    private static final String GITHUB_1931 = "GITHUB-1931 [NPE] TimesPanel.maxTime(ISuite suite)";
+
+    @Test(description = GITHUB_1931)
+    public void generateReportTimesPanelContentForSuiteWithoutStartedTests() {
+        XmlSuite xmlSuite = new XmlSuite();
+        xmlSuite.setName("GITHUB_1931");
+        XmlTest xmlTest = new XmlTest(xmlSuite);
+        List<XmlClass> xmlClasses = new ArrayList<>();
+        xmlClasses.add(new XmlClass(Object.class));
+        xmlTest.setXmlClasses(xmlClasses);
+        ISuite iSuite = new FakeSuite(xmlTest);
+        List<ISuite> suites = new ArrayList<>();
+        Model model = new Model(suites);
+        XMLStringBuffer buffer = new XMLStringBuffer();
+
+        TimesPanel panel = new TimesPanel(model);
+        panel.getContent(iSuite, buffer);
+        assertThat(panel.getContent(iSuite, buffer), containsString("Total running time: 0 ms"));
+    }
+
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -732,6 +732,12 @@
     </classes>
   </test>
 
+  <test name="Reporters">
+    <classes>
+      <class name="org.testng.reporters.jq.TimesPanelTest" />
+    </classes>
+  </test>
+
   <test name="Invoker">
     <classes>
       <class name="test.groupinvocation.InvokerTest"/>


### PR DESCRIPTION
The error of converting a Long object to a long primitive if the Map does not contain an object.
Fixes #1931
Closes #1931

- [x] Add test case(s)
- [x] Update `CHANGES.txt`

Fix bugs in TestNG