### PR TITLE
Fixed Suite summary table border issue #2172

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-2172: Suite summary report table issue with EmailableReporter2.java (Devendra Raju K)
 Fixed: GITHUB-2148: TestNG - configfailurepolicy=“continue” is not working for retried test (Krishnan Mahadevan)
 Fixed: GITHUB-2163: Test is executed infinite number of times when the data provider returns a new object (Krishnan Mahadevan)
 Fixed: GITHUB-2157: NullPointerException occurs when a Retried test has an exception in DataProvider (Krishnan Mahadevan)

--- a/src/main/java/org/testng/reporters/EmailableReporter2.java
+++ b/src/main/java/org/testng/reporters/EmailableReporter2.java
@@ -148,7 +148,7 @@ public class EmailableReporter2 implements IReporter {
 
     int testIndex = 0;
     for (SuiteResult suiteResult : suiteResults) {
-      writer.print("<tr><th colspan=\"7\">");
+      writer.print("<tr><th colspan=\"8\">");
       writer.print(Utils.escapeHtml(suiteResult.getSuiteName()));
       writer.println("</th></tr>");
 


### PR DESCRIPTION
Fixes #2172 .

Suite Summary, table header 'colspan' value should be increased to '8' from '7'.

Updated EmailableReporter2.java, method writeSuiteSummary() to fix table header border by changing 'colspan' value to '8' from '7'.