### PR TITLE
Fixing sporadicly failing tests

### DIFF
--- a/src/main/java/org/testng/internal/thread/graph/GraphThreadPoolExecutor.java
+++ b/src/main/java/org/testng/internal/thread/graph/GraphThreadPoolExecutor.java
@@ -61,7 +61,7 @@ public class GraphThreadPoolExecutor<T> extends ThreadPoolExecutor {
     synchronized (m_graph) {
       List<T> freeNodes = m_graph.getFreeNodes();
       if (m_comparator != null) {
-          Collections.sort(freeNodes, m_comparator);
+          freeNodes.sort(m_comparator);
       }
       runNodes(freeNodes);
     }


### PR DESCRIPTION
* The JUnitTestClassLoader test has been failing
consistently on OSX. Refactored the test to use
a temp directory every time instead of a class
variable.
* The DependentTest has been having sporadic 
failures for a combination which involves a class
that has methods (with dependent methods) and when
running in parallel. The failure is due to the fact
that the test assumes that the invocation order
is deterministic. This is not the case.