### PR TITLE
Streamline “default” config methods invocation

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-2400: BeforeClass/Method (and AfterClass/Method) configuration methods that override default methods are invoked multiple times (Krishnan Mahadevan)
 Fixed: GITHUB-2396: @Ignore on method level doesn't work as expected (Krishnan Mahadevan)
 Fixed: GITHUB-2382: TestNG version should be specified in MANIFEST.MF (Krishnan Mahadevan)
 Fixed: GITHUB-2096: 7.0.0-beta6 memory issues (regression) (Krishnan Mahadevan)

--- a/src/main/java/org/testng/internal/TestNGMethodFinder.java
+++ b/src/main/java/org/testng/internal/TestNGMethodFinder.java
@@ -107,7 +107,7 @@ public class TestNGMethodFinder implements ITestMethodFinder {
   private ITestNGMethod[] findConfiguration(final Class<?> clazz, final MethodType configurationType) {
     List<ITestNGMethod> vResult = Lists.newArrayList();
 
-    Set<Method> methods = ClassHelper.getAvailableMethods(clazz);
+    Set<Method> methods = ClassHelper.getAvailableMethodsExcludingDefaults(clazz);
 
     for (Method m : methods) {
       IConfigurationAnnotation configuration =

--- a/src/test/java/org/testng/internal/ClassHelperTest.java
+++ b/src/test/java/org/testng/internal/ClassHelperTest.java
@@ -9,11 +9,17 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import org.assertj.core.api.Assertions;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.testng.internal.issue1339.BabyPanda;
 import org.testng.internal.issue1339.LittlePanda;
 import org.testng.internal.issue1456.TestClassSample;
+import org.testng.internal.misamples.AbstractMoves;
+import org.testng.internal.misamples.Batman;
+import org.testng.internal.misamples.MickJagger;
+import org.testng.internal.misamples.JohnTravoltaMoves;
 import org.testng.xml.XmlClass;
 import org.testng.xml.XmlSuite;
 import org.testng.xml.XmlTest;
@@ -52,6 +58,32 @@ public class ClassHelperTest {
       ClassHelper.addClassLoader(urlClassLoader);
       String fakeClassName = UUID.randomUUID().toString();
       Assert.assertNull(ClassHelper.forName(fakeClassName), "The result should be null; no exception should be thrown.");
+  }
+
+  @Test(dataProvider = "data")
+  public void testWithDefaultMethodsBeingOverridden(Class<?>cls, int expectedCount, String...expected) {
+    Set<Method> methods = ClassHelper.getAvailableMethodsExcludingDefaults(cls);
+    Assertions.assertThat(methods).hasSize(expectedCount);
+    for (Method m : methods) {
+      String actual = m.getDeclaringClass().getName() + "." + m.getName();
+      Assertions.assertThat(expected).contains(actual);
+    }
+  }
+
+  @DataProvider(name = "data")
+  public Object[][] getTestData() {
+    return new Object[][]{
+        {MickJagger.class, 1, MickJagger.class.getName() + ".dance"},
+        {JohnTravoltaMoves.class, 2, new String[]{
+            JohnTravoltaMoves.class.getName() + ".walk",
+            AbstractMoves.class.getName() + ".dance"}
+        },
+        {Batman.class, 3, new String[] {
+            Batman.class.getName() + ".fly",
+            Batman.class.getName() + ".liftWeights",
+            Batman.class.getName() + ".yellSlogan"
+        }}
+    };
   }
 
   private static void runTest(Class<?> classToBeFound, int expectedCount, Class<?>... classes) {

--- a/src/test/java/org/testng/internal/misamples/AbstractMoves.java
+++ b/src/test/java/org/testng/internal/misamples/AbstractMoves.java
@@ -1,0 +1,11 @@
+package org.testng.internal.misamples;
+
+public abstract class AbstractMoves implements IDance {
+
+  @Override
+  public void dance() {
+
+  }
+
+  public abstract void walk();
+}

--- a/src/test/java/org/testng/internal/misamples/Batman.java
+++ b/src/test/java/org/testng/internal/misamples/Batman.java
@@ -1,0 +1,19 @@
+package org.testng.internal.misamples;
+
+public class Batman implements SuperHeroCapabilities {
+
+  @Override
+  public void fly() {
+
+  }
+
+  @Override
+  public void liftWeights() {
+
+  }
+
+  @Override
+  public void yellSlogan() {
+
+  }
+}

--- a/src/test/java/org/testng/internal/misamples/IDance.java
+++ b/src/test/java/org/testng/internal/misamples/IDance.java
@@ -1,0 +1,8 @@
+package org.testng.internal.misamples;
+
+public interface IDance {
+
+  default void dance() {
+  }
+
+}

--- a/src/test/java/org/testng/internal/misamples/JohnTravoltaMoves.java
+++ b/src/test/java/org/testng/internal/misamples/JohnTravoltaMoves.java
@@ -1,0 +1,9 @@
+package org.testng.internal.misamples;
+
+public class JohnTravoltaMoves extends AbstractMoves {
+
+  @Override
+  public void walk() {
+
+  }
+}

--- a/src/test/java/org/testng/internal/misamples/MickJagger.java
+++ b/src/test/java/org/testng/internal/misamples/MickJagger.java
@@ -1,0 +1,9 @@
+package org.testng.internal.misamples;
+
+public class MickJagger implements IDance {
+
+  @Override
+  public void dance() {
+
+  }
+}

--- a/src/test/java/org/testng/internal/misamples/SuperHeroCapabilities.java
+++ b/src/test/java/org/testng/internal/misamples/SuperHeroCapabilities.java
@@ -1,0 +1,12 @@
+package org.testng.internal.misamples;
+
+public interface SuperHeroCapabilities {
+
+  default void yellSlogan() {
+  }
+
+  void fly();
+
+  void liftWeights();
+
+}

--- a/src/test/java/test/configuration/issue2400/DataStore.java
+++ b/src/test/java/test/configuration/issue2400/DataStore.java
@@ -1,0 +1,20 @@
+package test.configuration.issue2400;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public enum DataStore {
+
+  INSTANCE;
+
+  private Map<String, AtomicInteger> tracker = new HashMap<>();
+
+  public void increment(String key) {
+    tracker.computeIfAbsent(key, k -> new AtomicInteger(0)).incrementAndGet();
+  }
+
+  public Map<String, AtomicInteger> getTracker() {
+    return tracker;
+  }
+}

--- a/src/test/java/test/configuration/issue2400/IssueTest.java
+++ b/src/test/java/test/configuration/issue2400/IssueTest.java
@@ -1,0 +1,24 @@
+package test.configuration.issue2400;
+
+import org.testng.TestNG;
+import org.testng.annotations.Test;
+import org.testng.asserts.SoftAssert;
+import test.SimpleBaseTest;
+
+public class IssueTest extends SimpleBaseTest {
+
+  @Test(description = "GITHUB-2400")
+  public void ensureDefaultConfigurationsAreSkipped() {
+    TestNG testng = create(TestNGTestClass.class);
+    testng.setVerbose(2);
+    testng.run();
+    SoftAssert softAssert = new SoftAssert();
+    DataStore.INSTANCE.getTracker()
+        .forEach(
+            (key, value) -> softAssert.assertEquals(value.get(), 1,
+                "Ensuring " + key + " got invoked only once")
+        );
+    softAssert.assertAll();
+  }
+
+}

--- a/src/test/java/test/configuration/issue2400/TestNGTestClass.java
+++ b/src/test/java/test/configuration/issue2400/TestNGTestClass.java
@@ -1,0 +1,66 @@
+package test.configuration.issue2400;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterSuite;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+public class TestNGTestClass implements TestRunnerCapabilities {
+
+  @BeforeSuite
+  @Override
+  public void beforeSuite() {
+    DataStore.INSTANCE.increment("beforeSuite");
+  }
+
+  @BeforeTest
+  @Override
+  public void beforeTest() {
+    DataStore.INSTANCE.increment("beforeTest");
+  }
+
+  @BeforeClass
+  @Override
+  public void beforeClass() {
+    DataStore.INSTANCE.increment("beforeClass");
+  }
+
+  @BeforeMethod
+  @Override
+  public void beforeMethod() {
+    DataStore.INSTANCE.increment("beforeMethod");
+  }
+
+  @Test
+  public void testMethod() {
+  }
+
+  @AfterMethod
+  @Override
+  public void afterMethod() {
+    DataStore.INSTANCE.increment("afterMethod");
+  }
+
+  @AfterClass
+  @Override
+  public void afterClass() {
+    DataStore.INSTANCE.increment("afterClass");
+  }
+
+  @AfterTest
+  @Override
+  public void afterTest() {
+    DataStore.INSTANCE.increment("afterTest");
+  }
+
+  @AfterSuite
+  @Override
+  public void afterSuite() {
+    DataStore.INSTANCE.increment("afterSuite");
+  }
+}

--- a/src/test/java/test/configuration/issue2400/TestRunnerCapabilities.java
+++ b/src/test/java/test/configuration/issue2400/TestRunnerCapabilities.java
@@ -1,0 +1,53 @@
+package test.configuration.issue2400;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterSuite;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.BeforeTest;
+
+public interface TestRunnerCapabilities {
+
+  @BeforeSuite
+  default void beforeSuite() {
+    DataStore.INSTANCE.increment("beforeSuite");
+  }
+
+  @BeforeTest
+  default void beforeTest() {
+    DataStore.INSTANCE.increment("beforeTest");
+  }
+
+  @BeforeClass
+  default void beforeClass() {
+    DataStore.INSTANCE.increment("beforeClass");
+  }
+
+  @BeforeMethod
+  default void beforeMethod() {
+    DataStore.INSTANCE.increment("beforeMethod");
+  }
+
+  @AfterMethod
+  default void afterMethod() {
+    DataStore.INSTANCE.increment("afterMethod");
+  }
+
+  @AfterClass
+  default void afterClass() {
+    DataStore.INSTANCE.increment("afterClass");
+  }
+
+  @AfterTest
+  default void afterTest() {
+    DataStore.INSTANCE.increment("afterTest");
+  }
+
+  @AfterSuite
+  default void afterSuite() {
+    DataStore.INSTANCE.increment("afterSuite");
+  }
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -850,6 +850,7 @@
       <class name="test.configuration.SingleConfigurationTest" />
       <class name="test.configuration.github1625.TestRunnerIssue1625"/>
       <class name="test.configuration.issue1753.IssueTest"/>
+      <class name="test.configuration.issue2400.IssueTest"/>
       <class name="test.configuration.BeforeClassTest"/>
       <class name="test.configuration.issue2209.IssueTest"/>
       <class name="test.configuration.issue2254.IssueTest"/>


### PR DESCRIPTION
Closes #2400

TestNG ends up invoking overridden “default” 
methods (from interfaces) which are marked as
Before/After[Class|Method] configuration methods
multiple times. Fixed this by pruning default
methods.

Fixes #2400  .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
