### PR TITLE
Test Timeout not respected-parallel="methods" mode

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-2009: Test Timeout not respected in parallel="methods" mode (Krishnan Mahadevan)
 Fixed: GITHUB-2008: Preserve parameters in each class and not all of the test parameters
 Fixed: GITHUB-1981: Fixes NPE in Assert.assertEquals when an array contains null (Maneesh MS)
 New: Upgrade to gradle5

--- a/src/test/java/test/timeout/TimeOutTest.java
+++ b/src/test/java/test/timeout/TimeOutTest.java
@@ -2,6 +2,8 @@ package test.timeout;
 
 import org.testng.Assert;
 import org.testng.ITestResult;
+import org.testng.TestListenerAdapter;
+import org.testng.TestNG;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.testng.internal.thread.ThreadTimeoutException;
@@ -12,8 +14,10 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
+import org.testng.xml.XmlSuite.ParallelMode;
 import test.BaseTest;
 import test.timeout.github1493.TestClassSample;
+import test.timeout.issue2009.TimeOutWithParallelSample;
 
 public class TimeOutTest extends BaseTest {
   private final long m_id;
@@ -85,6 +89,18 @@ public class TimeOutTest extends BaseTest {
             String.format("Method %s.testMethod() didn't finish within the time-out 1000", TestClassSample.class.getName()));
   }
 
+  @Test(description = "GITHUB-2009")
+  public void testTimeOutWhenParallelIsMethods() {
+    addClass(TimeOutWithParallelSample.class);
+    setParallel(ParallelMode.METHODS);
+    run();
+    Assert.assertEquals(getFailedTests().values().size(), 1);
+    Assert.assertEquals(getSkippedTests().values().size(), 0);
+    Assert.assertEquals(getPassedTests().values().size(), 0);
+    ITestResult result = getFailedTests().values().iterator().next().get(0);
+    long time = result.getEndMillis() - result.getStartMillis();
+    Assert.assertTrue(time < 2000);
+  }
 
   @Override
   public Long getId() {

--- a/src/test/java/test/timeout/issue2009/TimeOutWithParallelSample.java
+++ b/src/test/java/test/timeout/issue2009/TimeOutWithParallelSample.java
@@ -1,0 +1,10 @@
+package test.timeout.issue2009;
+
+import org.testng.annotations.Test;
+
+public class TimeOutWithParallelSample {
+  @Test(timeOut = 1000)
+  public void myTestMethod() throws InterruptedException {
+    Thread.sleep(2000);
+  }
+}


### PR DESCRIPTION
Closes #2009

When TestNG runs parallel tests without an 
executor monitoring the threads, the timeouts 
defined in the test methods aren’t honored and 
TestNG ends up running the tests till it runs to
completion and then uses the timeout value to 
mark the test as failed.

Fixed this by running the test only for as long as
the timeout has been defined after which the current
thread (which is where the test is running as well)
is interrupted.

Fixes #2009 .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
