### PR TITLE
Remove duplicated null check in assertNotNull

### DIFF
--- a/src/main/java/org/testng/Assert.java
+++ b/src/main/java/org/testng/Assert.java
@@ -873,7 +873,6 @@ public class Assert {
       }
       fail(formatted + "expected object to not be null");
     }
-    assertTrue(object != null, message);
   }
 
   /**


### PR DESCRIPTION
Both current duplicated implementations check for the same and only differ the way they build the message. I opted for the one with a better message description which is also the most recent implementation. If the other implementation is preferred, then a quick fix should be enough.

### Did you remember to?

- [x] Add test case(s)
- [ ] Update `CHANGES.txt`

Is it necessary to update `CHANGES.txt`?