### PR TITLE
Use builders for TestInvoker

### DIFF
--- a/src/main/java/org/testng/SuiteRunner.java
+++ b/src/main/java/org/testng/SuiteRunner.java
@@ -6,8 +6,8 @@ import org.testng.collections.Lists;
 import org.testng.collections.Maps;
 import org.testng.collections.Sets;
 import org.testng.internal.Attributes;
-import org.testng.internal.ConfigMethodAttributes;
-import org.testng.internal.ConfigMethodAttributes.Builder;
+import org.testng.internal.ConfigMethodArguments;
+import org.testng.internal.ConfigMethodArguments.Builder;
 import org.testng.internal.IConfiguration;
 import org.testng.internal.IInvoker;
 import org.testng.internal.Utils;
@@ -337,12 +337,12 @@ public class SuiteRunner implements ISuite, IInvokedMethodListener {
     //
     if (invoker != null) {
       if (!beforeSuiteMethods.values().isEmpty()) {
-        ConfigMethodAttributes attributes = new Builder()
+        ConfigMethodArguments arguments = new Builder()
             .usingConfigMethodsAs(beforeSuiteMethods.values())
             .forSuite(xmlSuite)
             .usingParameters(xmlSuite.getParameters())
             .build();
-        invoker.getConfigInvoker().invokeConfigurations(attributes);
+        invoker.getConfigInvoker().invokeConfigurations(arguments);
       }
 
       Utils.log("SuiteRunner", 3, "Created " + testRunners.size() + " TestRunners");
@@ -361,12 +361,12 @@ public class SuiteRunner implements ISuite, IInvokedMethodListener {
       // Invoke afterSuite methods
       //
       if (!afterSuiteMethods.values().isEmpty()) {
-        ConfigMethodAttributes attributes = new Builder()
+        ConfigMethodArguments arguments = new Builder()
             .usingConfigMethodsAs(afterSuiteMethods.values())
             .forSuite(xmlSuite)
             .usingParameters(xmlSuite.getAllParameters())
             .build();
-        invoker.getConfigInvoker().invokeConfigurations(attributes);
+        invoker.getConfigInvoker().invokeConfigurations(arguments);
       }
     }
   }

--- a/src/main/java/org/testng/TestRunner.java
+++ b/src/main/java/org/testng/TestRunner.java
@@ -22,8 +22,8 @@ import org.testng.collections.Sets;
 import org.testng.internal.AbstractParallelWorker;
 import org.testng.internal.Attributes;
 import org.testng.internal.ClassInfoMap;
-import org.testng.internal.ConfigMethodAttributes;
-import org.testng.internal.ConfigMethodAttributes.Builder;
+import org.testng.internal.ConfigMethodArguments;
+import org.testng.internal.ConfigMethodArguments.Builder;
 import org.testng.internal.ConfigurationGroupMethods;
 import org.testng.internal.DefaultListenerFactory;
 import org.testng.internal.DynamicGraph;
@@ -613,13 +613,17 @@ public class TestRunner
 
     // invoke @BeforeTest
     ITestNGMethod[] testConfigurationMethods = getBeforeTestConfigurationMethods();
+    invokeTestConfigurations(testConfigurationMethods);
+  }
+
+  private void invokeTestConfigurations(ITestNGMethod[] testConfigurationMethods) {
     if (null != testConfigurationMethods && testConfigurationMethods.length > 0) {
-      ConfigMethodAttributes attributes = new Builder()
+      ConfigMethodArguments arguments = new Builder()
           .usingConfigMethodsAs(testConfigurationMethods)
           .forSuite(m_xmlTest.getSuite())
           .usingParameters(m_xmlTest.getAllParameters())
           .build();
-      m_invoker.getConfigInvoker().invokeConfigurations(attributes);
+      m_invoker.getConfigInvoker().invokeConfigurations(arguments);
     }
   }
 
@@ -846,14 +850,7 @@ public class TestRunner
   private void afterRun() {
     // invoke @AfterTest
     ITestNGMethod[] testConfigurationMethods = getAfterTestConfigurationMethods();
-    if (null != testConfigurationMethods && testConfigurationMethods.length > 0) {
-      ConfigMethodAttributes attributes = new Builder()
-          .usingConfigMethodsAs(testConfigurationMethods)
-          .forSuite(m_xmlTest.getSuite())
-          .usingParameters(m_xmlTest.getAllParameters())
-          .build();
-      m_invoker.getConfigInvoker().invokeConfigurations(attributes);
-    }
+    invokeTestConfigurations(testConfigurationMethods);
 
     //
     // Log the end date

--- a/src/main/java/org/testng/internal/Arguments.java
+++ b/src/main/java/org/testng/internal/Arguments.java
@@ -1,0 +1,29 @@
+package org.testng.internal;
+
+import java.util.Map;
+import org.testng.ITestNGMethod;
+
+public class Arguments {
+
+  protected final Object instance;
+  protected final ITestNGMethod tm;
+  protected final Map<String, String> params;
+
+  protected Arguments(Object instance, ITestNGMethod tm, Map<String, String> params) {
+    this.instance = instance;
+    this.tm = tm;
+    this.params = params;
+  }
+
+  public Object getInstance() {
+    return instance;
+  }
+
+  public ITestNGMethod getTestMethod() {
+    return tm;
+  }
+
+  public Map<String, String> getParameters() {
+    return params;
+  }
+}

--- a/src/main/java/org/testng/internal/ConfigMethodArguments.java
+++ b/src/main/java/org/testng/internal/ConfigMethodArguments.java
@@ -7,36 +7,25 @@ import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
 import org.testng.xml.XmlSuite;
 
-public class ConfigMethodAttributes {
+public class ConfigMethodArguments extends MethodArguments {
 
   private IClass testClass;
-  private final ITestNGMethod currentTestMethod;
   private final ITestNGMethod[] allMethods;
   private final XmlSuite suite;
-  private final Map<String, String> params;
-  private final Object[] parameterValues;
-  private final Object instance;
   private final ITestResult testMethodResult;
 
-  private ConfigMethodAttributes(IClass testClass, ITestNGMethod currentTestMethod,
+  private ConfigMethodArguments(IClass testClass, ITestNGMethod currentTestMethod,
       ITestNGMethod[] allMethods, XmlSuite suite, Map<String, String> params,
       Object[] parameterValues, Object instance, ITestResult testMethodResult) {
+    super(instance, currentTestMethod, params, parameterValues);
     this.testClass = testClass;
-    this.currentTestMethod = currentTestMethod;
     this.allMethods = allMethods;
     this.suite = suite;
-    this.params = params;
-    this.parameterValues = parameterValues;
-    this.instance = instance;
     this.testMethodResult = testMethodResult;
   }
 
   public IClass getTestClass() {
     return testClass;
-  }
-
-  public ITestNGMethod getTestMethod() {
-    return currentTestMethod;
   }
 
   public ITestNGMethod[] getConfigMethods() {
@@ -126,8 +115,8 @@ public class ConfigMethodAttributes {
       return this;
     }
 
-    public ConfigMethodAttributes build() {
-      return new ConfigMethodAttributes(testClass, currentTestMethod, allMethods, suite, params,
+    public ConfigMethodArguments build() {
+      return new ConfigMethodArguments(testClass, currentTestMethod, allMethods, suite, params,
           parameterValues, instance, testMethodResult);
     }
   }

--- a/src/main/java/org/testng/internal/GroupConfigMethodArguments.java
+++ b/src/main/java/org/testng/internal/GroupConfigMethodArguments.java
@@ -4,26 +4,17 @@ import java.util.Map;
 import org.testng.ITestNGMethod;
 import org.testng.xml.XmlSuite;
 
-public class GroupConfigMethodAttributes {
+public class GroupConfigMethodArguments extends Arguments {
 
-  private final ITestNGMethod testMethod;
   private final ConfigurationGroupMethods groupMethods;
   private final XmlSuite suite;
-  private final Map<String, String> params;
-  private final Object instance;
 
-  private GroupConfigMethodAttributes(ITestNGMethod testMethod,
+  private GroupConfigMethodArguments(ITestNGMethod testMethod,
       ConfigurationGroupMethods groupMethods, XmlSuite suite, Map<String, String> params,
       Object instance) {
-    this.testMethod = testMethod;
+    super(instance, testMethod, params);
     this.groupMethods = groupMethods;
     this.suite = suite;
-    this.params = params;
-    this.instance = instance;
-  }
-
-  public ITestNGMethod getTestMethod() {
-    return testMethod;
   }
 
   public ConfigurationGroupMethods getGroupMethods() {
@@ -75,8 +66,8 @@ public class GroupConfigMethodAttributes {
       return this;
     }
 
-    public GroupConfigMethodAttributes build() {
-      return new GroupConfigMethodAttributes(testMethod, groupMethods, suite, params, instance);
+    public GroupConfigMethodArguments build() {
+      return new GroupConfigMethodArguments(testMethod, groupMethods, suite, params, instance);
     }
   }
 }

--- a/src/main/java/org/testng/internal/IConfigInvoker.java
+++ b/src/main/java/org/testng/internal/IConfigInvoker.java
@@ -8,10 +8,10 @@ public interface IConfigInvoker {
   boolean hasConfigurationFailureFor(
       ITestNGMethod testNGMethod, String[] groups, IClass testClass, Object instance);
 
-  void invokeBeforeGroupsConfigurations(GroupConfigMethodAttributes attributes);
+  void invokeBeforeGroupsConfigurations(GroupConfigMethodArguments arguments);
 
-  void invokeAfterGroupsConfigurations(GroupConfigMethodAttributes attributes);
+  void invokeAfterGroupsConfigurations(GroupConfigMethodArguments arguments);
 
-  void invokeConfigurations(ConfigMethodAttributes configMethodAttributes);
+  void invokeConfigurations(ConfigMethodArguments arguments);
 
 }

--- a/src/main/java/org/testng/internal/ITestInvoker.java
+++ b/src/main/java/org/testng/internal/ITestInvoker.java
@@ -1,8 +1,6 @@
 package org.testng.internal;
 
 import java.util.List;
-import java.util.Map;
-import org.testng.ITestClass;
 import org.testng.ITestContext;
 import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
@@ -23,31 +21,13 @@ public interface ITestInvoker {
       ITestContext context);
 
   ITestResult invokeTestMethod(
-      Object instance,
-      ITestNGMethod tm,
-      Object[] parameterValues,
-      int parametersIndex,
-      XmlSuite suite,
-      Map<String, String> params,
-      ITestClass testClass,
-      ITestNGMethod[] beforeMethods,
-      ITestNGMethod[] afterMethods,
-      ConfigurationGroupMethods groupMethods,
+      TestMethodArguments arguments, XmlSuite suite,
       FailureContext failureContext);
 
   FailureContext retryFailed(
-      Object instance,
-      ITestNGMethod tm,
-      Object[] paramValues,
-      ITestClass testClass,
-      ITestNGMethod[] beforeMethods,
-      ITestNGMethod[] afterMethods,
-      ConfigurationGroupMethods groupMethods,
-      List<ITestResult> result,
+      TestMethodArguments arguments, List<ITestResult> result,
       int failureCount,
-      ITestContext testContext,
-      Map<String, String> parameters,
-      int parametersIndex);
+      ITestContext testContext);
 
   void runTestResultListener(ITestResult tr);
 }

--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -8,12 +8,11 @@ import org.testng.IClass;
 import org.testng.IClassListener;
 import org.testng.IDataProviderListener;
 import org.testng.IInvokedMethodListener;
-import org.testng.ITestClass;
 import org.testng.ITestContext;
 import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
 import org.testng.SuiteRunState;
-import org.testng.internal.ConfigMethodAttributes.Builder;
+import org.testng.internal.ConfigMethodArguments.Builder;
 import org.testng.internal.ITestInvoker.FailureContext;
 import org.testng.xml.XmlSuite;
 
@@ -76,7 +75,7 @@ public class Invoker implements IInvoker {
       Map<String, String> params,
       Object[] parameterValues,
       Object instance) {
-    ConfigMethodAttributes attributes = new Builder()
+    ConfigMethodArguments attributes = new Builder()
         .forTestClass(testClass)
         .usingConfigMethodsAs(allMethods)
         .forSuite(suite).usingParameters(params)
@@ -96,8 +95,7 @@ public class Invoker implements IInvoker {
    * if any.
    *
    * <p>Note (alex): this method can be refactored to use a SingleTestMethodWorker that directly
-   * invokes {@link ITestInvoker#invokeTestMethod(Object, ITestNGMethod, Object[], int, XmlSuite, Map,
-   * ITestClass, ITestNGMethod[], ITestNGMethod[], ConfigurationGroupMethods, FailureContext)} and
+   * invokes {@link ITestInvoker#invokeTestMethod(TestMethodArguments, XmlSuite, FailureContext)} and
    * this would simplify the implementation (see how DataTestMethodWorker is used)
    */
   @Override

--- a/src/main/java/org/testng/internal/MethodArguments.java
+++ b/src/main/java/org/testng/internal/MethodArguments.java
@@ -1,0 +1,21 @@
+package org.testng.internal;
+
+import java.util.Map;
+import org.testng.ITestNGMethod;
+
+public class MethodArguments extends Arguments {
+
+  protected final Object[] parameterValues;
+
+  protected MethodArguments(
+      Object instance, ITestNGMethod tm,
+      Map<String, String> params, Object[] parameterValues) {
+    super(instance, tm, params);
+    this.parameterValues = parameterValues;
+  }
+
+  public Object[] getParameterValues() {
+    return parameterValues;
+  }
+
+}

--- a/src/main/java/org/testng/internal/TestMethodArguments.java
+++ b/src/main/java/org/testng/internal/TestMethodArguments.java
@@ -1,0 +1,121 @@
+package org.testng.internal;
+
+import java.util.Map;
+import org.testng.ITestClass;
+import org.testng.ITestNGMethod;
+
+public class TestMethodArguments extends MethodArguments {
+
+  private final ITestClass testClass;
+  private final int parametersIndex;
+  private final ITestNGMethod[] beforeMethods;
+  private final ITestNGMethod[] afterMethods;
+  private final ConfigurationGroupMethods groupMethods;
+
+  private TestMethodArguments(Object instance, ITestNGMethod tm, Object[] parameterValues,
+      int parametersIndex, Map<String, String> params, ITestClass testClass,
+      ITestNGMethod[] beforeMethods, ITestNGMethod[] afterMethods,
+      ConfigurationGroupMethods groupMethods) {
+    super(instance, tm, params, parameterValues);
+    this.parametersIndex = parametersIndex;
+    this.beforeMethods = beforeMethods;
+    this.afterMethods = afterMethods;
+    this.groupMethods = groupMethods;
+    this.testClass = testClass;
+  }
+
+  public int getParametersIndex() {
+    return parametersIndex;
+  }
+
+  public ITestNGMethod[] getBeforeMethods() {
+    return beforeMethods;
+  }
+
+  public ITestNGMethod[] getAfterMethods() {
+    return afterMethods;
+  }
+
+  public ConfigurationGroupMethods getGroupMethods() {
+    return groupMethods;
+  }
+
+  public ITestClass getTestClass() {
+    return testClass;
+  }
+
+  public static class Builder {
+
+    private Object instance;
+    private ITestNGMethod tm;
+    private Object[] parameterValues;
+    private int parametersIndex;
+    private Map<String, String> params;
+    private ITestClass testClass;
+    private ITestNGMethod[] beforeMethods;
+    private ITestNGMethod[] afterMethods;
+    private ConfigurationGroupMethods groupMethods;
+
+    public Builder usingInstance(Object instance) {
+      this.instance = instance;
+      return this;
+    }
+
+    public Builder forTestMethod(ITestNGMethod tm) {
+      this.tm = tm;
+      return this;
+    }
+
+    public Builder withParameterValues(Object[] parameterValues) {
+      this.parameterValues = parameterValues;
+      return this;
+    }
+
+    public Builder withParametersIndex(int parametersIndex) {
+      this.parametersIndex = parametersIndex;
+      return this;
+    }
+
+    public Builder withParameters(Map<String, String> params) {
+      this.params = params;
+      return this;
+    }
+
+    public Builder forTestClass(ITestClass testClass) {
+      this.testClass = testClass;
+      return this;
+    }
+
+    public Builder usingBeforeMethods(ITestNGMethod[] beforeMethods) {
+      this.beforeMethods = beforeMethods;
+      return this;
+    }
+
+    public Builder usingAfterMethods(ITestNGMethod[] afterMethods) {
+      this.afterMethods = afterMethods;
+      return this;
+    }
+
+    public Builder usingGroupMethods(ConfigurationGroupMethods groupMethods) {
+      this.groupMethods = groupMethods;
+      return this;
+    }
+
+    public Builder usingArguments(TestMethodArguments attributes) {
+      return usingInstance(attributes.getInstance())
+          .forTestMethod(attributes.getTestMethod())
+          .withParameterValues(attributes.getParameterValues())
+          .withParametersIndex(attributes.getParametersIndex())
+          .withParameters(attributes.getParameters())
+          .forTestClass(attributes.getTestClass())
+          .usingBeforeMethods(attributes.getBeforeMethods())
+          .usingAfterMethods(attributes.getAfterMethods())
+          .usingGroupMethods(attributes.getGroupMethods());
+    }
+
+    public TestMethodArguments build() {
+      return new TestMethodArguments(instance, tm, parameterValues, parametersIndex, params,
+          testClass, beforeMethods, afterMethods, groupMethods);
+    }
+  }
+}

--- a/src/main/java/org/testng/internal/TestMethodWithDataProviderMethodWorker.java
+++ b/src/main/java/org/testng/internal/TestMethodWithDataProviderMethodWorker.java
@@ -5,6 +5,7 @@ import org.testng.ITestContext;
 import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
 import org.testng.collections.Lists;
+import org.testng.internal.TestMethodArguments.Builder;
 import org.testng.xml.XmlSuite;
 
 import java.util.List;
@@ -74,16 +75,12 @@ public class TestMethodWithDataProviderMethodWorker implements Callable<List<ITe
     try {
       tmpResults.add(
           m_testInvoker.invokeTestMethod(
-              m_instance,
-              m_testMethod,
-              m_parameterValues,
-              m_parameterIndex,
-              suite,
-              m_parameters,
-              m_testClass,
-              m_beforeMethods,
-              m_afterMethods,
-              m_groupMethods,
+              new Builder().usingInstance(m_instance)
+                  .forTestMethod(m_testMethod).withParameterValues(m_parameterValues)
+                  .withParametersIndex(m_parameterIndex).withParameters(m_parameters)
+                  .forTestClass(m_testClass).usingBeforeMethods(m_beforeMethods)
+                  .usingAfterMethods(m_afterMethods).usingGroupMethods(m_groupMethods)
+                  .build(), suite,
               failure));
     } finally {
       m_failureCount = failure.count;
@@ -95,18 +92,15 @@ public class TestMethodWithDataProviderMethodWorker implements Callable<List<ITe
 
           m_failureCount =
               m_testInvoker.retryFailed(
-                      instance,
-                      m_testMethod,
-                      m_parameterValues,
-                      m_testClass,
-                      m_beforeMethods,
-                      m_afterMethods,
-                      m_groupMethods,
-                      retryResults,
+                  new Builder().usingInstance(instance)
+                      .forTestMethod(m_testMethod).withParameterValues(m_parameterValues)
+                      .withParametersIndex(m_parameterIndex).withParameters(m_parameters)
+                      .forTestClass(m_testClass).usingBeforeMethods(m_beforeMethods)
+                      .usingAfterMethods(m_afterMethods).usingGroupMethods(m_groupMethods)
+                      .build(), retryResults,
                       m_failureCount,
-                      m_testContext,
-                      m_parameters,
-                      m_parameterIndex)
+                      m_testContext
+              )
                   .count;
           m_testResults.addAll(retryResults);
         }

--- a/src/main/java/org/testng/internal/TestMethodWorker.java
+++ b/src/main/java/org/testng/internal/TestMethodWorker.java
@@ -9,7 +9,7 @@ import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
 import org.testng.collections.Lists;
 import org.testng.collections.Sets;
-import org.testng.internal.ConfigMethodAttributes.Builder;
+import org.testng.internal.ConfigMethodArguments.Builder;
 import org.testng.internal.thread.graph.IWorker;
 
 import javax.annotation.Nonnull;
@@ -174,7 +174,7 @@ public class TestMethodWorker implements IWorker<ITestNGMethod> {
         for (IClassListener listener : m_listeners) {
           listener.onBeforeClass(testClass);
         }
-        ConfigMethodAttributes attributes = new Builder()
+        ConfigMethodArguments attributes = new Builder()
             .forTestClass(testClass)
             .usingConfigMethodsAs(testClass.getBeforeClassMethods())
             .forSuite(m_testContext.getSuite().getXmlSuite())
@@ -216,7 +216,7 @@ public class TestMethodWorker implements IWorker<ITestNGMethod> {
       listener.onAfterClass(testClass);
     }
     for (Object invokeInstance : invokeInstances) {
-      ConfigMethodAttributes attributes = new Builder()
+      ConfigMethodArguments attributes = new Builder()
           .forTestClass(testClass)
           .usingConfigMethodsAs(testClass.getAfterClassMethods())
           .forSuite(m_testContext.getSuite().getXmlSuite())


### PR DESCRIPTION
Also re-organized all the argument holder Pojo 
classes to follow a class hierarchy

The below diagram shows the class hierarchy for `Arguments` (earlier it was called `Attributes`)

![attributes](https://user-images.githubusercontent.com/909773/49604543-27aed980-f9b4-11e8-8097-d0aa3c475113.png)

