### PR TITLE
Add a test scenario for @BeforeGroups having a dependsOnGroups

### DIFF
--- a/src/test/java/test/beforegroupdeps/BeforeGroupDependency.java
+++ b/src/test/java/test/beforegroupdeps/BeforeGroupDependency.java
@@ -1,0 +1,61 @@
+package test.beforegroupdeps;
+
+import static org.testng.Assert.*;
+import org.testng.annotations.BeforeGroups;
+import org.testng.annotations.Test;
+
+public class BeforeGroupDependency {
+  private boolean z1run = false;
+  private boolean z2run = false;
+  private boolean setupBrun = false;
+  private boolean a1run = false;
+  private boolean a2run = false;
+
+  @Test(groups="Z")
+  public void z1() {
+    System.out.println("z1");
+    assertFalse(setupBrun);
+    assertFalse(a1run);
+    assertFalse(a2run);
+    z1run = true;
+  }
+
+  @Test(groups="Z")
+  public void z2() {
+    System.out.println("z2");
+    assertFalse(setupBrun);
+    assertFalse(a1run);
+    assertFalse(a2run);
+    z2run = true;
+  }
+
+  @BeforeGroups(value="A", dependsOnGroups="Z")
+  public void setupA() {
+    System.out.println("setupB");
+    assertTrue(z1run);
+    assertTrue(z2run);
+    assertFalse(a1run);
+    assertFalse(a2run);
+    setupBrun = true;
+  }
+
+  @Test(groups="A")
+  public void a1() {
+    System.out.println("a1");
+    assertTrue(z1run);
+    assertTrue(z2run);
+    assertTrue(setupBrun);
+    a1run = true;
+  }
+
+  @Test(groups="A")
+  public void a2() {
+    System.out.println("a2");
+    assertTrue(z1run);
+    assertTrue(z2run);
+    assertTrue(setupBrun);
+    a2run = true;
+  }
+
+}
+

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -191,6 +191,7 @@
       <class name="test.methodselection.MethodSelectionTest"/>
       <class name="test.beforegroups.BeforeGroupsTest"/>
       <class name="test.invocationcount.issue1719.IssueTest"/>
+      <class name="test.beforegroupdeps.BeforeGroupDependency"/>
     </classes>
   </test>
 


### PR DESCRIPTION
TestNG ignores the dependsongroups parameter on @BeforeGroups annotations.

See: https://stackoverflow.com/questions/31929690/beforegroups-method-ignores-dependsongroups