### PR TITLE
Facilitate config retries via callbacks.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 Current
+Fixed: GITHUB-2257: Facilitate retry of configuration methods via call backs (Krishnan Mahadevan)
 Fixed: GITHUB-2223: testng 7.1.0 java.lang.ClassNotFoundException: com.google.inject.Stage (Krishnan Mahadevan)
-Fixed:GITHUB-217: Configure TestNG to fail when all tests are skipped (Krishnan Mahadevan)
+Fixed: GITHUB-217: Configure TestNG to fail when all tests are skipped (Krishnan Mahadevan)
 Fixed: GITHUB-2255: Ensure test method parameters are visible in BeforeMethod config method (Krishnan Mahadevan)
 Fixed: GITHUB-2251: NullPointerException at test with timeOut (Krishnan Mahadevan)
 Fixed: GITHUB-2249: Not abstract super-classes mess up test run order (Sergii Kim)

--- a/src/main/java/org/testng/internal/MethodInvocationHelper.java
+++ b/src/main/java/org/testng/internal/MethodInvocationHelper.java
@@ -407,6 +407,8 @@ public class MethodInvocationHelper {
           public void runConfigurationMethod(ITestResult tr) {
             try {
               invokeMethod(thisMethod, instance, parameters);
+              error[0] = null;
+              tr.setThrowable(null);
             } catch (Throwable t) {
               error[0] = t;
               tr.setThrowable(t); // make Throwable available to IConfigurable

--- a/src/test/java/test/hook/issue2257/IssueTest.java
+++ b/src/test/java/test/hook/issue2257/IssueTest.java
@@ -1,0 +1,22 @@
+package test.hook.issue2257;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.testng.TestListenerAdapter;
+import org.testng.TestNG;
+import org.testng.annotations.Test;
+import test.SimpleBaseTest;
+
+public class IssueTest extends SimpleBaseTest {
+
+  @Test(description = "GITHUB-2257")
+  public void ensureConfigurationsCanBeRetriedViaCallBacks() {
+    TestNG testng = create(TestClassSample.class);
+    TestListenerAdapter listener = new TestListenerAdapter();
+    testng.run();
+    assertThat(listener.getConfigurationSkips()).isEmpty();
+    assertThat(listener.getConfigurationFailures()).isEmpty();
+    assertThat(testng.getStatus()).isEqualTo(0);
+  }
+
+}

--- a/src/test/java/test/hook/issue2257/TestClassSample.java
+++ b/src/test/java/test/hook/issue2257/TestClassSample.java
@@ -1,0 +1,60 @@
+package test.hook.issue2257;
+
+import org.testng.Assert;
+import org.testng.IConfigurable;
+import org.testng.IConfigureCallBack;
+import org.testng.ITestResult;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+public class TestClassSample implements IConfigurable {
+
+  private int counter = 1;
+
+  @Override
+  public void run(IConfigureCallBack callBack, ITestResult testResult) {
+    callBack.runConfigurationMethod(testResult);
+    if (testResult.getThrowable() != null) {
+      for (int i = 0; i <= 3; i++) {
+        callBack.runConfigurationMethod(testResult);
+        if (testResult.getThrowable() == null) {
+          break;
+        }
+      }
+    }
+  }
+
+  @BeforeSuite
+  public void beforeSuite() {
+    runConfiguration();
+  }
+
+  @BeforeTest
+  public void beforeTest() {
+    runConfiguration();
+  }
+
+  @BeforeClass
+  public void beforeClass() {
+    runConfiguration();
+  }
+
+  @BeforeMethod
+  public void beforeMethod() {
+    runConfiguration();
+  }
+
+  @Test
+  public void runTest() {}
+
+  private void runConfiguration() {
+    if (counter++ == 2) {
+      counter = 1;
+    } else {
+      Assert.fail();
+    }
+  }
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -630,6 +630,7 @@
     <classes>
       <class name="test.hook.HookableTest"/>
       <class name="test.hook.issue2251.IssueTest"/>
+      <class name="test.hook.issue2257.IssueTest"/>
     </classes>
   </test>
 


### PR DESCRIPTION
Closes #2257

Currently TestNG facilitates retry of failed tests
via a retry analyser but the same mechanism doesn’t 
exist for a configuration method.

Instead of introducing a new retry analyses for 
configuration methods, found an alternative when
retries for configuration methods can be easily supported
via call backs.

This PR enables support for retry of configuration
methods via call back.

Fixes #2257  .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`