### PR TITLE
Streamline test-class instantiation

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-1924: Testclass instantiation fails when both no-arg constructor and factory method present (Krishnan Mahadevan)
 Fixed: GITHUB-1935: Wrong text for assertEquals (Krishnan Mahadevan)
 Fixed: GITHUB-1931: [NPE] Reporter org.testng.reporters.jq.Main failed (Krishnan Mahadevan, Oleg Shaburov)
 New: Remove raw type warnings in ConversionUtils

--- a/src/main/java/org/testng/internal/ClassImpl.java
+++ b/src/main/java/org/testng/internal/ClassImpl.java
@@ -184,14 +184,14 @@ public class ClassImpl implements IClass {
                   create)
             };
       }
+    }
+    if (m_instances.size() > 0) {
+      result = m_instances.toArray(new Object[0]);
     } else {
       Object defaultInstance = getDefaultInstance(create);
       if (defaultInstance != null) {
         result = new Object[] {defaultInstance};
       }
-    }
-    if (m_instances.size() > 0) {
-      result = m_instances.toArray(new Object[0]);
     }
 
     int m_instanceCount = m_instances.size();

--- a/src/test/java/test/factory/issue1924/IssueTest.java
+++ b/src/test/java/test/factory/issue1924/IssueTest.java
@@ -1,0 +1,23 @@
+package test.factory.issue1924;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.testng.TestNG;
+import org.testng.annotations.Test;
+import test.SimpleBaseTest;
+
+public class IssueTest extends SimpleBaseTest {
+
+  @Test
+  public void ensureTestClassInstantiationWorksWhenFactoryMethodAndCustomConstructorPresent() {
+    TestNG testng = create(TestclassSample.class);
+    testng.setVerbose(2);
+    testng.run();
+    List<String> expected = Arrays.asList("1", "2");
+    assertThat(TestclassSample.logs).containsExactlyInAnyOrderElementsOf(expected);
+  }
+
+}

--- a/src/test/java/test/factory/issue1924/TestclassSample.java
+++ b/src/test/java/test/factory/issue1924/TestclassSample.java
@@ -1,0 +1,30 @@
+package test.factory.issue1924;
+
+import java.util.List;
+import org.testng.Reporter;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+import org.testng.collections.Lists;
+
+public class TestclassSample {
+  public static List<String> logs = Lists.newArrayList();
+
+  private int i;
+
+  public TestclassSample(int i) {
+    this.i = i;
+  }
+
+  @Factory
+  public static Object[] produce() {
+    return new Object[]{
+        new TestclassSample(1),
+        new TestclassSample(2)
+    };
+  }
+
+  @Test
+  public void testMethod() {
+    logs.add(Integer.toString(this.i));
+  }
+}

--- a/src/test/java/test/priority/PriorityTest.java
+++ b/src/test/java/test/priority/PriorityTest.java
@@ -1,8 +1,7 @@
 package test.priority;
 
 import java.util.stream.Collectors;
-import org.assertj.core.api.Assertions;
-import org.testng.Assert;
+import static org.assertj.core.api.Assertions.assertThat;
 import org.testng.TestNG;
 import org.testng.annotations.Test;
 import org.testng.xml.XmlSuite;
@@ -23,7 +22,12 @@ public class PriorityTest extends SimpleBaseTest {
       tng.setParallel(XmlSuite.ParallelMode.METHODS);
     }
     tng.run();
-    Assert.assertEquals(listener.getInvokedMethodNames().toArray(), methods);
+    if (parallel) {
+      //If tests are being executed in parallel, then order of methods is non-deterministic.
+      assertThat(listener.getInvokedMethodNames()).containsExactlyInAnyOrder(methods);
+    } else {
+      assertThat(listener.getInvokedMethodNames()).containsExactly(methods);
+    }
   }
 
   @Test(enabled = false, description = "Make sure priorities work in parallel mode")
@@ -71,7 +75,7 @@ public class PriorityTest extends SimpleBaseTest {
         .stream()
         .filter(each -> !allSkipped.contains(each))
         .collect(Collectors.toList());
-    Assertions.assertThat(actual).containsExactlyElementsOf(expected);
+    assertThat(actual).containsExactlyElementsOf(expected);
   }
 
 }

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -181,6 +181,7 @@
       <class name="test.github1461.MemoryLeakTestNg" />
       <!-- TODO fix the random issue <class name="test.issue565.Issue565Test"/>-->
       <class name="test.factory.issue1041.IssueTest"/>
+      <class name="test.factory.issue1924.IssueTest"/>
       <class name="test.factory.github328.GitHub328Test" />
       <class name="test.factory.issue1745.Github1745Test"/>
       <class name="test.objectfactory.github1827.GitHub1827Test"/>


### PR DESCRIPTION
Closes #1924

Ensure test class gets instantiated even when 
there is both a factory method and a non default 
constructor is present.

Fixes #1924  .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
