### PR TITLE
Feature: Make method for error details, that can encourage downstream customization of SoftAssert errors

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+New: Added a method in Assertion class to allow downstream TestNG consumers to override the error message (Ryan Laseter)
 Fixed: GITHUB-165: @AfterGroups is not executed when group member fails or is skipped (Krishnan Mahadevan)
 Fixed: GITHUB-118: @BeforeGroups only called if group is specified explicitly (Krishnan Mahadevan)
 Fixed: GITHUB-182: Inherited test methods do not get expected group behavior (Krishnan Mahadevan)

--- a/src/main/java/org/testng/asserts/Assertion.java
+++ b/src/main/java/org/testng/asserts/Assertion.java
@@ -743,4 +743,21 @@ public class Assertion implements IAssertLifecycle {
           }
         });
   }
+
+  /***
+   * Override this method should you want to change
+   * the default way Throwable objects are logged.
+   * @param error Throwable of the Assertion
+   * @return default throwable formatted message for TestNG
+   */
+  protected String getErrorDetails(Throwable error) {
+    StringBuilder sb = new StringBuilder();
+    sb.append(error.getMessage());
+    Throwable cause = error.getCause();
+    while (cause != null) {
+      sb.append(" ").append(cause.getMessage());
+      cause = cause.getCause();
+    }
+    return sb.toString();
+  }
 }

--- a/src/main/java/org/testng/asserts/SoftAssert.java
+++ b/src/main/java/org/testng/asserts/SoftAssert.java
@@ -37,12 +37,7 @@ public class SoftAssert extends Assertion {
           sb.append(",");
         }
         sb.append("\n\t");
-        sb.append(error.getMessage());
-        Throwable cause = error.getCause();
-        while (cause != null) {
-          sb.append(" ").append(cause.getMessage());
-          cause = cause.getCause();
-        }
+        sb.append(getErrorDetails(error));
       }
       throw new AssertionError(sb.toString());
     }


### PR DESCRIPTION
**New Feature**

### Did you remember to?
- [x] Add test case(s)
- [X] Update `CHANGES.txt`

**Background:** I use TestNG heavily at my job, and we're using SoftAssert's when performing content checking. We would like to be able to include a custom message in the SoftAssert.assertAll() call that would make tracing easier.

Upon @krmahadevan suggestion, putting the default error formatting into a method would allow downstream TestNG users to override that, and add their own error logic should they need to.