### PR TITLE
@Listeners doesn't work for interfaces

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+New:   GITHUB-2385: Make @Listeners can work for implemented interfaces and Inherited class (Nan Liang)
 Fixed: GITHUB-2053: MethodHelper.collectAndOrderMethods() Hangs when Parallel Instance and dependsOnGroups (Krishnan Mahadevan)
 Fixed: GITHUB-2400: BeforeClass/Method (and AfterClass/Method) configuration methods that override default methods are invoked multiple times (Krishnan Mahadevan)
 Fixed: GITHUB-2396: @Ignore on method level doesn't work as expected (Krishnan Mahadevan)

--- a/src/main/java/org/testng/internal/TestListenerHelper.java
+++ b/src/main/java/org/testng/internal/TestListenerHelper.java
@@ -108,16 +108,20 @@ public final class TestListenerHelper {
     }
   }
 
-  /** @return all the @Listeners annotations found in the current class and its superclasses. */
+  /** @return all the @Listeners annotations found in the current class and its superclasses and inherited interfaces.  */
   @SuppressWarnings("unchecked")
   public static ListenerHolder findAllListeners(Class<?> cls, IAnnotationFinder finder) {
     ListenerHolder result = new ListenerHolder();
     result.listenerClasses = Lists.newArrayList();
 
     while (cls != Object.class) {
+      List<IListenersAnnotation> annotations = finder.findInheritedAnnotations(cls, IListenersAnnotation.class);
       IListenersAnnotation l = finder.findAnnotation(cls, IListenersAnnotation.class);
       if (l != null) {
-        Class<? extends ITestNGListener>[] classes = l.getValue();
+        annotations.add(l);
+      }
+      annotations.forEach(anno -> {
+        Class<? extends ITestNGListener>[] classes = anno.getValue();
         for (Class<? extends ITestNGListener> c : classes) {
           result.listenerClasses.add(c);
 
@@ -134,7 +138,7 @@ public final class TestListenerHelper {
             }
           }
         }
-      }
+      });
       cls = cls.getSuperclass();
     }
     return result;

--- a/src/main/java/org/testng/internal/annotations/IAnnotationFinder.java
+++ b/src/main/java/org/testng/internal/annotations/IAnnotationFinder.java
@@ -2,6 +2,7 @@ package org.testng.internal.annotations;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.util.List;
 
 import org.testng.ITestNGMethod;
 import org.testng.annotations.IAnnotation;
@@ -45,6 +46,17 @@ public interface IAnnotationFinder {
    *     class. If not found, return null.
    */
   <A extends IAnnotation> A findAnnotation(Constructor<?> cons, Class<A> annotationClass);
+
+
+  /**
+   *
+   * @param cls - The corresponding class.
+   * @param annotationClass - The class on which annotation is to be looked for.
+   * @param <A> - The expected {@link IAnnotation} type
+   * @return The annotations on the inherited interfaces. If not found, return the annotations on the declaring
+   *     interface. If not found, return an empty list.
+   */
+  <A extends IAnnotation> List<A> findInheritedAnnotations(Class<?> cls, Class<A> annotationClass);
 
   /**
    * @param method The <code>Method</code>

--- a/src/test/java/test/listeners/github2385/BaseTestCLass.java
+++ b/src/test/java/test/listeners/github2385/BaseTestCLass.java
@@ -1,0 +1,8 @@
+package test.listeners.github2385;
+
+import org.testng.annotations.Listeners;
+
+@Listeners(TestListener.class)
+public class BaseTestCLass {
+
+}

--- a/src/test/java/test/listeners/github2385/FatherTestClass.java
+++ b/src/test/java/test/listeners/github2385/FatherTestClass.java
@@ -1,0 +1,12 @@
+package test.listeners.github2385;
+
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+@Listeners(TestClassListener.class)
+public class FatherTestClass extends BaseTestCLass {
+    @Test
+    public void testClassListeners() {
+
+    }
+}

--- a/src/test/java/test/listeners/github2385/ITestClassInterface.java
+++ b/src/test/java/test/listeners/github2385/ITestClassInterface.java
@@ -1,0 +1,7 @@
+package test.listeners.github2385;
+
+import org.testng.annotations.Listeners;
+
+@Listeners(TestClassListener.class)
+public interface ITestClassInterface {
+}

--- a/src/test/java/test/listeners/github2385/ITestInheritedInterface.java
+++ b/src/test/java/test/listeners/github2385/ITestInheritedInterface.java
@@ -1,0 +1,7 @@
+package test.listeners.github2385;
+
+import org.testng.annotations.Listeners;
+
+@Listeners(TestClassListener.class)
+public interface ITestInheritedInterface extends ITestInterface {
+}

--- a/src/test/java/test/listeners/github2385/ITestInterface.java
+++ b/src/test/java/test/listeners/github2385/ITestInterface.java
@@ -1,0 +1,8 @@
+package test.listeners.github2385;
+
+import org.testng.annotations.Listeners;
+
+@Listeners(TestListener.class)
+public interface ITestInterface {
+
+}

--- a/src/test/java/test/listeners/github2385/ITestInterfaceSame.java
+++ b/src/test/java/test/listeners/github2385/ITestInterfaceSame.java
@@ -1,0 +1,7 @@
+package test.listeners.github2385;
+
+import org.testng.annotations.Listeners;
+
+@Listeners(TestListener.class)
+public interface ITestInterfaceSame {
+}

--- a/src/test/java/test/listeners/github2385/ITestInterfaceSameInherit.java
+++ b/src/test/java/test/listeners/github2385/ITestInterfaceSameInherit.java
@@ -1,0 +1,7 @@
+package test.listeners.github2385;
+
+import org.testng.annotations.Listeners;
+
+@Listeners(TestListener.class)
+public interface ITestInterfaceSameInherit extends ITestInterface {
+}

--- a/src/test/java/test/listeners/github2385/IssueTest.java
+++ b/src/test/java/test/listeners/github2385/IssueTest.java
@@ -1,0 +1,113 @@
+package test.listeners.github2385;
+
+import org.testng.TestNG;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+import org.testng.xml.XmlPackage;
+import org.testng.xml.XmlSuite;
+import org.testng.xml.XmlTest;
+import test.SimpleBaseTest;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class IssueTest extends SimpleBaseTest {
+    @Test
+    public void testExtendClass() {
+        TestNG testNG = create(SonTestClassSample.class);
+        testNG.run();
+        assertTrue(TestListener.listenerExecuted);
+        assertTrue(TestListener.listenerMethodInvoked);
+    }
+
+    @Test
+    public void testClassAndInterface() {
+        TestNG testNG = create(TestClassAndInterfaceInheritSample.class);
+        testNG.run();
+        assertTrue(TestListener.listenerExecuted);
+        assertTrue(TestListener.listenerMethodInvoked);
+        assertTrue(TestClassListener.listenerMethodInvoked);
+    }
+
+    @Test
+    public void testClassListeners() {
+        TestNG testNG = create(TestClassListenersInheritSample.class);
+        testNG.run();
+        assertTrue(TestListener.listenerExecuted);
+        assertTrue(TestListener.listenerMethodInvoked);
+    }
+
+    @Test
+    public void testInterface() {
+        TestNG testNG = create(TestInterfaceListenersInheritSample.class);
+        testNG.run();
+        assertTrue(TestListener.listenerExecuted);
+        assertTrue(TestListener.listenerMethodInvoked);
+    }
+
+    @Test
+    public void testMultiInherit() {
+        TestNG testNG = create(TestMultiInheritSample.class);
+        testNG.run();
+        assertTrue(TestListener.listenerMethodInvoked);
+        assertTrue(TestClassListener.listenerMethodInvoked);
+    }
+
+    @Test
+    public void testMultiInheritSameAnnotation() {
+        TestNG testNG = create(TestMultiInheritSameAnnotationSample.class);
+        testNG.run();
+        assertTrue(TestListener.listenerMethodInvoked);
+    }
+
+    @Test
+    public void testMultiLevel() {
+        TestNG testNG = create(TestMultiLevelInheritSample.class);
+        testNG.run();
+        assertTrue(TestListener.listenerExecuted);
+        assertTrue(TestListener.listenerMethodInvoked);
+        assertTrue(TestClassListener.listenerMethodInvoked);
+    }
+
+    @Test
+    public void testMultiLevelSameAnnotation() {
+        TestNG testNG = create(TestMultiLevelInheritSameAnnotationSample.class);
+        testNG.run();
+        assertTrue(TestListener.listenerExecuted);
+        assertTrue(TestListener.listenerMethodInvoked);
+    }
+
+    @Test
+    public void testPackages() {
+        List<XmlPackage> packages = new ArrayList<>();
+        XmlPackage xmlPackage = new XmlPackage("test.listeners.github2385.packages");
+        packages.add(xmlPackage);
+        XmlTest test = new XmlTest();
+        test.setName("MyTest");
+        test.setXmlPackages(packages);
+
+        XmlSuite xmlSuite = new XmlSuite();
+        xmlSuite.setName("MySuite");
+        xmlSuite.setTests(Collections.singletonList(test));
+
+        test.setXmlSuite(xmlSuite);
+
+        TestNG tng = new TestNG();
+        tng.setXmlSuites(Collections.singletonList(xmlSuite));
+        tng.setVerbose(2);
+        tng.run();
+
+        assertFalse(TestListener.listenerMethodInvoked);
+    }
+
+    @AfterMethod
+    public void reset() {
+        TestListener.listenerExecuted = false;
+        TestListener.listenerMethodInvoked = false;
+        TestClassListener.listenerMethodInvoked = false;
+    }
+}

--- a/src/test/java/test/listeners/github2385/SonTestClassSample.java
+++ b/src/test/java/test/listeners/github2385/SonTestClassSample.java
@@ -1,0 +1,10 @@
+package test.listeners.github2385;
+
+import org.testng.annotations.Test;
+
+public class SonTestClassSample extends FatherTestClass {
+    @Test
+    public void testSonClass() {
+
+    }
+}

--- a/src/test/java/test/listeners/github2385/TestClassAndInterfaceInheritSample.java
+++ b/src/test/java/test/listeners/github2385/TestClassAndInterfaceInheritSample.java
@@ -1,0 +1,12 @@
+package test.listeners.github2385;
+
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+@Listeners(TestClassListener.class)
+public class TestClassAndInterfaceInheritSample implements ITestInterface {
+    @Test
+    public void testClassAndInterface() {
+
+    }
+}

--- a/src/test/java/test/listeners/github2385/TestClassListener.java
+++ b/src/test/java/test/listeners/github2385/TestClassListener.java
@@ -1,0 +1,18 @@
+package test.listeners.github2385;
+
+import org.testng.IInvokedMethod;
+import org.testng.IInvokedMethodListener;
+import org.testng.ITestResult;
+
+public class TestClassListener implements IInvokedMethodListener {
+    public static boolean listenerExecuted = false;
+    public static boolean listenerMethodInvoked = false;
+    public TestClassListener() {
+        listenerExecuted = true;
+    }
+
+    @Override
+    public void beforeInvocation(IInvokedMethod method, ITestResult testResult) {
+        listenerMethodInvoked = true;
+    }
+}

--- a/src/test/java/test/listeners/github2385/TestClassListenersInheritSample.java
+++ b/src/test/java/test/listeners/github2385/TestClassListenersInheritSample.java
@@ -1,0 +1,10 @@
+package test.listeners.github2385;
+
+import org.testng.annotations.Test;
+
+public class TestClassListenersInheritSample extends BaseTestCLass {
+    @Test
+    public void testClassListeners() {
+
+    }
+}

--- a/src/test/java/test/listeners/github2385/TestInterfaceListenersInheritSample.java
+++ b/src/test/java/test/listeners/github2385/TestInterfaceListenersInheritSample.java
@@ -1,0 +1,11 @@
+package test.listeners.github2385;
+
+import org.testng.annotations.Test;
+
+public class TestInterfaceListenersInheritSample implements ITestInterface {
+
+    @Test
+    public void testInterface() {
+
+    }
+}

--- a/src/test/java/test/listeners/github2385/TestListener.java
+++ b/src/test/java/test/listeners/github2385/TestListener.java
@@ -1,0 +1,18 @@
+package test.listeners.github2385;
+
+import org.testng.IInvokedMethod;
+import org.testng.IInvokedMethodListener;
+import org.testng.ITestResult;
+
+public final class TestListener implements IInvokedMethodListener {
+    public static boolean listenerExecuted = false;
+    public static boolean listenerMethodInvoked = false;
+    public TestListener() {
+        listenerExecuted = true;
+    }
+
+    @Override
+    public void beforeInvocation(IInvokedMethod method, ITestResult testResult) {
+        listenerMethodInvoked = true;
+    }
+}

--- a/src/test/java/test/listeners/github2385/TestMultiInheritSameAnnotationSample.java
+++ b/src/test/java/test/listeners/github2385/TestMultiInheritSameAnnotationSample.java
@@ -1,0 +1,11 @@
+package test.listeners.github2385;
+
+import org.testng.annotations.Test;
+
+public class TestMultiInheritSameAnnotationSample implements ITestInterface, ITestInterfaceSame {
+
+    @Test
+    public void testMultiInheritSameAnnotation() {
+
+    }
+}

--- a/src/test/java/test/listeners/github2385/TestMultiInheritSample.java
+++ b/src/test/java/test/listeners/github2385/TestMultiInheritSample.java
@@ -1,0 +1,11 @@
+package test.listeners.github2385;
+
+import org.testng.annotations.Test;
+
+public class TestMultiInheritSample implements ITestClassInterface, ITestInterface {
+
+    @Test
+    public void testMultiInherit() {
+
+    }
+}

--- a/src/test/java/test/listeners/github2385/TestMultiLevelInheritSameAnnotationSample.java
+++ b/src/test/java/test/listeners/github2385/TestMultiLevelInheritSameAnnotationSample.java
@@ -1,0 +1,11 @@
+package test.listeners.github2385;
+
+import org.testng.annotations.Test;
+
+public class TestMultiLevelInheritSameAnnotationSample implements ITestInterfaceSameInherit {
+
+    @Test
+    public void testMultiLevel() {
+
+    }
+}

--- a/src/test/java/test/listeners/github2385/TestMultiLevelInheritSample.java
+++ b/src/test/java/test/listeners/github2385/TestMultiLevelInheritSample.java
@@ -1,0 +1,11 @@
+package test.listeners.github2385;
+
+import org.testng.annotations.Test;
+
+public class TestMultiLevelInheritSample implements ITestInheritedInterface {
+
+    @Test
+    public void testMultiLevel() {
+
+    }
+}

--- a/src/test/java/test/listeners/github2385/packages/ITestInterfaceWithoutImpl.java
+++ b/src/test/java/test/listeners/github2385/packages/ITestInterfaceWithoutImpl.java
@@ -1,0 +1,7 @@
+package test.listeners.github2385.packages;
+
+import org.testng.annotations.Listeners;
+
+@Listeners(TestPackageListener.class)
+public interface ITestInterfaceWithoutImpl {
+}

--- a/src/test/java/test/listeners/github2385/packages/TestPackageListener.java
+++ b/src/test/java/test/listeners/github2385/packages/TestPackageListener.java
@@ -1,0 +1,19 @@
+package test.listeners.github2385.packages;
+
+import org.testng.IInvokedMethod;
+import org.testng.IInvokedMethodListener;
+import org.testng.ITestResult;
+
+public class TestPackageListener implements IInvokedMethodListener {
+    public static boolean listenerExecuted = false;
+    public static boolean listenerMethodInvoked = false;
+
+    public TestPackageListener() {
+        listenerExecuted = true;
+    }
+
+    @Override
+    public void beforeInvocation(IInvokedMethod method, ITestResult testResult) {
+        listenerMethodInvoked = true;
+    }
+}

--- a/src/test/java/test/listeners/github2385/packages/TestWithoutImplSample.java
+++ b/src/test/java/test/listeners/github2385/packages/TestWithoutImplSample.java
@@ -1,0 +1,10 @@
+package test.listeners.github2385.packages;
+
+import org.testng.annotations.Test;
+
+public class TestWithoutImplSample {
+    @Test
+    public void testWithoutImpl() {
+
+    }
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -237,6 +237,7 @@
       <class name="test.listeners.github1130.GitHub1130Test"/>
       <class name="test.listeners.github1296.GitHub1296Test"/>
       <class name="test.listeners.github1465.IssueTest"/>
+      <class name="test.listeners.github2385.IssueTest"/>
     </classes>
   </test>
 


### PR DESCRIPTION
Features #2385
Make @Listeners can work for implemented interfaces and Inherited class.

### Did you remember to?

- [. ] Add test case(s)
- [. ] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
