### PR TITLE
Update ant to mitigate CVE 2020-1945

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,7 +72,7 @@ plugins {
 
 dependencies {
 
-    listOf("org.apache.ant:ant:1.10.3").forEach {
+    listOf("org.apache.ant:ant:1.10.9").forEach {
         "antApi"(it)
     }
 
@@ -96,7 +96,7 @@ dependencies {
         api(it)
     }
 
-    listOf("org.apache.ant:ant-testutil:1.10.3",
+    listOf("org.apache.ant:ant-testutil:1.10.9",
             "org.assertj:assertj-core:3.10.0",
             "org.codehaus.groovy:groovy-all:2.4.7",
             "org.spockframework:spock-core:1.0-groovy-2.4",

--- a/kobalt/src/Build.kt
+++ b/kobalt/src/Build.kt
@@ -58,7 +58,7 @@ val p = project {
         compile("com.beust:jcommander:1.72"
                 )
         provided("org.yaml:snakeyaml:1.17",
-                "org.apache.ant:ant:1.9.7",
+                "org.apache.ant:ant:1.10.9",
                 "junit:junit:4.12")
     }
 


### PR DESCRIPTION
Simple update dependency to the newest version with security fixes. https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1945
