### PR TITLE
Use SPI to load Guice modules

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-2273: Use SPI to load Guice modules (Bartosz Popiela)
 Fixed: GITHUB-2280: Prevent Retry from happening endlessly (Paweł Nadolski)
 Fixed: GITHUB-553:  Better error message when dealing with classes having both Constructor and Factory methods (Krishnan Mahadevan)
 Fixed: GITHUB-2267: RetryAnalyzer is not set properly and consistent when using dataprovider (Eric Kubenka)

--- a/src/main/java/org/testng/GuiceHelper.java
+++ b/src/main/java/org/testng/GuiceHelper.java
@@ -1,8 +1,13 @@
 package org.testng;
 
-import com.google.inject.Injector;
-import com.google.inject.Module;
-import com.google.inject.Stage;
+import static org.testng.internal.Utils.isStringEmpty;
+import static org.testng.internal.Utils.isStringNotEmpty;
+
+import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ServiceLoader;
+
 import org.testng.annotations.Guice;
 import org.testng.collections.Lists;
 import org.testng.internal.ClassHelper;
@@ -10,124 +15,137 @@ import org.testng.internal.ClassImpl;
 import org.testng.internal.InstanceCreator;
 import org.testng.internal.annotations.AnnotationHelper;
 
-import java.lang.reflect.Constructor;
-import java.util.List;
-import java.util.ServiceLoader;
-
-import static org.testng.internal.Utils.isStringEmpty;
-import static org.testng.internal.Utils.isStringNotEmpty;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.Stage;
 
 public class GuiceHelper {
-  private final ITestContext context;
+    private final ITestContext context;
 
-  GuiceHelper(ITestContext context) {
-    this.context = context;
-  }
-
-  /**
-   * @deprecated - This method stands deprecated as of 7.0.1
-   */
-  @Deprecated
-  Injector getInjector(IClass iClass) {
-    return getInjector(iClass, com.google.inject.Guice::createInjector);
-  }
-
-  Injector getInjector(IClass iClass, IInjectorFactory injectorFactory) {
-    Guice guice =
-        AnnotationHelper.findAnnotationSuperClasses(Guice.class, iClass.getRealClass());
-    if (guice == null) {
-      return null;
-    }
-    if (iClass instanceof TestClass) {
-      iClass = ((TestClass) iClass).getIClass();
-    }
-    if (!(iClass instanceof ClassImpl)) {
-      return null;
-    }
-    Injector parentInjector = ((ClassImpl) iClass).getParentInjector(injectorFactory);
-
-    List<Module> moduleInstances =
-        Lists.newArrayList(getModules(guice, parentInjector, iClass.getRealClass()));
-    List<Module> moduleLookup = Lists.newArrayList(moduleInstances);
-    Module parentModule = getParentModule(context);
-    if (parentModule != null) {
-      moduleInstances.add(parentModule);
+    GuiceHelper(ITestContext context) {
+        this.context = context;
     }
 
-    // Get an injector with the class's modules + any defined parent module installed
-    // Reuse the previous injector, if any, but don't create a child injector as JIT bindings can conflict
-    Injector injector = context.getInjector(moduleLookup);
-    if (injector == null) {
-      injector = createInjector(context, injectorFactory, moduleInstances);
-      context.addInjector(moduleInstances, injector);
+    private static Module getParentModule(ITestContext context) {
+        if ( isStringEmpty(context.getSuite()
+                .getParentModule()) ) {
+            return null;
+        }
+        Class<?> parentModule = ClassHelper.forName(context.getSuite()
+                .getParentModule());
+        if ( parentModule == null ) {
+            throw new TestNGException("Cannot load parent Guice module class: " + context.getSuite()
+                    .getParentModule());
+        }
+        if ( !Module.class.isAssignableFrom(parentModule) ) {
+            throw new TestNGException("Provided class is not a Guice module: " + parentModule.getName());
+        }
+        try {
+            Constructor<?> moduleConstructor = parentModule.getDeclaredConstructor(ITestContext.class);
+            return (Module) InstanceCreator.newInstance(moduleConstructor, context);
+        } catch (NoSuchMethodException e) {
+            return (Module) InstanceCreator.newInstance(parentModule);
+        }
     }
-    return injector;
-  }
 
-  private static Module getParentModule(ITestContext context) {
-    if (isStringEmpty(context.getSuite().getParentModule())) {
-      return null;
+    /**
+     * @deprecated - This method stands deprecated as of 7.0.1
+     */
+    @Deprecated
+    public static Injector createInjector(ITestContext context, List<Module> moduleInstances) {
+        return createInjector(context, com.google.inject.Guice::createInjector, moduleInstances);
     }
-    Class<?> parentModule = ClassHelper.forName(context.getSuite().getParentModule());
-    if (parentModule == null) {
-      throw new TestNGException(
-              "Cannot load parent Guice module class: " + context.getSuite().getParentModule());
-    }
-    if (!Module.class.isAssignableFrom(parentModule)) {
-      throw new TestNGException("Provided class is not a Guice module: " + parentModule.getName());
-    }
-    try {
-      Constructor<?> moduleConstructor = parentModule.getDeclaredConstructor(ITestContext.class);
-      return (Module)InstanceCreator.newInstance(moduleConstructor, context);
-    } catch (NoSuchMethodException e) {
-      return (Module)InstanceCreator.newInstance(parentModule);
-    }
-  }
 
-  /**
-   * @deprecated - This method stands deprecated as of 7.0.1
-   */
-  @Deprecated
-  public static Injector createInjector(ITestContext context, List<Module> moduleInstances) {
-    return createInjector(context, com.google.inject.Guice::createInjector, moduleInstances);
-  }
+    public static Injector createInjector(ITestContext context, IInjectorFactory injectorFactory, List<Module> moduleInstances) {
+        Module parentModule = getParentModule(context);
+        List<Module> fullModules = Lists.newArrayList(moduleInstances);
+        if ( parentModule != null ) {
+            fullModules.add(parentModule);
+        }
+        Stage stage = Stage.DEVELOPMENT;
+        String stageString = context.getSuite()
+                .getGuiceStage();
+        if ( isStringNotEmpty(stageString) ) {
+            stage = Stage.valueOf(stageString);
+        }
+        return injectorFactory.getInjector(stage, fullModules.toArray(new Module[0]));
+    }
 
-  public static Injector createInjector(ITestContext context,
-      IInjectorFactory injectorFactory, List<Module> moduleInstances) {
-    Module parentModule = getParentModule(context);
-    List<Module> fullModules = Lists.newArrayList(moduleInstances);
-    if (parentModule != null) {
-      fullModules.add(parentModule);
+    /**
+     * @deprecated - This method stands deprecated as of 7.0.1
+     */
+    @Deprecated
+    Injector getInjector(IClass iClass) {
+        return getInjector(iClass, com.google.inject.Guice::createInjector);
     }
-    Stage stage = Stage.DEVELOPMENT;
-    String stageString = context.getSuite().getGuiceStage();
-    if (isStringNotEmpty(stageString)) {
-      stage = Stage.valueOf(stageString);
-    }
-    return injectorFactory.getInjector(stage, fullModules.toArray(new Module[0]));
-  }
 
-  private List<Module> getModules(Guice guice, Injector parentInjector, Class<?> testClass) {
-    List<Module> result = Lists.newArrayList();
-    for (Class<? extends Module> moduleClass : guice.modules()) {
-      List<Module> modules = context.getGuiceModules(moduleClass);
-      if (modules != null && !modules.isEmpty()) {
-        result.addAll(modules);
-      } else {
-        Module instance = parentInjector.getInstance(moduleClass);
-        result.add(instance);
-        context.getGuiceModules(moduleClass).add(instance);
-      }
+    Injector getInjector(IClass iClass, IInjectorFactory injectorFactory) {
+        Guice guice = AnnotationHelper.findAnnotationSuperClasses(Guice.class, iClass.getRealClass());
+        if ( guice == null ) {
+            return null;
+        }
+        if ( iClass instanceof TestClass ) {
+            iClass = ((TestClass) iClass).getIClass();
+        }
+        if ( !(iClass instanceof ClassImpl) ) {
+            return null;
+        }
+        Injector parentInjector = ((ClassImpl) iClass).getParentInjector(injectorFactory);
+
+        List<Module> moduleInstances = Lists.newArrayList(getModules(guice, parentInjector, iClass.getRealClass()));
+        List<Module> moduleLookup = Lists.newArrayList(moduleInstances);
+        Module parentModule = getParentModule(context);
+        if ( parentModule != null ) {
+            moduleInstances.add(parentModule);
+        }
+
+        // Get an injector with the class's modules + any defined parent module installed
+        // Reuse the previous injector, if any, but don't create a child injector as JIT bindings can conflict
+        Injector injector = context.getInjector(moduleLookup);
+        if ( injector == null ) {
+            injector = createInjector(context, injectorFactory, moduleInstances);
+            context.addInjector(moduleInstances, injector);
+        }
+        return injector;
     }
-    Class<? extends IModuleFactory> factory = guice.moduleFactory();
-    if (factory != IModuleFactory.class) {
-      IModuleFactory factoryInstance = parentInjector.getInstance(factory);
-      Module module = factoryInstance.createModule(context, testClass);
-      if (module != null) {
-        result.add(module);
-      }
+
+    private List<Module> getModules(Guice guice, Injector parentInjector, Class<?> testClass) {
+        List<Module> result = Lists.newArrayList();
+        for (Class<? extends Module> moduleClass : guice.modules()) {
+            List<Module> modules = context.getGuiceModules(moduleClass);
+            if ( modules != null && !modules.isEmpty() ) {
+                result.addAll(modules);
+            } else {
+                Module instance = parentInjector.getInstance(moduleClass);
+                result.add(instance);
+                context.getGuiceModules(moduleClass)
+                        .add(instance);
+            }
+        }
+        Class<? extends IModuleFactory> factory = guice.moduleFactory();
+        if ( factory != IModuleFactory.class ) {
+            IModuleFactory factoryInstance = parentInjector.getInstance(factory);
+            Module module = factoryInstance.createModule(context, testClass);
+            if ( module != null ) {
+                result.add(module);
+            }
+        }
+        result.addAll(getSpiModules());
+        return result;
     }
-    ServiceLoader.load(IModule.class).forEach(result::add);
-    return result;
-  }
+
+    private List<Module> getSpiModules() {
+        List<Module> spiModules = new ArrayList<>();
+        for (IModule module : ServiceLoader.load(IModule.class)) {
+            Class<? extends IModule> moduleClass = module.getClass();
+            List<Module> cachedModules = context.getGuiceModules(moduleClass);
+            if ( cachedModules.isEmpty() ) {
+                cachedModules.add(module);
+                spiModules.add(module);
+            } else {
+                spiModules.add(cachedModules.get(0));
+            }
+        }
+        return spiModules;
+    }
 }

--- a/src/main/java/org/testng/GuiceHelper.java
+++ b/src/main/java/org/testng/GuiceHelper.java
@@ -20,132 +20,131 @@ import com.google.inject.Module;
 import com.google.inject.Stage;
 
 public class GuiceHelper {
-    private final ITestContext context;
+  private final ITestContext context;
 
-    GuiceHelper(ITestContext context) {
-        this.context = context;
+  GuiceHelper(ITestContext context) {
+    this.context = context;
+  }
+
+  /**
+   * @deprecated - This method stands deprecated as of 7.0.1
+   */
+  @Deprecated
+  Injector getInjector(IClass iClass) {
+    return getInjector(iClass, com.google.inject.Guice::createInjector);
+  }
+
+  Injector getInjector(IClass iClass, IInjectorFactory injectorFactory) {
+    Guice guice =
+        AnnotationHelper.findAnnotationSuperClasses(Guice.class, iClass.getRealClass());
+    if (guice == null) {
+      return null;
+    }
+    if (iClass instanceof TestClass) {
+      iClass = ((TestClass) iClass).getIClass();
+    }
+    if (!(iClass instanceof ClassImpl)) {
+      return null;
+    }
+    Injector parentInjector = ((ClassImpl) iClass).getParentInjector(injectorFactory);
+
+    List<Module> moduleInstances =
+        Lists.newArrayList(getModules(guice, parentInjector, iClass.getRealClass()));
+    List<Module> moduleLookup = Lists.newArrayList(moduleInstances);
+    Module parentModule = getParentModule(context);
+    if (parentModule != null) {
+      moduleInstances.add(parentModule);
     }
 
-    private static Module getParentModule(ITestContext context) {
-        if ( isStringEmpty(context.getSuite()
-                .getParentModule()) ) {
-            return null;
-        }
-        Class<?> parentModule = ClassHelper.forName(context.getSuite()
-                .getParentModule());
-        if ( parentModule == null ) {
-            throw new TestNGException("Cannot load parent Guice module class: " + context.getSuite()
-                    .getParentModule());
-        }
-        if ( !Module.class.isAssignableFrom(parentModule) ) {
-            throw new TestNGException("Provided class is not a Guice module: " + parentModule.getName());
-        }
-        try {
-            Constructor<?> moduleConstructor = parentModule.getDeclaredConstructor(ITestContext.class);
-            return (Module) InstanceCreator.newInstance(moduleConstructor, context);
-        } catch (NoSuchMethodException e) {
-            return (Module) InstanceCreator.newInstance(parentModule);
-        }
+    // Get an injector with the class's modules + any defined parent module installed
+    // Reuse the previous injector, if any, but don't create a child injector as JIT bindings can conflict
+    Injector injector = context.getInjector(moduleLookup);
+    if (injector == null) {
+      injector = createInjector(context, injectorFactory, moduleInstances);
+      context.addInjector(moduleInstances, injector);
     }
+    return injector;
+  }
 
-    /**
-     * @deprecated - This method stands deprecated as of 7.0.1
-     */
-    @Deprecated
-    public static Injector createInjector(ITestContext context, List<Module> moduleInstances) {
-        return createInjector(context, com.google.inject.Guice::createInjector, moduleInstances);
+  private static Module getParentModule(ITestContext context) {
+    if (isStringEmpty(context.getSuite().getParentModule())) {
+      return null;
     }
-
-    public static Injector createInjector(ITestContext context, IInjectorFactory injectorFactory, List<Module> moduleInstances) {
-        Module parentModule = getParentModule(context);
-        List<Module> fullModules = Lists.newArrayList(moduleInstances);
-        if ( parentModule != null ) {
-            fullModules.add(parentModule);
-        }
-        Stage stage = Stage.DEVELOPMENT;
-        String stageString = context.getSuite()
-                .getGuiceStage();
-        if ( isStringNotEmpty(stageString) ) {
-            stage = Stage.valueOf(stageString);
-        }
-        return injectorFactory.getInjector(stage, fullModules.toArray(new Module[0]));
+    Class<?> parentModule = ClassHelper.forName(context.getSuite().getParentModule());
+    if (parentModule == null) {
+      throw new TestNGException(
+              "Cannot load parent Guice module class: " + context.getSuite().getParentModule());
     }
-
-    /**
-     * @deprecated - This method stands deprecated as of 7.0.1
-     */
-    @Deprecated
-    Injector getInjector(IClass iClass) {
-        return getInjector(iClass, com.google.inject.Guice::createInjector);
+    if (!Module.class.isAssignableFrom(parentModule)) {
+      throw new TestNGException("Provided class is not a Guice module: " + parentModule.getName());
     }
-
-    Injector getInjector(IClass iClass, IInjectorFactory injectorFactory) {
-        Guice guice = AnnotationHelper.findAnnotationSuperClasses(Guice.class, iClass.getRealClass());
-        if ( guice == null ) {
-            return null;
-        }
-        if ( iClass instanceof TestClass ) {
-            iClass = ((TestClass) iClass).getIClass();
-        }
-        if ( !(iClass instanceof ClassImpl) ) {
-            return null;
-        }
-        Injector parentInjector = ((ClassImpl) iClass).getParentInjector(injectorFactory);
-
-        List<Module> moduleInstances = Lists.newArrayList(getModules(guice, parentInjector, iClass.getRealClass()));
-        List<Module> moduleLookup = Lists.newArrayList(moduleInstances);
-        Module parentModule = getParentModule(context);
-        if ( parentModule != null ) {
-            moduleInstances.add(parentModule);
-        }
-
-        // Get an injector with the class's modules + any defined parent module installed
-        // Reuse the previous injector, if any, but don't create a child injector as JIT bindings can conflict
-        Injector injector = context.getInjector(moduleLookup);
-        if ( injector == null ) {
-            injector = createInjector(context, injectorFactory, moduleInstances);
-            context.addInjector(moduleInstances, injector);
-        }
-        return injector;
+    try {
+      Constructor<?> moduleConstructor = parentModule.getDeclaredConstructor(ITestContext.class);
+      return (Module)InstanceCreator.newInstance(moduleConstructor, context);
+    } catch (NoSuchMethodException e) {
+      return (Module)InstanceCreator.newInstance(parentModule);
     }
+  }
 
-    private List<Module> getModules(Guice guice, Injector parentInjector, Class<?> testClass) {
-        List<Module> result = Lists.newArrayList();
-        for (Class<? extends Module> moduleClass : guice.modules()) {
-            List<Module> modules = context.getGuiceModules(moduleClass);
-            if ( modules != null && !modules.isEmpty() ) {
-                result.addAll(modules);
-            } else {
-                Module instance = parentInjector.getInstance(moduleClass);
-                result.add(instance);
-                context.getGuiceModules(moduleClass)
-                        .add(instance);
-            }
-        }
-        Class<? extends IModuleFactory> factory = guice.moduleFactory();
-        if ( factory != IModuleFactory.class ) {
-            IModuleFactory factoryInstance = parentInjector.getInstance(factory);
-            Module module = factoryInstance.createModule(context, testClass);
-            if ( module != null ) {
-                result.add(module);
-            }
-        }
-        result.addAll(getSpiModules());
-        return result;
-    }
+  /**
+   * @deprecated - This method stands deprecated as of 7.0.1
+   */
+  @Deprecated
+  public static Injector createInjector(ITestContext context, List<Module> moduleInstances) {
+    return createInjector(context, com.google.inject.Guice::createInjector, moduleInstances);
+  }
 
-    private List<Module> getSpiModules() {
-        List<Module> spiModules = new ArrayList<>();
-        for (IModule module : ServiceLoader.load(IModule.class)) {
-            Class<? extends IModule> moduleClass = module.getClass();
-            List<Module> cachedModules = context.getGuiceModules(moduleClass);
-            if ( cachedModules.isEmpty() ) {
-                cachedModules.add(module);
-                spiModules.add(module);
-            } else {
-                spiModules.add(cachedModules.get(0));
-            }
-        }
-        return spiModules;
+  public static Injector createInjector(ITestContext context,
+      IInjectorFactory injectorFactory, List<Module> moduleInstances) {
+    Module parentModule = getParentModule(context);
+    List<Module> fullModules = Lists.newArrayList(moduleInstances);
+    if (parentModule != null) {
+      fullModules.add(parentModule);
     }
+    Stage stage = Stage.DEVELOPMENT;
+    String stageString = context.getSuite().getGuiceStage();
+    if (isStringNotEmpty(stageString)) {
+      stage = Stage.valueOf(stageString);
+    }
+    return injectorFactory.getInjector(stage, fullModules.toArray(new Module[0]));
+  }
+
+  private List<Module> getModules(Guice guice, Injector parentInjector, Class<?> testClass) {
+    List<Module> result = Lists.newArrayList();
+    for (Class<? extends Module> moduleClass : guice.modules()) {
+      List<Module> modules = context.getGuiceModules(moduleClass);
+      if (modules != null && !modules.isEmpty()) {
+        result.addAll(modules);
+      } else {
+        Module instance = parentInjector.getInstance(moduleClass);
+        result.add(instance);
+        context.getGuiceModules(moduleClass).add(instance);
+      }
+    }
+    Class<? extends IModuleFactory> factory = guice.moduleFactory();
+    if (factory != IModuleFactory.class) {
+      IModuleFactory factoryInstance = parentInjector.getInstance(factory);
+      Module module = factoryInstance.createModule(context, testClass);
+      if (module != null) {
+        result.add(module);
+      }
+    }
+    result.addAll(getSpiModules());
+    return result;
+  }
+
+  private List<Module> getSpiModules() {
+    List<Module> spiModules = new ArrayList<>();
+    for (IModule module : ServiceLoader.load(IModule.class)) {
+      Class<? extends IModule> moduleClass = module.getClass();
+      List<Module> cachedModules = context.getGuiceModules(moduleClass);
+      if ( cachedModules.isEmpty() ) {
+        cachedModules.add(module);
+        spiModules.add(module);
+      } else {
+        spiModules.add(cachedModules.get(0));
+      }
+    }
+    return spiModules;
+  }
 }

--- a/src/main/java/org/testng/GuiceHelper.java
+++ b/src/main/java/org/testng/GuiceHelper.java
@@ -139,7 +139,7 @@ public class GuiceHelper {
       Class<? extends IModule> moduleClass = module.getClass();
       List<Module> cachedModules = context.getGuiceModules(moduleClass);
       if (cachedModules == null) {
-        // skip
+        // skip because ITestContext does not have a setter method for Guice module list
       } else if ( cachedModules.isEmpty() ) {
         cachedModules.add(module);
         spiModules.add(module);

--- a/src/main/java/org/testng/GuiceHelper.java
+++ b/src/main/java/org/testng/GuiceHelper.java
@@ -12,6 +12,7 @@ import org.testng.internal.annotations.AnnotationHelper;
 
 import java.lang.reflect.Constructor;
 import java.util.List;
+import java.util.ServiceLoader;
 
 import static org.testng.internal.Utils.isStringEmpty;
 import static org.testng.internal.Utils.isStringNotEmpty;
@@ -121,12 +122,12 @@ public class GuiceHelper {
     Class<? extends IModuleFactory> factory = guice.moduleFactory();
     if (factory != IModuleFactory.class) {
       IModuleFactory factoryInstance = parentInjector.getInstance(factory);
-      Module moduleClass = factoryInstance.createModule(context, testClass);
-      if (moduleClass != null) {
-        result.add(moduleClass);
+      Module module = factoryInstance.createModule(context, testClass);
+      if (module != null) {
+        result.add(module);
       }
     }
-
+    ServiceLoader.load(IModule.class).forEach(result::add);
     return result;
   }
 }

--- a/src/main/java/org/testng/GuiceHelper.java
+++ b/src/main/java/org/testng/GuiceHelper.java
@@ -138,7 +138,9 @@ public class GuiceHelper {
     for (IModule module : ServiceLoader.load(IModule.class)) {
       Class<? extends IModule> moduleClass = module.getClass();
       List<Module> cachedModules = context.getGuiceModules(moduleClass);
-      if ( cachedModules.isEmpty() ) {
+      if (cachedModules == null) {
+        // skip
+      } else if ( cachedModules.isEmpty() ) {
         cachedModules.add(module);
         spiModules.add(module);
       } else {

--- a/src/main/java/org/testng/IModule.java
+++ b/src/main/java/org/testng/IModule.java
@@ -1,0 +1,11 @@
+package org.testng;
+
+import com.google.inject.Module;
+
+/**
+ * This is a marker interface for a Guice module to be instantiated with {@link java.util.ServiceLoader}.
+ *
+ * @author Bartosz Popiela
+ */
+public interface IModule extends Module {
+}

--- a/src/main/java/org/testng/IModule.java
+++ b/src/main/java/org/testng/IModule.java
@@ -4,8 +4,6 @@ import com.google.inject.Module;
 
 /**
  * This is a marker interface for a Guice module to be instantiated with {@link java.util.ServiceLoader}.
- *
- * @author Bartosz Popiela
  */
 public interface IModule extends Module {
 }

--- a/src/main/java/org/testng/IModule.java
+++ b/src/main/java/org/testng/IModule.java
@@ -3,7 +3,9 @@ package org.testng;
 import com.google.inject.Module;
 
 /**
- * This is a marker interface for a Guice module to be instantiated with {@link java.util.ServiceLoader}.
+ * This interface provides {@link Module} to implicitly add to the Guice context.
+ * Classes that implement this interface are instantiated with {@link java.util.ServiceLoader ServiceLoader}.
  */
-public interface IModule extends Module {
+public interface IModule {
+    Module getModule();
 }

--- a/src/test/java/org/testng/GuiceHelperTest.java
+++ b/src/test/java/org/testng/GuiceHelperTest.java
@@ -15,16 +15,13 @@ import com.google.inject.Stage;
 
 import test.guice.FakeInjector;
 
-/**
- * @author Bartosz Popiela
- */
 @Guice
 public final class GuiceHelperTest {
 
     private final GuiceHelper guiceHelper = new GuiceHelper(new FakeTestContext());
 
     @Test(description = "GITHUB-2273")
-    public void getInjector_spiModule_moduleLoaded() {
+    public void getInjector_spiModule_injectorHasModule() {
         MockInjector injector = (MockInjector) guiceHelper.getInjector(new MockClass(), new MockInjectorFactory());
 
         assertNotNull(injector);

--- a/src/test/java/org/testng/GuiceHelperTest.java
+++ b/src/test/java/org/testng/GuiceHelperTest.java
@@ -28,7 +28,7 @@ public final class GuiceHelperTest {
         Module[] modules = injector.getModules();
         assertNotNull(modules);
         assertEquals(modules.length, 1);
-        assertTrue(modules[0] instanceof SampleModule);
+        assertEquals(modules[0], new SampleIModule().getModule());
     }
 
     private static final class MockInjectorFactory implements IInjectorFactory {

--- a/src/test/java/org/testng/GuiceHelperTest.java
+++ b/src/test/java/org/testng/GuiceHelperTest.java
@@ -1,0 +1,61 @@
+package org.testng;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import org.testng.annotations.Guice;
+import org.testng.annotations.Test;
+import org.testng.internal.ClassImpl;
+import org.testng.internal.paramhandler.FakeTestContext;
+
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.Stage;
+
+import test.guice.FakeInjector;
+
+/**
+ * @author Bartosz Popiela
+ */
+@Guice
+public final class GuiceHelperTest {
+
+    private final GuiceHelper guiceHelper = new GuiceHelper(new FakeTestContext());
+
+    @Test(description = "GITHUB-2273")
+    public void getInjector_spiModule_moduleLoaded() {
+        MockInjector injector = (MockInjector) guiceHelper.getInjector(new MockClass(), new MockInjectorFactory());
+
+        assertNotNull(injector);
+        Module[] modules = injector.getModules();
+        assertNotNull(modules);
+        assertEquals(modules.length, 1);
+        assertTrue(modules[0] instanceof SampleModule);
+    }
+
+    private static final class MockInjectorFactory implements IInjectorFactory {
+        @Override
+        public Injector getInjector(Stage stage, Module... modules) {
+            return new MockInjector(modules);
+        }
+    }
+
+    private static final class MockInjector extends FakeInjector {
+        private final Module[] modules;
+
+        public MockInjector(Module[] modules) {
+            this.modules = modules;
+        }
+
+        public Module[] getModules() {
+            return modules;
+        }
+    }
+
+    private static final class MockClass extends ClassImpl {
+        public MockClass() {
+            super(new FakeTestContext(), GuiceHelperTest.class, null, (ITest) () -> "GITHUB-2273", null, null, null);
+        }
+    }
+}

--- a/src/test/java/org/testng/SampleIModule.java
+++ b/src/test/java/org/testng/SampleIModule.java
@@ -1,0 +1,12 @@
+package org.testng;
+
+import com.google.inject.Module;
+
+public final class SampleIModule implements IModule {
+    private static final Module module = binder -> { };
+
+    @Override
+    public Module getModule() {
+        return module;
+    }
+}

--- a/src/test/java/org/testng/SampleModule.java
+++ b/src/test/java/org/testng/SampleModule.java
@@ -1,9 +1,0 @@
-package org.testng;
-
-import com.google.inject.Binder;
-
-public final class SampleModule implements IModule {
-    @Override
-    public void configure(Binder binder) {
-    }
-}

--- a/src/test/java/org/testng/SampleModule.java
+++ b/src/test/java/org/testng/SampleModule.java
@@ -1,0 +1,12 @@
+package org.testng;
+
+import com.google.inject.Binder;
+
+/**
+ * @author Bartosz Popiela
+ */
+public final class SampleModule implements IModule {
+    @Override
+    public void configure(Binder binder) {
+    }
+}

--- a/src/test/java/org/testng/SampleModule.java
+++ b/src/test/java/org/testng/SampleModule.java
@@ -2,9 +2,6 @@ package org.testng;
 
 import com.google.inject.Binder;
 
-/**
- * @author Bartosz Popiela
- */
 public final class SampleModule implements IModule {
     @Override
     public void configure(Binder binder) {

--- a/src/test/java/org/testng/internal/paramhandler/FakeTestContext.java
+++ b/src/test/java/org/testng/internal/paramhandler/FakeTestContext.java
@@ -12,6 +12,7 @@ import org.testng.xml.XmlClass;
 import org.testng.xml.XmlSuite;
 import org.testng.xml.XmlTest;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -132,7 +133,7 @@ public class FakeTestContext implements ITestContext {
 
   @Override
   public List<Module> getGuiceModules(Class<? extends Module> cls) {
-    return null;
+    return new ArrayList<>();
   }
 
   @Override

--- a/src/test/resources/META-INF/services/org.testng.IModule
+++ b/src/test/resources/META-INF/services/org.testng.IModule
@@ -1,1 +1,1 @@
-org.testng.SampleModule
+org.testng.SampleIModule

--- a/src/test/resources/META-INF/services/org.testng.IModule
+++ b/src/test/resources/META-INF/services/org.testng.IModule
@@ -1,0 +1,1 @@
+org.testng.SampleModule

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -971,5 +971,11 @@
       <class name="org.testng.internal.MethodHelperTest"/>
     </classes>
   </test>
+
+  <test name="GITHUB-2273">
+    <classes>
+      <class name="org.testng.GuiceHelperTest"/>
+    </classes>
+  </test>
 </suite>
 


### PR DESCRIPTION
Once an SPI configuration file for org.testng.IModule is present in the classpath, the listed Guice modules will be used to create a Guice injector for any org.testng.annotations.Guice annotated test class.

Fixes #2273

### Did you remember to?

- [x] Add test case(s)
- [x] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
