### PR TITLE
Use Trusty environment for oracle jdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 sudo: required
 language: java
 
@@ -25,6 +26,8 @@ matrix:
   include:
     - env: JDK='OpenJDK 8'
       jdk: openjdk8
+    - env: JDK='Oracle JDK 8'
+      jdk: oraclejdk8
     - env: JDK='Oracle JDK 9'
       jdk: oraclejdk9
     - env: JDK='OpenJDK 9'


### PR DESCRIPTION
Based on inputs from this thread:
https://travis-ci.community/t/install-of-oracle-jdk-8-failing/3038/8
