### PR TITLE
Fix outdated/incorrect documentation of @DataProvider

### DIFF
--- a/src/main/java/org/testng/annotations/DataProvider.java
+++ b/src/main/java/org/testng/annotations/DataProvider.java
@@ -7,10 +7,25 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
- * Mark a method as supplying data for a test method. The data provider name defaults to method
- * name. The annotated method must return an Object[][] where each Object[] can be assigned the
- * parameter list of the test method. The @Test method that wants to receive data from this
- * DataProvider needs to use a dataProvider name equals to the name of this annotation.
+ * <p>Mark a method as supplying data for a test method.</p>
+ *
+ * <p>The {@link #name() name} defaults to the name of the annotated method.</p>
+ *
+ * <p>The annotated method must return any of the following:</p>
+ *
+ * <ul>
+ *   <li>
+ *     {@code Object[][]} or {@code Iterator<Object[]>}, where each {@code Object[]} is assigned to
+ *     the parameter list of the test method.
+ *   </li>
+ *   <li>
+ *     {@code Object[]} or {@code Iterator<Object>}, where each {@code Object} is assigned to the
+ *     single parameter of the test method.
+ *   </li>
+ * </ul>
+ * 
+ * <p>The {@link Test @Test} method that wants to receive data from this {@link DataProvider} needs
+ * to use a {@link Test#dataProvider()} name equal to the name of this annotation.</p>
  */
 @Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
 @Target({METHOD})


### PR DESCRIPTION
The documentation for `@DataProvider` is outdated/incorrect: It has always been possible to use an `Iterator` and since #1161 it is also possible to use `Object[]` or `Iterator<Object>`, however none of this is reflected in the documentation. This PR updates the JavaDoc.