### PR TITLE
Streamline error reporting for Factory methods

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-1953: TestNG throws a misleading error when @Factory method returns empty array. (Krishnan Mahadevan)
 Fixed: GITHUB-1946: Retry analyzer does not work properly when coupled with a data provider (Krishnan Mahadevan)
 Fixed: GITHUB-1924: Testclass instantiation fails when both no-arg constructor and factory method present (Krishnan Mahadevan)
 Fixed: GITHUB-1935: Wrong text for assertEquals (Krishnan Mahadevan)

--- a/src/main/java/org/testng/IClass.java
+++ b/src/main/java/org/testng/IClass.java
@@ -30,6 +30,10 @@ public interface IClass {
    */
   Object[] getInstances(boolean create);
 
+  default Object[] getInstances(boolean create, String errorMsgPrefix) {
+    return getInstances(create);
+  }
+
   long[] getInstanceHashCodes();
 
   void addInstance(Object instance);

--- a/src/main/java/org/testng/TestClass.java
+++ b/src/main/java/org/testng/TestClass.java
@@ -24,6 +24,7 @@ class TestClass extends NoOpTestClass implements ITestClass {
   private String testName;
   private XmlTest xmlTest;
   private XmlClass xmlClass;
+  private String m_errorMsgPrefix;
 
   private static final Logger LOG = Logger.getLogger(TestClass.class);
 
@@ -32,7 +33,9 @@ class TestClass extends NoOpTestClass implements ITestClass {
       ITestMethodFinder testMethodFinder,
       IAnnotationFinder annotationFinder,
       XmlTest xmlTest,
-      XmlClass xmlClass) {
+      XmlClass xmlClass,
+      String errorMsgPrefix) {
+    this.m_errorMsgPrefix = errorMsgPrefix;
     init(cls, testMethodFinder, annotationFinder, xmlTest, xmlClass);
   }
 
@@ -76,7 +79,7 @@ class TestClass extends NoOpTestClass implements ITestClass {
     //
     // TestClasses and instances
     //
-    Object[] instances = getInstances(true);
+    Object[] instances = getInstances(true, this.m_errorMsgPrefix);
     for (Object instance : instances) {
       instance = IParameterInfo.embeddedInstance(instance);
       if (instance instanceof ITest) {
@@ -92,6 +95,11 @@ class TestClass extends NoOpTestClass implements ITestClass {
   @Override
   public Object[] getInstances(boolean create) {
     return iClass.getInstances(create);
+  }
+
+  @Override
+  public Object[] getInstances(boolean create, String errorMsgPrefix) {
+    return iClass.getInstances(create, this.m_errorMsgPrefix);
   }
 
   @Override

--- a/src/main/java/org/testng/TestRunner.java
+++ b/src/main/java/org/testng/TestRunner.java
@@ -32,6 +32,7 @@ import org.testng.internal.GroupsHelper;
 import org.testng.internal.IConfiguration;
 import org.testng.internal.IInvoker;
 import org.testng.internal.ITestResultNotifier;
+import org.testng.internal.InstanceCreator;
 import org.testng.internal.InvokedMethod;
 import org.testng.internal.Invoker;
 import org.testng.internal.TestMethodComparator;
@@ -417,7 +418,7 @@ public class TestRunner
     if (null != xmlTest.getMethodSelectors()) {
       for (org.testng.xml.XmlMethodSelector selector : xmlTest.getMethodSelectors()) {
         if (selector.getClassName() != null) {
-          IMethodSelector s = ClassHelper.createSelector(selector);
+          IMethodSelector s = InstanceCreator.createSelector(selector);
 
           m_runInfo.addMethodSelector(s, selector.getPriority());
         }
@@ -461,7 +462,7 @@ public class TestRunner
               testMethodFinder,
               m_annotationFinder,
               m_xmlTest,
-              classMap.getXmlClass(ic.getRealClass()));
+              classMap.getXmlClass(ic.getRealClass()), m_testClassFinder.getFactoryCreationFailedMessage());
       m_classMap.put(ic.getRealClass(), tc);
     }
 
@@ -648,7 +649,7 @@ public class TestRunner
               for (XmlInclude inc : includedMethods) {
                 methods.add(inc.getName());
               }
-              IJUnitTestRunner tr = ClassHelper.createTestRunner(TestRunner.this);
+              IJUnitTestRunner tr = IJUnitTestRunner.createTestRunner(TestRunner.this);
               tr.setInvokedMethodListeners(m_invokedMethodListeners);
               try {
                 tr.run(tc, methods.toArray(new String[0]));

--- a/src/main/java/org/testng/internal/ClassHelper.java
+++ b/src/main/java/org/testng/internal/ClassHelper.java
@@ -3,7 +3,6 @@ package org.testng.internal;
 import org.testng.IClass;
 import org.testng.IMethodSelector;
 import org.testng.IObjectFactory;
-import org.testng.IObjectFactory2;
 import org.testng.ITestObjectFactory;
 import org.testng.TestNGException;
 import org.testng.TestRunner;
@@ -20,7 +19,6 @@ import org.testng.xml.XmlSuite;
 import org.testng.xml.XmlTest;
 
 import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
@@ -32,13 +30,10 @@ import java.util.Vector;
 
 /** Utility class for different class manipulations. */
 public final class ClassHelper {
-  private static final String JUNIT_TESTRUNNER = "org.testng.junit.JUnitTestRunner";
-  private static final String JUNIT_4_TESTRUNNER = "org.testng.junit.JUnit4TestRunner";
 
   /** The additional class loaders to find classes in. */
   private static final List<ClassLoader> classLoaders = new Vector<>();
 
-  private static final String CANNOT_INSTANTIATE_CLASS = "Cannot instantiate class ";
   private static final String CLASS_HELPER = ClassHelper.class.getSimpleName();
 
   /**
@@ -60,36 +55,28 @@ public final class ClassHelper {
     classLoaders.add(loader);
   }
 
+  /**
+   * @deprecated - This method is deprecated as of TestNG 7.0.0
+   */
+  @Deprecated
   public static <T> T newInstance(Class<T> clazz) {
-    try {
-      return clazz.newInstance();
-    } catch (IllegalAccessException
-        | InstantiationException
-        | ExceptionInInitializerError
-        | SecurityException
-        | NullPointerException e) {
-      throw new TestNGException(CANNOT_INSTANTIATE_CLASS + clazz.getName(), e);
-    }
+    return InstanceCreator.newInstance(clazz);
   }
 
+  /**
+   * @deprecated - This method is deprecated as of TestNG 7.0.0
+   */
+  @Deprecated
   public static <T> T newInstanceOrNull(Class<T> clazz) {
-    try {
-      Constructor<T> constructor = clazz.getConstructor();
-      return newInstance(constructor);
-    } catch (ExceptionInInitializerError | SecurityException e) {
-      throw new TestNGException(CANNOT_INSTANTIATE_CLASS + clazz.getName(), e);
-    } catch (NoSuchMethodException e) {
-      return null;
-    }
+    return InstanceCreator.newInstanceOrNull(clazz);
   }
 
+  /**
+   * @deprecated - This method is deprecated as of TestNG 7.0.0
+   */
+  @Deprecated
   public static <T> T newInstance(Constructor<T> constructor, Object... parameters) {
-    try {
-      return constructor.newInstance(parameters);
-    } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
-      throw new TestNGException(
-          CANNOT_INSTANTIATE_CLASS + constructor.getDeclaringClass().getName(), e);
-    }
+    return InstanceCreator.newInstance(constructor, parameters);
   }
 
   /**
@@ -149,6 +136,9 @@ public final class ClassHelper {
    * @param finder The finder (JDK 1.4 or JDK 5.0+) use to search for the annotation.
    * @return the @Factory <CODE>methods</CODE>
    */
+  //Code smell: The javadocs for this method says that if more than one Factory method is found
+  //an exception is thrown. But the method is not doing that. This needs more investigation for
+  //regression side effects before being addressed.
   public static List<ConstructorOrMethod> findDeclaredFactoryMethods(
       Class<?> cls, IAnnotationFinder finder) {
     List<ConstructorOrMethod> result = new ArrayList<>();
@@ -208,33 +198,12 @@ public final class ClassHelper {
     return returnValue;
   }
 
+  /**
+   * @deprecated - This method is deprecated as of TestNG 7.0.0
+   */
+  @Deprecated
   public static IJUnitTestRunner createTestRunner(TestRunner runner) {
-    IJUnitTestRunner tr = null;
-    try {
-      // try to get runner for JUnit 4 first
-      Class.forName("org.junit.Test");
-      Class<?> clazz = ClassHelper.forName(JUNIT_4_TESTRUNNER);
-      if (clazz != null) {
-        tr = (IJUnitTestRunner) clazz.newInstance();
-        tr.setTestResultNotifier(runner);
-      }
-    } catch (Throwable t) {
-      Utils.log(CLASS_HELPER, 2, "JUnit 4 was not found on the classpath");
-      try {
-        // fallback to JUnit 3
-        Class.forName("junit.framework.Test");
-        Class<?> clazz = ClassHelper.forName(JUNIT_TESTRUNNER);
-        if (clazz != null) {
-          tr = (IJUnitTestRunner) clazz.newInstance();
-          tr.setTestResultNotifier(runner);
-        }
-      } catch (Exception ex) {
-        Utils.log(CLASS_HELPER, 2, "JUnit 3 was not found on the classpath");
-        // there's no JUnit on the classpath
-        throw new TestNGException("Cannot create JUnit runner", ex);
-      }
-    }
-    return tr;
+    return IJUnitTestRunner.createTestRunner(runner);
   }
 
   private static void appendMethod(Map<String, Set<Method>> methods, Method declaredMethod) {
@@ -314,38 +283,33 @@ public final class ClassHelper {
     return false;
   }
 
+  /**
+   * @deprecated - This method is deprecated as of TestNG 7.0.0
+   */
+  @Deprecated
   public static IMethodSelector createSelector(org.testng.xml.XmlMethodSelector selector) {
-    try {
-      Class<?> cls = Class.forName(selector.getClassName());
-      return (IMethodSelector) cls.newInstance();
-    } catch (Exception ex) {
-      throw new TestNGException("Couldn't find method selector : " + selector.getClassName(), ex);
-    }
+    return InstanceCreator.createSelector(selector);
   }
 
-  /** Create an instance for the given class. */
+  /**
+   * Create an instance for the given class.
+   * @deprecated - This method is deprecated as of TestNG 7.0.0
+   */
+  @Deprecated
   public static Object createInstance(
       Class<?> declaringClass,
       Map<Class<?>, IClass> classes,
       XmlTest xmlTest,
       IAnnotationFinder finder,
       ITestObjectFactory objectFactory,
-      boolean create
-  ) {
-    if (objectFactory instanceof IObjectFactory) {
-      return createInstance1(
-          declaringClass, classes, xmlTest, finder, (IObjectFactory) objectFactory, create);
-    } else if (objectFactory instanceof IObjectFactory2) {
-      return createInstance2(declaringClass, (IObjectFactory2) objectFactory);
-    } else {
-      throw new AssertionError("Unknown object factory type:" + objectFactory);
-    }
+      boolean create) {
+    return InstanceCreator.createInstance(declaringClass, classes, xmlTest, finder, objectFactory, create, "");
   }
 
-  private static Object createInstance2(Class<?> declaringClass, IObjectFactory2 objectFactory) {
-    return objectFactory.newInstance(declaringClass);
-  }
-
+  /**
+   * @deprecated - This method is deprecated as of TestNG 7.0.0
+   */
+  @Deprecated
   public static Object createInstance1(
       Class<?> declaringClass,
       Map<Class<?>, IClass> classes,
@@ -354,117 +318,11 @@ public final class ClassHelper {
       IObjectFactory factory,
       boolean create
   ) {
-    Object result = null;
-
-    try {
-      Constructor<?> constructor = findAnnotatedConstructor(finder, declaringClass);
-      if (null != constructor) {
-      // Any annotated constructor?
-        try {
-          result = instantiateUsingParameterizedConstructor(finder, constructor, xmlTest, factory);
-        } catch(IllegalArgumentException e) {
-          return null;
-        }
-      } else {
-        // No, just try to instantiate the parameterless constructor (or the one with a String)
-        result = instantiateUsingDefaultConstructor(declaringClass, classes, xmlTest, factory);
-      }
-    } catch (TestNGException ex) {
-      throw ex;
-    } catch (NoSuchMethodException ex) {
-      // Empty catch block
-    } catch (Throwable cause) {
-      // Something else went wrong when running the constructor
-      throw new TestNGException(
-          "An error occurred while instantiating class "
-              + declaringClass.getName() + ": " + cause.getMessage(), cause);
-    }
-
-    if (result == null && create) {
-      String suffix = "instantiated";
-      if (!Modifier.isPublic(declaringClass.getModifiers())) {
-        suffix += "/accessed.";
-      }
-      throw new TestNGException("An error occurred while instantiating class " + declaringClass.getName() + ". "
-              + "Check to make sure it can be " + suffix);
-    }
-
-    return result;
-  }
-
-  private static Object instantiateUsingParameterizedConstructor(IAnnotationFinder finder,
-      Constructor<?> constructor, XmlTest xmlTest, IObjectFactory objectFactory) {
-    IFactoryAnnotation factoryAnnotation = finder
-        .findAnnotation(constructor, IFactoryAnnotation.class);
-    if (factoryAnnotation != null) {
-      throw new IllegalArgumentException("No factory annotation found.");
-    }
-
-    IParametersAnnotation parametersAnnotation =
-        finder.findAnnotation(constructor, IParametersAnnotation.class);
-    if (parametersAnnotation == null) {
-      // null if the annotation is @Factory
-      return null;
-    }
-    String[] parameterNames = parametersAnnotation.getValue();
-    Object[] parameters =
-        Parameters.createInstantiationParameters(
-            constructor,
-            "@Parameters",
-            finder,
-            parameterNames,
-            xmlTest.getAllParameters(),
-            xmlTest.getSuite());
-    return objectFactory.newInstance(constructor, parameters);
-  }
-
-
-  private static Object instantiateUsingDefaultConstructor(Class<?> declaringClass,
-      Map<Class<?>, IClass> classes, XmlTest xmlTest, IObjectFactory factory)
-      throws NoSuchMethodException, IllegalAccessException, InstantiationException {
-    // If this class is a (non-static) nested class, the constructor contains a hidden
-    // parameter of the type of the enclosing class
-    Class<?>[] parameterTypes = new Class[0];
-    Object[] parameters = new Object[0];
-    Class<?> ec = declaringClass.getEnclosingClass();
-    boolean isStatic = 0 != (declaringClass.getModifiers() & Modifier.STATIC);
-
-    // Only add the extra parameter if the nested class is not static
-    if ((null != ec) && !isStatic) {
-      parameterTypes = new Class[] {ec};
-      parameters = new Object[]{computeParameters(classes, ec, factory)};
-    } // isStatic
-
-    Constructor<?> ct;
-    try {
-      ct = declaringClass.getDeclaredConstructor(parameterTypes);
-    } catch (NoSuchMethodException ex) {
-      ct = declaringClass.getDeclaredConstructor(String.class);
-      parameters = new Object[]{xmlTest.getName()};
-      // If ct == null here, we'll pass a null
-      // constructor to the factory and hope it can deal with it
-    }
-    return factory.newInstance(ct, parameters);
-  }
-
-  private static Object computeParameters(Map<Class<?>, IClass> classes,
-      Class<?> ec, IObjectFactory factory)
-      throws NoSuchMethodException, IllegalAccessException, InstantiationException {
-    // Create an instance of the enclosing class so we can instantiate
-    // the nested class (actually, we reuse the existing instance).
-    IClass enclosingIClass = classes.get(ec);
-    if (enclosingIClass == null) {
-      return ec.newInstance();
-    }
-    Object[] enclosingInstances = enclosingIClass.getInstances(false);
-    if (enclosingInstances == null || enclosingInstances.length == 0) {
-      return factory.newInstance(ec.getConstructor(ec));
-    }
-    return enclosingInstances[0];
+    return InstanceCreator.createInstanceUsingObjectFactory(declaringClass, classes, xmlTest, finder, factory, create, "");
   }
 
   /** Find the best constructor given the parameters found on the annotation */
-  private static Constructor<?> findAnnotatedConstructor(
+  static Constructor<?> findAnnotatedConstructor(
       IAnnotationFinder finder, Class<?> declaringClass) {
     Constructor<?>[] constructors = declaringClass.getDeclaredConstructors();
 

--- a/src/main/java/org/testng/internal/ClassImpl.java
+++ b/src/main/java/org/testng/internal/ClassImpl.java
@@ -96,7 +96,7 @@ public class ClassImpl implements IClass {
     return m_xmlClass;
   }
 
-  private Object getDefaultInstance(boolean create) {
+  private Object getDefaultInstance(boolean create, String errMsgPrefix) {
     if (m_defaultInstance == null) {
       if (m_instance != null) {
         m_defaultInstance = m_instance;
@@ -107,13 +107,13 @@ public class ClassImpl implements IClass {
           m_defaultInstance = instance;
         } else {
           m_defaultInstance =
-              ClassHelper.createInstance(
+              InstanceCreator.createInstance(
                   m_class,
                   m_classes,
                   m_testContext.getCurrentXmlTest(),
                   m_annotationFinder,
                   m_objectFactory,
-                  create);
+                  create, errMsgPrefix);
         }
       }
     }
@@ -161,34 +161,39 @@ public class ClassImpl implements IClass {
   private Module newModule(Class<Module> module) {
     try {
       Constructor<Module> moduleConstructor = module.getDeclaredConstructor(ITestContext.class);
-      return ClassHelper.newInstance(moduleConstructor, m_testContext);
+      return InstanceCreator.newInstance(moduleConstructor, m_testContext);
     } catch (NoSuchMethodException e) {
-      return ClassHelper.newInstance(module);
+      return InstanceCreator.newInstance(module);
     }
   }
 
   @Override
   public Object[] getInstances(boolean create) {
+    return getInstances(create, "");
+  }
+
+  @Override
+  public Object[] getInstances(boolean create, String errorMsgPrefix) {
     Object[] result = {};
 
     if (m_testContext.getCurrentXmlTest().isJUnit()) {
       if (create) {
         result =
             new Object[] {
-              ClassHelper.createInstance(
-                  m_class,
-                  m_classes,
-                  m_testContext.getCurrentXmlTest(),
-                  m_annotationFinder,
-                  m_objectFactory,
-                  create)
+                InstanceCreator.createInstance(
+                    m_class,
+                    m_classes,
+                    m_testContext.getCurrentXmlTest(),
+                    m_annotationFinder,
+                    m_objectFactory,
+                    create, errorMsgPrefix)
             };
       }
     }
     if (m_instances.size() > 0) {
       result = m_instances.toArray(new Object[0]);
     } else {
-      Object defaultInstance = getDefaultInstance(create);
+      Object defaultInstance = getDefaultInstance(create, errorMsgPrefix);
       if (defaultInstance != null) {
         result = new Object[] {defaultInstance};
       }

--- a/src/main/java/org/testng/internal/InstanceCreator.java
+++ b/src/main/java/org/testng/internal/InstanceCreator.java
@@ -1,0 +1,212 @@
+package org.testng.internal;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
+import java.util.Map;
+import org.testng.IClass;
+import org.testng.IMethodSelector;
+import org.testng.IObjectFactory;
+import org.testng.IObjectFactory2;
+import org.testng.ITestObjectFactory;
+import org.testng.TestNGException;
+import org.testng.annotations.IFactoryAnnotation;
+import org.testng.annotations.IParametersAnnotation;
+import org.testng.internal.annotations.IAnnotationFinder;
+import org.testng.util.Strings;
+import org.testng.xml.XmlTest;
+
+/** Utility class for object instantiations. */
+public final class InstanceCreator {
+
+  private static final String CANNOT_INSTANTIATE_CLASS = "Cannot instantiate class ";
+
+  private InstanceCreator() {
+    // Hide Constructor
+  }
+
+  public static <T> T newInstance(Class<T> clazz) {
+    try {
+      return clazz.newInstance();
+    } catch (IllegalAccessException
+        | InstantiationException
+        | ExceptionInInitializerError
+        | SecurityException
+        | NullPointerException e) {
+      throw new TestNGException(CANNOT_INSTANTIATE_CLASS + clazz.getName(), e);
+    }
+  }
+
+  public static <T> T newInstanceOrNull(Class<T> clazz) {
+    try {
+      Constructor<T> constructor = clazz.getConstructor();
+      return newInstance(constructor);
+    } catch (ExceptionInInitializerError | SecurityException e) {
+      throw new TestNGException(CANNOT_INSTANTIATE_CLASS + clazz.getName(), e);
+    } catch (NoSuchMethodException e) {
+      return null;
+    }
+  }
+
+  public static <T> T newInstance(Constructor<T> constructor, Object... parameters) {
+    try {
+      return constructor.newInstance(parameters);
+    } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+      throw new TestNGException(
+          CANNOT_INSTANTIATE_CLASS + constructor.getDeclaringClass().getName(), e);
+    }
+  }
+
+  public static IMethodSelector createSelector(org.testng.xml.XmlMethodSelector selector) {
+    try {
+      Class<?> cls = Class.forName(selector.getClassName());
+      return (IMethodSelector) cls.newInstance();
+    } catch (Exception ex) {
+      throw new TestNGException("Couldn't find method selector : " + selector.getClassName(), ex);
+    }
+  }
+
+  /** Create an instance for the given class. */
+  public static Object createInstance(
+      Class<?> declaringClass,
+      Map<Class<?>, IClass> classes,
+      XmlTest xmlTest,
+      IAnnotationFinder finder,
+      ITestObjectFactory objectFactory,
+      boolean create,
+      String errorMsgPrefix) {
+    if (objectFactory instanceof IObjectFactory) {
+      return createInstanceUsingObjectFactory(
+          declaringClass, classes, xmlTest, finder, (IObjectFactory) objectFactory, create, errorMsgPrefix);
+    } else if (objectFactory instanceof IObjectFactory2) {
+      return createInstanceUsingObjectFactory(declaringClass, (IObjectFactory2) objectFactory);
+    } else {
+      throw new AssertionError("Unknown object factory type:" + objectFactory);
+    }
+  }
+
+  private static Object createInstanceUsingObjectFactory(Class<?> declaringClass, IObjectFactory2 objectFactory) {
+    return objectFactory.newInstance(declaringClass);
+  }
+
+  public static Object createInstanceUsingObjectFactory(
+      Class<?> declaringClass,
+      Map<Class<?>, IClass> classes,
+      XmlTest xmlTest,
+      IAnnotationFinder finder,
+      IObjectFactory factory,
+      boolean create,
+      String errorMsgPrefix) {
+    Object result = null;
+
+    try {
+      Constructor<?> constructor = ClassHelper.findAnnotatedConstructor(finder, declaringClass);
+      if (null != constructor) {
+      // Any annotated constructor?
+        try {
+          result = instantiateUsingParameterizedConstructor(finder, constructor, xmlTest, factory);
+        } catch(IllegalArgumentException e) {
+          return null;
+        }
+      } else {
+        // No, just try to instantiate the parameterless constructor (or the one with a String)
+        result = instantiateUsingDefaultConstructor(declaringClass, classes, xmlTest, factory);
+      }
+    } catch (TestNGException ex) {
+      throw ex;
+    } catch (NoSuchMethodException ex) {
+      // Empty catch block
+    } catch (Throwable cause) {
+      // Something else went wrong when running the constructor
+      throw new TestNGException(
+          "An error occurred while instantiating class "
+              + declaringClass.getName() + ": " + cause.getMessage(), cause);
+    }
+
+    if (result == null && create) {
+      String suffix = "instantiated";
+      if (!Modifier.isPublic(declaringClass.getModifiers())) {
+        suffix += "/accessed.";
+      }
+      if (Strings.isNotNullAndNotEmpty(errorMsgPrefix)) {
+        suffix = suffix + ". Root cause: " + errorMsgPrefix;
+      }
+      throw new TestNGException("An error occurred while instantiating class " + declaringClass.getName() + ". "
+              + "Check to make sure it can be " + suffix);
+    }
+
+    return result;
+  }
+
+  private static Object instantiateUsingParameterizedConstructor(IAnnotationFinder finder,
+      Constructor<?> constructor, XmlTest xmlTest, IObjectFactory objectFactory) {
+    IFactoryAnnotation factoryAnnotation = finder
+        .findAnnotation(constructor, IFactoryAnnotation.class);
+    if (factoryAnnotation != null) {
+      throw new IllegalArgumentException("No factory annotation found.");
+    }
+
+    IParametersAnnotation parametersAnnotation =
+        finder.findAnnotation(constructor, IParametersAnnotation.class);
+    if (parametersAnnotation == null) {
+      // null if the annotation is @Factory
+      return null;
+    }
+    String[] parameterNames = parametersAnnotation.getValue();
+    Object[] parameters =
+        Parameters.createInstantiationParameters(
+            constructor,
+            "@Parameters",
+            finder,
+            parameterNames,
+            xmlTest.getAllParameters(),
+            xmlTest.getSuite());
+    return objectFactory.newInstance(constructor, parameters);
+  }
+
+
+  private static Object instantiateUsingDefaultConstructor(Class<?> declaringClass,
+      Map<Class<?>, IClass> classes, XmlTest xmlTest, IObjectFactory factory)
+      throws NoSuchMethodException, IllegalAccessException, InstantiationException {
+    // If this class is a (non-static) nested class, the constructor contains a hidden
+    // parameter of the type of the enclosing class
+    Class<?>[] parameterTypes = new Class[0];
+    Object[] parameters = new Object[0];
+    Class<?> ec = declaringClass.getEnclosingClass();
+    boolean isStatic = 0 != (declaringClass.getModifiers() & Modifier.STATIC);
+
+    // Only add the extra parameter if the nested class is not static
+    if ((null != ec) && !isStatic) {
+      parameterTypes = new Class[] {ec};
+      parameters = new Object[]{computeParameters(classes, ec, factory)};
+    } // isStatic
+
+    Constructor<?> ct;
+    try {
+      ct = declaringClass.getDeclaredConstructor(parameterTypes);
+    } catch (NoSuchMethodException ex) {
+      ct = declaringClass.getDeclaredConstructor(String.class);
+      parameters = new Object[]{xmlTest.getName()};
+      // If ct == null here, we'll pass a null
+      // constructor to the factory and hope it can deal with it
+    }
+    return factory.newInstance(ct, parameters);
+  }
+
+  private static Object computeParameters(Map<Class<?>, IClass> classes,
+      Class<?> ec, IObjectFactory factory)
+      throws NoSuchMethodException, IllegalAccessException, InstantiationException {
+    // Create an instance of the enclosing class so we can instantiate
+    // the nested class (actually, we reuse the existing instance).
+    IClass enclosingIClass = classes.get(ec);
+    if (enclosingIClass == null) {
+      return ec.newInstance();
+    }
+    Object[] enclosingInstances = enclosingIClass.getInstances(false);
+    if (enclosingInstances == null || enclosingInstances.length == 0) {
+      return factory.newInstance(ec.getConstructor(ec));
+    }
+    return enclosingInstances[0];
+  }
+
+}

--- a/src/main/java/org/testng/internal/Parameters.java
+++ b/src/main/java/org/testng/internal/Parameters.java
@@ -679,14 +679,14 @@ public class Parameters {
           if (injector != null) {
             instanceToUse = injector.getInstance(dataProviderClass);
           } else {
-            instanceToUse = ClassHelper.newInstance(dataProviderClass);
+            instanceToUse = InstanceCreator.newInstance(dataProviderClass);
           }
         } else {
           instanceToUse = instance;
         }
         // Not a static method but no instance exists, then create new one if possible
         if ((m.getModifiers() & Modifier.STATIC) == 0 && instanceToUse == null) {
-          instanceToUse = ClassHelper.newInstanceOrNull(cls);
+          instanceToUse = InstanceCreator.newInstanceOrNull(cls);
         }
 
         if (result != null) {

--- a/src/main/java/org/testng/internal/TestNGClassFinder.java
+++ b/src/main/java/org/testng/internal/TestNGClassFinder.java
@@ -40,6 +40,12 @@ public class TestNGClassFinder extends BaseClassFinder {
   private final ITestObjectFactory objectFactory;
   private final IAnnotationFinder annotationFinder;
 
+  private String m_factoryCreationFailedMessage = null;
+
+  public String getFactoryCreationFailedMessage() {
+    return m_factoryCreationFailedMessage;
+  }
+
   public TestNGClassFinder(
       ClassInfoMap cim,
       Map<Class<?>, List<Object>> instanceMap,
@@ -197,6 +203,7 @@ public class TestNGClassFinder extends BaseClassFinder {
       }
       i++;
     }
+    this.m_factoryCreationFailedMessage = fm.getFactoryCreationFailedMessage();
     return moreClasses;
   }
 

--- a/src/main/java/org/testng/junit/IJUnitTestRunner.java
+++ b/src/main/java/org/testng/junit/IJUnitTestRunner.java
@@ -5,14 +5,21 @@ import java.util.List;
 
 import org.testng.IInvokedMethodListener;
 import org.testng.ITestNGMethod;
+import org.testng.TestNGException;
+import org.testng.TestRunner;
+import org.testng.internal.ClassHelper;
 import org.testng.internal.ITestResultNotifier;
+import org.testng.internal.Utils;
 
 /**
  * An abstraction interface over JUnit test runners.
  *
- * @author <a href='mailto:the_mindstorm@evolva.ro'>Alexandru Popescu</a>
  */
 public interface IJUnitTestRunner {
+
+  String JUNIT_TESTRUNNER = "org.testng.junit.JUnitTestRunner";
+  String JUNIT_4_TESTRUNNER = "org.testng.junit.JUnit4TestRunner";
+
 
   void setInvokedMethodListeners(Collection<IInvokedMethodListener> listener);
 
@@ -21,4 +28,33 @@ public interface IJUnitTestRunner {
   void run(Class junitTestClass, String... methods);
 
   List<ITestNGMethod> getTestMethods();
+
+  static IJUnitTestRunner createTestRunner(TestRunner runner) {
+    IJUnitTestRunner tr = null;
+    try {
+      // try to get runner for JUnit 4 first
+      Class.forName("org.junit.Test");
+      Class<?> clazz = ClassHelper.forName(JUNIT_4_TESTRUNNER);
+      if (clazz != null) {
+        tr = (IJUnitTestRunner) clazz.newInstance();
+        tr.setTestResultNotifier(runner);
+      }
+    } catch (Throwable t) {
+      Utils.log(IJUnitTestRunner.class.getSimpleName(), 2, "JUnit 4 was not found on the classpath");
+      try {
+        // fallback to JUnit 3
+        Class.forName("junit.framework.Test");
+        Class<?> clazz = ClassHelper.forName(JUNIT_TESTRUNNER);
+        if (clazz != null) {
+          tr = (IJUnitTestRunner) clazz.newInstance();
+          tr.setTestResultNotifier(runner);
+        }
+      } catch (Exception ex) {
+        Utils.log(IJUnitTestRunner.class.getSimpleName(), 2, "JUnit 3 was not found on the classpath");
+        // there's no JUnit on the classpath
+        throw new TestNGException("Cannot create JUnit runner", ex);
+      }
+    }
+    return tr;
+  }
 }

--- a/src/test/java/test/factory/FactoryFailureNoInstancesSample.java
+++ b/src/test/java/test/factory/FactoryFailureNoInstancesSample.java
@@ -1,0 +1,20 @@
+package test.factory;
+
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+
+public class FactoryFailureNoInstancesSample {
+
+  public static final String METHOD_NAME = FactoryFailureNoInstancesSample.class.getName() + ".factory()";
+
+  public FactoryFailureNoInstancesSample(int i) {
+  }
+
+  @Factory
+  public static Object[] factory() {
+    return new Object[] {};
+  }
+
+  @Test
+  public void f() {}
+}

--- a/src/test/java/test/factory/FactoryFailureTest.java
+++ b/src/test/java/test/factory/FactoryFailureTest.java
@@ -1,6 +1,6 @@
 package test.factory;
 
-import org.testng.Assert;
+import static org.assertj.core.api.Assertions.assertThat;
 import org.testng.TestNG;
 import org.testng.annotations.Test;
 
@@ -11,12 +11,26 @@ public class FactoryFailureTest extends SimpleBaseTest {
   @Test
   public void factoryThrowingShouldNotRunTests() {
     TestNG tng = create(FactoryFailureSample.class);
-
+    Throwable actual = new Throwable();
     try {
       tng.run();
-      Assert.fail();
     } catch (Exception ex) {
-      // success
+      actual = ex;
     }
+    assertThat(actual.getCause()).hasCauseInstanceOf(NullPointerException.class);
+  }
+
+  @Test(description = "GITHUB-1953")
+  public void factoryProducesNoInstancesTest() {
+    TestNG tng = create(FactoryFailureNoInstancesSample.class);
+    String actualErr = "";
+    String expected = String.format("The Factory method %s should have produced at-least one instance.",
+        FactoryFailureNoInstancesSample.METHOD_NAME);
+    try {
+      tng.run();
+    } catch (Exception ex) {
+      actualErr = ex.getMessage();
+    }
+    assertThat(actualErr).contains(expected);
   }
 }


### PR DESCRIPTION
Closes #1953

Gist of changes:

* Provided a mechanism wherein when a factory method
fails to produce an instance, that info is rallied
downstream as an error message prefix, so that 
if TestNG fails at creating a test class instance 
the prefix could be used conditionally to inform 
the user the root cause of the failure.
This had to be done, because TestNG already has a 
behavior defined wherein “A method that's both a test 
and a factory would not invoke its data provider” via
the commit https://github.com/cbeust/testng/commit/c1022cce58a65c630cc7d9eea1392f871c9b64a2#diff-2759bd7092e219d3789d697004fb5fe4

* Also refactored ClassHelper and moved out object 
instantiation logic to its own class.

Fixes #1953 .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
