### PR TITLE
Configure TestNG to fail when all tests are skipped

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 Current
-Fixed: GITHUB2255: Ensure test method parameters are visible in BeforeMethod config method (Krishnan Mahadevan)
+Fixed:GITHUB-217: Configure TestNG to fail when all tests are skipped (Krishnan Mahadevan)
+Fixed: GITHUB-2255: Ensure test method parameters are visible in BeforeMethod config method (Krishnan Mahadevan)
 Fixed: GITHUB-2251: NullPointerException at test with timeOut (Krishnan Mahadevan)
 Fixed: GITHUB-2249: Not abstract super-classes mess up test run order (Sergii Kim)
 Fixed: GITHUB-2195: NPE Using groups and @Before/@AfterMethod with alwaysRun and dependsOnMethods (Tomas & Julien Herr)

--- a/src/main/java/org/testng/CommandLineArgs.java
+++ b/src/main/java/org/testng/CommandLineArgs.java
@@ -222,4 +222,11 @@ public class CommandLineArgs {
       description = "The dependency injector factory implementation that TestNG should use.")
   public String dependencyInjectorFactoryClass;
 
+  public static final String FAIL_IF_ALL_TESTS_SKIPPED = "-failwheneverythingskipped";
+
+  @Parameter(
+      names = FAIL_IF_ALL_TESTS_SKIPPED,
+      description = "Should TestNG fail execution if all tests were skipped and nothing was run.")
+  public Boolean failIfAllTestsSkipped = false;
+
 }

--- a/src/main/java/org/testng/internal/ExitCode.java
+++ b/src/main/java/org/testng/internal/ExitCode.java
@@ -23,7 +23,7 @@ public class ExitCode {
 
   public static final int HAS_NO_TEST = 8;
   private static final int FAILED_WITHIN_SUCCESS = 4;
-  private static final int SKIPPED = 2;
+  public static final int SKIPPED = 2;
   private static final int FAILED = 1;
   private static final int SIZE = 3;
 

--- a/src/main/java/org/testng/internal/ExitCodeListener.java
+++ b/src/main/java/org/testng/internal/ExitCodeListener.java
@@ -1,18 +1,25 @@
 package org.testng.internal;
 
+import org.testng.IExecutionListener;
 import org.testng.IReporter;
 import org.testng.ISuite;
 import org.testng.ISuiteResult;
 import org.testng.ITestContext;
 import org.testng.ITestListener;
 import org.testng.ITestResult;
+import org.testng.TestNGException;
 import org.testng.xml.XmlSuite;
 
 import java.util.List;
 
-public class ExitCodeListener implements ITestListener, IReporter {
+public class ExitCodeListener implements ITestListener, IReporter, IExecutionListener {
   private boolean hasTests = false;
   private final ExitCode status = new ExitCode();
+  private boolean failIfAllTestsSkipped = false;
+
+  public void failIfAllTestsSkipped() {
+    this.failIfAllTestsSkipped = true;
+  }
 
   public ExitCode getStatus() {
     return status;
@@ -63,4 +70,11 @@ public class ExitCodeListener implements ITestListener, IReporter {
 
   @Override
   public void onFinish(ITestContext context) {}
+
+  @Override
+  public void onExecutionFinish() {
+    if (failIfAllTestsSkipped && (getStatus().getExitCode() == ExitCode.SKIPPED)) {
+      throw new TestNGException("All tests were skipped. Nothing was run.");
+    }
+  }
 }

--- a/src/test/java/test/dataprovider/issue217/IssueTest.java
+++ b/src/test/java/test/dataprovider/issue217/IssueTest.java
@@ -1,0 +1,17 @@
+package test.dataprovider.issue217;
+
+import org.testng.TestNG;
+import org.testng.TestNGException;
+import org.testng.annotations.Test;
+import test.SimpleBaseTest;
+
+public class IssueTest extends SimpleBaseTest {
+
+  @Test(description = "GITHUB-217", expectedExceptions = TestNGException.class)
+  public void ensureTestNGThrowsExceptionWhenAllTestsAreSkipped() {
+    TestNG testng = create(SampleTestCase.class);
+    testng.toggleFailureIfAllTestsWereSkipped(true);
+    testng.run();
+  }
+
+}

--- a/src/test/java/test/dataprovider/issue217/SampleTestCase.java
+++ b/src/test/java/test/dataprovider/issue217/SampleTestCase.java
@@ -1,0 +1,17 @@
+package test.dataprovider.issue217;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class SampleTestCase {
+    public static final String DP_NAME = "dataProvider";
+
+    @DataProvider(name = DP_NAME)
+    public static Object[][] getData() {
+        throw new IllegalStateException("guess me!");
+    }
+
+    @Test(dataProvider = DP_NAME)
+    public void test() {
+    }
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -583,6 +583,7 @@
       <class name="test.dataprovider.issue1987.IssueTest"/>
       <class name="test.dataprovider.InterceptorTest"/>
       <class name="test.dataprovider.issue2255.IssueTest"/>
+      <class name="test.dataprovider.issue217.IssueTest"/>
     </classes>
   </test>
 


### PR DESCRIPTION
Closes #217

Currently TestNG doesn’t throw an exception which
build tools can leverage to fail a build, when all
the “@Test” methods get skipped and nothing was run.
TestNG returns the proper status, but sometimes 
build tools may not be reading that status and take
appropriate action.

Introduced a new configuration through this PR using
which a user can instruct TestNG itself to trigger
an exception when no tests were executed.

If one is using surefire plugin, then your surefire
plugin configuration would look like below:


```xml
<configuration>
  <properties>
    <property>
      <name>failwheneverythingskipped</name>
      <value>true</value>
    </property>
  </properties>
</configuration>
```

If you are using command line, then this feature
can be turned on by passing 
-failwheneverythingskipped=true

Fixes #217  .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`