### PR TITLE
Configuration methods have the same test class instance when @Factory is being used

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-2428: Configuration methods have the same test class instance when @Factory is being used (Nan Liang)
 Fixed: GITHUB-2440: Fixed an issue when case timeout returned an incorrect exception and effect the next other test case (Yao Ma)
 New:   GITHUB-2407: Adds "overrideIncludedMethods" to the global config as a command-line argument, which excludes explicitly included test methods if they belong to any excluded groups (Nikhil Suri)
 Fixed: GITHUB-2432: Rework MethodInheritance.fixMethodInheritance to "soft" dependencies (Krishnan Mahadevan)

--- a/src/main/java/org/testng/TestRunner.java
+++ b/src/main/java/org/testng/TestRunner.java
@@ -34,6 +34,7 @@ import org.testng.internal.IConfigEavesdropper;
 import org.testng.internal.IConfiguration;
 import org.testng.internal.IContainer;
 import org.testng.internal.IInvoker;
+import org.testng.internal.ITestClassConfigInfo;
 import org.testng.internal.ITestResultNotifier;
 import org.testng.internal.InstanceCreator;
 import org.testng.internal.Invoker;
@@ -477,7 +478,7 @@ public class TestRunner
     //
     for (ITestClass tc : m_classMap.values()) {
       fixMethodsWithClass(tc.getTestMethods(), tc, testMethods);
-      fixMethodsWithClass(tc.getBeforeClassMethods(), tc, beforeClassMethods);
+      fixMethodsWithClass(((ITestClassConfigInfo) tc).getAllBeforeClassMethods().toArray(new ITestNGMethod[0]), tc, beforeClassMethods);
       fixMethodsWithClass(tc.getBeforeTestMethods(), tc, null);
       fixMethodsWithClass(tc.getAfterTestMethods(), tc, null);
       fixMethodsWithClass(tc.getAfterClassMethods(), tc, afterClassMethods);

--- a/src/main/java/org/testng/internal/ITestClassConfigInfo.java
+++ b/src/main/java/org/testng/internal/ITestClassConfigInfo.java
@@ -1,0 +1,28 @@
+package org.testng.internal;
+
+import org.testng.ITestNGMethod;
+import org.testng.collections.Lists;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public interface ITestClassConfigInfo {
+
+    /**
+     * get all before class config methods
+     * @return all before class config methods
+     */
+    default List<ITestNGMethod> getAllBeforeClassMethods() {
+        return Lists.newArrayList();
+    }
+
+    /**
+     * Query the instance before class methods from config methods map
+     * @param instance object hashcode
+     * @return All before class methods of instance
+     */
+    default List<ITestNGMethod> getInstanceBeforeClassMethods(String instance) {
+        return Lists.newArrayList();
+    }
+}

--- a/src/main/java/org/testng/internal/TestMethodWorker.java
+++ b/src/main/java/org/testng/internal/TestMethodWorker.java
@@ -168,7 +168,7 @@ public class TestMethodWorker implements IWorker<ITestNGMethod> {
       }
       ConfigMethodArguments attributes = new Builder()
           .forTestClass(testClass)
-          .usingConfigMethodsAs(testClass.getBeforeClassMethods())
+          .usingConfigMethodsAs(((ITestClassConfigInfo) testClass).getInstanceBeforeClassMethods(instance.toString()))
           .forSuite(m_testContext.getSuite().getXmlSuite())
           .usingParameters(m_parameters)
           .usingInstance(instance)

--- a/src/test/java/test/factory/github2428/FactoryTest.java
+++ b/src/test/java/test/factory/github2428/FactoryTest.java
@@ -1,0 +1,37 @@
+package test.factory.github2428;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+
+public class FactoryTest {
+
+    int i;
+
+    @Factory(dataProvider = "dp")
+    public FactoryTest(int i) {
+        this.i = i;
+    }
+
+    @DataProvider(parallel = true)
+    public static Object[][] dp() {
+        return new Object[][] {
+                {5},
+                {4},
+                {12},
+                {9},
+                {2}
+        };
+    }
+
+    @BeforeClass
+    public void beforeClassBody()  {
+
+    }
+
+    @Test
+    public void testBody() {
+
+    }
+}

--- a/src/test/java/test/factory/github2428/IssueTest.java
+++ b/src/test/java/test/factory/github2428/IssueTest.java
@@ -1,0 +1,18 @@
+package test.factory.github2428;
+
+import org.testng.Assert;
+import org.testng.TestNG;
+import org.testng.annotations.Test;
+import test.SimpleBaseTest;
+
+public class IssueTest extends SimpleBaseTest {
+    @Test
+    public void issue2438() {
+        TestNG testng = create(FactoryTest.class);
+        testng.setDefaultSuiteName("factory tests");
+        Reporter reporter = new Reporter();
+        testng.addListener(reporter);
+        testng.run();
+        Assert.assertEquals(reporter.getResults().size(), 5);
+    }
+}

--- a/src/test/java/test/factory/github2428/Reporter.java
+++ b/src/test/java/test/factory/github2428/Reporter.java
@@ -1,0 +1,26 @@
+package test.factory.github2428;
+
+import org.testng.IReporter;
+import org.testng.ISuite;
+import org.testng.xml.XmlSuite;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class Reporter implements IReporter {
+    private final Set<String> results = new HashSet<>();
+
+    public Set<String> getResults() {
+        return results;
+    }
+
+    public void generateReport(List<XmlSuite> xmlSuites, List<ISuite> suites,
+                               String outputDirectory) {
+        suites.get(0).getResults().get("Command line test")
+                .getTestContext()
+                .getPassedConfigurations()
+                .getAllResults()
+                .forEach(x -> results.add(x.getInstance().toString()));
+    }
+}

--- a/src/test/resources/testng.xml
+++ b/src/test/resources/testng.xml
@@ -427,6 +427,12 @@
 
       <class name="test.factory.github1131.GitHub1131Test" />
       <class name="test.factory.nested.GitHub1307Test"/>
+
+    </classes>
+  </test>
+  <test name="factory test" parallel = "instances" thread-count="3" group-by-instances="true">
+    <classes>
+      <class name="test.factory.github2428.IssueTest" />
     </classes>
   </test>
 


### PR DESCRIPTION
Configuration methods have the same test class instance when @Factory is being used

Fixes #2428 .

### Did you remember to?

- [x] Add test case(s)
- [x] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
