### PR TITLE
Inherited groups should run only for groups selection

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-2152: Multiple Test Groups Causing @BeforeMethod and @AfterMethod to be called multiple times for a single test (Krishnan Mahadevan)
 Fixed: GITHUB-2172: Suite summary report table issue with EmailableReporter2.java (Devendra Raju K)
 Fixed: GITHUB-2148: TestNG - configfailurepolicy=“continue” is not working for retried test (Krishnan Mahadevan)
 Fixed: GITHUB-2163: Test is executed infinite number of times when the data provider returns a new object (Krishnan Mahadevan)

--- a/src/main/java/org/testng/internal/ConfigInvoker.java
+++ b/src/main/java/org/testng/internal/ConfigInvoker.java
@@ -112,6 +112,10 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
    * @param arguments
    */
   public void invokeBeforeGroupsConfigurations(GroupConfigMethodArguments arguments) {
+    if (arguments.isGroupFilteringDisabled()) {
+      return;
+    }
+
     List<ITestNGMethod> filteredMethods = Lists.newArrayList();
     String[] groups = arguments.getTestMethod().getGroups();
 
@@ -149,6 +153,10 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
     // (only a method that belongs to a group can trigger the invocation
     // of afterGroups methods)
     if (arguments.getTestMethod().getGroups().length == 0) {
+      return;
+    }
+
+    if (arguments.isGroupFilteringDisabled()) {
       return;
     }
 

--- a/src/main/java/org/testng/internal/GroupConfigMethodArguments.java
+++ b/src/main/java/org/testng/internal/GroupConfigMethodArguments.java
@@ -7,14 +7,12 @@ import org.testng.xml.XmlSuite;
 public class GroupConfigMethodArguments extends Arguments {
 
   private final ConfigurationGroupMethods groupMethods;
-  private final XmlSuite suite;
 
   private GroupConfigMethodArguments(ITestNGMethod testMethod,
-      ConfigurationGroupMethods groupMethods, XmlSuite suite, Map<String, String> params,
+      ConfigurationGroupMethods groupMethods, Map<String, String> params,
       Object instance) {
     super(instance, testMethod, params);
     this.groupMethods = groupMethods;
-    this.suite = suite;
   }
 
   public ConfigurationGroupMethods getGroupMethods() {
@@ -22,7 +20,7 @@ public class GroupConfigMethodArguments extends Arguments {
   }
 
   public XmlSuite getSuite() {
-    return suite;
+    return getTestMethod().getXmlTest().getSuite();
   }
 
   public Map<String, String> getParameters() {
@@ -33,11 +31,14 @@ public class GroupConfigMethodArguments extends Arguments {
     return instance;
   }
 
+  public boolean isGroupFilteringDisabled() {
+    return getTestMethod().getXmlTest().isGroupFilteringDisabled();
+  }
+
   public static class Builder {
 
     private ITestNGMethod testMethod;
     private ConfigurationGroupMethods groupMethods;
-    private XmlSuite suite;
     private Map<String, String> params;
     private Object instance;
 
@@ -48,11 +49,6 @@ public class GroupConfigMethodArguments extends Arguments {
 
     public Builder withGroupConfigMethods(ConfigurationGroupMethods groupMethods) {
       this.groupMethods = groupMethods;
-      return this;
-    }
-
-    public Builder forSuite(XmlSuite suite) {
-      this.suite = suite;
       return this;
     }
 
@@ -67,7 +63,7 @@ public class GroupConfigMethodArguments extends Arguments {
     }
 
     public GroupConfigMethodArguments build() {
-      return new GroupConfigMethodArguments(testMethod, groupMethods, suite, params, instance);
+      return new GroupConfigMethodArguments(testMethod, groupMethods, params, instance);
     }
   }
 }

--- a/src/main/java/org/testng/internal/TestInvoker.java
+++ b/src/main/java/org/testng/internal/TestInvoker.java
@@ -107,7 +107,6 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
       GroupConfigMethodArguments args = new Builder()
           .forTestMethod(testMethod)
           .withGroupConfigMethods(groupMethods)
-          .forSuite(suite)
           .forInstance(instance)
           .withParameters(parameters)
           .build();
@@ -315,7 +314,6 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
       GroupConfigMethodArguments arguments = new GroupConfigMethodArguments.Builder()
           .forTestMethod(testMethod)
           .withGroupConfigMethods(groupMethods)
-          .forSuite(suite)
           .withParameters(parameters)
           .forInstance(instance)
           .build();
@@ -347,7 +345,6 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
       GroupConfigMethodArguments arguments = new GroupConfigMethodArguments.Builder()
           .forTestMethod(testMethod)
           .withGroupConfigMethods(groupMethods)
-          .forSuite(suite)
           .withParameters(parameters)
           .forInstance(instance)
           .build();
@@ -515,7 +512,6 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
     GroupConfigMethodArguments cfgArgs = new GroupConfigMethodArguments.Builder()
         .forTestMethod(arguments.getTestMethod())
         .withGroupConfigMethods(arguments.getGroupMethods())
-        .forSuite(suite)
         .withParameters(arguments.getParameters())
         .forInstance(arguments.getInstance())
         .build();
@@ -677,7 +673,6 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
     GroupConfigMethodArguments grpArgs = new GroupConfigMethodArguments.Builder()
         .forTestMethod(arguments.getTestMethod())
         .withGroupConfigMethods(arguments.getGroupMethods())
-        .forSuite(suite)
         .withParameters(arguments.getParameters())
         .forInstance(arguments.getInstance())
         .build();

--- a/src/main/java/org/testng/xml/XmlTest.java
+++ b/src/main/java/org/testng/xml/XmlTest.java
@@ -119,6 +119,10 @@ public class XmlTest implements Cloneable {
     return Collections.unmodifiableList(result);
   }
 
+  public boolean isGroupFilteringDisabled() {
+    return getIncludedGroups().isEmpty() && getExcludedGroups().isEmpty();
+  }
+
   /**
    * Sets the XML Classes.
    *

--- a/src/test/java/test/configuration/BaseGroupsTest.java
+++ b/src/test/java/test/configuration/BaseGroupsTest.java
@@ -20,6 +20,7 @@ public class BaseGroupsTest extends SimpleBaseTest {
               + "no matter how many subclasses it has")
   public void verifySingleInvocation() {
     TestNG tng = create(BaseGroupsASampleTest.class, BaseGroupsBSampleTest.class);
+    tng.setGroups("foo");
 
     InvokedMethodNameListener listener = new InvokedMethodNameListener();
     tng.addListener(listener);

--- a/src/test/java/test/configuration/ConfigurationGroupsTest.java
+++ b/src/test/java/test/configuration/ConfigurationGroupsTest.java
@@ -1,0 +1,41 @@
+package test.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.testng.TestNG;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import test.SimpleBaseTest;
+
+public class ConfigurationGroupsTest extends SimpleBaseTest {
+
+  @Test
+  public void multipleBeforeGroupTest() {
+    TestNG testng = create(MultipleBeforeGroupTest.class);
+    testng.setGroups("foo");
+    testng.run();
+    assertThat(testng.getStatus()).isEqualTo(0);
+  }
+
+  @Test(dataProvider = "getTestData")
+  public void runTest(Class<?> testClass, String groupName) {
+    TestNG testng = create(testClass);
+    testng.setGroups(groupName);
+    testng.run();
+    assertThat(testng.getStatus()).isEqualTo(0);
+  }
+
+  @DataProvider
+  public Object[][] getTestData() {
+    return new Object[][]{
+        {ConfigurationGroups1SampleTest.class, "cg1-a, cg1-1"},
+        {ConfigurationGroups2SampleTest.class, "cg2-a,cg2-1"},
+        {ConfigurationGroups3SampleTest.class, "cg34-a, cg34-1"},
+        {ConfigurationGroups4SampleTest.class, "cg4-1"},
+        {ConfigurationGroups5SampleTest.class, "cg5-1, cg5-2"},
+        {ConfigurationGroups6SampleTest.class, "cg6-1"},
+        {ConfigurationGroups7SampleTest.class, "A"}
+    };
+  }
+
+}

--- a/src/test/java/test/configuration/GroupsTest.java
+++ b/src/test/java/test/configuration/GroupsTest.java
@@ -46,10 +46,11 @@ public class GroupsTest {
         Arrays.asList(1, 2, 2, 2, 2, 2, 2, 3));
   }
 
-  private void runTest(Class cls, List<Integer> list, List<Integer> expected) {
-      m_testNg.setTestClasses(new Class[] {
+  private void runTest(Class<?> cls, List<Integer> list, List<Integer> expected) {
+      m_testNg.setTestClasses(new Class<?>[] {
           cls
       });
+      m_testNg.setGroups("twice");
       m_testNg.run();
       Assert.assertEquals(list, expected);
   }

--- a/src/test/java/test/configurationfailurepolicy/ClassWithFailedBeforeClassMethodAndBeforeGroupsAfterClassAfterGroups.java
+++ b/src/test/java/test/configurationfailurepolicy/ClassWithFailedBeforeClassMethodAndBeforeGroupsAfterClassAfterGroups.java
@@ -8,7 +8,7 @@ import org.testng.annotations.Test;
 
 public class ClassWithFailedBeforeClassMethodAndBeforeGroupsAfterClassAfterGroups {
 
-  @BeforeClass
+  @BeforeClass(groups = "group1")
   public void setupClassFails() {
     throw new RuntimeException("setup class fail");
   }
@@ -19,7 +19,7 @@ public class ClassWithFailedBeforeClassMethodAndBeforeGroupsAfterClassAfterGroup
   @Test(groups = "group1")
   public void test1() {}
 
-  @AfterClass
+  @AfterClass(groups = "group1")
   public void tearDownClass() {}
 
   @AfterGroups(groups = "group1")

--- a/src/test/java/test/configurationfailurepolicy/FailurePolicyTest.java
+++ b/src/test/java/test/configurationfailurepolicy/FailurePolicyTest.java
@@ -36,12 +36,7 @@ public class FailurePolicyTest {
         3,
         1
       },
-      new Object[] {
-        new Class[] {ClassWithFailedBeforeClassMethodAndBeforeGroupsAfterClassAfterGroups.class},
-        1,
-        3,
-        1
-      },
+
       new Object[] {new Class[] {ClassWithFailedBeforeMethodAndMultipleInvocations.class}, 4, 0, 4},
       new Object[] {new Class[] {ExtendsClassWithFailedBeforeMethod.class}, 2, 2, 2},
       new Object[] {new Class[] {ExtendsClassWithFailedBeforeClassMethod.class}, 1, 2, 2},
@@ -79,6 +74,24 @@ public class FailurePolicyTest {
     testng.run();
 
     verify(tla, configurationFailures, configurationSkips, skippedTests);
+  }
+
+  @Test
+  public void confFailureTestInvolvingGroups() {
+    Class[] classesUnderTest = new Class[]{
+        ClassWithFailedBeforeClassMethodAndBeforeGroupsAfterClassAfterGroups.class
+    };
+
+    TestListenerAdapter tla = new TestListenerAdapter();
+    TestNG testng = new TestNG();
+    testng.setOutputDirectory(OutputDirectoryPatch.getOutputDirectory());
+    testng.setTestClasses(classesUnderTest);
+    testng.addListener(tla);
+    testng.setVerbose(0);
+    testng.setConfigFailurePolicy(XmlSuite.FailurePolicy.CONTINUE);
+    testng.setGroups("group1");
+    testng.run();
+    verify(tla, 1, 3, 1);
   }
 
   @Test

--- a/src/test/java/test/groups/issue2152/IssueTest.java
+++ b/src/test/java/test/groups/issue2152/IssueTest.java
@@ -1,0 +1,18 @@
+package test.groups.issue2152;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import org.testng.TestNG;
+import org.testng.annotations.Test;
+import test.SimpleBaseTest;
+
+public class IssueTest extends SimpleBaseTest {
+
+  @Test(description = "GITHUB-2152")
+  public void ensureConfigurationsDontInheritGroupsWhenRunningWithoutGroupFiltering() {
+    TestNG testng = create(TestClassSample.class);
+    testng.run();
+    String[] expected = new String[]{"setup", "test1", "teardown"};
+    assertThat(TestClassSample.logs).containsExactly(expected);
+  }
+
+}

--- a/src/test/java/test/groups/issue2152/TestClassSample.java
+++ b/src/test/java/test/groups/issue2152/TestClassSample.java
@@ -1,0 +1,27 @@
+package test.groups.issue2152;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.testng.ITestResult;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@Test(groups = {"Group1", "Group2", "Group3", "Group4"})
+public class TestClassSample {
+  static List<String> logs = new ArrayList<>();
+
+  @BeforeMethod
+  public void setUp() {
+    logs.add("setup");
+  }
+
+  @AfterMethod
+  public void tearDown(ITestResult result) {
+    logs.add("teardown");
+  }
+
+  public void test1() {
+    logs.add("test1");
+  }
+}

--- a/src/test/java/test/regression/groupsordering/A.java
+++ b/src/test/java/test/regression/groupsordering/A.java
@@ -6,7 +6,7 @@ import org.testng.annotations.Test;
 public class A extends Base {
 
   @Test(groups= "a")
-  public void testA() throws Exception {
+  public void testA() {
     s_childAWasRun= true;
   }
 }

--- a/src/test/java/test/regression/groupsordering/Base.java
+++ b/src/test/java/test/regression/groupsordering/Base.java
@@ -1,6 +1,5 @@
 package test.regression.groupsordering;
 
-
 import org.testng.Assert;
 import org.testng.annotations.AfterGroups;
 import org.testng.annotations.BeforeGroups;
@@ -10,14 +9,12 @@ public abstract class Base {
   protected static boolean s_childBWasRun;
 
   @BeforeGroups(value= "a", groups= "a")
-  public void setUp() throws Exception {
-//    System.out.println("class is " + getClass().getName() + " Before group  ");
+  public void setUp() {
     Assert.assertFalse(s_childAWasRun || s_childBWasRun, "Static field was not reset: @AfterGroup method not invoked");
   }
 
   @AfterGroups(value= "a", groups= "a")
   public void tearDown() {
-//    System.out.println("class is " + getClass().getName() + " After group  ");
     Assert.assertTrue(s_childAWasRun, "Child A was not run");
     Assert.assertTrue(s_childBWasRun, "Child B was not run");
     s_childAWasRun = false;

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -153,6 +153,7 @@
       <class name="test.groupbug.GroupBugTest" />
       <class name="test.groups.issue1834.IssueTest"/>
       <class name="test.groups.issue182.IssueTest"/>
+      <class name="test.groups.issue2152.IssueTest"/>
       <class name="test.parameters.ShadowTest" />
       <class name="test.parameters.ParameterOverrideTest" />
       <class name="test.parameters.ParameterInjectAndOptionTest" />
@@ -626,13 +627,7 @@
 
   <test name="BeforeGroups-AfterGroups-1" >
     <classes>
-      <class name="test.configuration.ConfigurationGroups1SampleTest" />
-      <class name="test.configuration.ConfigurationGroups2SampleTest" />
-      <class name="test.configuration.ConfigurationGroups3SampleTest" />
-      <class name="test.configuration.ConfigurationGroups4SampleTest" />
-      <class name="test.configuration.ConfigurationGroups5SampleTest" />
-      <class name="test.configuration.ConfigurationGroups6SampleTest" />
-      <class name="test.configuration.ConfigurationGroups7SampleTest" />
+      <class name="test.configuration.ConfigurationGroupsTest" />
     </classes>
   </test>
 
@@ -668,6 +663,11 @@
 
   <!-- Group ordering 1 -->
   <test name="Class Run">
+    <groups>
+      <run>
+        <include name="a"/>
+      </run>
+    </groups>
     <classes>
       <class name="test.regression.groupsordering.A" />
       <class name="test.regression.groupsordering.B" />
@@ -823,7 +823,6 @@
       <class name="test.configuration.ExternalConfigurationClass"/>
       <class name="test.configuration.GroupsTest"/>
       <class name="test.configuration.MethodCallOrderTest"/>
-      <class name="test.configuration.MultipleBeforeGroupTest" />
       <class name="test.configuration.BeforeMethodWithGroupFiltersTest" />
       <class name="test.configuration.AfterMethodWithGroupFiltersTest" />
       <class name="test.configuration.ReflectMethodParametrizedConfigurationMethodTest" />


### PR DESCRIPTION
Closes #2152

When a class is annotated with a “@Test” and which
includes one or more groups, and when the test class
has one or more configuration methods, currently 
TestNG inherits the groups information and ends
up running all the configurations even though 
group filtering is not enabled.

Fixes #2152  .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
