### PR TITLE
Allow user to provide DI Injector

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+New  : GITHUB-2199: Allow users to provide their own Injector for Dependency Injection (Krishnan Mahadevan)
 Fixed: GITHUB-2180: Write scenario details for Retried tests (Devendra Raju K)
 Fixed: GITHUB-2124: JUnit Report should contain the output of org.testng.Reporter (Krishnan Mahadevan)
 Fixed: GITHUB-2171: Ability to embed attachments and make them available on TestNG XML report (Krishnan Mahadevan)

--- a/src/main/java/org/testng/CommandLineArgs.java
+++ b/src/main/java/org/testng/CommandLineArgs.java
@@ -215,5 +215,11 @@ public class CommandLineArgs {
       description = "The threadpool executor factory implementation that TestNG should use.")
   public String threadPoolFactoryClass;
 
+  public static final String DEPENDENCY_INJECTOR_FACTORY = "-dependencyinjectorfactory";
+
+  @Parameter(
+      names = DEPENDENCY_INJECTOR_FACTORY,
+      description = "The dependency injector factory implementation that TestNG should use.")
+  public String dependencyInjectoryFactoryClass;
 
 }

--- a/src/main/java/org/testng/IInjectorFactory.java
+++ b/src/main/java/org/testng/IInjectorFactory.java
@@ -1,0 +1,21 @@
+package org.testng;
+
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.Stage;
+
+/**
+ * Allows customization of the {@link Injector} creation when working with dependency injection.
+ */
+@FunctionalInterface
+public interface IInjectorFactory {
+
+  /**
+   * @param stage - A {@link Stage} object that defines the appropriate stage
+   * @param modules - An array of {@link Module}
+   * @return - An {@link com.google.inject.Inject} instance that can be used to perform dependency
+   * injection.
+   */
+  Injector getInjector(Stage stage, Module... modules);
+
+}

--- a/src/main/java/org/testng/TestNG.java
+++ b/src/main/java/org/testng/TestNG.java
@@ -1351,6 +1351,12 @@ public class TestNG {
     if (cla.verbose != null) {
       setVerbose(cla.verbose);
     }
+    if (cla.dependencyInjectoryFactoryClass != null) {
+      Class<?> clazz = ClassHelper.forName(cla.dependencyInjectoryFactoryClass);
+      if (clazz != null && IInjectorFactory.class.isAssignableFrom(clazz)) {
+        m_configuration.setInjectorFactory(InstanceCreator.newInstance((Class<IInjectorFactory>) clazz));
+      }
+    }
     if (cla.threadPoolFactoryClass != null) {
       setExecutorFactoryClass(cla.threadPoolFactoryClass);
     }
@@ -1835,7 +1841,8 @@ public class TestNG {
     return Lists.newArrayList(serviceLoaderListeners.values());
   }
 
-  //
-  // ServiceLoader testing
-  /////
+  public void setInjectorFactory(IInjectorFactory factory) {
+    this.m_configuration.setInjectorFactory(factory);
+  }
+
 }

--- a/src/main/java/org/testng/TestRunner.java
+++ b/src/main/java/org/testng/TestRunner.java
@@ -75,6 +75,7 @@ public class TestRunner
   private ISuite m_suite;
   private XmlTest m_xmlTest;
   private String m_testName;
+  private IInjectorFactory m_injectorFactory;
 
   private final GuiceHelper guiceHelper = new GuiceHelper(this);
 
@@ -244,6 +245,7 @@ public class TestRunner
     m_testName = test.getName();
     m_host = suite.getHost();
     m_testClassesFromXml = test.getXmlClasses();
+    m_injectorFactory = m_configuration.getInjectorFactory();
     setVerbose(test.getVerbose());
 
     boolean preserveOrder = test.getPreserveOrder();
@@ -1230,7 +1232,7 @@ public class TestRunner
 
   @Override
   public Injector getInjector(IClass iClass) {
-    return guiceHelper.getInjector(iClass);
+    return guiceHelper.getInjector(iClass, this.m_injectorFactory);
   }
 
   @Override

--- a/src/main/java/org/testng/internal/ClassImpl.java
+++ b/src/main/java/org/testng/internal/ClassImpl.java
@@ -2,18 +2,15 @@ package org.testng.internal;
 
 import static org.testng.internal.Utils.isStringNotEmpty;
 
-import com.google.inject.Guice;
 import com.google.inject.Injector;
-import com.google.inject.Module;
-import com.google.inject.Stage;
 
 import org.testng.GuiceHelper;
 import org.testng.IClass;
+import org.testng.IInjectorFactory;
 import org.testng.ISuite;
 import org.testng.ITest;
 import org.testng.ITestContext;
 import org.testng.ITestObjectFactory;
-import org.testng.TestNGException;
 import org.testng.annotations.ITestAnnotation;
 import org.testng.collections.Lists;
 import org.testng.collections.Objects;
@@ -21,8 +18,6 @@ import org.testng.internal.annotations.IAnnotationFinder;
 import org.testng.xml.XmlClass;
 import org.testng.xml.XmlTest;
 
-import java.lang.reflect.Constructor;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -132,12 +127,12 @@ public class ClassImpl implements IClass {
     return injector.getInstance(m_class);
   }
 
-  public Injector getParentInjector() {
+  public Injector getParentInjector(IInjectorFactory injectorFactory) {
     ISuite suite = m_testContext.getSuite();
     // Reuse the previous parent injector, if any
     Injector injector = suite.getParentInjector();
     if (injector == null) {
-      injector = GuiceHelper.createInjector(m_testContext, Collections.emptyList());
+      injector = GuiceHelper.createInjector(m_testContext, injectorFactory, Collections.emptyList());
       suite.setParentInjector(injector);
     }
     return injector;

--- a/src/main/java/org/testng/internal/Configuration.java
+++ b/src/main/java/org/testng/internal/Configuration.java
@@ -1,14 +1,19 @@
 package org.testng.internal;
 
-import org.testng.*;
+import com.google.inject.Guice;
+import java.util.List;
+import java.util.Map;
+import org.testng.IConfigurable;
+import org.testng.IConfigurationListener;
+import org.testng.IExecutionListener;
+import org.testng.IHookable;
+import org.testng.IInjectorFactory;
+import org.testng.ITestObjectFactory;
 import org.testng.collections.Lists;
 import org.testng.collections.Maps;
 import org.testng.internal.annotations.DefaultAnnotationTransformer;
 import org.testng.internal.annotations.IAnnotationFinder;
 import org.testng.internal.annotations.JDK15AnnotationFinder;
-
-import java.util.List;
-import java.util.Map;
 import org.testng.internal.thread.DefaultThreadPoolExecutorFactory;
 import org.testng.thread.IExecutorFactory;
 
@@ -24,6 +29,8 @@ public class Configuration implements IConfiguration {
       m_configurationListeners = Maps.newHashMap();
   private boolean alwaysRunListeners = true;
   private IExecutorFactory m_executorFactory = new DefaultThreadPoolExecutorFactory();
+
+  private IInjectorFactory injectorFactory = Guice::createInjector;
 
   public Configuration() {
     init(new JDK15AnnotationFinder(new DefaultAnnotationTransformer()));
@@ -116,5 +123,15 @@ public class Configuration implements IConfiguration {
   @Override
   public boolean alwaysRunListeners() {
     return alwaysRunListeners;
+  }
+
+  @Override
+  public void setInjectorFactory(IInjectorFactory factory) {
+    this.injectorFactory = factory;
+  }
+
+  @Override
+  public IInjectorFactory getInjectorFactory() {
+    return this.injectorFactory;
   }
 }

--- a/src/main/java/org/testng/internal/IConfiguration.java
+++ b/src/main/java/org/testng/internal/IConfiguration.java
@@ -42,4 +42,8 @@ public interface IConfiguration {
   void setExecutorFactory(IExecutorFactory factory);
 
   IExecutorFactory getExecutorFactory();
+
+  IInjectorFactory getInjectorFactory();
+
+  void setInjectorFactory(IInjectorFactory factory);
 }

--- a/src/test/java/test/guice/FakeInjector.java
+++ b/src/test/java/test/guice/FakeInjector.java
@@ -1,0 +1,126 @@
+package test.guice;
+
+import com.google.inject.Binding;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.MembersInjector;
+import com.google.inject.Module;
+import com.google.inject.Provider;
+import com.google.inject.Scope;
+import com.google.inject.TypeLiteral;
+import com.google.inject.spi.TypeConverterBinding;
+import java.lang.annotation.Annotation;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class FakeInjector implements Injector {
+
+  private static FakeInjector instance;
+
+  public FakeInjector() {
+  }
+
+  private static void setInstance(FakeInjector i) {
+    instance = i;
+  }
+
+  public static FakeInjector getInstance() {
+    return instance;
+  }
+
+  @Override
+  public void injectMembers(Object instance) {
+
+  }
+
+  @Override
+  public <T> MembersInjector<T> getMembersInjector(TypeLiteral<T> typeLiteral) {
+    return null;
+  }
+
+  @Override
+  public <T> MembersInjector<T> getMembersInjector(Class<T> type) {
+    return null;
+  }
+
+  @Override
+  public Map<Key<?>, Binding<?>> getBindings() {
+    return null;
+  }
+
+  @Override
+  public Map<Key<?>, Binding<?>> getAllBindings() {
+    return null;
+  }
+
+  @Override
+  public <T> Binding<T> getBinding(Key<T> key) {
+    return null;
+  }
+
+  @Override
+  public <T> Binding<T> getBinding(Class<T> type) {
+    return null;
+  }
+
+  @Override
+  public <T> Binding<T> getExistingBinding(Key<T> key) {
+    return null;
+  }
+
+  @Override
+  public <T> List<Binding<T>> findBindingsByType(TypeLiteral<T> type) {
+    return null;
+  }
+
+  @Override
+  public <T> Provider<T> getProvider(Key<T> key) {
+    return null;
+  }
+
+  @Override
+  public <T> Provider<T> getProvider(Class<T> type) {
+    return null;
+  }
+
+  @Override
+  public <T> T getInstance(Key<T> key) {
+    return null;
+  }
+
+  @Override
+  public <T> T getInstance(Class<T> type) {
+    try {
+      setInstance(this);
+      return type.newInstance();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public Injector getParent() {
+    return null;
+  }
+
+  @Override
+  public Injector createChildInjector(Iterable<? extends Module> modules) {
+    return null;
+  }
+
+  @Override
+  public Injector createChildInjector(Module... modules) {
+    return null;
+  }
+
+  @Override
+  public Map<Class<? extends Annotation>, Scope> getScopeBindings() {
+    return null;
+  }
+
+  @Override
+  public Set<TypeConverterBinding> getTypeConverterBindings() {
+    return null;
+  }
+}

--- a/src/test/java/test/guice/GuiceTest.java
+++ b/src/test/java/test/guice/GuiceTest.java
@@ -25,4 +25,12 @@ public class GuiceTest extends SimpleBaseTest {
     TestNG tng = create(GuiceNoModuleTest.class);
     tng.run();
   }
+
+  @Test(description = "GITHUB-2199")
+  public void guiceWithExternalDependencyInjector() {
+    TestNG testng = create(Guice1Test.class);
+    testng.setInjectorFactory((stage, modules) -> new FakeInjector());
+    testng.run();
+    assertThat(FakeInjector.getInstance()).isNotNull();
+  }
 }


### PR DESCRIPTION
Closes #2199

You can now specify your own Dependency Injector
creation mechanism by doing the following:

1. Implement the interface org.testng.IInjectorFactory
2. Plugin the fully qualified class name of the
newly created implementation via the command line 
argument “-dependencyinjectorfactory”

Fixes #2199  .

### Did you remember to?

- [ ] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
