### PR TITLE
Include assertEquals(Map, Map) into Assert class

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -109,6 +109,7 @@ New  : Removed deprecated attributes from annotations (Julien Herr)
 New  : Support all JSR-223 compatible script engine
 Fixed: GITHUB-1827: TestNG does not throw an error when a test class does not have a proper constructor (Julien Herr & Krishnan Mahadevan)
 Fixed: Annotated default methods of indirectly implemented interfaces should still be called (Ilya Korobitsyn)
+New  : GITHUB-2105: Include assertEquals(Map, Map) into Assert class
 
 6.14.3
 Fixed: GITHUB-1077: TestNG cannot handle load (Aheiss)

--- a/src/main/java/org/testng/Assert.java
+++ b/src/main/java/org/testng/Assert.java
@@ -1307,6 +1307,10 @@ public class Assert {
     }
   }
 
+  public static void assertEquals(Map<?, ?> actual, Map<?, ?> expected) {
+    assertEquals(actual, expected, null);
+  }
+
   /** Asserts that two maps are equal. */
   public static void assertEquals(Map<?, ?> actual, Map<?, ?> expected, String message) {
     if (actual == expected) {


### PR DESCRIPTION
Fixes #2105 .

### Did you remember to?

- [ ] Add test case(s) -> They are already tested as the assertEquals is already called in the AssertTest with two maps
- [x] Update `CHANGES.txt`


