### PR TITLE
fix(#2445): Fix for NPE when generating FailedReport with tests creat…

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-2445: NPE in FailedReporter.java With Tests Created in Factory (Arham Jain)
 Fixed: GITHUB-2428: Configuration methods have the same test class instance when @Factory is being used (Nan Liang)
 Fixed: GITHUB-2440: Fixed an issue when case timeout returned an incorrect exception and effect the next other test case (Yao Ma)
 New:   GITHUB-2407: Adds "overrideIncludedMethods" to the global config as a command-line argument, which excludes explicitly included test methods if they belong to any excluded groups (Nikhil Suri)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -107,7 +107,8 @@ dependencies {
             "org.apache-extras.beanshell:bsh:2.0b6",
             "org.mockito:mockito-core:2.12.0",
             "org.jboss.shrinkwrap:shrinkwrap-api:1.2.6",
-            "org.jboss.shrinkwrap:shrinkwrap-impl-base:1.2.6").forEach {
+            "org.jboss.shrinkwrap:shrinkwrap-impl-base:1.2.6",
+            "org.xmlunit:xmlunit-assertj:2.8.2").forEach {
         testImplementation(it)
     }
 }

--- a/src/main/java/org/testng/reporters/FailedReporter.java
+++ b/src/main/java/org/testng/reporters/FailedReporter.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * This reporter is responsible for creating testng-failed.xml
@@ -199,7 +200,11 @@ public class FailedReporter implements IReporter {
         methodNames.add(methodName);
       }
       xmlClass.setIncludedMethods(methodNames);
-      xmlClass.setParameters(classParameters.get(xmlClass.getName()));
+      xmlClass.setParameters(classParameters.getOrDefault(xmlClass.getName(), classParameters
+              .values()
+              .stream()
+              .flatMap(map -> map.entrySet().stream())
+              .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))));
       result.add(xmlClass);
     }
 

--- a/src/main/java/org/testng/reporters/FailedReporter.java
+++ b/src/main/java/org/testng/reporters/FailedReporter.java
@@ -204,7 +204,7 @@ public class FailedReporter implements IReporter {
               .values()
               .stream()
               .flatMap(map -> map.entrySet().stream())
-              .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))));
+              .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (v1, v2)-> v2))));
       result.add(xmlClass);
     }
 

--- a/src/test/java/test/reports/FailedReporterTest.java
+++ b/src/test/java/test/reports/FailedReporterTest.java
@@ -66,11 +66,14 @@ public class FailedReporterTest extends SimpleBaseTest {
     tng.setOutputDirectory(temp.toAbsolutePath().toString());
     tng.addListener(new FailedReporter());
     tng.run();
+
     final Diff myDiff = DiffBuilder.compare(Input.fromFile(expectedResult))
-                             .withTest(Input.fromFile(temp.resolve(FailedReporter.TESTNG_FAILED_XML).toAbsolutePath().toString()))
-                             .checkForSimilar()
-                             .ignoreWhitespace()
-                             .build();
+                                   .withTest(Input.fromFile(temp.resolve(FailedReporter.TESTNG_FAILED_XML)
+                                                                .toAbsolutePath()
+                                                                .toString()))
+                                   .checkForSimilar()
+                                   .ignoreWhitespace()
+                                   .build();
     Assert.assertFalse(myDiff.hasDifferences());
   }
 }

--- a/src/test/java/test/reports/FailedReporterTest.java
+++ b/src/test/java/test/reports/FailedReporterTest.java
@@ -1,6 +1,5 @@
 package test.reports;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import org.testng.Assert;
 import org.testng.ITestNGListener;
 import org.testng.TestNG;
@@ -13,16 +12,12 @@ import org.testng.xml.XmlSuite;
 import org.testng.xml.XmlTest;
 import org.xml.sax.SAXException;
 import test.SimpleBaseTest;
-import test.failedreporter.FailedReporterParametersTest;
-import test.thread.Github1636Sample;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
-import java.util.Collections;
 
 public class FailedReporterTest extends SimpleBaseTest {
 

--- a/src/test/java/test/reports/FailedReporterTest.java
+++ b/src/test/java/test/reports/FailedReporterTest.java
@@ -1,22 +1,28 @@
 package test.reports;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import org.testng.Assert;
 import org.testng.ITestNGListener;
 import org.testng.TestNG;
 import org.testng.annotations.Test;
 import org.testng.reporters.FailedReporter;
 import org.testng.xml.Parser;
+import org.testng.xml.SuiteXmlParser;
 import org.testng.xml.XmlClass;
 import org.testng.xml.XmlSuite;
 import org.testng.xml.XmlTest;
 import org.xml.sax.SAXException;
 import test.SimpleBaseTest;
-
+import test.failedreporter.FailedReporterParametersTest;
+import test.thread.Github1636Sample;
 import javax.xml.parsers.ParserConfigurationException;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Collections;
 
 public class FailedReporterTest extends SimpleBaseTest {
 
@@ -48,5 +54,23 @@ public class FailedReporterTest extends SimpleBaseTest {
 
     XmlClass failedClass = failedTest.getClasses().get(0);
     Assert.assertEquals("44", failedClass.getAllParameters().get("p"));
+  }
+
+  @Test(description = "ISSUE-2445")
+  public void testParameterPreservationWithFactory() throws IOException {
+    final SuiteXmlParser parser = new SuiteXmlParser();
+    final String file = "src/test/resources/xml/issue2445.xml";
+    final XmlSuite xmlSuite = parser.parse(file, new FileInputStream(file), true);
+    final TestNG tng = create(xmlSuite);
+
+    final Path temp = Files.createTempDirectory("tmp");
+    tng.setOutputDirectory(temp.toAbsolutePath().toString());
+    tng.addListener(new FailedReporter());
+    tng.run();
+
+    final Collection<XmlSuite> failedSuites =
+            new Parser(temp.resolve(FailedReporter.TESTNG_FAILED_XML).toAbsolutePath().toString()).parse();
+    final XmlSuite failedSuite = failedSuites.iterator().next();
+    Assert.assertEquals("value", failedSuite.getAllParameters().get("key"));
   }
 }

--- a/src/test/java/test/reports/issue2445/FailureTestFactory.java
+++ b/src/test/java/test/reports/issue2445/FailureTestFactory.java
@@ -1,0 +1,13 @@
+package test.reports.issue2445;
+
+import org.testng.annotations.Factory;
+
+public class FailureTestFactory {
+  @Factory
+  public Object[] getTestClasses() {
+    Object[] tests = new Object[2];
+    tests[0] = new Test1();
+    tests[1] = new Test2();
+    return tests;
+  }
+}

--- a/src/test/java/test/reports/issue2445/Test1.java
+++ b/src/test/java/test/reports/issue2445/Test1.java
@@ -1,0 +1,12 @@
+package test.reports.issue2445;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class Test1 {
+  @Test
+  public void test1() {
+    System.out.println("Test1 test method");
+    Assert.fail();
+  }
+}

--- a/src/test/java/test/reports/issue2445/Test1.java
+++ b/src/test/java/test/reports/issue2445/Test1.java
@@ -6,7 +6,6 @@ import org.testng.annotations.Test;
 public class Test1 {
   @Test
   public void test1() {
-    System.out.println("Test1 test method");
-    Assert.fail();
+    Assert.fail("Simulate failure");
   }
 }

--- a/src/test/java/test/reports/issue2445/Test2.java
+++ b/src/test/java/test/reports/issue2445/Test2.java
@@ -1,11 +1,12 @@
 package test.reports.issue2445;
 
+import org.junit.Assert;
 import org.testng.annotations.Test;
 
 public class Test2 {
   @Test
   public void test2() {
-    System.out.println("Test2 test method");
+    Assert.assertEquals("Simulate success", "1", "1");
   }
 }
 

--- a/src/test/java/test/reports/issue2445/Test2.java
+++ b/src/test/java/test/reports/issue2445/Test2.java
@@ -1,0 +1,11 @@
+package test.reports.issue2445;
+
+import org.testng.annotations.Test;
+
+public class Test2 {
+  @Test
+  public void test2() {
+    System.out.println("Test2 test method");
+  }
+}
+

--- a/src/test/resources/xml/github2445/expected-failed-report.xml
+++ b/src/test/resources/xml/github2445/expected-failed-report.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd">
+<suite thread-count="15" configfailurepolicy="continue" guice-stage="DEVELOPMENT" verbose="0" name="Failed suite [issue2445]" parallel="methods">
+    <parameter name="suiteParamKey" value="suiteParamValue"/>
+    <test thread-count="15" verbose="0" name="factory-failed-reporter-npe-check(failed)" parallel="methods">
+        <parameter name="testParamKey" value="testParamKey"/>
+        <classes>
+            <class name="test.reports.issue2445.Test1">
+                <methods>
+                    <include name="test1"/>
+                </methods>
+            </class> <!-- test.reports.issue2445.Test1 -->
+        </classes>
+    </test> <!-- factory-failed-reporter-npe-check(failed) -->
+</suite> <!-- Failed suite [issue2445] -->

--- a/src/test/resources/xml/github2445/test-suite.xml
+++ b/src/test/resources/xml/github2445/test-suite.xml
@@ -1,7 +1,8 @@
 <!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
 <suite name="issue2445" verbose="1" parallel="methods" thread-count="15" configfailurepolicy="continue">
+    <parameter name="suiteParamKey" value="suiteParamValue"/>
     <test name="factory-failed-reporter-npe-check">
-        <parameter name="key" value="value"/>
+        <parameter name="testParamKey" value="testParamKey"/>
         <classes>
             <class name="test.reports.issue2445.FailureTestFactory"/>
         </classes>

--- a/src/test/resources/xml/issue2445.xml
+++ b/src/test/resources/xml/issue2445.xml
@@ -1,0 +1,9 @@
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
+<suite name="issue2445" verbose="1" parallel="methods" thread-count="15" configfailurepolicy="continue">
+    <test name="factory-failed-reporter-npe-check">
+        <parameter name="key" value="value"/>
+        <classes>
+            <class name="test.reports.issue2445.FailureTestFactory"/>
+        </classes>
+    </test>
+</suite>


### PR DESCRIPTION
The recent update to separate out local parameters class wise causes an NPE in case of tests created in a factory as the actual class is fetched when getRealClass is called. To fix this have added a fallback to the old behaviour i.e., aggregating all of the parameters when setting XML class parameters when a specific classes' parameters are not found

Fixes #2445.

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
