### PR TITLE
TextReporter can log data provider arrays from object's toString() (#…

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+New:   GITHUB-2315: TextReporter console output does not nicely print native array data parameters (James Sassano)
 Fixed: GITHUB-2301: Add support for object-based reporter configurations (Scott Babcock)
 New: Deprecate org.testng.ReporterConfig (Julien Herr)
 Fixed: GITHUB-2300: Vulnerable Dependency: Please upgrade JCommander to 1.75 or above (Krishnan Mahadevan)

--- a/src/main/java/org/testng/internal/Utils.java
+++ b/src/main/java/org/testng/internal/Utils.java
@@ -421,7 +421,7 @@ public final class Utils {
     if (null == object) {
       return "null";
     }
-    final String toString = object.toString();
+    final String toString = toString(object);
     if (isStringEmpty(toString)) {
       return "\"\"";
     } else if (String.class.equals(objectClass)) {

--- a/src/test/java/test/reports/ReportTest.java
+++ b/src/test/java/test/reports/ReportTest.java
@@ -5,6 +5,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.testng.reporters.FailedReporter;
 import org.testng.reporters.TestHTMLReporter;
+import org.testng.reporters.TextReporter;
 import org.testng.xml.Parser;
 import org.testng.xml.XmlSuite;
 import test.InvokedMethodNameListener;
@@ -14,7 +15,9 @@ import test.reports.issue1756.CustomTestNGReporter;
 import test.reports.issue1756.SampleTestClass;
 import test.simple.SimpleSample;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -234,5 +237,39 @@ public class ReportTest extends SimpleBaseTest {
     assertThat(testngFailedXml2).exists();
 
     return testngFailedXml2;
+  }
+
+  public static class DpArrays {
+    public enum Item {
+      ITEM1,
+      ITEM2
+    }
+
+    @DataProvider
+    public static Object[][] dpArrays() {
+      return new Object[][]{
+          {new Item[]{Item.ITEM1}},
+          {new Item[]{Item.ITEM1, Item.ITEM2}}
+      };
+    }
+
+    @Test(dataProvider = "dpArrays")
+    public void testMethod(Item[] strings) {
+    }
+  }
+
+  @Test
+  public void reportArraysToString() throws IOException {
+    TestNG tng = create(DpArrays.class);
+    tng.addListener(new TextReporter("name", 2));
+
+    PrintStream previousOut = System.out;
+    ByteArrayOutputStream systemOutCapture = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(systemOutCapture));
+    tng.run();
+    System.setOut(previousOut);
+
+    Assert.assertTrue(systemOutCapture.toString().contains("testMethod([ITEM1])"));
+    Assert.assertTrue(systemOutCapture.toString().contains("testMethod([ITEM1, ITEM2])"));
   }
 }


### PR DESCRIPTION
…2315)

Current console output:

    PASSED: testMethod([Ltest.reports.ReportTest$DpArrays$Item;@5f84329c)
    PASSED: testMethod([Ltest.reports.ReportTest$DpArrays$Item;@31d1c166)

New console output:

    PASSED: testMethod([ITEM1])
    PASSED: testMethod([ITEM1, ITEM2])

Fixes # .

### Did you remember to?

- [x] Add test case(s)
- [x] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
