### PR TITLE
Adding Retry scenario details to report to Fix #2180

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-2180: Write scenario details for Retried tests (Devendra Raju K)
 Fixed: GITHUB-2124: JUnit Report should contain the output of org.testng.Reporter (Krishnan Mahadevan)
 Fixed: GITHUB-2171: Ability to embed attachments and make them available on TestNG XML report (Krishnan Mahadevan)
 Fixed: GITHUB-2152: Multiple Test Groups Causing @BeforeMethod and @AfterMethod to be called multiple times for a single test (Krishnan Mahadevan)

--- a/src/main/java/org/testng/reporters/EmailableReporter2.java
+++ b/src/main/java/org/testng/reporters/EmailableReporter2.java
@@ -404,6 +404,7 @@ public class EmailableReporter2 implements IReporter {
         scenarioIndex +=
             writeScenarioDetails(testResult.getSkippedConfigurationResults(), scenarioIndex);
         scenarioIndex += writeScenarioDetails(testResult.getSkippedTestResults(), scenarioIndex);
+        scenarioIndex += writeScenarioDetails(testResult.getRetriedTestResults(), scenarioIndex);
         scenarioIndex += writeScenarioDetails(testResult.getPassedTestResults(), scenarioIndex);
       }
     }


### PR DESCRIPTION
Fixes #Adding Retry scenario details to report .

Updated `writeScenarioDetails()` to display retried tests scenario details in testng report.

### Did you remember to?

- [x] Update `CHANGES.txt`
