### PR TITLE
Configurable ThreadPoolExecutor

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-1835: Configurable ThreadPoolExecutor (Krishnan Mahadevan)
 Fixed: GITHUB-1691: Support reading data provider information from Class level @Test annotation (Krishnan Mahadevan)
 Fixed: GITHUB-326: When group-by-instances is set to true the instances created by @Factory does not run in parallel (Krishnan Mahadevan)
 Fixed: GITHUB-1930: Running testng-failed.xml correctly runs failed test in child class but incorrectly runs all tests in base class (Krishnan Mahadevan)

--- a/src/main/java/org/testng/CommandLineArgs.java
+++ b/src/main/java/org/testng/CommandLineArgs.java
@@ -208,4 +208,12 @@ public class CommandLineArgs {
       description = "Should MethodInvocation Listeners be run even for skipped methods")
   public Boolean alwaysRunListeners = Boolean.TRUE;
 
+  public static final String THREAD_POOL_FACTORY_CLASS = "-threadpoolfactoryclass";
+
+  @Parameter(
+      names = THREAD_POOL_FACTORY_CLASS,
+      description = "The threadpool executor factory implementation that TestNG should use.")
+  public String threadPoolFactoryClass;
+
+
 }

--- a/src/main/java/org/testng/IDynamicGraph.java
+++ b/src/main/java/org/testng/IDynamicGraph.java
@@ -1,0 +1,44 @@
+package org.testng;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Represents the graphical representative capabilities of an entity.
+ * The entities could be either a {@link ISuite} or an {@link ITestNGMethod} object which are
+ * usually the logical units of work that TestNG deals with.
+ */
+public interface IDynamicGraph<T> {
+
+  boolean addNode(T node);
+
+  void addEdge(int weight, T from, T to);
+
+  void setVisualisers(Set<IExecutionVisualiser> listener);
+
+  void addEdges(int weight, T from, Iterable<T> tos);
+
+  List<T> getFreeNodes();
+
+  List<T> getDependenciesFor(T node);
+
+  void setStatus(Collection<T> nodes, Status status);
+
+  void setStatus(T node, Status status);
+
+  int getNodeCount();
+
+  int getNodeCountWithStatus(Status status);
+
+  Set<T> getNodesWithStatus(Status status);
+
+  String toDot();
+
+  enum Status {
+    READY,
+    RUNNING,
+    FINISHED
+  }
+
+}

--- a/src/main/java/org/testng/SuiteRunnerWorker.java
+++ b/src/main/java/org/testng/SuiteRunnerWorker.java
@@ -5,7 +5,7 @@ import org.testng.collections.Maps;
 import org.testng.collections.Objects;
 import org.testng.internal.SuiteRunnerMap;
 import org.testng.internal.Utils;
-import org.testng.internal.thread.graph.IWorker;
+import org.testng.thread.IWorker;
 import org.testng.xml.XmlSuite;
 
 import javax.annotation.Nonnull;

--- a/src/main/java/org/testng/TestNG.java
+++ b/src/main/java/org/testng/TestNG.java
@@ -20,6 +20,7 @@ import org.testng.collections.Maps;
 import org.testng.collections.Sets;
 import org.testng.internal.ClassHelper;
 import org.testng.internal.Configuration;
+import org.testng.internal.DynamicGraph;
 import org.testng.internal.ExitCode;
 import org.testng.internal.IConfiguration;
 import org.testng.internal.InstanceCreator;
@@ -1106,7 +1107,7 @@ public class TestNG {
     // Multithreaded: generate a dynamic graph that stores the suite hierarchy. This is then
     // used to run related suites in specific order. Parent suites are run only
     // once all the child suites have completed execution
-    IDynamicGraph<ISuite> suiteGraph = new org.testng.internal.DynamicGraph<>();
+    IDynamicGraph<ISuite> suiteGraph = new DynamicGraph<>();
     for (XmlSuite xmlSuite : m_suites) {
       populateSuiteGraph(suiteGraph, suiteRunnerMap, xmlSuite);
     }

--- a/src/main/java/org/testng/TestNG.java
+++ b/src/main/java/org/testng/TestNG.java
@@ -20,9 +20,9 @@ import org.testng.collections.Maps;
 import org.testng.collections.Sets;
 import org.testng.internal.ClassHelper;
 import org.testng.internal.Configuration;
-import org.testng.internal.DynamicGraph;
 import org.testng.internal.ExitCode;
 import org.testng.internal.IConfiguration;
+import org.testng.internal.InstanceCreator;
 import org.testng.internal.OverrideProcessor;
 import org.testng.internal.RuntimeBehavior;
 import org.testng.internal.SuiteRunnerMap;
@@ -32,8 +32,9 @@ import org.testng.internal.Version;
 import org.testng.internal.annotations.DefaultAnnotationTransformer;
 import org.testng.internal.annotations.IAnnotationFinder;
 import org.testng.internal.annotations.JDK15AnnotationFinder;
-import org.testng.internal.thread.graph.GraphThreadPoolExecutor;
-import org.testng.internal.thread.graph.IThreadWorkerFactory;
+import org.testng.thread.IExecutorFactory;
+import org.testng.thread.ITestNGThreadPoolExecutor;
+import org.testng.thread.IThreadWorkerFactory;
 import org.testng.internal.thread.graph.SuiteWorkerFactory;
 import org.testng.junit.JUnitTestFinder;
 import org.testng.log4testng.Logger;
@@ -109,6 +110,8 @@ public class TestNG {
   /** The default name for a test launched from the command line */
   public static final String DEFAULT_COMMAND_LINE_TEST_NAME = "Command line test";
 
+  private static final String DEFAULT_THREADPOOL_FACTORY = "org.testng.internal.thread.DefaultThreadPoolExecutorFactory";
+
   /** The default name of the result's output directory (keep public, used by Eclipse). */
   public static final String DEFAULT_OUTPUTDIR = "test-output";
 
@@ -140,6 +143,8 @@ public class TestNG {
   private final Map<Class<? extends IReporter>, IReporter> m_reporters = Maps.newHashMap();
   private final Map<Class<? extends IDataProviderListener>, IDataProviderListener>
       m_dataProviderListeners = Maps.newHashMap();
+
+  private IExecutorFactory m_executorFactory = null;
 
   public static final Integer DEFAULT_VERBOSE = 1;
 
@@ -753,6 +758,31 @@ public class TestNG {
     m_verbose = verbose;
   }
 
+  public void setExecutorFactoryClass(String clazzName) {
+    this.m_executorFactory = createExecutorFactoryInstanceUsing(clazzName);
+  }
+
+  private IExecutorFactory createExecutorFactoryInstanceUsing(String clazzName) {
+    Class<?> cls = ClassHelper.forName(clazzName);
+    Object instance = InstanceCreator.newInstance(cls);
+    if (instance instanceof IExecutorFactory) {
+      return (IExecutorFactory) instance;
+    }
+    throw new IllegalArgumentException(
+        clazzName + " does not implement " + IExecutorFactory.class.getName());
+  }
+
+  public void setExecutorFactory(IExecutorFactory factory) {
+    this.m_executorFactory = factory;
+  }
+
+  public IExecutorFactory getExecutorFactory() {
+    if (this.m_executorFactory == null) {
+      this.m_executorFactory = createExecutorFactoryInstanceUsing(DEFAULT_THREADPOOL_FACTORY);
+    }
+    return this.m_executorFactory;
+  }
+
   private void initializeCommandLineSuites() {
     if (m_commandLineTestClasses != null || m_commandLineMethods != null) {
       if (null != m_commandLineMethods) {
@@ -887,6 +917,7 @@ public class TestNG {
     m_configuration.setConfigurable(m_configurable);
     m_configuration.setObjectFactory(factory);
     m_configuration.setAlwaysRunListeners(this.m_alwaysRun);
+    m_configuration.setExecutorFactory(getExecutorFactory());
   }
 
   private void addListeners(XmlSuite s) {
@@ -1075,7 +1106,7 @@ public class TestNG {
     // Multithreaded: generate a dynamic graph that stores the suite hierarchy. This is then
     // used to run related suites in specific order. Parent suites are run only
     // once all the child suites have completed execution
-    DynamicGraph<ISuite> suiteGraph = new DynamicGraph<>();
+    IDynamicGraph<ISuite> suiteGraph = new org.testng.internal.DynamicGraph<>();
     for (XmlSuite xmlSuite : m_suites) {
       populateSuiteGraph(suiteGraph, suiteRunnerMap, xmlSuite);
     }
@@ -1083,8 +1114,7 @@ public class TestNG {
     IThreadWorkerFactory<ISuite> factory =
         new SuiteWorkerFactory(
             suiteRunnerMap, 0 /* verbose hasn't been set yet */, getDefaultSuiteName());
-    GraphThreadPoolExecutor<ISuite> pooledExecutor =
-        new GraphThreadPoolExecutor<>(
+    ITestNGThreadPoolExecutor pooledExecutor = this.getExecutorFactory().newSuiteExecutor(
             "suites",
             suiteGraph,
             factory,
@@ -1156,7 +1186,7 @@ public class TestNG {
    * @param xmlSuite XML Suite
    */
   private void populateSuiteGraph(
-      DynamicGraph<ISuite> suiteGraph /* OUT */, SuiteRunnerMap suiteRunnerMap, XmlSuite xmlSuite) {
+      IDynamicGraph<ISuite> suiteGraph /* OUT */, SuiteRunnerMap suiteRunnerMap, XmlSuite xmlSuite) {
     ISuite parentSuiteRunner = suiteRunnerMap.get(xmlSuite);
     if (xmlSuite.getChildSuites().isEmpty()) {
       suiteGraph.addNode(parentSuiteRunner);
@@ -1306,6 +1336,9 @@ public class TestNG {
   protected void configure(CommandLineArgs cla) {
     if (cla.verbose != null) {
       setVerbose(cla.verbose);
+    }
+    if (cla.threadPoolFactoryClass != null) {
+      setExecutorFactoryClass(cla.threadPoolFactoryClass);
     }
     setOutputDirectory(cla.outputDirectory);
 

--- a/src/main/java/org/testng/internal/AbstractParallelWorker.java
+++ b/src/main/java/org/testng/internal/AbstractParallelWorker.java
@@ -6,7 +6,7 @@ import org.testng.ITestContext;
 import org.testng.ITestNGMethod;
 import org.testng.collections.Lists;
 import org.testng.internal.annotations.IAnnotationFinder;
-import org.testng.internal.thread.graph.IWorker;
+import org.testng.thread.IWorker;
 import org.testng.xml.XmlSuite;
 
 import java.util.Collection;

--- a/src/main/java/org/testng/internal/ClassBasedParallelWorker.java
+++ b/src/main/java/org/testng/internal/ClassBasedParallelWorker.java
@@ -4,7 +4,7 @@ import org.testng.IMethodInstance;
 import org.testng.ITestNGMethod;
 import org.testng.collections.Lists;
 import org.testng.collections.Sets;
-import org.testng.internal.thread.graph.IWorker;
+import org.testng.thread.IWorker;
 import org.testng.xml.XmlSuite;
 import org.testng.xml.XmlTest;
 

--- a/src/main/java/org/testng/internal/Configuration.java
+++ b/src/main/java/org/testng/internal/Configuration.java
@@ -9,6 +9,8 @@ import org.testng.internal.annotations.JDK15AnnotationFinder;
 
 import java.util.List;
 import java.util.Map;
+import org.testng.internal.thread.DefaultThreadPoolExecutorFactory;
+import org.testng.thread.IExecutorFactory;
 
 public class Configuration implements IConfiguration {
 
@@ -21,6 +23,7 @@ public class Configuration implements IConfiguration {
   private final Map<Class<? extends IConfigurationListener>, IConfigurationListener>
       m_configurationListeners = Maps.newHashMap();
   private boolean alwaysRunListeners = true;
+  private IExecutorFactory m_executorFactory = new DefaultThreadPoolExecutorFactory();
 
   public Configuration() {
     init(new JDK15AnnotationFinder(new DefaultAnnotationTransformer()));
@@ -97,6 +100,17 @@ public class Configuration implements IConfiguration {
   @Override
   public void setAlwaysRunListeners(boolean alwaysRunListeners) {
     this.alwaysRunListeners = alwaysRunListeners;
+  }
+
+  @Override
+  public void setExecutorFactory(IExecutorFactory factory) {
+    this.m_executorFactory = factory;
+
+  }
+
+  @Override
+  public IExecutorFactory getExecutorFactory() {
+    return this.m_executorFactory;
   }
 
   @Override

--- a/src/main/java/org/testng/internal/DynamicGraph.java
+++ b/src/main/java/org/testng/internal/DynamicGraph.java
@@ -7,25 +7,20 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.testng.IDynamicGraph;
 import org.testng.IExecutionVisualiser;
 import org.testng.collections.Lists;
 import org.testng.collections.Maps;
 import org.testng.collections.Sets;
 
 /** Representation of the graph of methods. */
-public class DynamicGraph<T> {
+public class DynamicGraph<T> implements IDynamicGraph<T> {
 
   private final Set<T> m_nodesReady = Sets.newLinkedHashSet();
   private final Set<T> m_nodesRunning = Sets.newLinkedHashSet();
   private final Set<T> m_nodesFinished = Sets.newLinkedHashSet();
   private final Edges<T> m_edges = new Edges<>();
   private Set<IExecutionVisualiser> visualisers = Sets.newHashSet();
-
-  public enum Status {
-    READY,
-    RUNNING,
-    FINISHED
-  }
 
   /** Add a node to the graph. */
   public boolean addNode(T node) {

--- a/src/main/java/org/testng/internal/IConfiguration.java
+++ b/src/main/java/org/testng/internal/IConfiguration.java
@@ -4,6 +4,7 @@ import org.testng.*;
 import org.testng.internal.annotations.IAnnotationFinder;
 
 import java.util.List;
+import org.testng.thread.IExecutorFactory;
 
 public interface IConfiguration {
   IAnnotationFinder getAnnotationFinder();
@@ -37,4 +38,8 @@ public interface IConfiguration {
   boolean alwaysRunListeners();
 
   void setAlwaysRunListeners(boolean alwaysRun);
+
+  void setExecutorFactory(IExecutorFactory factory);
+
+  IExecutorFactory getExecutorFactory();
 }

--- a/src/main/java/org/testng/internal/InstanceBasedParallelParallelWorker.java
+++ b/src/main/java/org/testng/internal/InstanceBasedParallelParallelWorker.java
@@ -5,7 +5,7 @@ import org.testng.ITestNGMethod;
 import org.testng.collections.ListMultiMap;
 import org.testng.collections.Lists;
 import org.testng.collections.Maps;
-import org.testng.internal.thread.graph.IWorker;
+import org.testng.thread.IWorker;
 
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/org/testng/internal/TestInvoker.java
+++ b/src/main/java/org/testng/internal/TestInvoker.java
@@ -36,7 +36,7 @@ import org.testng.internal.InvokeMethodRunnable.TestNGRuntimeException;
 import org.testng.internal.ParameterHandler.ParameterBag;
 import org.testng.internal.thread.ThreadExecutionException;
 import org.testng.internal.thread.ThreadUtil;
-import org.testng.internal.thread.graph.IWorker;
+import org.testng.thread.IWorker;
 import org.testng.xml.XmlSuite;
 
 class TestInvoker extends BaseInvoker implements ITestInvoker {

--- a/src/main/java/org/testng/internal/TestMethodWorker.java
+++ b/src/main/java/org/testng/internal/TestMethodWorker.java
@@ -10,7 +10,7 @@ import org.testng.ITestResult;
 import org.testng.collections.Lists;
 import org.testng.collections.Sets;
 import org.testng.internal.ConfigMethodArguments.Builder;
-import org.testng.internal.thread.graph.IWorker;
+import org.testng.thread.IWorker;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;

--- a/src/main/java/org/testng/internal/thread/DefaultThreadPoolExecutorFactory.java
+++ b/src/main/java/org/testng/internal/thread/DefaultThreadPoolExecutorFactory.java
@@ -1,0 +1,34 @@
+package org.testng.internal.thread;
+
+import java.util.Comparator;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+import org.testng.IDynamicGraph;
+import org.testng.thread.IExecutorFactory;
+import org.testng.ISuite;
+import org.testng.ITestNGMethod;
+import org.testng.thread.ITestNGThreadPoolExecutor;
+import org.testng.internal.thread.graph.GraphThreadPoolExecutor;
+import org.testng.thread.IThreadWorkerFactory;
+
+public class DefaultThreadPoolExecutorFactory implements IExecutorFactory {
+
+  @Override
+  public ITestNGThreadPoolExecutor newSuiteExecutor(String name, IDynamicGraph<ISuite> graph,
+      IThreadWorkerFactory<ISuite> factory, int corePoolSize, int maximumPoolSize,
+      long keepAliveTime, TimeUnit unit, BlockingQueue<Runnable> workQueue,
+      Comparator<ISuite> comparator) {
+    return new GraphThreadPoolExecutor<>(name, graph, factory, corePoolSize, maximumPoolSize,
+        keepAliveTime, unit, workQueue, comparator);
+  }
+
+  @Override
+  public ITestNGThreadPoolExecutor newTestMethodExecutor(String name,
+      IDynamicGraph<ITestNGMethod> graph,
+      IThreadWorkerFactory<ITestNGMethod> factory, int corePoolSize, int maximumPoolSize,
+      long keepAliveTime, TimeUnit unit, BlockingQueue<Runnable> workQueue,
+      Comparator<ITestNGMethod> comparator) {
+    return new GraphThreadPoolExecutor<>(name, graph, factory, corePoolSize, maximumPoolSize,
+        keepAliveTime, unit, workQueue, comparator);
+  }
+}

--- a/src/main/java/org/testng/internal/thread/graph/SuiteWorkerFactory.java
+++ b/src/main/java/org/testng/internal/thread/graph/SuiteWorkerFactory.java
@@ -6,6 +6,8 @@ import org.testng.collections.Lists;
 import org.testng.internal.SuiteRunnerMap;
 
 import java.util.List;
+import org.testng.thread.IThreadWorkerFactory;
+import org.testng.thread.IWorker;
 
 /**
  * An {@code IThreadWorkerFactory} for {@code SuiteRunner}s

--- a/src/main/java/org/testng/thread/IExecutorFactory.java
+++ b/src/main/java/org/testng/thread/IExecutorFactory.java
@@ -1,0 +1,72 @@
+package org.testng.thread;
+
+import java.util.Comparator;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+import org.testng.IDynamicGraph;
+import org.testng.ISuite;
+import org.testng.ITestNGMethod;
+
+/**
+ * Represents the capabilities to be possessed by any implementation that can be plugged into TestNG
+ * to execute nodes from a {@link org.testng.IDynamicGraph} object.
+ */
+public interface IExecutorFactory {
+
+  /**
+   * @param name - The name to be used as a prefix for all created threads.
+   * @param graph - A {@link org.testng.IDynamicGraph} object that represents the graph of methods and the
+   * hierarchy of execution.
+   * @param factory - A {@link IThreadWorkerFactory} factory to create threads.
+   * @param corePoolSize the number of threads to keep in the pool, even if they are idle, unless
+   * {@code allowCoreThreadTimeOut} is set
+   * @param maximumPoolSize the maximum number of threads to allow in the pool
+   * @param keepAliveTime when the number of threads is greater than the core, this is the maximum
+   * time that excess idle threads will wait for new tasks before terminating.
+   * @param unit the time unit for the {@code keepAliveTime} argument
+   * @param workQueue the queue to use for holding tasks before they are executed.  This queue will
+   * hold only the {@code Runnable} tasks submitted by the {@code execute} method.
+   * @param comparator - A {@link Comparator} to order nodes internally.
+   * @return - A new {@link ITestNGThreadPoolExecutor} that is capable of running suites in
+   * parallel.
+   */
+  ITestNGThreadPoolExecutor newSuiteExecutor(String name,
+      IDynamicGraph<ISuite> graph,
+      IThreadWorkerFactory<ISuite> factory,
+      int corePoolSize,
+      int maximumPoolSize,
+      long keepAliveTime,
+      TimeUnit unit,
+      BlockingQueue<Runnable> workQueue,
+      Comparator<ISuite> comparator);
+
+  /**
+   * @param name - The name to be used as a prefix for all created threads.
+   * @param graph - A {@link IDynamicGraph} object that represents the graph of methods and the
+   * hierarchy of execution.
+   * @param factory - A {@link IThreadWorkerFactory} factory to create threads.
+   * @param corePoolSize the number of threads to keep in the pool, even if they are idle, unless
+   * {@code allowCoreThreadTimeOut} is set
+   * @param maximumPoolSize the maximum number of threads to allow in the pool
+   * @param keepAliveTime when the number of threads is greater than the core, this is the maximum
+   * time that excess idle threads will wait for new tasks before terminating.
+   * @param unit the time unit for the {@code keepAliveTime} argument
+   * @param workQueue the queue to use for holding tasks before they are executed.  This queue will
+   * hold only the {@code Runnable} tasks submitted by the {@code execute} method.
+   * @param comparator - A {@link Comparator} to order nodes internally.
+   * @return - A new {@link ITestNGThreadPoolExecutor} that is capable of running test methods in
+   * parallel.
+   */
+  ITestNGThreadPoolExecutor newTestMethodExecutor(
+      String name,
+      IDynamicGraph<ITestNGMethod> graph,
+      IThreadWorkerFactory<ITestNGMethod> factory,
+      int corePoolSize,
+      int maximumPoolSize,
+      long keepAliveTime,
+      TimeUnit unit,
+      BlockingQueue<Runnable> workQueue,
+      Comparator<ITestNGMethod> comparator
+  );
+
+}

--- a/src/main/java/org/testng/thread/ITestNGThreadPoolExecutor.java
+++ b/src/main/java/org/testng/thread/ITestNGThreadPoolExecutor.java
@@ -1,0 +1,14 @@
+package org.testng.thread;
+
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Represents the capabilities of a TestNG specific {@link ExecutorService}
+ */
+public interface ITestNGThreadPoolExecutor extends ExecutorService {
+
+  /**
+   * Helps kick start the execution and is the point of entry for execution.
+   */
+  void run();
+}

--- a/src/main/java/org/testng/thread/IThreadWorkerFactory.java
+++ b/src/main/java/org/testng/thread/IThreadWorkerFactory.java
@@ -1,4 +1,4 @@
-package org.testng.internal.thread.graph;
+package org.testng.thread;
 
 import java.util.List;
 

--- a/src/main/java/org/testng/thread/IWorker.java
+++ b/src/main/java/org/testng/thread/IWorker.java
@@ -1,4 +1,4 @@
-package org.testng.internal.thread.graph;
+package org.testng.thread;
 
 import java.util.List;
 

--- a/src/test/java/org/testng/internal/DynamicGraphTest.java
+++ b/src/test/java/org/testng/internal/DynamicGraphTest.java
@@ -7,13 +7,14 @@ import java.util.Collections;
 import java.util.List;
 
 import org.testng.Assert;
+import org.testng.IDynamicGraph;
+import org.testng.IDynamicGraph.Status;
 import org.testng.ITestNGMethod;
 import org.testng.TestNG;
 import org.testng.annotations.Test;
 import org.testng.collections.ListMultiMap;
 import org.testng.collections.Lists;
 import org.testng.collections.Maps;
-import org.testng.internal.DynamicGraph.Status;
 import org.testng.internal.dynamicgraph.EdgeWeightTestSample1;
 import org.testng.internal.dynamicgraph.EdgeWeightTestSample2;
 import org.testng.internal.dynamicgraph.LotsOfEdgesTest;
@@ -38,11 +39,11 @@ public class DynamicGraphTest extends SimpleBaseTest {
   }
 
   @SafeVarargs
-  private static <T> void assertFreeNodesEquals(DynamicGraph<T> graph, T... expected) {
+  private static <T> void assertFreeNodesEquals(IDynamicGraph<T> graph, T... expected) {
     assertFreeNodesEquals(graph, Arrays.asList(expected));
   }
 
-  private static <T> void assertFreeNodesEquals(DynamicGraph<T> graph, List<T> expected) {
+  private static <T> void assertFreeNodesEquals(IDynamicGraph<T> graph, List<T> expected) {
     // Compare free nodes using isEqualTo instead of containsOnly as we care about ordering too.
     assertThat(graph.getFreeNodes()).isEqualTo(expected);
   }
@@ -275,7 +276,7 @@ public class DynamicGraphTest extends SimpleBaseTest {
     Assert.assertEquals(listener.getSucceedMethodNames(), expectedOrder2);
   }
 
-  private static void runAssertion(DynamicGraph<ITestNGMethod> graph, List<String> expected) {
+  private static void runAssertion(IDynamicGraph<ITestNGMethod> graph, List<String> expected) {
     List<ITestNGMethod> p1Methods = graph.getFreeNodes();
     Assert.assertEquals(p1Methods.size(), 3);
     graph.setStatus(p1Methods, Status.FINISHED);


### PR DESCRIPTION
Closes #1835

Here’s how a custom threadpoolexecutor implementation
can be plugged into TestNG.

1. Implement the interface org.testng.IExecutorFactory
2. If using the TestNG API, then the implementation
should be hooked into TestNG via 

a. tng.setExecutorFactory() (or) 
b. tng.setExecutorFactoryClass() 

3. If using a build tool, for e.g., Maven, then 
pass in a classname via the property

```xml
<property>
  <name>threadpoolfactoryclass</name>
  <value>fully.qualified.class.name.goes.here</value>
</property>
```

4. If using the TestNG CLI, then the fully qualified
class name that implements the IExecutorFactory 
interface can be passed via 
“-threadpoolfactoryclass”

Fixes #1835  .

### Did you remember to?

- [ ] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
