### PR TITLE
Refactor IConfigInvoker to use builder

### DIFF
--- a/src/main/java/org/testng/SuiteRunner.java
+++ b/src/main/java/org/testng/SuiteRunner.java
@@ -6,6 +6,8 @@ import org.testng.collections.Lists;
 import org.testng.collections.Maps;
 import org.testng.collections.Sets;
 import org.testng.internal.Attributes;
+import org.testng.internal.ConfigMethodAttributes;
+import org.testng.internal.ConfigMethodAttributes.Builder;
 import org.testng.internal.IConfiguration;
 import org.testng.internal.IInvoker;
 import org.testng.internal.Utils;
@@ -335,13 +337,12 @@ public class SuiteRunner implements ISuite, IInvokedMethodListener {
     //
     if (invoker != null) {
       if (!beforeSuiteMethods.values().isEmpty()) {
-        invoker.getConfigInvoker().invokeConfigurations(
-            null,
-            beforeSuiteMethods.values().toArray(new ITestNGMethod[0]),
-            xmlSuite,
-            xmlSuite.getParameters(),
-            null, /* no parameter values */
-            null /* instance */);
+        ConfigMethodAttributes attributes = new Builder()
+            .usingConfigMethodsAs(beforeSuiteMethods.values())
+            .forSuite(xmlSuite)
+            .usingParameters(xmlSuite.getParameters())
+            .build();
+        invoker.getConfigInvoker().invokeConfigurations(attributes);
       }
 
       Utils.log("SuiteRunner", 3, "Created " + testRunners.size() + " TestRunners");
@@ -360,13 +361,12 @@ public class SuiteRunner implements ISuite, IInvokedMethodListener {
       // Invoke afterSuite methods
       //
       if (!afterSuiteMethods.values().isEmpty()) {
-        invoker.getConfigInvoker().invokeConfigurations(
-            null,
-            afterSuiteMethods.values().toArray(new ITestNGMethod[0]),
-            xmlSuite,
-            xmlSuite.getAllParameters(),
-            null, /* no parameter values */
-            null /* instance */);
+        ConfigMethodAttributes attributes = new Builder()
+            .usingConfigMethodsAs(afterSuiteMethods.values())
+            .forSuite(xmlSuite)
+            .usingParameters(xmlSuite.getAllParameters())
+            .build();
+        invoker.getConfigInvoker().invokeConfigurations(attributes);
       }
     }
   }
@@ -553,7 +553,7 @@ public class SuiteRunner implements ISuite, IInvokedMethodListener {
     System.out.println("[SuiteRunner] " + s);
   }
 
-  /** The default implementation of {@link ITestRunnerFactory}. */
+  /** The default implementation of {@link ITestRunnerFactory2}. */
   private static class DefaultTestRunnerFactory implements ITestRunnerFactory2 {
     private ITestListener[] failureGenerators;
     private boolean useDefaultListeners;

--- a/src/main/java/org/testng/TestRunner.java
+++ b/src/main/java/org/testng/TestRunner.java
@@ -22,6 +22,8 @@ import org.testng.collections.Sets;
 import org.testng.internal.AbstractParallelWorker;
 import org.testng.internal.Attributes;
 import org.testng.internal.ClassInfoMap;
+import org.testng.internal.ConfigMethodAttributes;
+import org.testng.internal.ConfigMethodAttributes.Builder;
 import org.testng.internal.ConfigurationGroupMethods;
 import org.testng.internal.DefaultListenerFactory;
 import org.testng.internal.DynamicGraph;
@@ -612,13 +614,12 @@ public class TestRunner
     // invoke @BeforeTest
     ITestNGMethod[] testConfigurationMethods = getBeforeTestConfigurationMethods();
     if (null != testConfigurationMethods && testConfigurationMethods.length > 0) {
-      m_invoker.getConfigInvoker().invokeConfigurations(
-          null,
-          testConfigurationMethods,
-          m_xmlTest.getSuite(),
-          m_xmlTest.getAllParameters(),
-          null, /* no parameter values */
-          null /* instance */);
+      ConfigMethodAttributes attributes = new Builder()
+          .usingConfigMethodsAs(testConfigurationMethods)
+          .forSuite(m_xmlTest.getSuite())
+          .usingParameters(m_xmlTest.getAllParameters())
+          .build();
+      m_invoker.getConfigInvoker().invokeConfigurations(attributes);
     }
   }
 
@@ -846,13 +847,12 @@ public class TestRunner
     // invoke @AfterTest
     ITestNGMethod[] testConfigurationMethods = getAfterTestConfigurationMethods();
     if (null != testConfigurationMethods && testConfigurationMethods.length > 0) {
-      m_invoker.getConfigInvoker().invokeConfigurations(
-          null,
-          testConfigurationMethods,
-          m_xmlTest.getSuite(),
-          m_xmlTest.getAllParameters(),
-          null, /* no parameter values */
-          null /* instance */);
+      ConfigMethodAttributes attributes = new Builder()
+          .usingConfigMethodsAs(testConfigurationMethods)
+          .forSuite(m_xmlTest.getSuite())
+          .usingParameters(m_xmlTest.getAllParameters())
+          .build();
+      m_invoker.getConfigInvoker().invokeConfigurations(attributes);
     }
 
     //

--- a/src/main/java/org/testng/internal/ConfigMethodAttributes.java
+++ b/src/main/java/org/testng/internal/ConfigMethodAttributes.java
@@ -1,0 +1,134 @@
+package org.testng.internal;
+
+import java.util.Collection;
+import java.util.Map;
+import org.testng.IClass;
+import org.testng.ITestNGMethod;
+import org.testng.ITestResult;
+import org.testng.xml.XmlSuite;
+
+public class ConfigMethodAttributes {
+
+  private IClass testClass;
+  private final ITestNGMethod currentTestMethod;
+  private final ITestNGMethod[] allMethods;
+  private final XmlSuite suite;
+  private final Map<String, String> params;
+  private final Object[] parameterValues;
+  private final Object instance;
+  private final ITestResult testMethodResult;
+
+  private ConfigMethodAttributes(IClass testClass, ITestNGMethod currentTestMethod,
+      ITestNGMethod[] allMethods, XmlSuite suite, Map<String, String> params,
+      Object[] parameterValues, Object instance, ITestResult testMethodResult) {
+    this.testClass = testClass;
+    this.currentTestMethod = currentTestMethod;
+    this.allMethods = allMethods;
+    this.suite = suite;
+    this.params = params;
+    this.parameterValues = parameterValues;
+    this.instance = instance;
+    this.testMethodResult = testMethodResult;
+  }
+
+  public IClass getTestClass() {
+    return testClass;
+  }
+
+  public ITestNGMethod getTestMethod() {
+    return currentTestMethod;
+  }
+
+  public ITestNGMethod[] getConfigMethods() {
+    return allMethods;
+  }
+
+  public XmlSuite getSuite() {
+    return suite;
+  }
+
+  public Map<String, String> getParameters() {
+    return params;
+  }
+
+  public Object[] getParameterValues() {
+    return parameterValues;
+  }
+
+  public Object getInstance() {
+    return instance;
+  }
+
+  public ITestResult getTestMethodResult() {
+    return testMethodResult;
+  }
+
+  public void setTestClass(IClass testClass) {
+    this.testClass = testClass;
+  }
+
+
+  public static class Builder {
+
+    private IClass testClass;
+    private ITestNGMethod currentTestMethod;
+    private ITestNGMethod[] allMethods;
+    private XmlSuite suite;
+    private Map<String, String> params;
+    private Object[] parameterValues;
+    private Object instance;
+    private ITestResult testMethodResult;
+
+    public Builder forTestClass(IClass testClass) {
+      this.testClass = testClass;
+      return this;
+    }
+
+    public Builder forTestMethod(ITestNGMethod currentTestMethod) {
+      this.currentTestMethod = currentTestMethod;
+      return this;
+    }
+
+    public Builder usingConfigMethodsAs(ITestNGMethod[] allMethods) {
+      if (allMethods == null) {
+        allMethods = new ITestNGMethod[] {};
+      }
+      this.allMethods = allMethods;
+      return this;
+    }
+
+    public Builder usingConfigMethodsAs(Collection<ITestNGMethod> allMethods) {
+      return usingConfigMethodsAs(allMethods.toArray(new ITestNGMethod[0]));
+    }
+
+    public Builder forSuite(XmlSuite suite) {
+      this.suite = suite;
+      return this;
+    }
+
+    public Builder usingParameters(Map<String, String> params) {
+      this.params = params;
+      return this;
+    }
+
+    public Builder usingParameterValues(Object[] parameterValues) {
+      this.parameterValues = parameterValues;
+      return this;
+    }
+
+    public Builder usingInstance(Object instance) {
+      this.instance = instance;
+      return this;
+    }
+
+    public Builder withResult(ITestResult testMethodResult) {
+      this.testMethodResult = testMethodResult;
+      return this;
+    }
+
+    public ConfigMethodAttributes build() {
+      return new ConfigMethodAttributes(testClass, currentTestMethod, allMethods, suite, params,
+          parameterValues, instance, testMethodResult);
+    }
+  }
+}

--- a/src/main/java/org/testng/internal/IConfigInvoker.java
+++ b/src/main/java/org/testng/internal/IConfigInvoker.java
@@ -3,7 +3,6 @@ package org.testng.internal;
 import java.util.Map;
 import org.testng.IClass;
 import org.testng.ITestNGMethod;
-import org.testng.ITestResult;
 import org.testng.xml.XmlSuite;
 
 public interface IConfigInvoker {
@@ -25,23 +24,7 @@ public interface IConfigInvoker {
       Map<String, String> params,
       Object instance);
 
-  void invokeConfigurations(
-      IClass testClass,
-      ITestNGMethod[] allMethods,
-      XmlSuite suite,
-      Map<String, String> params,
-      Object[] parameterValues,
-      Object instance);
-
-  void invokeConfigurations(
-      IClass testClass,
-      ITestNGMethod currentTestMethod,
-      ITestNGMethod[] allMethods,
-      XmlSuite suite,
-      Map<String, String> params,
-      Object[] parameterValues,
-      Object instance,
-      ITestResult testMethodResult);
+  void invokeConfigurations(ConfigMethodAttributes configMethodAttributes);
 
 
 }

--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -13,7 +13,7 @@ import org.testng.ITestContext;
 import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
 import org.testng.SuiteRunState;
-import org.testng.collections.Lists;
+import org.testng.internal.ConfigMethodAttributes.Builder;
 import org.testng.internal.ITestInvoker.FailureContext;
 import org.testng.xml.XmlSuite;
 
@@ -76,8 +76,14 @@ public class Invoker implements IInvoker {
       Map<String, String> params,
       Object[] parameterValues,
       Object instance) {
-    m_configInvoker
-        .invokeConfigurations(testClass, allMethods, suite, params, parameterValues, instance);
+    ConfigMethodAttributes attributes = new Builder()
+        .forTestClass(testClass)
+        .usingConfigMethodsAs(allMethods)
+        .forSuite(suite).usingParameters(params)
+        .usingParameterValues(parameterValues)
+        .usingInstance(instance)
+        .build();
+    m_configInvoker.invokeConfigurations(attributes);
   }
 
   /**

--- a/src/main/java/org/testng/internal/TestInvoker.java
+++ b/src/main/java/org/testng/internal/TestInvoker.java
@@ -28,6 +28,7 @@ import org.testng.TestNGException;
 import org.testng.collections.Lists;
 import org.testng.collections.Maps;
 import org.testng.collections.Sets;
+import org.testng.internal.ConfigMethodAttributes.Builder;
 import org.testng.internal.InvokeMethodRunnable.TestNGRuntimeException;
 import org.testng.internal.ParameterHandler.ParameterBag;
 import org.testng.internal.thread.ThreadExecutionException;
@@ -638,8 +639,17 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
 
     ITestNGMethod[] setupConfigMethods =
         TestNgMethodUtils.filterSetupConfigurationMethods(tm, beforeMethods);
-    invoker.invokeConfigurations(
-        testClass, tm, setupConfigMethods, suite, params, parameterValues, instance, testResult);
+    ConfigMethodAttributes attributes = new Builder()
+        .forTestClass(testClass)
+        .forTestMethod(tm)
+        .usingConfigMethodsAs(setupConfigMethods)
+        .forSuite(suite)
+        .usingParameters(params)
+        .usingParameterValues(parameterValues)
+        .usingInstance(instance)
+        .withResult(testResult)
+        .build();
+    invoker.invokeConfigurations(attributes);
 
     long startTime = System.currentTimeMillis();
     InvokedMethod invokedMethod = new InvokedMethod(instance, tm, startTime, testResult);
@@ -779,14 +789,10 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
     ITestNGMethod[] teardownConfigMethods =
         TestNgMethodUtils.filterTeardownConfigurationMethods(tm, afterMethods);
     invoker.invokeConfigurations(
-        testClass,
-        tm,
-        teardownConfigMethods,
-        suite,
-        params,
-        parameterValues,
-        instance,
-        testResult);
+        new Builder().forTestClass(testClass).forTestMethod(tm)
+            .usingConfigMethodsAs(teardownConfigMethods).forSuite(suite).usingParameters(params)
+            .usingParameterValues(parameterValues).usingInstance(instance).withResult(testResult)
+            .build());
     invoker.invokeAfterGroupsConfigurations(tm, groupMethods, suite, params, instance);
   }
 

--- a/src/main/java/org/testng/internal/TestMethodWorker.java
+++ b/src/main/java/org/testng/internal/TestMethodWorker.java
@@ -9,6 +9,7 @@ import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
 import org.testng.collections.Lists;
 import org.testng.collections.Sets;
+import org.testng.internal.ConfigMethodAttributes.Builder;
 import org.testng.internal.thread.graph.IWorker;
 
 import javax.annotation.Nonnull;
@@ -173,13 +174,14 @@ public class TestMethodWorker implements IWorker<ITestNGMethod> {
         for (IClassListener listener : m_listeners) {
           listener.onBeforeClass(testClass);
         }
-        m_configInvoker.invokeConfigurations(
-            testClass,
-            testClass.getBeforeClassMethods(),
-            m_testContext.getSuite().getXmlSuite(),
-            m_parameters,
-            null, /* no parameter values */
-            instance);
+        ConfigMethodAttributes attributes = new Builder()
+            .forTestClass(testClass)
+            .usingConfigMethodsAs(testClass.getBeforeClassMethods())
+            .forSuite(m_testContext.getSuite().getXmlSuite())
+            .usingParameters(m_parameters)
+            .usingInstance(instance)
+            .build();
+        m_configInvoker.invokeConfigurations(attributes);
       }
     }
   }
@@ -214,13 +216,14 @@ public class TestMethodWorker implements IWorker<ITestNGMethod> {
       listener.onAfterClass(testClass);
     }
     for (Object invokeInstance : invokeInstances) {
-      m_configInvoker.invokeConfigurations(
-          testClass,
-          testClass.getAfterClassMethods(),
-          m_testContext.getSuite().getXmlSuite(),
-          m_parameters,
-          null, /* no parameter values */
-          invokeInstance);
+      ConfigMethodAttributes attributes = new Builder()
+          .forTestClass(testClass)
+          .usingConfigMethodsAs(testClass.getAfterClassMethods())
+          .forSuite(m_testContext.getSuite().getXmlSuite())
+          .usingParameters(m_parameters)
+          .usingInstance(invokeInstance)
+          .build();
+      m_configInvoker.invokeConfigurations(attributes);
     }
   }
 


### PR DESCRIPTION
Refactored IConfigInvoker to use a builder and 
thus reduce two method variants into a single one.