### PR TITLE
Attempt at reducing memory foot print

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-2096: 7.0.0-beta6 memory issues (regression) (Krishnan Mahadevan)
 Fixed: GITHUB-2355: TestNG creates multiple Guice Module Instances (Krishnan Mahadevan)
 Fixed: GITHUB-2374: Add file name to the warning message (Krishnan Mahadevan)
 Fixed: GITHUB-2321: -Dtestng.thread.affinity=true do not work when running multiple instance of test in parallel (Nan Liang)

--- a/src/main/java/org/testng/IInvocationStatus.java
+++ b/src/main/java/org/testng/IInvocationStatus.java
@@ -1,0 +1,8 @@
+package org.testng;
+
+public interface IInvocationStatus {
+  void markAsInvoked();
+
+  boolean isInvoked();
+
+}

--- a/src/main/java/org/testng/SuiteRunner.java
+++ b/src/main/java/org/testng/SuiteRunner.java
@@ -34,7 +34,6 @@ public class SuiteRunner implements ISuite, IInvokedMethodListener {
       Collections.synchronizedMap(Maps.newLinkedHashMap());
   private final List<TestRunner> testRunners = Lists.newArrayList();
   private final Map<Class<? extends ISuiteListener>, ISuiteListener> listeners = Maps.newConcurrentMap();
-  private final TestListenerAdapter textReporter = new TestListenerAdapter();
 
   private String outputDir;
   private XmlSuite xmlSuite;
@@ -64,7 +63,6 @@ public class SuiteRunner implements ISuite, IInvokedMethodListener {
   /** The list of all the methods invoked during this run */
   private final Collection<IInvokedMethod> invokedMethods = new ConcurrentLinkedQueue<>();
 
-  private final List<ITestNGMethod> allTestMethods = Lists.newArrayList();
   private final SuiteRunState suiteState = new SuiteRunState();
   private final IAttributes attributes = new Attributes();
   private final Set<IExecutionVisualiser> visualisers = Sets.newHashSet();
@@ -190,13 +188,8 @@ public class SuiteRunner implements ISuite, IInvokedMethodListener {
         tr.addMethodInterceptor(methodInterceptor);
       }
 
-      // Reuse the same text reporter so we can accumulate all the results
-      // (this is used to display the final suite report at the end)
-      tr.addListener(textReporter);
       testRunners.add(tr);
 
-      // Add the methods found in this test to our global count
-      allTestMethods.addAll(Arrays.asList(tr.getAllTestMethods()));
     }
   }
 
@@ -743,6 +736,8 @@ public class SuiteRunner implements ISuite, IInvokedMethodListener {
 
   @Override
   public List<ITestNGMethod> getAllMethods() {
-    return allTestMethods;
+    return this.testRunners.stream()
+        .flatMap(tr -> Arrays.stream(tr.getAllTestMethods()))
+        .collect(Collectors.toList());
   }
 }

--- a/src/main/java/org/testng/TestRunner.java
+++ b/src/main/java/org/testng/TestRunner.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.PriorityBlockingQueue;
@@ -1024,8 +1023,8 @@ public class TestRunner
   }
 
   @Override
-  public void addInvokedMethod(InvokedMethod im) {
-    m_invokedMethods.add(im);
+  public void recordInvocationStatus(IInvocationStatus im) {
+    im.markAsInvoked();
   }
 
   @Override
@@ -1151,14 +1150,8 @@ public class TestRunner
     m_configurationListeners.add(icl);
   }
 
-  private final Collection<IInvokedMethod> m_invokedMethods = new ConcurrentLinkedQueue<>();
-
   private void dumpInvokedMethods() {
-    MethodHelper.dumpInvokedMethodsInfoToConsole(m_invokedMethods, getVerbose());
-  }
-
-  public List<ITestNGMethod> getInvokedMethods() {
-    return MethodHelper.invokedMethodsToMethods(m_invokedMethods);
+    MethodHelper.dumpInvokedMethodInfoToConsole(m_allTestMethods, getVerbose());
   }
 
   private final IResultMap m_passedConfigurations = new ResultMap();

--- a/src/main/java/org/testng/internal/BaseTestMethod.java
+++ b/src/main/java/org/testng/internal/BaseTestMethod.java
@@ -12,6 +12,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
 import org.testng.IClass;
+import org.testng.IInvocationStatus;
 import org.testng.IRetryAnalyzer;
 import org.testng.ITestClass;
 import org.testng.ITestNGMethod;
@@ -27,7 +28,7 @@ import org.testng.xml.XmlInclude;
 import org.testng.xml.XmlTest;
 
 /** Superclass to represent both &#64;Test and &#64;Configuration methods. */
-public abstract class BaseTestMethod implements ITestNGMethod {
+public abstract class BaseTestMethod implements ITestNGMethod, IInvocationStatus {
 
   private static final Pattern SPACE_SEPARATOR_PATTERN = Pattern.compile(" +");
 
@@ -754,6 +755,18 @@ public abstract class BaseTestMethod implements ITestNGMethod {
       return (IParameterInfo) m_instance;
     }
     return null;
+  }
+
+  private boolean invoked = false;
+
+  @Override
+  public void markAsInvoked() {
+    invoked = true;
+  }
+
+  @Override
+  public boolean isInvoked() {
+    return invoked;
   }
 
   private IRetryAnalyzer getRetryAnalyzerConsideringMethodParameters(ITestResult tr) {

--- a/src/main/java/org/testng/internal/ConfigInvoker.java
+++ b/src/main/java/org/testng/internal/ConfigInvoker.java
@@ -280,7 +280,7 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
             arguments.getInstance()) && !alwaysRun) {
           log(3, "Skipping " + Utils.detailedMethodName(tm, true));
           InvokedMethod invokedMethod =
-              new InvokedMethod(arguments.getInstance(), tm, System.currentTimeMillis(), testResult);
+              new InvokedMethod(System.currentTimeMillis(), testResult);
           runInvokedMethodListeners(BEFORE_INVOCATION, invokedMethod, testResult);
           testResult.setStatus(ITestResult.SKIP);
           runInvokedMethodListeners(AFTER_INVOCATION, invokedMethod, testResult);
@@ -347,7 +347,7 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
     tm.setId(ThreadUtil.currentThreadInfo());
 
     InvokedMethod invokedMethod =
-        new InvokedMethod(targetInstance, tm, System.currentTimeMillis(), testResult);
+        new InvokedMethod(System.currentTimeMillis(), testResult);
 
     runInvokedMethodListeners(BEFORE_INVOCATION, invokedMethod, testResult);
     if (tm instanceof IInvocationStatus) {

--- a/src/main/java/org/testng/internal/ConfigInvoker.java
+++ b/src/main/java/org/testng/internal/ConfigInvoker.java
@@ -13,6 +13,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import org.testng.IClass;
 import org.testng.IConfigurable;
+import org.testng.IInvocationStatus;
 import org.testng.IInvokedMethodListener;
 import org.testng.ITestContext;
 import org.testng.ITestNGMethod;
@@ -349,7 +350,9 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
         new InvokedMethod(targetInstance, tm, System.currentTimeMillis(), testResult);
 
     runInvokedMethodListeners(BEFORE_INVOCATION, invokedMethod, testResult);
-    m_notifier.addInvokedMethod(invokedMethod);
+    if (tm instanceof IInvocationStatus) {
+      m_notifier.recordInvocationStatus((IInvocationStatus) tm);
+    }
     try {
       Reporter.setCurrentTestResult(testResult);
       ConstructorOrMethod method = tm.getConstructorOrMethod();

--- a/src/main/java/org/testng/internal/ITestResultNotifier.java
+++ b/src/main/java/org/testng/internal/ITestResultNotifier.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.testng.IConfigurationListener;
+import org.testng.IInvocationStatus;
 import org.testng.ITestListener;
 import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
@@ -31,7 +32,13 @@ public interface ITestResultNotifier {
 
   void addFailedButWithinSuccessPercentageTest(ITestNGMethod tm, ITestResult tr);
 
-  void addInvokedMethod(InvokedMethod im);
+  /**
+   * @deprecated - Deprecated as of 7.4.0
+   */
+  @Deprecated
+  default void addInvokedMethod(InvokedMethod im) {}
+
+  default void recordInvocationStatus(IInvocationStatus im) {}
 
   XmlTest getTest();
 

--- a/src/main/java/org/testng/internal/InvokedMethod.java
+++ b/src/main/java/org/testng/internal/InvokedMethod.java
@@ -6,14 +6,10 @@ import org.testng.ITestResult;
 
 public class InvokedMethod implements IInvokedMethod {
 
-  private final Object m_instance;
-  private final ITestNGMethod m_testMethod;
   private final long m_date;
   private final ITestResult m_testResult;
 
-  public InvokedMethod(Object instance, ITestNGMethod method, long date, ITestResult testResult) {
-    m_instance = instance;
-    m_testMethod = method;
+  public InvokedMethod(long date, ITestResult testResult) {
     m_date = date;
     m_testResult = testResult;
   }
@@ -23,16 +19,17 @@ public class InvokedMethod implements IInvokedMethod {
    */
   @Override
   public boolean isTestMethod() {
-    return m_testMethod.isTest();
+    return m_testResult.getMethod().isTest();
   }
 
   @Override
   public String toString() {
-    StringBuilder result = new StringBuilder().append(m_testMethod);
+    StringBuilder result = new StringBuilder().append(m_testResult.getMethod());
     for (Object p : m_testResult.getParameters()) {
       result.append(p).append(" ");
     }
-    result.append(" ").append(m_instance != null ? m_instance.hashCode() : " <static>");
+    Object instance = m_testResult.getInstance();
+    result.append(" ").append(instance != null ? instance.hashCode() : " <static>");
 
     return result.toString();
   }
@@ -42,7 +39,7 @@ public class InvokedMethod implements IInvokedMethod {
    */
   @Override
   public boolean isConfigurationMethod() {
-    return TestNgMethodUtils.isConfigurationMethod(m_testMethod);
+    return TestNgMethodUtils.isConfigurationMethod(m_testResult.getMethod());
   }
 
   /* (non-Javadoc)
@@ -50,7 +47,7 @@ public class InvokedMethod implements IInvokedMethod {
    */
   @Override
   public ITestNGMethod getTestMethod() {
-    return m_testMethod;
+    return m_testResult.getMethod();
   }
 
   /* (non-Javadoc)

--- a/src/main/java/org/testng/internal/MethodHelper.java
+++ b/src/main/java/org/testng/internal/MethodHelper.java
@@ -13,6 +13,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
 import java.util.stream.Collectors;
+import org.testng.IInvocationStatus;
 import org.testng.IInvokedMethod;
 import org.testng.IMethodInstance;
 import org.testng.ITestClass;
@@ -433,6 +434,35 @@ public class MethodHelper {
   public static List<ITestNGMethod> methodInstancesToMethods(
       List<IMethodInstance> methodInstances) {
     return methodInstances.stream().map(IMethodInstance::getMethod).collect(Collectors.toList());
+  }
+
+  public static void dumpInvokedMethodInfoToConsole(
+      ITestNGMethod[] methods, int currentVerbosity) {
+    if (currentVerbosity < 3) {
+      return;
+    }
+    System.out.println("===== Invoked methods");
+    Arrays.stream(methods).filter(m -> m instanceof IInvocationStatus)
+        .filter(m -> ((IInvocationStatus) m).isInvoked())
+        .forEach(im -> {
+          if (im.isTest()) {
+            System.out.print("    ");
+          } else if (isConfigurationMethod(im)) {
+            System.out.print("  ");
+          } else {
+            return;
+          }
+          System.out.println("" + im);
+        });
+    System.out.println("=====");
+  }
+
+  private static boolean isConfigurationMethod(ITestNGMethod tm) {
+    return tm.isBeforeSuiteConfiguration() || tm.isAfterSuiteConfiguration() ||
+        tm.isBeforeTestConfiguration() || tm.isAfterTestConfiguration() ||
+        tm.isBeforeClassConfiguration() || tm.isAfterClassConfiguration() ||
+        tm.isBeforeGroupsConfiguration() || tm.isAfterGroupsConfiguration() ||
+        tm.isBeforeMethodConfiguration() || tm.isAfterMethodConfiguration();
   }
 
   public static void dumpInvokedMethodsInfoToConsole(

--- a/src/main/java/org/testng/internal/MethodRunner.java
+++ b/src/main/java/org/testng/internal/MethodRunner.java
@@ -70,8 +70,7 @@ class MethodRunner implements IMethodRunner {
                     null);
             result.add(r);
             InvokedMethod invokedMethod =
-                new InvokedMethod(r.getInstance(), tmArguments.getTestMethod(),
-                    System.currentTimeMillis(), r);
+                new InvokedMethod(System.currentTimeMillis(), r);
             testInvoker.invokeListenersForSkippedTestResult(r, invokedMethod);
           }
         }

--- a/src/main/java/org/testng/internal/TestInvoker.java
+++ b/src/main/java/org/testng/internal/TestInvoker.java
@@ -19,6 +19,7 @@ import org.testng.DataProviderInvocationException;
 import org.testng.IClassListener;
 import org.testng.IDataProviderListener;
 import org.testng.IHookable;
+import org.testng.IInvocationStatus;
 import org.testng.IInvokedMethod;
 import org.testng.IInvokedMethodListener;
 import org.testng.IRetryAnalyzer;
@@ -575,7 +576,9 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
       log(3, "Invoking " + arguments.getTestMethod().getQualifiedName());
       runInvokedMethodListeners(BEFORE_INVOCATION, invokedMethod, testResult);
 
-      m_notifier.addInvokedMethod(invokedMethod);
+      if (arguments.getTestMethod() instanceof IInvocationStatus) {
+        m_notifier.recordInvocationStatus((IInvocationStatus) arguments.getTestMethod());
+      }
 
       Method thisMethod = arguments.getTestMethod().getConstructorOrMethod().getMethod();
 

--- a/src/main/java/org/testng/internal/TestInvoker.java
+++ b/src/main/java/org/testng/internal/TestInvoker.java
@@ -102,8 +102,7 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
           registerSkippedTestResult(
               testMethod, System.currentTimeMillis(), new Throwable(okToProceed));
       m_notifier.addSkippedTest(testMethod, result);
-      InvokedMethod invokedMethod = new InvokedMethod(result.getInstance(), testMethod,
-          System.currentTimeMillis(), result);
+      InvokedMethod invokedMethod = new InvokedMethod(System.currentTimeMillis(), result);
       invokeListenersForSkippedTestResult(result, invokedMethod);
       testMethod.incrementCurrentInvocationCount();
       GroupConfigMethodArguments args = new Builder()
@@ -528,8 +527,7 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
     runConfigMethods(arguments, suite, testResult, setupConfigMethods);
 
     long startTime = System.currentTimeMillis();
-    InvokedMethod invokedMethod = new InvokedMethod(arguments.getInstance(),
-        arguments.getTestMethod(), startTime, testResult);
+    InvokedMethod invokedMethod = new InvokedMethod(startTime, testResult);
 
     if (!failureContext.representsRetriedMethod && invoker.hasConfigurationFailureFor(
         arguments.getTestMethod(), arguments.getTestMethod().getGroups() ,
@@ -543,8 +541,7 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
       m_notifier.addSkippedTest(arguments.getTestMethod(), result);
       arguments.getTestMethod().incrementCurrentInvocationCount();
       testResult.setMethod(arguments.getTestMethod());
-      invokedMethod = new InvokedMethod(arguments.getInstance(),
-          arguments.getTestMethod(), startTime, result);
+      invokedMethod = new InvokedMethod(startTime, result);
       invokeListenersForSkippedTestResult(result, invokedMethod);
       runAfterGroupsConfigurations(arguments, suite, testResult);
 
@@ -558,8 +555,7 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
       testResult = TestResult
           .newTestResultFrom(testResult, arguments.getTestMethod(), m_testContext, System.currentTimeMillis());
       //Recreate the invoked method object again, because we now have a new test result object
-      invokedMethod = new InvokedMethod(arguments.getInstance(),
-          arguments.getTestMethod(), invokedMethod.getDate(), testResult);
+      invokedMethod = new InvokedMethod(invokedMethod.getDate(), testResult);
 
       testResult.setStatus(ITestResult.STARTED);
 

--- a/src/main/java/org/testng/junit/JUnit4TestRunner.java
+++ b/src/main/java/org/testng/junit/JUnit4TestRunner.java
@@ -220,7 +220,7 @@ public class JUnit4TestRunner implements IJUnitTestRunner {
 
     private void runAfterInvocationListeners(ITestResult tr) {
       InvokedMethod im =
-          new InvokedMethod(tr.getTestClass(), tr.getMethod(), tr.getEndMillis(), tr);
+          new InvokedMethod(tr.getEndMillis(), tr);
       for (IInvokedMethodListener l : m_invokeListeners) {
         l.afterInvocation(im, tr);
       }
@@ -244,8 +244,7 @@ public class JUnit4TestRunner implements IJUnitTestRunner {
 
     TestResult tr = TestResult.newTestResultFor(tm);
 
-    InvokedMethod im =
-        new InvokedMethod(tr.getTestClass(), tr.getMethod(), tr.getStartMillis(), tr);
+    InvokedMethod im = new InvokedMethod(tr.getStartMillis(), tr);
     if (tr.getMethod() instanceof IInvocationStatus) {
       m_parentRunner.recordInvocationStatus((IInvocationStatus) tr.getMethod());
     }

--- a/src/main/java/org/testng/junit/JUnit4TestRunner.java
+++ b/src/main/java/org/testng/junit/JUnit4TestRunner.java
@@ -246,7 +246,9 @@ public class JUnit4TestRunner implements IJUnitTestRunner {
 
     InvokedMethod im =
         new InvokedMethod(tr.getTestClass(), tr.getMethod(), tr.getStartMillis(), tr);
-    m_parentRunner.addInvokedMethod(im);
+    if (tr.getMethod() instanceof IInvocationStatus) {
+      m_parentRunner.recordInvocationStatus((IInvocationStatus) tr.getMethod());
+    }
     for (IInvokedMethodListener l : m_invokeListeners) {
       l.beforeInvocation(im, tr);
     }

--- a/src/main/java/org/testng/junit/JUnitTestRunner.java
+++ b/src/main/java/org/testng/junit/JUnitTestRunner.java
@@ -121,7 +121,7 @@ public class JUnitTestRunner implements TestListener, IJUnitTestRunner {
       m_parentRunner.addPassedTest(tm, tr);
     }
 
-    InvokedMethod im = new InvokedMethod(test, tm, tri.m_start, tr);
+    InvokedMethod im = new InvokedMethod(tri.m_start, tr);
     if (tm instanceof IInvocationStatus) {
       m_parentRunner.recordInvocationStatus(tm);
     }

--- a/src/main/java/org/testng/junit/JUnitTestRunner.java
+++ b/src/main/java/org/testng/junit/JUnitTestRunner.java
@@ -122,7 +122,9 @@ public class JUnitTestRunner implements TestListener, IJUnitTestRunner {
     }
 
     InvokedMethod im = new InvokedMethod(test, tm, tri.m_start, tr);
-    m_parentRunner.addInvokedMethod(im);
+    if (tm instanceof IInvocationStatus) {
+      m_parentRunner.recordInvocationStatus(tm);
+    }
     m_methods.add(tm);
     for (IInvokedMethodListener l : m_invokedMethodListeners) {
       l.beforeInvocation(im, tr);

--- a/src/main/java/org/testng/reporters/DotTestListener.java
+++ b/src/main/java/org/testng/reporters/DotTestListener.java
@@ -1,9 +1,10 @@
 package org.testng.reporters;
 
+import org.testng.ITestListener;
 import org.testng.ITestResult;
 import org.testng.TestListenerAdapter;
 
-public class DotTestListener extends TestListenerAdapter {
+public class DotTestListener implements ITestListener {
   private int m_count = 0;
 
   @Override

--- a/src/main/java/org/testng/reporters/FailedReporter.java
+++ b/src/main/java/org/testng/reporters/FailedReporter.java
@@ -7,7 +7,6 @@ import org.testng.ITestClass;
 import org.testng.ITestContext;
 import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
-import org.testng.TestListenerAdapter;
 import org.testng.collections.Lists;
 import org.testng.collections.Maps;
 import org.testng.collections.Sets;
@@ -31,7 +30,7 @@ import java.util.Set;
  * @author <a href="mailto:cedric@beust.com">Cedric Beust</a>
  * @author <a href='mailto:the_mindstorm[at]evolva[dot]ro'>Alexandru Popescu</a>
  */
-public class FailedReporter extends TestListenerAdapter implements IReporter {
+public class FailedReporter implements IReporter {
   public static final String TESTNG_FAILED_XML = "testng-failed.xml";
 
   private XmlSuite m_xmlSuite;

--- a/src/main/java/org/testng/reporters/TestHTMLReporter.java
+++ b/src/main/java/org/testng/reporters/TestHTMLReporter.java
@@ -1,10 +1,10 @@
 package org.testng.reporters;
 
 import org.testng.ITestContext;
+import org.testng.ITestListener;
 import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
 import org.testng.Reporter;
-import org.testng.TestListenerAdapter;
 import org.testng.TestRunner;
 import org.testng.internal.Utils;
 import org.testng.log4testng.Logger;
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.Objects;
 
 /** This class implements an HTML reporter for individual tests. */
-public class TestHTMLReporter extends TestListenerAdapter {
+public class TestHTMLReporter implements ITestListener {
   private static final Comparator<ITestResult> NAME_COMPARATOR = new NameComparator();
   private static final Comparator<ITestResult> CONFIGURATION_COMPARATOR =
       new ConfigurationComparator();
@@ -39,12 +39,12 @@ public class TestHTMLReporter extends TestListenerAdapter {
         m_testContext,
         null /* host */,
         m_testContext.getOutputDirectory(),
-        getConfigurationFailures(),
-        getConfigurationSkips(),
-        getPassedTests(),
-        getFailedTests(),
-        getSkippedTests(),
-        getFailedButWithinSuccessPercentageTests());
+        context.getFailedConfigurations().getAllResults(),
+        context.getSkippedConfigurations().getAllResults(),
+        context.getPassedTests().getAllResults(),
+        context.getFailedTests().getAllResults(),
+        context.getSkippedTests().getAllResults(),
+        context.getFailedButWithinSuccessPercentageTests().getAllResults());
   }
   //
   // implements ITestListener


### PR DESCRIPTION
Closes #2096

As part of reducing the memory foot print following
was done:

* No TestNG listeners would now extend 
TestListenerAdapter. Instead everyone will implement
the required interfaces.
* Remove unwanted aggregation of method references
and instead resort to providing the same info
on demand.
* Refactored TestRunner to not explicitly keep
track of invoked methods and instead baked that
knowledge into the ITestNGMethod object itself
via a boolean.

Fixes #2096  .

### Did you remember to?

- [ ] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
