### PR TITLE
Allow skipping SPI listeners

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-2259: Missing configuration for ServiceLoader Listeners (Krishnan Mahadevan)
 Fixed: GITHUB-2257: Facilitate retry of configuration methods via call backs (Krishnan Mahadevan)
 Fixed: GITHUB-2223: testng 7.1.0 java.lang.ClassNotFoundException: com.google.inject.Stage (Krishnan Mahadevan)
 Fixed: GITHUB-217: Configure TestNG to fail when all tests are skipped (Krishnan Mahadevan)

--- a/src/main/java/org/testng/CommandLineArgs.java
+++ b/src/main/java/org/testng/CommandLineArgs.java
@@ -229,4 +229,11 @@ public class CommandLineArgs {
       description = "Should TestNG fail execution if all tests were skipped and nothing was run.")
   public Boolean failIfAllTestsSkipped = false;
 
+  public static final String LISTENERS_TO_SKIP_VIA_SPI = "-spilistenerstoskip";
+
+  @Parameter(
+      names = LISTENERS_TO_SKIP_VIA_SPI,
+      description = "Comma separated fully qualified class names of listeners that should be skipped from being wired in via Service Loaders.")
+  public String spiListenersToSkip = "";
+
 }


### PR DESCRIPTION
Closes #2259

Providing a configuration using which service loader
backed listeners can be skipped from being wired in.

If one is using surefire plugin, then your surefire
plugin configuration would look like below:

```xml
<configuration>
  <properties>
    <property>
      <name>spilistenerstoskip</name>
      <value>org.kungfu.DragonWarrior,org.kungfu.MasterShifu</value>
    </property>
  </properties>
</configuration>
```

If you are using command line, then this feature
can be turned on by passing
`-spilistenerstoskip=org.kungfu.DragonWarrior,org.kungfu.MasterShifu`

Fixes #2259  .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`