### PR TITLE
Better error msg for classes with factory & constructors

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-553:  Better error message when dealing with classes having both Constructor and Factory methods (Krishnan Mahadevan)
 Fixed: GITHUB-2267: RetryAnalyzer is not set properly and consistent when using dataprovider (Eric Kubenka)
 Fixed: GITHUB-2266: Support Test retries via Callbacks (Krishnan Mahadevan)
 Fixed: GITHUB-2209: @Before and @After are not executed as expected when a combination of class and method level grouping is applied (Krishnan Mahadevan)

--- a/src/main/java/org/testng/internal/FactoryMethod.java
+++ b/src/main/java/org/testng/internal/FactoryMethod.java
@@ -82,8 +82,14 @@ public class FactoryMethod extends BaseTestMethod {
     Utils.checkReturnType(com.getMethod(), Object[].class, IInstanceInfo[].class);
     Class<?> declaringClass = com.getDeclaringClass();
     if (instance != null && !declaringClass.isAssignableFrom(instance.getClass())) {
-      throw new TestNGException(
-          "Mismatch between instance/method classes:" + instance.getClass() + " " + declaringClass);
+      if (instance instanceof IParameterInfo) {
+        instance = ((IParameterInfo) instance).getInstance();
+      }
+      Class<?> cls = instance.getClass();
+      String msg = "Found a default constructor and also a Factory method when working with "
+          + declaringClass.getName() + ". Root cause: Mismatch between instance/method classes:[" + cls.getName()
+          + "] [" + declaringClass.getName() + "]";
+      throw new TestNGException(msg);
     }
     if (instance == null
         && com.getMethod() != null

--- a/src/test/java/test/factory/issue553/Base.java
+++ b/src/test/java/test/factory/issue553/Base.java
@@ -1,0 +1,17 @@
+package test.factory.issue553;
+
+import org.testng.annotations.Factory;
+
+public abstract class Base {
+  @Factory
+  public Object[] createTests() {
+    return new Object[] {new Inner()};
+  }
+
+  public class Inner {
+    @Factory
+    public Object[] createTests() {
+      return new Object[0];
+    }
+  }
+}

--- a/src/test/java/test/factory/issue553/Concrete.java
+++ b/src/test/java/test/factory/issue553/Concrete.java
@@ -1,0 +1,3 @@
+package test.factory.issue553;
+
+public class Concrete extends Base {}

--- a/src/test/java/test/factory/issue553/IssueTest.java
+++ b/src/test/java/test/factory/issue553/IssueTest.java
@@ -1,0 +1,24 @@
+package test.factory.issue553;
+
+import org.testng.TestListenerAdapter;
+import org.testng.TestNG;
+import org.testng.TestNGException;
+import org.testng.annotations.Test;
+import org.testng.xml.XmlTest;
+import test.SimpleBaseTest;
+
+public class IssueTest extends SimpleBaseTest {
+
+  @Test(description = "GITHUB-553",
+      expectedExceptions = TestNGException.class,
+      expectedExceptionsMessageRegExp = "\\nFound a default constructor and also a Factory method when working with .*")
+  public void testMethod() {
+    XmlTest xmltest = createXmlTest("suite", "test", Concrete.class);
+    xmltest.setVerbose(2);
+    TestNG testng = create(xmltest.getSuite());
+    TestListenerAdapter listener = new TestListenerAdapter();
+    testng.addListener(listener);
+    testng.run();
+  }
+
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -192,6 +192,7 @@
       <class name="test.github1461.MemoryLeakTestNg" />
       <!-- TODO fix the random issue <class name="test.issue565.Issue565Test"/>-->
       <class name="test.factory.issue326.IssueTest"/>
+      <class name="test.factory.issue553.IssueTest"/>
       <class name="test.factory.issue1041.IssueTest"/>
       <class name="test.factory.issue1924.IssueTest"/>
       <class name="test.factory.github328.GitHub328Test" />


### PR DESCRIPTION
Closes #553

Currently when TestNG encounters both a default 
constructor and a Factory method, the error msg
doesn’t tell as to what is the root cause. Fixed
this by making the error message a bit more verbose.

Fixes #553 .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`