### PR TITLE
Added a catch statement for NoClassDefFoundError

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-2149: Handle NoClassDefFoundError when classloader fails to load a class
 New:   GITHUB-2111: Provide an interceptor for Data Provider (Krishnan Mahadevan)
 Fixed: GITHUB-1709: @Ignore doesn't work when used on child class, and parent has multiple @Test methods (Krishnan Mahadevan)
 New:   GITHUB-2118: Default assertion message (Jiong Fu)

--- a/src/main/java/org/testng/internal/ClassHelper.java
+++ b/src/main/java/org/testng/internal/ClassHelper.java
@@ -108,8 +108,8 @@ public final class ClassHelper {
       }
       try {
         return classLoader.loadClass(className);
-      } catch (ClassNotFoundException ex) {
-        // With additional class loaders, it is legitimate to ignore ClassNotFoundException
+      } catch (ClassNotFoundException | NoClassDefFoundError ex) {
+        // With additional class loaders, it is legitimate to ignore ClassNotFoundException / NoClassDefFoundError
         if (classLoaders.isEmpty()) {
           logClassNotFoundError(className, ex);
         }
@@ -127,7 +127,7 @@ public final class ClassHelper {
     }
   }
 
-  private static void logClassNotFoundError(String className, Exception ex) {
+  private static void logClassNotFoundError(String className, Throwable ex) {
     Utils.log(
         CLASS_HELPER,
         2,

--- a/src/test/java/org/testng/internal/ClassHelperTest.java
+++ b/src/test/java/org/testng/internal/ClassHelperTest.java
@@ -1,5 +1,14 @@
 package org.testng.internal;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import org.testng.internal.issue1339.BabyPanda;
@@ -8,14 +17,6 @@ import org.testng.internal.issue1456.TestClassSample;
 import org.testng.xml.XmlClass;
 import org.testng.xml.XmlSuite;
 import org.testng.xml.XmlTest;
-
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class ClassHelperTest {
 
@@ -38,6 +39,19 @@ public class ClassHelperTest {
   @Test
   public void testFindClassesInSameTest() {
     runTest(TestClassSample.class, 2, TestClassSample.class, BabyPanda.class);
+  }
+
+  @Test
+  public void testNoClassDefFoundError() {
+      URLClassLoader urlClassLoader = new URLClassLoader(new URL[]{}) {
+        @Override
+        public Class<?> loadClass(String name) throws ClassNotFoundException {
+            throw new NoClassDefFoundError();
+        }
+      };
+      ClassHelper.addClassLoader(urlClassLoader);
+      String fakeClassName = UUID.randomUUID().toString();
+      Assert.assertNull(ClassHelper.forName(fakeClassName), "The result should be null; no exception should be thrown.");
   }
 
   private static void runTest(Class<?> classToBeFound, int expectedCount, Class<?>... classes) {


### PR DESCRIPTION
This error may be thrown by a `URLClassLoader` in some cases. It should not
be rethrown in this case since we want to try to load it from the other
configured classloaders.

See more details in #2149 

Fixes #2149 

### Did you remember to?

- [x] Add test case(s)
- [x] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
