### PR TITLE
Streamline parameter initialization

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-2238: Parameter values should be overridable from JVM arguments (Krishnan Mahadevan)
 Fixed: GITHUB-2231: Incorrect hierarchy in testng.xml file created programmatically and failed to run. (Krishnan Mahadevan)
 Fixed: GITHUB-2235: expectedExceptions mismatch because of wrapping (Krishnan Mahadevan)
 Fixed: GITHUB-2220: ITestListener's methods get called multiple times for one test, when @Listeners annotation is used in multiple test classes (Krishnan Mahadevan)

--- a/src/main/java/org/testng/internal/Parameters.java
+++ b/src/main/java/org/testng/internal/Parameters.java
@@ -249,11 +249,7 @@ public class Parameters {
 
     for (int i = 0; i < parameterNames.length; i++) {
       String p = parameterNames[i];
-      String value = params.xmlParameters.get(p);
-      if (null == value) {
-        // try SysEnv entries
-        value = System.getProperty(p);
-      }
+      String value = System.getProperty(p, params.xmlParameters.get(p));
       if (null == value) {
         if (optionalValues != null) {
           value = optionalValues[i];

--- a/src/test/java/test/parameters/ParameterOverrideTest.java
+++ b/src/test/java/test/parameters/ParameterOverrideTest.java
@@ -1,6 +1,5 @@
 package test.parameters;
 
-import org.testng.ITest;
 import org.testng.ITestNGListener;
 import org.testng.TestNG;
 import org.testng.annotations.DataProvider;

--- a/src/test/java/test/parameters/issue2238/ExampleTestCase.java
+++ b/src/test/java/test/parameters/issue2238/ExampleTestCase.java
@@ -1,0 +1,16 @@
+package test.parameters.issue2238;
+
+import org.testng.Assert;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+public class ExampleTestCase {
+
+  @Test
+  @Parameters("value")
+  public void testMethod(int value) {
+    int expected = Integer.parseInt(System.getProperty("value"));
+    Assert.assertEquals(value, expected);
+  }
+
+}

--- a/src/test/java/test/parameters/issue2238/IssueTest.java
+++ b/src/test/java/test/parameters/issue2238/IssueTest.java
@@ -1,0 +1,61 @@
+package test.parameters.issue2238;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import org.testng.TestListenerAdapter;
+import org.testng.TestNG;
+import org.testng.annotations.Test;
+import org.testng.xml.XmlClass;
+import org.testng.xml.XmlInclude;
+import org.testng.xml.XmlSuite;
+import org.testng.xml.XmlTest;
+import test.SimpleBaseTest;
+
+public class IssueTest extends SimpleBaseTest {
+
+  @Test
+  public void ensureParametersCanBeOverriddenAtSuiteLevel() {
+    XmlSuite xmlSuite = createXmlSuite("suite", "test", ExampleTestCase.class);
+    xmlSuite.getParameters().put("value", "100");
+    runTest(xmlSuite);
+  }
+
+  @Test
+  public void ensureParametersCanBeOverriddenAtTestLevel() {
+    XmlSuite xmlSuite = createXmlSuite("suite");
+    XmlTest xmltest = createXmlTest(xmlSuite, "test", ExampleTestCase.class);
+    xmltest.getLocalParameters().put("value", "100");
+    runTest(xmlSuite);
+  }
+
+  @Test
+  public void ensureParametersCanBeOverriddenAtClassLevel() {
+    XmlSuite xmlSuite = createXmlSuite("suite");
+    XmlTest xmlTest = createXmlTest(xmlSuite, "test");
+    XmlClass xmlclass = createXmlClass(xmlTest, ExampleTestCase.class);
+    xmlclass.getLocalParameters().put("value", "100");
+    runTest(xmlSuite);
+  }
+
+  @Test
+  public void ensureParametersCanBeOverriddenAtMethodLevel() {
+    XmlSuite xmlSuite = createXmlSuite("suite");
+    XmlTest xmlTest = createXmlTest(xmlSuite, "test");
+    XmlClass xmlclass = createXmlClass(xmlTest, ExampleTestCase.class);
+    XmlInclude xmlInclude = new XmlInclude();
+    xmlInclude.setName("testMethod");
+    xmlInclude.getLocalParameters().put("value", "100");
+    xmlclass.getIncludedMethods().add(xmlInclude);
+    runTest(xmlSuite);
+  }
+
+
+  private void runTest(XmlSuite xmlSuite) {
+    System.setProperty("value", "200");
+    TestNG testng = create(xmlSuite);
+    TestListenerAdapter listener = new TestListenerAdapter();
+    testng.addListener(listener);
+    testng.run();
+    assertThat(listener.getFailedTests()).isEmpty();
+  }
+
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -160,6 +160,7 @@
       <class name="test.parameters.ParameterOverrideTest" />
       <class name="test.parameters.ParameterInjectAndOptionTest" />
       <class name="test.parameters.ParametersPackageLevelMethodTest" />
+      <class name="test.parameters.issue2238.IssueTest"/>
       <class name="test.reports.FailedReporterTest" />
       <class name="test.reports.EmailableReporterTest"/>
       <class name="test.failedreporter.FailedReporterScenariosTest"/>


### PR DESCRIPTION
Closes #2238

TestNG reads the JVM arguments to find if a 
parameter had a value, “if and only if” the parameter
was not defined in the testng suite xml file.

It should read the JVM argument all the time and use
the JVM argument’s value as the highest priority
value.

Fixed this discrepancy as part of this PR.

Fixes #2238  .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
