### PR TITLE
Fix NPE in Thread affinity mode

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-2110: NPE is thrown when running with Thread affinity (Krishnan Mahadevan)
 Fixed: GITHUB-2069: JUnit TestSuite not handled correctly in Reports (Krishnan Mahadevan)
 Fixed: GITHUB-2075: Thread interrupt flag persists between test methods (Krishnan Mahadevan)
 Fixed: GITHUB-2074: Thread Interrupted when using expectedException (Krishnan Mahadevan)

--- a/src/test/java/test/thread/parallelization/issue2110/IssueTest.java
+++ b/src/test/java/test/thread/parallelization/issue2110/IssueTest.java
@@ -1,0 +1,29 @@
+package test.thread.parallelization.issue2110;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import org.testng.TestNG;
+import org.testng.annotations.Test;
+import org.testng.xml.XmlSuite;
+import org.testng.xml.XmlSuite.ParallelMode;
+import test.SimpleBaseTest;
+
+public class IssueTest extends SimpleBaseTest {
+
+  @Test
+  public void testMethod() {
+    System.setProperty("testng.thread.affinity", "true");
+    try {
+      XmlSuite xmlsuite = createXmlSuite("2110_suite");
+      xmlsuite.setParallel(ParallelMode.CLASSES);
+      xmlsuite.setThreadCount(50);
+      createXmlTest(xmlsuite, "2110_test", TestClass.class);
+      TestNG testng = create(xmlsuite);
+      testng.setVerbose(2);
+      testng.run();
+      assertThat(TestClass.threadIds).hasSize(1);
+    } finally {
+      System.setProperty("testng.thread.affinity", "false");
+    }
+  }
+
+}

--- a/src/test/java/test/thread/parallelization/issue2110/TestClass.java
+++ b/src/test/java/test/thread/parallelization/issue2110/TestClass.java
@@ -1,0 +1,37 @@
+package test.thread.parallelization.issue2110;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.testng.annotations.Test;
+
+public class TestClass {
+
+  static Set<Long> threadIds = Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+  @Test
+  public void test0() {
+    threadIds.add(Thread.currentThread().getId());
+  }
+
+  @Test
+  public void test1() {
+    threadIds.add(Thread.currentThread().getId());
+  }
+
+  @Test(dependsOnMethods = "test1")
+  public void test2() {
+    threadIds.add(Thread.currentThread().getId());
+  }
+
+  @Test(dependsOnMethods = "test2")
+  public void test3() {
+    threadIds.add(Thread.currentThread().getId());
+  }
+
+  @Test
+  public void test4() {
+    threadIds.add(Thread.currentThread().getId());
+  }
+
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -935,6 +935,7 @@
   <test name="threadAffinity">
     <classes>
       <class name="test.thread.parallelization.issue1773.IssueTest"/>
+      <class name="test.thread.parallelization.issue2110.IssueTest"/>
     </classes>
   </test>
 


### PR DESCRIPTION
Closes #2110

When there is just one test class and user does the
following:

1. Enables thread affinity 
2. Chooses to run with parallel=“classes”

TestNG is throwing a NPE. Fixed the problem.

Fixes #2110 

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
