### PR TITLE
expectedExceptions mismatch because of wrapping

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-2235: expectedExceptions mismatch because of wrapping (Krishnan Mahadevan)
 Fixed: GITHUB-2220: ITestListener's methods get called multiple times for one test, when @Listeners annotation is used in multiple test classes (Krishnan Mahadevan)
 Fixed: GITHUB-2211: assertEquals for Map sometimes does not use provided message (Krishnan Mahadevan)
 Fixed: GITHUB-1632: throwing SkipException sets iTestResult status to Failure instead of Skip (Krishnan Mahadevan)

--- a/src/main/java/org/testng/internal/MethodInvocationHelper.java
+++ b/src/main/java/org/testng/internal/MethodInvocationHelper.java
@@ -12,6 +12,7 @@ import org.testng.ITestContext;
 import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
 import org.testng.TestNGException;
+import org.testng.internal.InvokeMethodRunnable.TestNGRuntimeException;
 import org.testng.internal.annotations.IAnnotationFinder;
 import org.testng.internal.collections.ArrayIterator;
 import org.testng.internal.collections.OneToTwoDimArrayIterator;
@@ -328,7 +329,11 @@ public class MethodInvocationHelper {
       }
     } catch (Exception ex) {
       if (notTimedout) {
-        testResult.setThrowable(ex.getCause());
+        Throwable e = ex.getCause();
+        if (e instanceof TestNGRuntimeException) {
+          e = e.getCause();
+        }
+        testResult.setThrowable(e);
       } else {
         ThreadTimeoutException exception =
             new ThreadTimeoutException(

--- a/src/test/java/test/expectedexceptions/issue2235/ExampleTestCase.java
+++ b/src/test/java/test/expectedexceptions/issue2235/ExampleTestCase.java
@@ -1,0 +1,11 @@
+package test.expectedexceptions.issue2235;
+
+import org.testng.annotations.Test;
+
+public class ExampleTestCase {
+
+  @Test(timeOut = 1000, expectedExceptions = IllegalArgumentException.class)
+  public void testMethod() {
+    throw new IllegalArgumentException("foo");
+  }
+}

--- a/src/test/java/test/expectedexceptions/issue2235/IssueTest.java
+++ b/src/test/java/test/expectedexceptions/issue2235/IssueTest.java
@@ -1,0 +1,25 @@
+package test.expectedexceptions.issue2235;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.testng.TestListenerAdapter;
+import org.testng.TestNG;
+import org.testng.annotations.Test;
+import org.testng.xml.XmlSuite;
+import org.testng.xml.XmlSuite.ParallelMode;
+import test.SimpleBaseTest;
+
+public class IssueTest extends SimpleBaseTest {
+
+  @Test(description = "GITHUB-2235")
+  public void testExpectedExceptions() {
+    XmlSuite xmlSuite = createXmlSuite("main_suite", "main_test", ExampleTestCase.class);
+    xmlSuite.setParallel(ParallelMode.METHODS);
+    TestNG testng = create(xmlSuite);
+    TestListenerAdapter listener = new TestListenerAdapter();
+    testng.addListener(listener);
+    testng.run();
+    assertThat(listener.getPassedTests()).isNotEmpty();
+    assertThat(listener.getFailedTests()).isEmpty();
+  }
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -61,6 +61,7 @@
       <class name="test.CtorCalledOnce" />
       <class name="test.expectedexceptions.ExpectedExceptionsTest" />
       <class name="test.expectedexceptions.issue2074.IssueTest"/>
+      <class name="test.expectedexceptions.issue2235.IssueTest"/>
       <class name="test.access.PrivateAccessConfigurationMethods" />
       <class name="test.expectedexceptions.WrappedExpectedExceptionTest" />
       <class name="test.parameters.OptionalParameterTest"/>


### PR DESCRIPTION
Closes #2235

When executing tests in parallel that involve an 
expected exception and a timeout, tests were failing
even though the test threw the expected exception.

Fixes #2235  .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
