### PR TITLE
Support configurable start time - emailable report

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+New  : GITHUB-2459: Support configurable start time - emailable report (Barry Evans)
 Fixed: GITHUB-2467: XmlTest does not copy the xmlClasses during clone (C.V.Aditya)
 Fixed: GITHUB-2469: Parameters added in XmlTest during AlterSuiteListener not available in SuiteListener (C.V.Aditya)
 Fixed: GITHUB-2296: Fix for assertEquals not working for sets as order is not guaranteed. (Prashant Maroti)

--- a/src/main/java/org/testng/reporters/EmailableReporter2.java
+++ b/src/main/java/org/testng/reporters/EmailableReporter2.java
@@ -344,7 +344,7 @@ public class EmailableReporter2 implements IReporter {
               .append("<td rowspan=\"")
               .append(resultsCount)
               .append("\">")
-              .append(start)
+              .append(getFormattedStartTime(start))
               .append("</td>")
               .append("<td rowspan=\"")
               .append(resultsCount)
@@ -387,6 +387,10 @@ public class EmailableReporter2 implements IReporter {
       scenarioCount = scenarioIndex - startingScenarioIndex;
     }
     return scenarioCount;
+  }
+
+  protected String getFormattedStartTime(long startTimeInMillisFromEpoch) {
+    return String.valueOf(startTimeInMillisFromEpoch);
   }
 
   /** Writes the details for all test scenarios. */


### PR DESCRIPTION
The `EmailableReport2` class provides test start time values which
are in millisecond value from the epoch (01/01/1970 00:00:00):
- sample value `1610359715103`
  - GMT : January 11, 2021 Monday 10: 08: 35.103
- see `test-output/emailable-report.html` for start time report usage
- see https://www.epochconverter.com/clock

This value is not very human readable, and this change adds a protected
method which can be overridden in sub classes to provide a more human
readable version of the test start time (e.g. `2021-01-01 12:34:56`)

Fixes #2459.

### Did you remember to?

- [ ] Add test case(s)
  - I could not find any existing test cases to update, please let me know if I should add/update any in this PR @krmahadevan 
- [x] Update `CHANGES.txt`