### PR TITLE
Favor runtime computation of test methods

### DIFF
--- a/src/main/java/org/testng/ITestNGMethod.java
+++ b/src/main/java/org/testng/ITestNGMethod.java
@@ -266,4 +266,8 @@ public interface ITestNGMethod extends Cloneable {
   default IDataProviderMethod getDataProviderMethod() {
     return null;
   }
+
+  default Class<?>[] getParameterTypes() {
+    return new Class<?>[] {};
+  }
 }

--- a/src/main/java/org/testng/TestNG.java
+++ b/src/main/java/org/testng/TestNG.java
@@ -201,6 +201,9 @@ public class TestNG {
   /** Default constructor. Setting also usage of default listeners/reporters. */
   public TestNG() {
     init(true);
+    if (RuntimeBehavior.isMemoryFriendlyMode()) {
+      Logger.getLogger(TestNG.class).warn("TestNG is running in memory friendly mode.");
+    }
   }
 
   /**

--- a/src/main/java/org/testng/TestRunner.java
+++ b/src/main/java/org/testng/TestRunner.java
@@ -7,7 +7,6 @@ import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -105,7 +104,8 @@ public class TestRunner
 
   private Date m_startDate = new Date();
   private Date m_endDate = null;
-  private IContainer<ITestNGMethod> testMethodsContainer;
+  private final IContainer<ITestNGMethod> testMethodsContainer =
+      new TestMethodContainer(this::computeAndGetAllTestMethods);
 
   /** A map to keep track of Class <-> IClass. */
   private final Map<Class<?>, ITestClass> m_classMap = Maps.newLinkedHashMap();
@@ -511,7 +511,6 @@ public class TestRunner
             m_excludedMethods,
             comparator);
 
-    testMethodsContainer = new TestMethodContainer(getAllTestMethods());
     m_classMethodMap = new ClassMethodMap(Arrays.asList(testMethodsContainer.getItems()), m_xmlMethodSelector);
     m_groupMethods = new ConfigurationGroupMethods(testMethodsContainer, beforeGroupMethods, afterGroupMethods);
 
@@ -809,7 +808,7 @@ public class TestRunner
     if (resultArray.length != testMethodsContainer.getItems().length) {
       m_groupMethods =
           new ConfigurationGroupMethods(
-              new TestMethodContainer(resultArray),
+              new TestMethodContainer(() -> resultArray),
               m_groupMethods.getBeforeGroupsMethods(),
               m_groupMethods.getAfterGroupsMethods());
     }
@@ -979,12 +978,7 @@ public class TestRunner
       //This is true only when we are running JUnit mode
       return m_allJunitTestMethods;
     }
-    if (Objects.nonNull(testMethodsContainer) && testMethodsContainer.hasItems()) {
-      return testMethodsContainer.getItems();
-    }
-    //If we are here, then it means that its ok to compute the methods every time
-    // Since we aren't being invoked from the core test execution code path.
-    return computeAndGetAllTestMethods();
+    return testMethodsContainer.getItems();
   }
 
   @Override

--- a/src/main/java/org/testng/internal/BaseInvoker.java
+++ b/src/main/java/org/testng/internal/BaseInvoker.java
@@ -50,7 +50,7 @@ class BaseInvoker {
     }
 
     InvokedMethodListenerInvoker invoker =
-        new InvokedMethodListenerInvoker(listenerMethod, testResult, m_testContext);
+        new InvokedMethodListenerInvoker(listenerMethod, testResult, testResult.getTestContext());
     for (IInvokedMethodListener currentListener : m_invokedMethodListeners) {
       invoker.invokeListener(currentListener, invokedMethod);
     }

--- a/src/main/java/org/testng/internal/BaseTestMethod.java
+++ b/src/main/java/org/testng/internal/BaseTestMethod.java
@@ -22,8 +22,6 @@ import org.testng.collections.Maps;
 import org.testng.collections.Sets;
 import org.testng.internal.annotations.DisabledRetryAnalyzer;
 import org.testng.internal.annotations.IAnnotationFinder;
-import org.testng.xml.XmlClass;
-import org.testng.xml.XmlInclude;
 import org.testng.xml.XmlTest;
 
 /** Superclass to represent both &#64;Test and &#64;Configuration methods. */
@@ -715,22 +713,13 @@ public abstract class BaseTestMethod implements ITestNGMethod, IInvocationStatus
   }
 
   @Override
-  public Map<String, String> findMethodParameters(XmlTest test) {
-    // Get the test+suite parameters
-    Map<String, String> result = test.getAllParameters();
-    for (XmlClass xmlClass : test.getXmlClasses()) {
-      if (xmlClass.getName().equals(getTestClass().getName())) {
-        result.putAll(xmlClass.getLocalParameters());
-        for (XmlInclude include : xmlClass.getIncludedMethods()) {
-          if (include.getName().equals(getMethodName())) {
-            result.putAll(include.getLocalParameters());
-            break;
-          }
-        }
-      }
-    }
+  public Class<?>[] getParameterTypes() {
+    return m_method.getParameterTypes();
+  }
 
-    return result;
+  @Override
+  public Map<String, String> findMethodParameters(XmlTest test) {
+    return XmlTestUtils.findMethodParameters(test, getTestClass().getName(), getMethodName());
   }
 
   @Override

--- a/src/main/java/org/testng/internal/ConfigurationGroupMethods.java
+++ b/src/main/java/org/testng/internal/ConfigurationGroupMethods.java
@@ -37,16 +37,12 @@ public class ConfigurationGroupMethods {
   private volatile Map<String, List<ITestNGMethod>> m_afterGroupsMap = null;
 
   public ConfigurationGroupMethods(
-      ITestNGMethod[] allMethods,
+      IContainer<ITestNGMethod> container,
       Map<String, List<ITestNGMethod>> beforeGroupsMethods,
       Map<String, List<ITestNGMethod>> afterGroupsMethods) {
-    m_allMethods = allMethods;
+    m_allMethods = container.getItems();
     m_beforeGroupsMethods = new ConcurrentHashMap<>(beforeGroupsMethods);
     m_afterGroupsMethods = new ConcurrentHashMap<>(afterGroupsMethods);
-  }
-
-  public ITestNGMethod[] getAllTestMethods() {
-    return this.m_allMethods;
   }
 
   public Map<String, List<ITestNGMethod>> getBeforeGroupsMethods() {

--- a/src/main/java/org/testng/internal/ConstructorOrMethod.java
+++ b/src/main/java/org/testng/internal/ConstructorOrMethod.java
@@ -92,14 +92,7 @@ public class ConstructorOrMethod {
   }
 
   public String stringifyParameterTypes() {
-    StringBuilder result = new StringBuilder();
-    int i = 0;
-    for (Class<?> p : getParameterTypes()) {
-      if (i++ > 0) {
-        result.append(", ");
-      }
-      result.append(p.getName());
-    }
-    return result.toString();
+    return Utils.stringifyTypes(getParameterTypes());
   }
+
 }

--- a/src/main/java/org/testng/internal/IContainer.java
+++ b/src/main/java/org/testng/internal/IContainer.java
@@ -1,0 +1,22 @@
+package org.testng.internal;
+
+/**
+ * Represents the capabilities of a simple container to hold data
+ */
+public interface IContainer<M> {
+
+  /**
+   * @return - Retrieves data from the container
+   */
+  M[] getItems();
+
+  /**
+   * @return - <code>true</code> if there are elements in the container.
+   */
+  boolean hasItems();
+
+  /**
+   * Clears the container
+   */
+  void clearItems();
+}

--- a/src/main/java/org/testng/internal/IContainer.java
+++ b/src/main/java/org/testng/internal/IContainer.java
@@ -11,12 +11,12 @@ public interface IContainer<M> {
   M[] getItems();
 
   /**
-   * @return - <code>true</code> if there are elements in the container.
-   */
-  boolean hasItems();
-
-  /**
    * Clears the container
    */
   void clearItems();
+
+  /**
+   * @return - <code>true</code> if the container items were cleared.
+   */
+  boolean isCleared();
 }

--- a/src/main/java/org/testng/internal/LiteWeightTestNGMethod.java
+++ b/src/main/java/org/testng/internal/LiteWeightTestNGMethod.java
@@ -1,0 +1,549 @@
+package org.testng.internal;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import org.testng.IClass;
+import org.testng.IDataProviderMethod;
+import org.testng.IRetryAnalyzer;
+import org.testng.ITestClass;
+import org.testng.ITestNGMethod;
+import org.testng.ITestResult;
+import org.testng.collections.Lists;
+import org.testng.xml.XmlTest;
+
+public class LiteWeightTestNGMethod implements ITestNGMethod {
+
+  private final Class<?> realClass;
+  private ITestClass testClass;
+  private final String methodName;
+  private final Object instance;
+  private final long[] instanceHashCodes;
+  private final String[] groups;
+  private final String[] groupsDependedUpon;
+  private String missingGroup;
+  private final String[] beforeGroups;
+  private final String[] afterGroups;
+  private final List<String> methodsDependedUpon = new LinkedList<>();
+  private int priority;
+  private int interceptedPriority;
+  private final XmlTest xmlTest;
+  private final String qualifiedName;
+  private final boolean isBeforeTestConfiguration;
+  private final boolean isAfterTestConfiguration;
+  private final boolean isBeforeGroupsConfiguration;
+  private final boolean isAfterGroupsConfiguration;
+  private final boolean isTest;
+  private final boolean isBeforeMethodConfiguration;
+  private final boolean isAfterMethodConfiguration;
+  private final boolean isBeforeClassConfiguration;
+  private final boolean isAfterClassConfiguration;
+  private final boolean isBeforeSuiteConfiguration;
+  private final boolean isAfterSuiteConfiguration;
+  private List<Integer> invocationNumbers;
+  private final List<Integer> failedInvocationNumbers;
+  private boolean ignoreMissingDependencies;
+  private final long invocationTimeout;
+  private boolean skipFailedInvocations;
+
+  private long timeout;
+  private int invocationCount;
+  private final int successPercentage;
+  private String id;
+  private long date;
+  private final boolean isAlwaysRun;
+  private int threadPoolSize;
+  private final boolean enabled;
+  private String description;
+  private final int currentInvocationCount;
+  private int parameterInvocationCount;
+  private final boolean hasMoreInvocation;
+  private final Class<? extends IRetryAnalyzer> retryAnalyzerClass;
+  private final String toString;
+  private final IDataProviderMethod dataProviderMethod;
+  private final int hashCode;
+  private final Class<?>[] parameterTypes;
+
+
+  public LiteWeightTestNGMethod(ITestNGMethod iTestNGMethod) {
+    realClass = iTestNGMethod.getRealClass();
+    testClass = iTestNGMethod.getTestClass();
+    methodName = iTestNGMethod.getMethodName();
+    instance = iTestNGMethod.getInstance();
+    instanceHashCodes = iTestNGMethod.getInstanceHashCodes();
+    groups = iTestNGMethod.getGroups();
+    groupsDependedUpon = iTestNGMethod.getGroupsDependedUpon();
+    missingGroup = iTestNGMethod.getMissingGroup();
+    beforeGroups = iTestNGMethod.getBeforeGroups();
+    afterGroups = iTestNGMethod.getAfterGroups();
+    if (iTestNGMethod.getMethodsDependedUpon() != null) {
+      methodsDependedUpon.addAll(Arrays.asList(iTestNGMethod.getMethodsDependedUpon()));
+    }
+    priority = iTestNGMethod.getPriority();
+    interceptedPriority = iTestNGMethod.getInterceptedPriority();
+    xmlTest = iTestNGMethod.getXmlTest();
+    qualifiedName = iTestNGMethod.getQualifiedName();
+    isBeforeTestConfiguration = iTestNGMethod.isBeforeTestConfiguration();
+    isAfterTestConfiguration = iTestNGMethod.isAfterTestConfiguration();
+    isBeforeGroupsConfiguration = iTestNGMethod.isBeforeGroupsConfiguration();
+    isAfterGroupsConfiguration = iTestNGMethod.isAfterGroupsConfiguration();
+    isTest = iTestNGMethod.isTest();
+    isBeforeMethodConfiguration = iTestNGMethod.isBeforeMethodConfiguration();
+    isAfterMethodConfiguration = iTestNGMethod.isAfterMethodConfiguration();
+    isBeforeClassConfiguration = iTestNGMethod.isBeforeClassConfiguration();
+    isAfterClassConfiguration = iTestNGMethod.isAfterClassConfiguration();
+    isBeforeSuiteConfiguration = iTestNGMethod.isBeforeSuiteConfiguration();
+    isAfterSuiteConfiguration = iTestNGMethod.isAfterSuiteConfiguration();
+    invocationNumbers = iTestNGMethod.getInvocationNumbers();
+    failedInvocationNumbers = iTestNGMethod.getFailedInvocationNumbers();
+    ignoreMissingDependencies = iTestNGMethod.ignoreMissingDependencies();
+    invocationTimeout = iTestNGMethod.getInvocationTimeOut();
+    skipFailedInvocations = iTestNGMethod.skipFailedInvocations();
+    timeout = iTestNGMethod.getTimeOut();
+    invocationCount = iTestNGMethod.getInvocationCount();
+    successPercentage = iTestNGMethod.getSuccessPercentage();
+    id = iTestNGMethod.getId();
+    date = iTestNGMethod.getDate();
+    isAlwaysRun = iTestNGMethod.isAlwaysRun();
+    threadPoolSize = iTestNGMethod.getThreadPoolSize();
+    enabled = iTestNGMethod.getEnabled();
+    description = iTestNGMethod.getDescription();
+    currentInvocationCount = iTestNGMethod.getCurrentInvocationCount();
+    parameterInvocationCount = iTestNGMethod.getParameterInvocationCount();
+    hasMoreInvocation = iTestNGMethod.hasMoreInvocation();
+    retryAnalyzerClass = iTestNGMethod.getRetryAnalyzerClass();
+    toString = iTestNGMethod.toString();
+    IDataProviderMethod dp = iTestNGMethod.getDataProviderMethod();
+    dataProviderMethod = new IDataProviderMethod() {
+      @Override
+      public Object getInstance() {
+        return dp.getInstance();
+      }
+
+      @Override
+      public Method getMethod() {
+        throw new UnsupportedOperationException("method() retrieval not supported");
+      }
+
+      @Override
+      public String getName() {
+        if (dp == null) {
+          return "";
+        }
+        return dp.getName();
+      }
+
+      @Override
+      public boolean isParallel() {
+        if (dp == null) {
+          return false;
+        }
+        return dp.isParallel();
+      }
+
+      @Override
+      public List<Integer> getIndices() {
+        if (dp == null) {
+          return Lists.newArrayList();
+        }
+        return dp.getIndices();
+      }
+    };
+    hashCode = iTestNGMethod.hashCode();
+    parameterTypes = iTestNGMethod.getConstructorOrMethod().getParameterTypes();
+  }
+
+  @Override
+  public Class<?>[] getParameterTypes() {
+    return parameterTypes;
+  }
+
+  @Override
+  public Class getRealClass() {
+    return realClass;
+  }
+
+  @Override
+  public ITestClass getTestClass() {
+    return testClass;
+  }
+
+  @Override
+  public void setTestClass(ITestClass cls) {
+    this.testClass = cls;
+  }
+
+  @Override
+  public String getMethodName() {
+    return methodName;
+  }
+
+  @Override
+  public Object getInstance() {
+    return instance;
+  }
+
+  @Override
+  public long[] getInstanceHashCodes() {
+    return instanceHashCodes;
+  }
+
+  @Override
+  public String[] getGroups() {
+    return groups;
+  }
+
+  @Override
+  public String[] getGroupsDependedUpon() {
+    return groupsDependedUpon;
+  }
+
+  @Override
+  public String getMissingGroup() {
+    return missingGroup;
+  }
+
+  @Override
+  public void setMissingGroup(String group) {
+    this.missingGroup = group;
+  }
+
+  @Override
+  public String[] getBeforeGroups() {
+    return beforeGroups;
+  }
+
+  @Override
+  public String[] getAfterGroups() {
+    return afterGroups;
+  }
+
+  @Override
+  public String[] getMethodsDependedUpon() {
+    return methodsDependedUpon.toArray(new String[0]);
+  }
+
+  @Override
+  public void addMethodDependedUpon(String methodName) {
+    methodsDependedUpon.add(methodName);
+  }
+
+  @Override
+  public boolean isTest() {
+    return isTest;
+  }
+
+  @Override
+  public boolean isBeforeMethodConfiguration() {
+    return isBeforeMethodConfiguration;
+  }
+
+  @Override
+  public boolean isAfterMethodConfiguration() {
+    return isAfterMethodConfiguration;
+  }
+
+  @Override
+  public boolean isBeforeClassConfiguration() {
+    return isBeforeClassConfiguration;
+  }
+
+  @Override
+  public boolean isAfterClassConfiguration() {
+    return isAfterClassConfiguration;
+  }
+
+  @Override
+  public boolean isBeforeSuiteConfiguration() {
+    return isBeforeSuiteConfiguration;
+  }
+
+  @Override
+  public boolean isAfterSuiteConfiguration() {
+    return isAfterSuiteConfiguration;
+  }
+
+  @Override
+  public boolean isBeforeTestConfiguration() {
+    return isBeforeTestConfiguration;
+  }
+
+  @Override
+  public boolean isAfterTestConfiguration() {
+    return isAfterTestConfiguration;
+  }
+
+  @Override
+  public boolean isBeforeGroupsConfiguration() {
+    return isBeforeGroupsConfiguration;
+  }
+
+  @Override
+  public boolean isAfterGroupsConfiguration() {
+    return isAfterGroupsConfiguration;
+  }
+
+  @Override
+  public long getTimeOut() {
+    return timeout;
+  }
+
+  @Override
+  public void setTimeOut(long timeOut) {
+    this.timeout = timeOut;
+  }
+
+  @Override
+  public int getInvocationCount() {
+    return invocationCount;
+  }
+
+  @Override
+  public void setInvocationCount(int count) {
+    this.invocationCount = count;
+  }
+
+  @Override
+  public int getSuccessPercentage() {
+    return successPercentage;
+  }
+
+  @Override
+  public String getId() {
+    return id;
+  }
+
+  @Override
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  @Override
+  public long getDate() {
+    return date;
+  }
+
+  @Override
+  public void setDate(long date) {
+    this.date = date;
+  }
+
+  @Override
+  public boolean canRunFromClass(IClass testClass) {
+    return getTestClass().getRealClass().isAssignableFrom(testClass.getRealClass());
+  }
+
+
+  @Override
+  public boolean isAlwaysRun() {
+    return isAlwaysRun;
+  }
+
+  @Override
+  public int getThreadPoolSize() {
+    return threadPoolSize;
+  }
+
+  @Override
+  public void setThreadPoolSize(int threadPoolSize) {
+    this.threadPoolSize = threadPoolSize;
+  }
+
+  @Override
+  public boolean getEnabled() {
+    return enabled;
+  }
+
+  @Override
+  public String getDescription() {
+    return description;
+  }
+
+  @Override
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  @Override
+  public void incrementCurrentInvocationCount() {
+
+  }
+
+  @Override
+  public int getCurrentInvocationCount() {
+    return currentInvocationCount;
+  }
+
+  @Override
+  public void setParameterInvocationCount(int n) {
+    this.parameterInvocationCount = n;
+
+  }
+
+  @Override
+  public int getParameterInvocationCount() {
+    return parameterInvocationCount;
+  }
+
+  @Override
+  public void setMoreInvocationChecker(Callable<Boolean> moreInvocationChecker) {
+
+  }
+
+  @Override
+  public boolean hasMoreInvocation() {
+    return hasMoreInvocation;
+  }
+
+  @Override
+  public ITestNGMethod clone() {
+    throw new UnsupportedOperationException("clone() not supported");
+  }
+
+  @Override
+  public IRetryAnalyzer getRetryAnalyzer(ITestResult result) {
+    throw new UnsupportedOperationException("getRetryAnalyzer() not supported");
+  }
+
+  @Override
+  public void setRetryAnalyzerClass(Class<? extends IRetryAnalyzer> clazz) {
+
+  }
+
+
+  @Override
+  public Class<? extends IRetryAnalyzer> getRetryAnalyzerClass() {
+    return retryAnalyzerClass;
+  }
+
+  @Override
+  public boolean skipFailedInvocations() {
+    return skipFailedInvocations;
+  }
+
+  @Override
+  public void setSkipFailedInvocations(boolean skip) {
+    this.skipFailedInvocations = skip;
+  }
+
+  @Override
+  public long getInvocationTimeOut() {
+    return invocationTimeout;
+  }
+
+  @Override
+  public boolean ignoreMissingDependencies() {
+    return ignoreMissingDependencies;
+  }
+
+  @Override
+  public void setIgnoreMissingDependencies(boolean ignore) {
+    this.ignoreMissingDependencies = ignore;
+  }
+
+  @Override
+  public List<Integer> getInvocationNumbers() {
+    return invocationNumbers;
+  }
+
+  @Override
+  public void setInvocationNumbers(List<Integer> numbers) {
+    this.invocationNumbers = numbers;
+  }
+
+  @Override
+  public void addFailedInvocationNumber(int number) {
+    failedInvocationNumbers.add(number);
+  }
+
+  @Override
+  public List<Integer> getFailedInvocationNumbers() {
+    return failedInvocationNumbers;
+  }
+
+  @Override
+  public int getPriority() {
+    return priority;
+  }
+
+  @Override
+  public void setPriority(int priority) {
+    this.priority = priority;
+  }
+
+  @Override
+  public int getInterceptedPriority() {
+    return interceptedPriority;
+  }
+
+  @Override
+  public void setInterceptedPriority(int priority) {
+    this.interceptedPriority = priority;
+  }
+
+  @Override
+  public XmlTest getXmlTest() {
+    return xmlTest;
+  }
+
+  @Override
+  public ConstructorOrMethod getConstructorOrMethod() {
+    throw new UnsupportedOperationException("Not supported");
+  }
+
+  @Override
+  public Map<String, String> findMethodParameters(XmlTest test) {
+    return XmlTestUtils.findMethodParameters(xmlTest, getTestClass().getName(), getMethodName());
+  }
+
+  @Override
+  public String getQualifiedName() {
+    return qualifiedName;
+  }
+
+  @Override
+  public IDataProviderMethod getDataProviderMethod() {
+    return dataProviderMethod;
+  }
+
+  @Override
+  public String toString() {
+    return toString;
+  }
+
+  @Override
+  public int hashCode() {
+    return hashCode;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    //Intentionally not checking the parameter type
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ITestNGMethod)) {
+      return false;
+    }
+
+    ITestNGMethod that = (ITestNGMethod) o;
+    boolean value = realClass.equals(that.getRealClass()) &&
+        qualifiedName.equals(that.getQualifiedName()) &&
+        equalParamTypes(parameterTypes, that.getParameterTypes());
+    return value;
+  }
+
+  boolean equalParamTypes(Class<?>[] params1, Class<?>[] params2) {
+    if (params1.length == params2.length) {
+      for (int i = 0; i < params1.length; i++) {
+        if (params1[i] != params2[i])
+          return false;
+      }
+      return true;
+    }
+    return false;
+  }
+}

--- a/src/main/java/org/testng/internal/RunInfo.java
+++ b/src/main/java/org/testng/internal/RunInfo.java
@@ -1,11 +1,11 @@
 package org.testng.internal;
 
+import java.util.Set;
+import java.util.TreeSet;
 import org.testng.IMethodSelector;
 import org.testng.IMethodSelectorContext;
 import org.testng.ITestNGMethod;
-import org.testng.collections.Lists;
 
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -15,7 +15,7 @@ import java.util.List;
  */
 public class RunInfo {
 
-  private final List<MethodSelectorDescriptor> m_methodSelectors = Lists.newArrayList();
+  private final Set<MethodSelectorDescriptor> m_methodSelectors = new TreeSet<>();
 
   public void addMethodSelector(IMethodSelector selector, int priority) {
     Utils.log("RunInfo", 3, "Adding method selector: " + selector + " priority: " + priority);
@@ -25,7 +25,6 @@ public class RunInfo {
 
   /** @return true as soon as we fond a Method Selector that returns true for the method "tm". */
   public boolean includeMethod(ITestNGMethod tm, boolean isTestMethod) {
-    Collections.sort(m_methodSelectors);
     boolean foundNegative = false;
     IMethodSelectorContext context = new DefaultMethodSelectorContext();
 
@@ -40,7 +39,7 @@ public class RunInfo {
         break;
       }
 
-      // Proceeed normally
+      // Proceed normally
       IMethodSelector md = mds.getMethodSelector();
       result = md.includeMethod(context, tm, isTestMethod);
       if (context.isStopped()) {

--- a/src/main/java/org/testng/internal/RuntimeBehavior.java
+++ b/src/main/java/org/testng/internal/RuntimeBehavior.java
@@ -11,6 +11,7 @@ public final class RuntimeBehavior {
   private static final String SKIP_CALLER_CLS_LOADER = "skip.caller.clsLoader";
   public static final String TESTNG_USE_UNSECURED_URL = "testng.dtd.http";
   public static final String SHOW_TESTNG_STACK_FRAMES = "testng.show.stack.frames";
+  private static final String MEMORY_FRIENDLY_MODE = "testng.memory.friendly";
 
   private RuntimeBehavior() {}
 
@@ -20,6 +21,10 @@ public final class RuntimeBehavior {
 
   public static boolean useSecuredUrlForDtd() {
     return !Boolean.getBoolean(TESTNG_USE_UNSECURED_URL);
+  }
+
+  public static boolean isMemoryFriendlyMode() {
+    return Boolean.parseBoolean(System.getProperty(MEMORY_FRIENDLY_MODE, "false"));
   }
 
   public static String unsecuredUrlDocumentation() {

--- a/src/main/java/org/testng/internal/TestInvoker.java
+++ b/src/main/java/org/testng/internal/TestInvoker.java
@@ -91,7 +91,7 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
     // By the time this testMethod to be invoked,
     // all dependencies should be already run or we need to skip this method,
     // so invocation count should not affect dependencies check
-    String okToProceed = checkDependencies(testMethod, context.getAllTestMethods());
+    String okToProceed = checkDependencies(testMethod);
 
     if (okToProceed != null) {
       //
@@ -244,7 +244,7 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
    * @param testMethod test method being checked for
    * @return error message or null if dependencies have been run successfully
    */
-  private String checkDependencies(ITestNGMethod testMethod, ITestNGMethod[] allTestMethods) {
+  private String checkDependencies(ITestNGMethod testMethod) {
     // If this method is marked alwaysRun, no need to check for its dependencies
     if (testMethod.isAlwaysRun()) {
       return null;
@@ -262,12 +262,13 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
     // If this method depends on groups, collect all the methods that
     // belong to these groups and make sure they have been run successfully
     String[] groups = testMethod.getGroupsDependedUpon();
+    ITestNGMethod[] allTestMethods = m_testContext.getAllTestMethods();
     if (null != groups && groups.length > 0) {
       // Get all the methods that belong to the group depended upon
       for (String element : groups) {
         ITestNGMethod[] methods =
             MethodGroupsHelper.findMethodsThatBelongToGroup(
-                testMethod, m_testContext.getAllTestMethods(), element);
+                testMethod, allTestMethods, element);
         if (methods.length == 0 && !testMethod.ignoreMissingDependencies()) {
           // Group is missing
           return "Method " + testMethod + " depends on nonexistent group \"" + element + "\"";

--- a/src/main/java/org/testng/internal/TestMethodContainer.java
+++ b/src/main/java/org/testng/internal/TestMethodContainer.java
@@ -1,29 +1,50 @@
 package org.testng.internal;
 
 import java.util.Arrays;
+import java.util.function.Supplier;
 import org.testng.ITestNGMethod;
 
+/**
+ * This implementation leverages a supplier to lazily load the test methods (data) for the very
+ * first time and "remembers it" for later invocations. If the user clears the data (the one that we
+ * were remembering) then, it resorts to just using the supplier to provide on-demand evaluation of
+ * test methods. This implementation is built such that once its been asked to forget the data, it
+ * no longer caches it anymore.
+ */
 public final class TestMethodContainer implements IContainer<ITestNGMethod> {
 
   private ITestNGMethod[] methods;
+  private final Supplier<ITestNGMethod[]> supplier;
+  private boolean isCleared = false;
 
-  public TestMethodContainer(ITestNGMethod[] methods) {
-    this.methods = methods;
+  public TestMethodContainer(Supplier<ITestNGMethod[]> supplier) {
+    this.supplier = supplier;
   }
 
   public ITestNGMethod[] getItems() {
+    if (isCleared()) {
+      //If the cached data was cleared, no longer try to refer to it, but instead
+      //just resort to on-demand computation.
+      return supplier.get();
+    }
+    if (methods == null) {
+      //The first time we are here, methods would be null. So lets lazily initialise it.
+      methods = supplier.get();
+    }
     return methods;
   }
 
-  public boolean hasItems() {
-    return methods != null && methods.length != 0;
+  @Override
+  public boolean isCleared() {
+    return isCleared;
   }
 
   public void clearItems() {
-    if (methods == null) {
+    if (isCleared) {
       return;
     }
     Arrays.fill(methods, null);
     methods = null;
+    isCleared = true;
   }
 }

--- a/src/main/java/org/testng/internal/TestMethodContainer.java
+++ b/src/main/java/org/testng/internal/TestMethodContainer.java
@@ -1,0 +1,29 @@
+package org.testng.internal;
+
+import java.util.Arrays;
+import org.testng.ITestNGMethod;
+
+public final class TestMethodContainer implements IContainer<ITestNGMethod> {
+
+  private ITestNGMethod[] methods;
+
+  public TestMethodContainer(ITestNGMethod[] methods) {
+    this.methods = methods;
+  }
+
+  public ITestNGMethod[] getItems() {
+    return methods;
+  }
+
+  public boolean hasItems() {
+    return methods != null && methods.length != 0;
+  }
+
+  public void clearItems() {
+    if (methods == null) {
+      return;
+    }
+    Arrays.fill(methods, null);
+    methods = null;
+  }
+}

--- a/src/main/java/org/testng/internal/TestMethodWorker.java
+++ b/src/main/java/org/testng/internal/TestMethodWorker.java
@@ -277,7 +277,7 @@ public class TestMethodWorker implements IWorker<ITestNGMethod> {
 /** Extends {@code TestMethodWorker} and is used to work on only a single method instance */
 class SingleTestMethodWorker extends TestMethodWorker {
   private static final ConfigurationGroupMethods EMPTY_GROUP_METHODS =
-      new ConfigurationGroupMethods(new ITestNGMethod[0], new HashMap<>(), new HashMap<>());
+      new ConfigurationGroupMethods(new TestMethodContainer(new ITestNGMethod[0]), new HashMap<>(), new HashMap<>());
 
   public SingleTestMethodWorker(
       TestInvoker testInvoker,

--- a/src/main/java/org/testng/internal/TestMethodWorker.java
+++ b/src/main/java/org/testng/internal/TestMethodWorker.java
@@ -277,7 +277,8 @@ public class TestMethodWorker implements IWorker<ITestNGMethod> {
 /** Extends {@code TestMethodWorker} and is used to work on only a single method instance */
 class SingleTestMethodWorker extends TestMethodWorker {
   private static final ConfigurationGroupMethods EMPTY_GROUP_METHODS =
-      new ConfigurationGroupMethods(new TestMethodContainer(new ITestNGMethod[0]), new HashMap<>(), new HashMap<>());
+      new ConfigurationGroupMethods(new TestMethodContainer(() -> new ITestNGMethod[0]),
+          new HashMap<>(), new HashMap<>());
 
   public SingleTestMethodWorker(
       TestInvoker testInvoker,

--- a/src/main/java/org/testng/internal/TestResult.java
+++ b/src/main/java/org/testng/internal/TestResult.java
@@ -93,7 +93,11 @@ public class TestResult implements ITestResult {
     }
     m_startMillis = start;
     m_endMillis = end;
-    m_method = method;
+    if (RuntimeBehavior.isMemoryFriendlyMode()) {
+      m_method = new LiteWeightTestNGMethod(method);
+    } else {
+      m_method = method;
+    }
     m_context = ctx;
 
     Object instance = method.getInstance();

--- a/src/main/java/org/testng/internal/Utils.java
+++ b/src/main/java/org/testng/internal/Utils.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.testng.ITestNGMethod;
 import org.testng.TestNGException;
@@ -600,4 +601,17 @@ public final class Utils {
     }
     return result;
   }
+
+  public static Class<?>[] extractParameterTypes(Object[] objects) {
+    return Arrays.stream(objects)
+        .map(Object::getClass)
+        .toArray(Class<?>[]::new);
+  }
+
+  public static String stringifyTypes(Class<?>[] parameterTypes) {
+    return Arrays.stream(parameterTypes)
+        .map(Class::getName)
+        .collect(Collectors.joining(","));
+  }
+
 }

--- a/src/main/java/org/testng/internal/XmlTestUtils.java
+++ b/src/main/java/org/testng/internal/XmlTestUtils.java
@@ -1,0 +1,32 @@
+package org.testng.internal;
+
+import java.util.Map;
+import org.testng.xml.XmlClass;
+import org.testng.xml.XmlInclude;
+import org.testng.xml.XmlTest;
+
+final class XmlTestUtils {
+
+  private XmlTestUtils() {
+
+  }
+
+  static Map<String, String> findMethodParameters(XmlTest test, String className,
+      String methodName) {
+    Map<String, String> result = test.getAllParameters();
+    for (XmlClass xmlClass : test.getXmlClasses()) {
+      if (xmlClass.getName().equals(className)) {
+        result.putAll(xmlClass.getLocalParameters());
+        for (XmlInclude include : xmlClass.getIncludedMethods()) {
+          if (include.getName().equals(methodName)) {
+            result.putAll(include.getLocalParameters());
+            break;
+          }
+        }
+      }
+    }
+
+    return result;
+  }
+
+}

--- a/src/main/java/org/testng/reporters/JUnitXMLReporter.java
+++ b/src/main/java/org/testng/reporters/JUnitXMLReporter.java
@@ -183,7 +183,7 @@ public class JUnitXMLReporter implements IResultListener2 {
   private Set<String> getPackages(ITestContext context) {
     Set<String> result = Sets.newHashSet();
     for (ITestNGMethod m : context.getAllTestMethods()) {
-      Package pkg = m.getConstructorOrMethod().getDeclaringClass().getPackage();
+      Package pkg = m.getRealClass().getPackage();
       if (pkg != null) {
         result.add(pkg.getName());
       }

--- a/src/main/java/org/testng/reporters/SuiteHTMLReporter.java
+++ b/src/main/java/org/testng/reporters/SuiteHTMLReporter.java
@@ -11,7 +11,6 @@ import org.testng.ITestContext;
 import org.testng.ITestNGMethod;
 import org.testng.Reporter;
 import org.testng.collections.Maps;
-import org.testng.internal.ConstructorOrMethod;
 import org.testng.internal.Utils;
 import org.testng.log4testng.Logger;
 import org.testng.xml.XmlSuite;
@@ -43,7 +42,7 @@ public class SuiteHTMLReporter implements IReporter {
   private static final String TD_A_TARGET_MAIN_FRAME_HREF = "<td><a target='mainFrame' href='";
   private static final String CLOSE_TD = "</td>";
 
-  private Map<String, ITestClass> m_classes = Maps.newHashMap();
+  private final Map<String, ITestClass> m_classes = Maps.newHashMap();
   private String m_outputDirectory;
 
   @Override
@@ -214,18 +213,12 @@ public class SuiteHTMLReporter implements IReporter {
     Collection<ITestNGMethod> excluded = suite.getExcludedMethods();
     StringBuilder sb2 = new StringBuilder("<h2>Methods that were not run</h2><table>\n");
     for (ITestNGMethod method : excluded) {
-      ConstructorOrMethod m = method.getConstructorOrMethod();
-      if (m != null) {
-        sb2.append("<tr><td>")
-            .append(m.getDeclaringClass().getName())
-            .append(".")
-            .append(m.getName());
-        String description = method.getDescription();
-        if (isStringNotEmpty(description)) {
-          sb2.append("<br/>").append(SP2).append("<i>").append(description).append("</i>");
-        }
-        sb2.append("</td></tr>\n");
+      sb2.append("<tr><td>").append(method.getQualifiedName());
+      String description = method.getDescription();
+      if (isStringNotEmpty(description)) {
+        sb2.append("<br/>").append(SP2).append("<i>").append(description).append("</i>");
       }
+      sb2.append("</td></tr>\n");
     }
     sb2.append("</table>");
 

--- a/src/main/java/org/testng/reporters/TextReporter.java
+++ b/src/main/java/org/testng/reporters/TextReporter.java
@@ -55,7 +55,7 @@ public class TextReporter implements ITestListener {
           tr.getMethod().getDescription(),
           stackTrace,
           tr.getParameters(),
-          tr.getMethod().getConstructorOrMethod().getParameterTypes());
+          Utils.extractParameterTypes(tr.getParameters()));
     }
 
     results = context.getSkippedConfigurations().getAllResults();
@@ -66,7 +66,7 @@ public class TextReporter implements ITestListener {
           tr.getMethod().getDescription(),
           null,
           tr.getParameters(),
-          tr.getMethod().getConstructorOrMethod().getParameterTypes());
+          Utils.extractParameterTypes(tr.getParameters()));
     }
 
     results = context.getPassedTests().getAllResults();
@@ -137,7 +137,7 @@ public class TextReporter implements ITestListener {
         tr.getMethod().getDescription(),
         stackTrace,
         tr.getParameters(),
-        tr.getMethod().getConstructorOrMethod().getParameterTypes());
+        Utils.extractParameterTypes(tr.getParameters()));
   }
 
   private void logExceptions(String status, List<ITestResult> results) {

--- a/src/main/java/org/testng/reporters/VerboseReporter.java
+++ b/src/main/java/org/testng/reporters/VerboseReporter.java
@@ -7,7 +7,6 @@ import org.testng.ITestContext;
 import org.testng.ITestListener;
 import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
-import org.testng.internal.ConstructorOrMethod;
 import org.testng.internal.Utils;
 
 /**
@@ -183,9 +182,9 @@ public class VerboseReporter implements IConfigurationListener, ITestListener {
     }
     ITestNGMethod tm = itr.getMethod();
     int identLevel = sb.length();
-    sb.append(getMethodDeclaration(tm));
+    sb.append(getMethodDeclaration(tm, itr));
     Object[] params = itr.getParameters();
-    Class<?>[] paramTypes = tm.getConstructorOrMethod().getParameterTypes();
+    Class<?>[] paramTypes = Utils.extractParameterTypes(itr.getParameters());
     if (null != params && params.length > 0) {
       // The error might be a data provider parameter mismatch, so make
       // a special case here
@@ -248,10 +247,10 @@ public class VerboseReporter implements IConfigurationListener, ITestListener {
    * @return FQN of a class + method declaration for a method passed in ie.
    *     test.triangle.CheckCount.testCheckCount(java.lang.String)
    */
-  private String getMethodDeclaration(ITestNGMethod method) {
+  private String getMethodDeclaration(ITestNGMethod method, ITestResult tr) {
+
     // see Utils.detailedMethodName
     // perhaps should rather adopt the original method instead
-    ConstructorOrMethod m = method.getConstructorOrMethod();
     StringBuilder buf = new StringBuilder();
     buf.append("\"");
     if (suiteName != null) {
@@ -265,10 +264,9 @@ public class VerboseReporter implements IConfigurationListener, ITestListener {
     if (!tempName.isEmpty()) {
       buf.append(Utils.annotationFormFor(method)).append(" ");
     }
-    buf.append(m.getDeclaringClass().getName());
-    buf.append(".");
-    buf.append(m.getName());
-    buf.append("(").append(m.stringifyParameterTypes()).append(")");
+    buf.append(method.getQualifiedName());
+    Class<?>[] objects = Utils.extractParameterTypes(tr.getParameters());
+    buf.append("(").append(Utils.stringifyTypes(objects)).append(")");
     return buf.toString();
   }
 

--- a/src/main/java/org/testng/reporters/XMLSuiteResultWriter.java
+++ b/src/main/java/org/testng/reporters/XMLSuiteResultWriter.java
@@ -1,15 +1,14 @@
 package org.testng.reporters;
 
+import org.testng.IDataProviderMethod;
 import org.testng.IResultMap;
 import org.testng.ISuiteResult;
 import org.testng.ITestContext;
 import org.testng.ITestResult;
 import org.testng.Reporter;
-import org.testng.annotations.Test;
 import org.testng.collections.Lists;
 import org.testng.collections.Maps;
 import org.testng.collections.Sets;
-import org.testng.internal.ConstructorOrMethod;
 import org.testng.internal.Utils;
 import org.testng.util.Strings;
 import org.testng.util.TimeUtils;
@@ -231,15 +230,11 @@ public class XMLSuiteResultWriter {
       }
     }
 
-    ConstructorOrMethod cm = testResult.getMethod().getConstructorOrMethod();
-    Test testAnnotation;
-    if (cm.getMethod() != null) {
-      testAnnotation = cm.getMethod().getAnnotation(Test.class);
-      if (testAnnotation != null) {
-        String dataProvider = testAnnotation.dataProvider();
-        if (!Strings.isNullOrEmpty(dataProvider)) {
-          attributes.setProperty(XMLReporterConfig.ATTR_DATA_PROVIDER, dataProvider);
-        }
+    IDataProviderMethod dp = testResult.getMethod().getDataProviderMethod();
+    if (dp != null) {
+      String dataProvider = dp.getName();
+      if (!Strings.isNullOrEmpty(dataProvider)) {
+        attributes.setProperty(XMLReporterConfig.ATTR_DATA_PROVIDER, dataProvider);
       }
     }
 


### PR DESCRIPTION
Fixes #2096

TestRunner currently remembers all test methods.
Refactored such that test methods are now 
computed on runtime.

