### PR TITLE
Remove IInvokedMethod references from SuiteRunner

### DIFF
--- a/src/main/java/org/testng/IInvocationStatus.java
+++ b/src/main/java/org/testng/IInvocationStatus.java
@@ -1,8 +1,0 @@
-package org.testng;
-
-public interface IInvocationStatus {
-  void markAsInvoked();
-
-  boolean isInvoked();
-
-}

--- a/src/main/java/org/testng/internal/BaseTestMethod.java
+++ b/src/main/java/org/testng/internal/BaseTestMethod.java
@@ -12,7 +12,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
 import org.testng.IClass;
-import org.testng.IInvocationStatus;
 import org.testng.IRetryAnalyzer;
 import org.testng.ITestClass;
 import org.testng.ITestNGMethod;
@@ -747,16 +746,16 @@ public abstract class BaseTestMethod implements ITestNGMethod, IInvocationStatus
     return null;
   }
 
-  private boolean invoked = false;
+  private long invocationTime;
 
   @Override
-  public void markAsInvoked() {
-    invoked = true;
+  public void setInvokedAt(long date) {
+    this.invocationTime = date;
   }
 
   @Override
-  public boolean isInvoked() {
-    return invoked;
+  public long getInvocationTime() {
+    return invocationTime;
   }
 
   private IRetryAnalyzer getRetryAnalyzerConsideringMethodParameters(ITestResult tr) {

--- a/src/main/java/org/testng/internal/ConfigInvoker.java
+++ b/src/main/java/org/testng/internal/ConfigInvoker.java
@@ -13,7 +13,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import org.testng.IClass;
 import org.testng.IConfigurable;
-import org.testng.IInvocationStatus;
 import org.testng.IInvokedMethodListener;
 import org.testng.ITestContext;
 import org.testng.ITestNGMethod;
@@ -351,7 +350,7 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
 
     runInvokedMethodListeners(BEFORE_INVOCATION, invokedMethod, testResult);
     if (tm instanceof IInvocationStatus) {
-      m_notifier.recordInvocationStatus((IInvocationStatus) tm);
+      ((IInvocationStatus) tm).setInvokedAt(invokedMethod.getDate());
     }
     try {
       Reporter.setCurrentTestResult(testResult);

--- a/src/main/java/org/testng/internal/IConfigEavesdropper.java
+++ b/src/main/java/org/testng/internal/IConfigEavesdropper.java
@@ -1,0 +1,7 @@
+package org.testng.internal;
+
+import org.testng.IResultMap;
+
+public interface IConfigEavesdropper {
+  IResultMap getConfigurationsScheduledForInvocation();
+}

--- a/src/main/java/org/testng/internal/IInvocationStatus.java
+++ b/src/main/java/org/testng/internal/IInvocationStatus.java
@@ -1,0 +1,17 @@
+package org.testng.internal;
+
+/**
+ * Helps keep track of when a method was invoked
+ */
+public interface IInvocationStatus {
+
+  /**
+   * @param date - The timestamp at which a method was invoked.
+   */
+  void setInvokedAt(long date);
+
+  /**
+   * @return - The timestamp at which a method got invoked.
+   */
+  long getInvocationTime();
+}

--- a/src/main/java/org/testng/internal/ITestResultNotifier.java
+++ b/src/main/java/org/testng/internal/ITestResultNotifier.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.testng.IConfigurationListener;
-import org.testng.IInvocationStatus;
 import org.testng.ITestListener;
 import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
@@ -37,8 +36,6 @@ public interface ITestResultNotifier {
    */
   @Deprecated
   default void addInvokedMethod(InvokedMethod im) {}
-
-  default void recordInvocationStatus(IInvocationStatus im) {}
 
   XmlTest getTest();
 

--- a/src/main/java/org/testng/internal/MethodHelper.java
+++ b/src/main/java/org/testng/internal/MethodHelper.java
@@ -13,7 +13,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
 import java.util.stream.Collectors;
-import org.testng.IInvocationStatus;
 import org.testng.IInvokedMethod;
 import org.testng.IMethodInstance;
 import org.testng.ITestClass;
@@ -443,7 +442,7 @@ public class MethodHelper {
     }
     System.out.println("===== Invoked methods");
     Arrays.stream(methods).filter(m -> m instanceof IInvocationStatus)
-        .filter(m -> ((IInvocationStatus) m).isInvoked())
+        .filter(m -> ((IInvocationStatus) m).getInvocationTime() > 0)
         .forEach(im -> {
           if (im.isTest()) {
             System.out.print("    ");
@@ -463,25 +462,6 @@ public class MethodHelper {
         tm.isBeforeClassConfiguration() || tm.isAfterClassConfiguration() ||
         tm.isBeforeGroupsConfiguration() || tm.isAfterGroupsConfiguration() ||
         tm.isBeforeMethodConfiguration() || tm.isAfterMethodConfiguration();
-  }
-
-  public static void dumpInvokedMethodsInfoToConsole(
-      Collection<IInvokedMethod> iInvokedMethods, int currentVerbosity) {
-    if (currentVerbosity < 3) {
-      return;
-    }
-    System.out.println("===== Invoked methods");
-    for (IInvokedMethod im : iInvokedMethods) {
-      if (im.isTestMethod()) {
-        System.out.print("    ");
-      } else if (im.isConfigurationMethod()) {
-        System.out.print("  ");
-      } else {
-        continue;
-      }
-      System.out.println("" + im);
-    }
-    System.out.println("=====");
   }
 
   protected static String calculateMethodCanonicalName(Class<?> methodClass, String methodName) {

--- a/src/main/java/org/testng/internal/TestInvoker.java
+++ b/src/main/java/org/testng/internal/TestInvoker.java
@@ -19,7 +19,6 @@ import org.testng.DataProviderInvocationException;
 import org.testng.IClassListener;
 import org.testng.IDataProviderListener;
 import org.testng.IHookable;
-import org.testng.IInvocationStatus;
 import org.testng.IInvokedMethod;
 import org.testng.IInvokedMethodListener;
 import org.testng.IRetryAnalyzer;
@@ -573,7 +572,7 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
       runInvokedMethodListeners(BEFORE_INVOCATION, invokedMethod, testResult);
 
       if (arguments.getTestMethod() instanceof IInvocationStatus) {
-        m_notifier.recordInvocationStatus((IInvocationStatus) arguments.getTestMethod());
+        ((IInvocationStatus) arguments.getTestMethod()).setInvokedAt(invokedMethod.getDate());
       }
 
       Method thisMethod = arguments.getTestMethod().getConstructorOrMethod().getMethod();

--- a/src/main/java/org/testng/junit/JUnit4TestRunner.java
+++ b/src/main/java/org/testng/junit/JUnit4TestRunner.java
@@ -11,6 +11,7 @@ import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunListener;
 import org.testng.*;
 import org.testng.collections.Lists;
+import org.testng.internal.IInvocationStatus;
 import org.testng.internal.ITestResultNotifier;
 import org.testng.internal.InvokedMethod;
 import org.testng.internal.TestResult;
@@ -246,7 +247,7 @@ public class JUnit4TestRunner implements IJUnitTestRunner {
 
     InvokedMethod im = new InvokedMethod(tr.getStartMillis(), tr);
     if (tr.getMethod() instanceof IInvocationStatus) {
-      m_parentRunner.recordInvocationStatus((IInvocationStatus) tr.getMethod());
+      ((IInvocationStatus) tr.getMethod()).setInvokedAt(im.getDate());
     }
     for (IInvokedMethodListener l : m_invokeListeners) {
       l.beforeInvocation(im, tr);

--- a/src/main/java/org/testng/junit/JUnitTestRunner.java
+++ b/src/main/java/org/testng/junit/JUnitTestRunner.java
@@ -122,9 +122,7 @@ public class JUnitTestRunner implements TestListener, IJUnitTestRunner {
     }
 
     InvokedMethod im = new InvokedMethod(tri.m_start, tr);
-    if (tm instanceof IInvocationStatus) {
-      m_parentRunner.recordInvocationStatus(tm);
-    }
+    tm.setInvokedAt(im.getDate());
     m_methods.add(tm);
     for (IInvokedMethodListener l : m_invokedMethodListeners) {
       l.beforeInvocation(im, tr);

--- a/src/test/java/test_result/issue1590/TestclassSample.java
+++ b/src/test/java/test_result/issue1590/TestclassSample.java
@@ -1,5 +1,6 @@
 package test_result.issue1590;
 
+import org.testng.IInvokedMethod;
 import org.testng.ITestContext;
 import org.testng.ITestResult;
 import org.testng.annotations.AfterClass;
@@ -17,7 +18,7 @@ public class TestclassSample {
   @BeforeClass
   public void beforeClass(ITestContext context) throws InterruptedException {
     TimeUnit.SECONDS.sleep(1);
-    ITestResult result = context.getSuite().getAllInvokedMethods().get(0).getTestResult();
+    ITestResult result = findConfigurationMethod(context).getTestResult();
     startStatus = result.getStatus();
     startTimestamp = result.getEndMillis();
   }
@@ -28,8 +29,15 @@ public class TestclassSample {
 
   @AfterClass
   public void afterClass(ITestContext context) {
-    ITestResult result = context.getSuite().getAllInvokedMethods().get(0).getTestResult();
+    ITestResult result = findConfigurationMethod(context).getTestResult();
     endTimestamp = result.getEndMillis();
     endStatus = ITestResult.SUCCESS;
+  }
+
+  private static IInvokedMethod findConfigurationMethod(ITestContext context) {
+    return context.getSuite()
+        .getAllInvokedMethods().stream()
+        .filter(iInvokedMethod -> iInvokedMethod.getTestMethod().getMethodName().equals("beforeClass"))
+        .findFirst().orElseThrow(IllegalStateException::new);
   }
 }


### PR DESCRIPTION
Instead of saving all invoked methods, now we are
resorting to computing it on a need basis.

Fixes #2096 
