### PR TITLE
[NO-OP Change][TrivialFix] Fix typo in javadoc @Ignore

### DIFF
--- a/src/main/java/org/testng/annotations/Ignore.java
+++ b/src/main/java/org/testng/annotations/Ignore.java
@@ -8,7 +8,7 @@ import static java.lang.annotation.ElementType.PACKAGE;
 import static java.lang.annotation.ElementType.TYPE;
 
 /**
- * Alternative of @Test(enable=false)
+ * Alternative of @Test(enabled=false)
  *
  * <p>Notice that @Ignore on a class will disable all test methods of the class.
  *


### PR DESCRIPTION
Alternative of @Ignore is @Test(enabled=false) not @Test(enable=false).
This typo caused me confused when copy the suggestion from javadoc
and paste to my tests but IDE complains that it's not correct. To solve
it, I had to download the source of @Test and check its attributes.
We can avoid this troublesome by correcting the doc.

Fixes # .

### Did you remember to?

- [ ] Add test case(s)
- [ ] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
