### PR TITLE
GITHUB-2008: Preserve parameters in each class and not all of the test parameters

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-2008: Preserve parameters in each class and not all of the test parameters
 Fixed: GITHUB-1981: Fixes NPE in Assert.assertEquals when an array contains null (Maneesh MS)
 New: Upgrade to gradle5
 New: Added a method in Assertion class to allow downstream TestNG consumers to override the error message (Ryan Laseter)

--- a/src/main/java/org/testng/reporters/FailedReporter.java
+++ b/src/main/java/org/testng/reporters/FailedReporter.java
@@ -173,11 +173,10 @@ public class FailedReporter extends TestListenerAdapter implements IReporter {
       methodList.add(m);
     }
 
-    // Ideally, we should preserve each parameter in each class but putting them
-    // all in the same bag for now
-    Map<String, String> parameters = Maps.newHashMap();
+    // Store parameters per XmlClass
+    Map<String,  Map<String,  String>> classParameters = new HashMap<String,Map<String,  String>>();
     for (XmlClass c : srcXmlTest.getClasses()) {
-      parameters.putAll(c.getLocalParameters());
+      classParameters.put(c.getName(),c.getLocalParameters());
     }
 
     int index = 0;
@@ -197,7 +196,7 @@ public class FailedReporter extends TestListenerAdapter implements IReporter {
         methodNames.add(methodName);
       }
       xmlClass.setIncludedMethods(methodNames);
-      xmlClass.setParameters(parameters);
+      xmlClass.setParameters(classParameters.get(xmlClass.getName()));
       result.add(xmlClass);
     }
 

--- a/src/main/java/org/testng/reporters/FailedReporter.java
+++ b/src/main/java/org/testng/reporters/FailedReporter.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.HashMap;
 import java.util.Set;
 
 /**

--- a/src/main/java/org/testng/reporters/FailedReporter.java
+++ b/src/main/java/org/testng/reporters/FailedReporter.java
@@ -21,10 +21,8 @@ import org.testng.xml.XmlTest;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.HashMap;
 import java.util.Set;
 
 /**
@@ -88,7 +86,7 @@ public class FailedReporter extends TestListenerAdapter implements IReporter {
 
       // Get the transitive closure of all the failed methods and the methods
       // they depend on
-      Set<ITestResult> allTests = new HashSet<>();
+      Set<ITestResult> allTests = Sets.newHashSet();
       allTests.addAll(failedTests);
       allTests.addAll(skippedTests);
       for (ITestResult failedTest : allTests) {
@@ -168,14 +166,15 @@ public class FailedReporter extends TestListenerAdapter implements IReporter {
       Class clazz = instances == null ? m.getRealClass() : instances.getClass();
       Set<ITestNGMethod> methodList = methodsMap.get(clazz);
       if (null == methodList) {
-        methodList = new HashSet<>();
+        methodList = Sets.newHashSet();
         methodsMap.put(clazz, methodList);
       }
       methodList.add(m);
     }
 
     // Store parameters per XmlClass
-    Map<String,  Map<String,  String>> classParameters = new HashMap<String,Map<String,  String>>();
+
+    Map<String,  Map<String,  String>> classParameters = Maps.newHashMap();
     for (XmlClass c : srcXmlTest.getClasses()) {
       classParameters.put(c.getName(),c.getLocalParameters());
     }

--- a/src/test/java/test/failedreporter/FailedReporterParametersTest.java
+++ b/src/test/java/test/failedreporter/FailedReporterParametersTest.java
@@ -81,7 +81,7 @@ public class FailedReporterParametersTest extends SimpleBaseTest {
 
     TestNG tng = create(xmlSuite);
 
-    Path temp = Files.createTempDirectory("tmp");
+    Path temp = Files.createTempDirectory("preserveParameters");
     tng.setOutputDirectory(temp.toAbsolutePath().toString());
     tng.addListener(new FailedReporter());
     tng.run();
@@ -90,8 +90,12 @@ public class FailedReporterParametersTest extends SimpleBaseTest {
             new Parser(temp.resolve(FailedReporter.TESTNG_FAILED_XML).toAbsolutePath().toString()).parse();
     XmlSuite failedSuite = failedSuites.iterator().next();
     XmlTest failedTest = failedSuite.getTests().get(0);
-    XmlClass failedClass1 = failedTest.getClasses().get(0);
-    XmlClass failedClass2 = failedTest.getClasses().get(1);
+    XmlClass failedClass1 = failedTest.getClasses().stream()
+            .filter( failedClass -> failedClass.getName().equals("test.reports.SimpleFailedSample"))
+            .findFirst().get();
+    XmlClass failedClass2 = failedTest.getClasses().stream()
+            .filter( failedClass -> failedClass.getName().equals("test.failedreporter.FailedReporterParametersTest$AnotherSimpleFailedSample"))
+            .findFirst().get();
 
     // Cheeck class1 Parameters
     Assert.assertEquals("44", failedClass1.getAllParameters().get("sharedParameter"));

--- a/src/test/java/test/failedreporter/FailedReporterParametersTest.java
+++ b/src/test/java/test/failedreporter/FailedReporterParametersTest.java
@@ -1,21 +1,32 @@
 package test.failedreporter;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
 import org.testng.Assert;
+import org.testng.ITestNGListener;
 import org.testng.TestNG;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.testng.collections.Lists;
 import org.testng.collections.Maps;
+import org.testng.reporters.FailedReporter;
+import org.testng.xml.Parser;
 import org.testng.xml.XmlClass;
 import org.testng.xml.XmlSuite;
 import org.testng.xml.XmlTest;
 
+import org.xml.sax.SAXException;
 import test.SimpleBaseTest;
+import test.reports.SimpleFailedSample;
+
+import javax.xml.parsers.ParserConfigurationException;
 
 public class FailedReporterParametersTest extends SimpleBaseTest {
   private File mTempDirectory;
@@ -54,6 +65,46 @@ public class FailedReporterParametersTest extends SimpleBaseTest {
         new String[] {"suiteParam", "testParam", "classParam", "methodParam"});
   }
 
+  @Test(description = "github-2008")
+  public void preserveParameters() throws IOException {
+    XmlSuite xmlSuite = createXmlSuite("Suite");
+
+    XmlTest xmlTest = createXmlTest(xmlSuite, "Test");
+
+    XmlClass xmlClass1 = createXmlClass(xmlTest, SimpleFailedSample.class);
+    xmlClass1.getLocalParameters().put("sharedParameter", "44");
+    xmlClass1.getLocalParameters().put("class1Parameter", "43");
+
+    XmlClass xmlClass2 = createXmlClass(xmlTest, AnotherSimpleFailedSample.class);
+    xmlClass2.getLocalParameters().put("sharedParameter", "55");
+    xmlClass2.getLocalParameters().put("class2Parameter", "56");
+
+    TestNG tng = create(xmlSuite);
+
+    Path temp = Files.createTempDirectory("tmp");
+    tng.setOutputDirectory(temp.toAbsolutePath().toString());
+    tng.addListener(new FailedReporter());
+    tng.run();
+
+    Collection<XmlSuite> failedSuites =
+            new Parser(temp.resolve(FailedReporter.TESTNG_FAILED_XML).toAbsolutePath().toString()).parse();
+    XmlSuite failedSuite = failedSuites.iterator().next();
+    XmlTest failedTest = failedSuite.getTests().get(0);
+    XmlClass failedClass1 = failedTest.getClasses().get(0);
+    XmlClass failedClass2 = failedTest.getClasses().get(1);
+
+    // Cheeck class1 Parameters
+    Assert.assertEquals("44", failedClass1.getAllParameters().get("sharedParameter"));
+    Assert.assertEquals("43", failedClass1.getAllParameters().get("class1Parameter"));
+    Assert.assertNull(failedClass1.getAllParameters().get("class2Parameter"));
+
+    // Cheeck class2 Parameters
+    Assert.assertEquals("55", failedClass2.getAllParameters().get("sharedParameter"));
+    Assert.assertEquals("56", failedClass2.getAllParameters().get("class2Parameter"));
+    Assert.assertNull(failedClass2.getAllParameters().get("class1Parameter"));
+
+  }
+
   private static Map<String, String> create(String prefix) {
     Map<String, String> params = Maps.newHashMap();
     params.put(prefix + "Param", prefix + "ParamValue");
@@ -67,6 +118,14 @@ public class FailedReporterParametersTest extends SimpleBaseTest {
       grep(failed, String.format(expectedFormat, expectedKey, expectedKey + "Value"), resultLines);
       int expectedSize = 1;
       Assert.assertEquals(resultLines.size(), expectedSize, "Mismatch param:" + expectedKey);
+    }
+  }
+
+  class AnotherSimpleFailedSample {
+
+    @Test
+    public void failed() {
+      throw new RuntimeException("Failing intentionally");
     }
   }
 }


### PR DESCRIPTION
Now the parameters are specify correctly to the testng-failed.xml Report

Fixes # .
https://github.com/cbeust/testng/issues/2008

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`
