### PR TITLE
Support parallelism at suite level

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-188: suite parallel="methods" does not work when there are multiple <test> tags in the testng.xml (Krishnan Mahadevan)
 Fixed: GITHUB-346: When a method is annotated with both BeforeGroups and AfterGroups only AfterGroup is executed (Krishnan Mahadevan)
 Fixed: GITHUB-2403: Suite.xml files attempt to make web request when suite references standard TestNG DTD using HTTP (Krishnan Mahadevan)
 New:   GITHUB-2385: Make @Listeners can work for implemented interfaces and Inherited class (Nan Liang)

--- a/src/main/java/org/testng/SuiteRunner.java
+++ b/src/main/java/org/testng/SuiteRunner.java
@@ -323,10 +323,13 @@ public class SuiteRunner implements ISuite, IInvokedMethodListener {
       // Run all the test runners
       //
       boolean testsInParallel = XmlSuite.ParallelMode.TESTS.equals(xmlSuite.getParallel());
-      if (!testsInParallel) {
-        runSequentially();
-      } else {
+      if (RuntimeBehavior.strictParallelism()) {
+        testsInParallel = !XmlSuite.ParallelMode.NONE.equals(xmlSuite.getParallel());
+      }
+      if (testsInParallel) {
         runInParallelTestMode();
+      } else {
+        runSequentially();
       }
 
       //

--- a/src/main/java/org/testng/internal/RuntimeBehavior.java
+++ b/src/main/java/org/testng/internal/RuntimeBehavior.java
@@ -12,8 +12,13 @@ public final class RuntimeBehavior {
   public static final String TESTNG_USE_UNSECURED_URL = "testng.dtd.http";
   public static final String SHOW_TESTNG_STACK_FRAMES = "testng.show.stack.frames";
   private static final String MEMORY_FRIENDLY_MODE = "testng.memory.friendly";
+  public static final String STRICTLY_HONOUR_PARALLEL_MODE = "testng.strict.parallel";
 
   private RuntimeBehavior() {}
+
+  public static boolean strictParallelism() {
+    return Boolean.getBoolean(STRICTLY_HONOUR_PARALLEL_MODE);
+  }
 
   public static boolean showTestNGStackFrames() {
     return Boolean.getBoolean(SHOW_TESTNG_STACK_FRAMES);

--- a/src/main/java/org/testng/xml/XmlTest.java
+++ b/src/main/java/org/testng/xml/XmlTest.java
@@ -355,12 +355,7 @@ public class XmlTest implements Cloneable {
   }
 
   public XmlSuite.ParallelMode getParallel() {
-    XmlSuite.ParallelMode result = getSuite().getParallel();
-    if (null != m_parallel) {
-      result = m_parallel;
-    }
-
-    return result;
+    return Optional.ofNullable(m_parallel).orElse(getSuite().getParallel());
   }
 
   public String getTimeOut() {

--- a/src/test/java/test/thread/issue188/Issue188TestSample.java
+++ b/src/test/java/test/thread/issue188/Issue188TestSample.java
@@ -1,0 +1,28 @@
+package test.thread.issue188;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.testng.ITestResult;
+import org.testng.Reporter;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class Issue188TestSample {
+  public static final Map<Long, Set<String>> timestamps = new ConcurrentHashMap<>();
+
+  @BeforeMethod
+  public void logTime(ITestResult itr) {
+    String txt = Reporter.getCurrentTestResult().getTestContext().getName() + "_" + itr.getMethod().getQualifiedName();
+    timestamps.computeIfAbsent(System.currentTimeMillis(), k-> ConcurrentHashMap.newKeySet()).add(txt);
+  }
+
+  @Test
+  public void sampleTest() {
+  }
+
+  @Test
+  public void anotherSampleTest() {
+  }
+
+}

--- a/src/test/java/test/thread/issue188/IssueTest.java
+++ b/src/test/java/test/thread/issue188/IssueTest.java
@@ -1,0 +1,45 @@
+package test.thread.issue188;
+
+import java.util.Collections;
+import java.util.Set;
+import org.assertj.core.api.Assertions;
+import org.testng.TestNG;
+import org.testng.annotations.Test;
+import org.testng.internal.RuntimeBehavior;
+import org.testng.xml.XmlSuite;
+import test.SimpleBaseTest;
+
+public class IssueTest extends SimpleBaseTest {
+
+  @Test
+  public void testSuiteLevelParallelMode() {
+    System.setProperty(RuntimeBehavior.STRICTLY_HONOUR_PARALLEL_MODE, "true");
+    try {
+      TestNG testng = new TestNG();
+      XmlSuite xmlSuite = new XmlSuite();
+      xmlSuite.setParallel(XmlSuite.ParallelMode.METHODS);
+      xmlSuite.setVerbose(2);
+      xmlSuite.setThreadCount(10);
+      xmlSuite.setName("Parallel Issue Suite");
+      createXmlTest(xmlSuite, "Test1", Issue188TestSample.class);
+      createXmlTest(xmlSuite, "Test2", Issue188TestSample.class);
+      createXmlTest(xmlSuite, "Test3", Issue188TestSample.class);
+      testng.setXmlSuites(Collections.singletonList(xmlSuite));
+      testng.run();
+      Set<Long> timestamps = Issue188TestSample.timestamps.keySet();
+      if (timestamps.size() == 1) {
+      Assertions.assertThat(Issue188TestSample.timestamps.values().iterator().next())
+          .withFailMessage("Since all tests were started simultaneously,test method count should have been 6")
+          .hasSize(6);
+      } else {
+        long answer = Issue188TestSample.timestamps.keySet().stream()
+            .reduce(0L, (x, y) -> Math.abs(x - y));
+        Assertions.assertThat(answer)
+            .withFailMessage("test methods should have started within a lag of max 20 ms")
+            .isLessThanOrEqualTo(20);
+      }
+    } finally {
+      System.setProperty(RuntimeBehavior.STRICTLY_HONOUR_PARALLEL_MODE, "false");
+    }
+  }
+}

--- a/src/test/resources/188.xml
+++ b/src/test/resources/188.xml
@@ -1,0 +1,8 @@
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
+<suite name="188_suite">
+  <test name="188_test">
+    <classes>
+      <class name="test.thread.issue188.IssueTest"/>
+    </classes>
+  </test>
+</suite>

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -6,6 +6,7 @@
   <suite-files>
     <suite-file path="./junit-suite.xml" />
     <suite-file path="./parent-module-suite.xml" />
+    <suite-file path="./188.xml"/>
   </suite-files>
 
   <listeners>


### PR DESCRIPTION
Closes #188

Current behavior:

1. Suite parallel mode = methods
2. Suite has 2 or more <test> tags
3. TestNG doesn’t necessarily start all the 
test methods at the same time.

Fixed this by adding a new JVM argument
named `-Dtestng.strict.parallel=true`

When this is set, TestNG will attempt to start all
test methods that are part of all the <test> tags
at the same time (according to the thread pool size)

Fixes #188  .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
