### PR TITLE
Use Java provided predicates

### DIFF
--- a/src/main/java/org/testng/internal/Invoker.java
+++ b/src/main/java/org/testng/internal/Invoker.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import java.util.function.BiPredicate;
 import org.testng.IClass;
 import org.testng.IClassListener;
 import org.testng.IDataProviderListener;
@@ -26,10 +27,10 @@ import org.testng.xml.XmlSuite;
 public class Invoker implements IInvoker {
 
   /** Predicate to filter methods */
-  static final Predicate<ITestNGMethod, IClass> CAN_RUN_FROM_CLASS =
-      new CanRunFromClassPredicate();
+  static final BiPredicate<ITestNGMethod, IClass> CAN_RUN_FROM_CLASS = ITestNGMethod::canRunFromClass;
   /** Predicate to filter methods */
-  static final Predicate<ITestNGMethod, IClass> SAME_CLASS = new SameClassNamePredicate();
+  static final BiPredicate<ITestNGMethod, IClass> SAME_CLASS =
+      (m, c) -> c == null || m.getTestClass().getName().equals(c.getName());
 
   private final TestInvoker m_testInvoker;
   private final ConfigInvoker m_configInvoker;
@@ -107,24 +108,6 @@ public class Invoker implements IInvoker {
       ITestContext testContext) {
     return m_testInvoker
         .invokeTestMethods(testMethod, groupMethods, instance, testContext);
-  }
-
-  interface Predicate<K, T> {
-    boolean isTrue(K k, T v);
-  }
-
-  static class CanRunFromClassPredicate implements Predicate<ITestNGMethod, IClass> {
-    @Override
-    public boolean isTrue(ITestNGMethod m, IClass v) {
-      return m.canRunFromClass(v);
-    }
-  }
-
-  static class SameClassNamePredicate implements Predicate<ITestNGMethod, IClass> {
-    @Override
-    public boolean isTrue(ITestNGMethod m, IClass c) {
-      return c == null || m.getTestClass().getName().equals(c.getName());
-    }
   }
 
   static void log(int level, String s) {

--- a/src/main/java/org/testng/internal/TestNgMethodUtils.java
+++ b/src/main/java/org/testng/internal/TestNgMethodUtils.java
@@ -1,5 +1,6 @@
 package org.testng.internal;
 
+import java.util.function.BiPredicate;
 import org.testng.IClass;
 import org.testng.ITestClass;
 import org.testng.ITestNGMethod;
@@ -67,12 +68,12 @@ class TestNgMethodUtils {
   }
 
   static ITestNGMethod[] filterBeforeTestMethods(
-      ITestClass testClass, Invoker.Predicate<ITestNGMethod, IClass> predicate) {
+      ITestClass testClass, BiPredicate<ITestNGMethod, IClass> predicate) {
     return filterMethods(testClass, testClass.getBeforeTestMethods(), predicate);
   }
 
   static ITestNGMethod[] filterAfterTestMethods(
-      ITestClass testClass, Invoker.Predicate<ITestNGMethod, IClass> predicate) {
+      ITestClass testClass, BiPredicate<ITestNGMethod, IClass> predicate) {
     return filterMethods(testClass, testClass.getAfterTestMethods(), predicate);
   }
 
@@ -80,12 +81,12 @@ class TestNgMethodUtils {
   static ITestNGMethod[] filterMethods(
       IClass testClass,
       ITestNGMethod[] methods,
-      Invoker.Predicate<ITestNGMethod, IClass> predicate) {
+      BiPredicate<ITestNGMethod, IClass> predicate) {
     List<ITestNGMethod> vResult = Lists.newArrayList();
 
     for (ITestNGMethod tm : methods) {
       String msg;
-      if (predicate.isTrue(tm, testClass)
+      if (predicate.test(tm, testClass)
           && (!TestNgMethodUtils.containsConfigurationMethod(tm, vResult))) {
         msg = "Keeping method " + tm + " for class " + testClass;
         vResult.add(tm);


### PR DESCRIPTION
Now that we are in JDK8 we can very well leverage
the java provided functional interfaces (Predicates)
to be specific for our needs instead of creating
our own custom ones.

*Note:* I have intentionally not gone through the deprecation strategy since the refactored code resides in the *internal* package and we needn't follow the deprecation strategy for internal implementations.