### PR TITLE
Annotated default methods of indirectly implemented interfaces should still be called

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -101,6 +101,7 @@ Fixed: GITHUB-1706: Retrying of methods fail when test method involves native in
 New  : Removed deprecated attributes from annotations (Julien Herr)
 New  : Support all JSR-223 compatible script engine
 Fixed: GITHUB-1827: TestNG does not throw an error when a test class does not have a proper constructor (Julien Herr & Krishnan Mahadevan)
+Fixed: Annotated default methods of indirectly implemented interfaces should still be called (Ilya Korobitsyn)
 
 6.14.3
 Fixed: GITHUB-1077: TestNG cannot handle load (Aheiss)

--- a/src/main/java/org/testng/internal/reflect/ReflectionHelper.java
+++ b/src/main/java/org/testng/internal/reflect/ReflectionHelper.java
@@ -1,14 +1,16 @@
 package org.testng.internal.reflect;
 
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.testng.collections.Lists;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.util.LinkedList;
-import java.util.List;
 
 public class ReflectionHelper {
   /**
@@ -97,9 +99,18 @@ public class ReflectionHelper {
   }
 
   private static List<Method> getDefaultMethods(Class<?> clazz) {
-    return Arrays.stream(clazz.getInterfaces())
+    return getAllInterfaces(clazz).stream()
         .flatMap(each -> Arrays.stream(each.getMethods()))
         .filter(method -> !Modifier.isAbstract(method.getModifiers()))
         .collect(Collectors.toList());
+  }
+
+  private static Set<Class<?>> getAllInterfaces(Class<?> clazz) {
+    Set<Class<?>> result = new HashSet<>();
+    while(clazz != null && clazz != Object.class) {
+      result.addAll(Arrays.asList(clazz.getInterfaces()));
+      clazz = clazz.getSuperclass();
+    }
+    return result;
   }
 }

--- a/src/test/java/test/defaultmethods/DefaultMethodTest.java
+++ b/src/test/java/test/defaultmethods/DefaultMethodTest.java
@@ -4,59 +4,69 @@ import org.testng.Assert;
 import org.testng.ITestClass;
 import org.testng.ITestNGMethod;
 import org.testng.TestNG;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import test.SimpleBaseTest;
 import test.listeners.TestAndClassListener;
 
 public class DefaultMethodTest extends SimpleBaseTest {
 
-  @Test(description = "Test default methods defined in an interface should be run")
-  public void testDefaultShouldRun() {
-    ITestClass testClass = runTestWithDefaultMethods();
+  @DataProvider
+  public Object[][] classes() {
+    return new Object[][] {
+            new Object[] { TestA.class },
+            new Object[] { TestB.class },
+            new Object[] { TestC.class }
+    };
+  }
+
+  @Test(description = "Test default methods defined in an interface should be run", dataProvider = "classes")
+  public void testDefaultShouldRun(Class<?> clazz) {
+    ITestClass testClass = runTestWithDefaultMethods(clazz);
 
     ITestNGMethod[] testMethods = testClass.getTestMethods();
     Assert.assertEquals(testMethods.length, 1);
     Assert.assertEquals(testMethods[0].getMethodName(), "defaultMethodTest");
   }
 
-  @Test(description = "Before class default methods defined in an interface should be run")
-  public void beforeClassDefaultShouldRun() {
-    ITestClass testClass = runTestWithDefaultMethods();
+  @Test(description = "Before class default methods defined in an interface should be run", dataProvider = "classes")
+  public void beforeClassDefaultShouldRun(Class<?> clazz) {
+    ITestClass testClass = runTestWithDefaultMethods(clazz);
 
     ITestNGMethod[] beforeClassMethods = testClass.getBeforeClassMethods();
     Assert.assertEquals(beforeClassMethods.length, 1);
     Assert.assertEquals(beforeClassMethods[0].getMethodName(), "beforeClassRun");
   }
 
-  @Test(description = "After class default methods defined in an interface should be run")
-  public void afterClassDefaultShouldRun() {
-    ITestClass testClass = runTestWithDefaultMethods();
+  @Test(description = "After class default methods defined in an interface should be run", dataProvider = "classes")
+  public void afterClassDefaultShouldRun(Class<?> clazz) {
+    ITestClass testClass = runTestWithDefaultMethods(clazz);
 
     ITestNGMethod[] afterClassMethods = testClass.getAfterClassMethods();
     Assert.assertEquals(afterClassMethods.length, 1);
     Assert.assertEquals(afterClassMethods[0].getMethodName(), "afterClassRun");
   }
 
-  @Test(description = "Before method default methods defined in an interface should be run")
-  public void beforeMethodDefaultShouldRun() {
-    final ITestClass testClass = runTestWithDefaultMethods();
+  @Test(description = "Before method default methods defined in an interface should be run", dataProvider = "classes")
+  public void beforeMethodDefaultShouldRun(Class<?> clazz) {
+    final ITestClass testClass = runTestWithDefaultMethods(clazz);
 
     ITestNGMethod[] beforeMethods = testClass.getBeforeTestMethods();
     Assert.assertEquals(beforeMethods.length, 1);
     Assert.assertEquals(beforeMethods[0].getMethodName(), "beforeMethodRun");
   }
 
-  @Test(description = "After method default methods defined in an interface should be run")
-  public void afterMethodDefaultShouldRun() {
-    final ITestClass testClass = runTestWithDefaultMethods();
+  @Test(description = "After method default methods defined in an interface should be run", dataProvider = "classes")
+  public void afterMethodDefaultShouldRun(Class<?> clazz) {
+    final ITestClass testClass = runTestWithDefaultMethods(clazz);
 
     ITestNGMethod[] afterMethods = testClass.getAfterTestMethods();
     Assert.assertEquals(afterMethods.length, 1);
     Assert.assertEquals(afterMethods[0].getMethodName(), "afterMethodRun");
   }
 
-  private ITestClass runTestWithDefaultMethods() {
-    TestNG tng = create(TestA.class);
+  private ITestClass runTestWithDefaultMethods(Class<?> clazz) {
+    TestNG tng = create(clazz);
     TestClassListener listener = new TestClassListener();
     tng.addListener(listener);
     tng.run();

--- a/src/test/java/test/defaultmethods/TestB.java
+++ b/src/test/java/test/defaultmethods/TestB.java
@@ -1,0 +1,3 @@
+package test.defaultmethods;
+
+public class TestB extends TestA {}

--- a/src/test/java/test/defaultmethods/TestC.java
+++ b/src/test/java/test/defaultmethods/TestC.java
@@ -1,0 +1,3 @@
+package test.defaultmethods;
+
+public class TestC extends TestA implements InterfaceA {}


### PR DESCRIPTION
Summary: If test class implements an interface that contains default methods annotated with `@Test` or `@Before/After` annotations TestNG calls them.
Currently, if this kind of interface is implemented indirectly by the test class, for example inherited from the parent (`BaseTestClass`, common pattern for us), it will not be executed.
This PR fixes that.

Fixes # .

### Did you remember to?

- [x] Add test case(s)
- [x] Update `CHANGES.txt`