### PR TITLE
Streamline DTD Loading

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-2403: Suite.xml files attempt to make web request when suite references standard TestNG DTD using HTTP (Krishnan Mahadevan)
 New:   GITHUB-2385: Make @Listeners can work for implemented interfaces and Inherited class (Nan Liang)
 Fixed: GITHUB-2053: MethodHelper.collectAndOrderMethods() Hangs when Parallel Instance and dependsOnGroups (Krishnan Mahadevan)
 Fixed: GITHUB-2400: BeforeClass/Method (and AfterClass/Method) configuration methods that override default methods are invoked multiple times (Krishnan Mahadevan)

--- a/src/main/java/org/testng/xml/Parser.java
+++ b/src/main/java/org/testng/xml/Parser.java
@@ -1,7 +1,8 @@
 package org.testng.xml;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Arrays;
-import java.util.Collections;
 import org.testng.collections.Lists;
 import org.testng.collections.Maps;
 
@@ -18,6 +19,7 @@ import java.util.Queue;
 import java.util.ArrayDeque;
 
 /** <code>Parser</code> is a parser for a TestNG XML test suite file. */
+@SuppressWarnings("unused")
 public class Parser {
 
   /** The name of the TestNG DTD. */
@@ -26,18 +28,13 @@ public class Parser {
   /** The URL to the deprecated TestNG DTD. */
   //It has to be public because its being used by TestNG eclipse plugin
   public static final String OLD_TESTNG_DTD_URL = "https://beust.com/testng/" + TESTNG_DTD;
-  private static final String HTTPS_OLD_TESTNG_DTD_URL = "https://beust.com/testng/" + TESTNG_DTD;
 
   /** The URL to the TestNG DTD. */
   //It has to be public because its being used by TestNG eclipse plugin
   public static final String TESTNG_DTD_URL = "https://testng.org/" + TESTNG_DTD;
   public static final String HTTPS_TESTNG_DTD_URL = "https://testng.org/" + TESTNG_DTD;
 
-  private static final List<String> URLS = Collections.unmodifiableList(Arrays.asList(
-      OLD_TESTNG_DTD_URL,
-      HTTPS_OLD_TESTNG_DTD_URL,
-      TESTNG_DTD_URL,
-      HTTPS_TESTNG_DTD_URL));
+  private static final List<String> DOMAINS = Arrays.asList("beust.com", "testng.org");
 
   /** The default file name for the TestNG test suite if none is specified (testng.xml). */
   public static final String DEFAULT_FILENAME = "testng.xml";
@@ -52,8 +49,13 @@ public class Parser {
     }
   }
 
-  static boolean isUnRecognizedPublicId(String publicId) {
-    return !URLS.contains(publicId);
+  static boolean isDTDDomainInternallyKnownToTestNG(String publicId) {
+    try {
+      URL url = new URL(publicId.toLowerCase().trim());
+      return DOMAINS.contains(url.getHost());
+    } catch (MalformedURLException e) {
+      return false;
+    }
   }
 
   /**


### PR DESCRIPTION
Closes #2403

Following is the logic followed in the PR:

1. If the DTD URL either refers to “testng.org” 
(or) “beust.com” then always resort to loading 
the embedded DTD.
2. If (1) fails, then just fall back to attempting
to load the DTD from the TestNG site (use “https” 
protocol)
3. If the DTD URL is not known to us (i.e., 
is neither “testng.org” nor “beust.com”) then we 
check if the user is using “http” protocol.
4. If http protocol is being used and if the JVM 
argument [-Dtestng.dtd.http=true] is missing then
throw the error, else load the URL.
5. If its a https protocol then just load the DTD
as is.

Fixes #2403  .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
