### PR TITLE
@BeforeGroups to honor “inherited” attribute

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-118: @BeforeGroups only called if group is specified explicitly (Krishnan Mahadevan)
 Fixed: GITHUB-182: Inherited test methods do not get expected group behavior (Krishnan Mahadevan)
 Fixed: GITHUB-1988: Add Automatic-Module-Name to MANIFEST.MF (Krishnan Mahadevan)
 Fixed: GITHUB-1985: Custom "IMethodSelector" implementation doesn't filter methods properly (Krishnan Mahadevan)

--- a/src/main/java/org/testng/annotations/AfterGroups.java
+++ b/src/main/java/org/testng/annotations/AfterGroups.java
@@ -54,7 +54,7 @@ public @interface AfterGroups {
    * If true, this &#64;Configuration method will belong to groups specified in the &#64;Test
    * annotation on the class (if any).
    */
-  boolean inheritGroups() default true;
+  boolean inheritGroups() default false;
 
   /**
    * The description for this method. The string used will appear in the HTML report and also on

--- a/src/main/java/org/testng/annotations/BeforeGroups.java
+++ b/src/main/java/org/testng/annotations/BeforeGroups.java
@@ -54,7 +54,7 @@ public @interface BeforeGroups {
    * If true, this &#64;Configuration method will belong to groups specified in the &#64;Test
    * annotation on the class (if any).
    */
-  boolean inheritGroups() default true;
+  boolean inheritGroups() default false;
 
   /**
    * The description for this method. The string used will appear in the HTML report and also on

--- a/src/main/java/org/testng/internal/MethodGroupsHelper.java
+++ b/src/main/java/org/testng/internal/MethodGroupsHelper.java
@@ -1,6 +1,7 @@
 package org.testng.internal;
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -8,6 +9,8 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.testng.ITestClass;
 import org.testng.ITestNGMethod;
 import org.testng.annotations.IConfigurationAnnotation;
@@ -134,7 +137,10 @@ public class MethodGroupsHelper {
     for (ITestClass cls : classes) {
       ITestNGMethod[] methods = before ? cls.getBeforeGroupsMethods() : cls.getAfterGroupsMethods();
       for (ITestNGMethod method : methods) {
-        for (String group : before ? method.getBeforeGroups() : method.getAfterGroups()) {
+        String[] grp = before ? method.getBeforeGroups() : method.getAfterGroups();
+        List<String> groups = Stream.concat(Arrays.stream(grp), Arrays.stream(method.getGroups()))
+            .collect(Collectors.toList());
+        for (String group : groups) {
           List<ITestNGMethod> methodList = result.computeIfAbsent(group, k -> Lists.newArrayList());
           // NOTE(cbeust, 2007/01/23)
           // BeforeGroups/AfterGroups methods should only be invoked once.

--- a/src/main/java/org/testng/internal/TestNGMethodFinder.java
+++ b/src/main/java/org/testng/internal/TestNGMethodFinder.java
@@ -164,12 +164,12 @@ public class TestNGMethodFinder implements ITestMethodFinder {
           break;
         case BEFORE_GROUPS:
           beforeGroups = configuration.getBeforeGroups();
-          create = beforeGroups.length > 0;
+          create = shouldCreateBeforeAfterGroup(beforeGroups, annotationFinder, clazz, configuration.getInheritGroups());
           isBeforeTestMethod = true;
           break;
         case AFTER_GROUPS:
           afterGroups = configuration.getAfterGroups();
-          create = afterGroups.length > 0;
+          create = shouldCreateBeforeAfterGroup(afterGroups, annotationFinder, clazz, configuration.getInheritGroups());
           isBeforeTestMethod = true;
           break;
         default:
@@ -205,6 +205,18 @@ public class TestNGMethodFinder implements ITestMethodFinder {
         unique,
         excludedMethods,
         comparator);
+  }
+
+  private static boolean shouldCreateBeforeAfterGroup(String[] groups, IAnnotationFinder finder,
+      Class<?> clazz, boolean isInheritGroups) {
+    if (!isInheritGroups) {
+      return groups.length > 0;
+    }
+    ITestAnnotation test = AnnotationHelper.findTest(finder, clazz);
+    if (test == null) {
+      return groups.length > 0;
+    }
+    return groups.length > 0 || test.getGroups().length > 0;
   }
 
   private void addConfigurationMethod(

--- a/src/test/java/test/beforegroups/BeforeGroupsTest.java
+++ b/src/test/java/test/beforegroups/BeforeGroupsTest.java
@@ -1,5 +1,6 @@
 package test.beforegroups;
 
+import org.testng.TestListenerAdapter;
 import org.testng.TestNG;
 import org.testng.annotations.Test;
 import org.testng.collections.Lists;
@@ -9,6 +10,7 @@ import org.testng.xml.XmlSuite;
 import org.testng.xml.XmlTest;
 import test.InvokedMethodNameListener;
 import test.SimpleBaseTest;
+import test.beforegroups.issue118.TestclassSample;
 import test.beforegroups.issue1694.BaseClassWithBeforeGroups;
 
 import java.io.IOException;
@@ -26,6 +28,17 @@ public class BeforeGroupsTest extends SimpleBaseTest {
   @Test
   public void testParallelMode() throws IOException {
     runTest(XmlSuite.ParallelMode.CLASSES);
+  }
+
+  @Test(description = "GITHUB-118")
+  public void ensureInheritedAttributeWorksForBeforeGroups() {
+    XmlSuite xmlSuite = createXmlSuite("suite", "test", TestclassSample.class);
+    xmlSuite.addIncludedGroup("group1");
+    TestNG testng = create(xmlSuite);
+    TestListenerAdapter listener = new TestListenerAdapter();
+    testng.addListener(listener);
+    testng.run();
+    assertThat(listener.getFailedTests()).isEmpty();
   }
 
   private static void runTest(XmlSuite.ParallelMode mode) throws IOException {

--- a/src/test/java/test/beforegroups/issue118/TestclassSample.java
+++ b/src/test/java/test/beforegroups/issue118/TestclassSample.java
@@ -1,0 +1,19 @@
+package test.beforegroups.issue118;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeGroups;
+import org.testng.annotations.Test;
+
+@Test(groups = "group1")
+public class TestclassSample {
+  private Object testObject;
+
+  @BeforeGroups(inheritGroups = true)
+  public void setUpGroup() {
+    testObject = new Object();
+  }
+
+  public void test1() {
+    Assert.assertNotNull(testObject, "@BeforeGroups not invoked if nothing explicitly specified");
+  }
+}


### PR DESCRIPTION
Closes #118

As part of fixing this issue, flipped the attribute
“inheritGroups” to “false”. This was done because
this attribute has not worked till now and with the 
bug fix, it will start breaking compatibility for 
everyone, because now @BeforeGroups will inherit
any class level groups specified.

By inverting this attribute to false, backward 
compatibility is retained and it also gives a chance
to the users to turn it on explicitly when needed.

Fixes #118  .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`