### PR TITLE
Github 2490 - Added equals method check even if actual/expected is null

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,7 @@ Current
 Fixes: GITHUB-2493: Avoid NPE from TextReporter execution when a dataprovider method provides null (baflQA)
 Fixed: GITHUB-2483: Asymmetric not equals (cdalexndr)
 Fixed: GITHUB-2486: assertSame/assertNotSame broken after GITHUB-2296 (Vitalii Diravka)
+Fixed: GITHUB-2490: assertNotEquals returns fast when argument is null, not calling equals(Object) (Anindya Roy)
 
 7.4.0
 New  : GITHUB-2459: Support configurable start time - emailable report (Barry Evans)

--- a/src/main/java/org/testng/Assert.java
+++ b/src/main/java/org/testng/Assert.java
@@ -153,10 +153,10 @@ public class Assert {
       return false;
     }
     if (expected == null) {
-      return actual.equals("");
+      return actual.equals(actual);
     }
     if (actual == null) {
-      return expected.equals("");
+      return expected.equals(expected);
     }
     return !expected.equals(actual);
   }

--- a/src/main/java/org/testng/Assert.java
+++ b/src/main/java/org/testng/Assert.java
@@ -152,7 +152,7 @@ public class Assert {
     if ((expected == null) && (actual == null)) {
       return false;
     }
-    if (expected == null ^ actual == null) {
+    if(((expected == null) && !actual.equals(expected)) ^ ((actual == null) && !expected.equals(actual))){
       return true;
     }
     if (!expected.equals(actual) && !actual.equals(expected)) {

--- a/src/main/java/org/testng/Assert.java
+++ b/src/main/java/org/testng/Assert.java
@@ -153,7 +153,7 @@ public class Assert {
       return false;
     }
     if (expected == null) {
-      return !actual.equals(expected);
+      return true;
     }
     return !expected.equals(actual);
   }

--- a/src/main/java/org/testng/Assert.java
+++ b/src/main/java/org/testng/Assert.java
@@ -153,7 +153,10 @@ public class Assert {
       return false;
     }
     if (expected == null) {
-      return true;
+      return actual.equals("");
+    }
+    if (actual == null) {
+      return expected.equals("");
     }
     return !expected.equals(actual);
   }

--- a/src/main/java/org/testng/Assert.java
+++ b/src/main/java/org/testng/Assert.java
@@ -152,8 +152,11 @@ public class Assert {
     if ((expected == null) && (actual == null)) {
       return false;
     }
-    if(((expected == null) && !actual.equals(expected)) ^ ((actual == null) && !expected.equals(actual))){
-      return true;
+    if (expected == null) {
+      return !actual.equals(expected);
+    }
+    if (actual == null) {
+      return !expected.equals(actual);
     }
     if (!expected.equals(actual) && !actual.equals(expected)) {
       return true;

--- a/src/main/java/org/testng/Assert.java
+++ b/src/main/java/org/testng/Assert.java
@@ -155,13 +155,7 @@ public class Assert {
     if (expected == null) {
       return !actual.equals(expected);
     }
-    if (actual == null) {
-      return !expected.equals(actual);
-    }
-    if (!expected.equals(actual) && !actual.equals(expected)) {
-      return true;
-    }
-    return false;
+    return !expected.equals(actual);
   }
 
   private static boolean areEqualImpl(Object actual, Object expected) {

--- a/src/test/java/org/testng/AssertTest.java
+++ b/src/test/java/org/testng/AssertTest.java
@@ -391,6 +391,21 @@ public class AssertTest {
     Assert.assertNotEquals(new BrokenEquals(), null);
   }
 
+  @Test(description = "GITHUB-2490")
+  public void testAssertNotEqualsWithExpectedNullAndNewObject() {
+    Assert.assertNotEquals(new Object(), null);
+  }
+
+  @Test
+  public void testAssertNotEqualsWithActualNullExceptedEmptyString() {
+    Assert.assertNotEquals(null, "");
+  }
+
+  @Test
+  public void testAssertNotEqualsWithActualEmptyStringExceptedNull() {
+    Assert.assertNotEquals("", null);
+  }
+
   class Contrived {
 
     int integer;

--- a/src/test/java/org/testng/AssertTest.java
+++ b/src/test/java/org/testng/AssertTest.java
@@ -381,12 +381,12 @@ public class AssertTest {
     Assert.assertSame(object2, object);
   }
 
-  @Test(description = "GITHUB-2490", expectedExceptions = AssertionError.class)
+  @Test(description = "GITHUB-2490")
   public void testAssertNotEqualsWithActualNull() {
     Assert.assertNotEquals(null, new BrokenEquals());
   }
 
-  @Test(description = "GITHUB-2490", expectedExceptions = AssertionError.class)
+  @Test(description = "GITHUB-2490")
   public void testAssertNotEqualsWithExpectedNull() {
     Assert.assertNotEquals(new BrokenEquals(), null);
   }

--- a/src/test/java/org/testng/AssertTest.java
+++ b/src/test/java/org/testng/AssertTest.java
@@ -381,10 +381,14 @@ public class AssertTest {
     Assert.assertSame(object2, object);
   }
 
-  @Test(description = "GITHUB-2490")
-  public void testAssertNotEqualsWithNullObject() {
-    Assert.assertNotEquals(null, new Object());
-    Assert.assertNotEquals(new Object(), null);
+  @Test(description = "GITHUB-2490", expectedExceptions = AssertionError.class)
+  public void testAssertNotEqualsWithActualNull() {
+    Assert.assertNotEquals(null, new BrokenEquals());
+  }
+
+  @Test(description = "GITHUB-2490", expectedExceptions = AssertionError.class)
+  public void testAssertNotEqualsWithExpectedNull() {
+    Assert.assertNotEquals(new BrokenEquals(), null);
   }
 
   class Contrived {
@@ -469,6 +473,13 @@ public class AssertTest {
     @Override
     public int hashCode() {
       return Objects.hashCode(value);
+    }
+  }
+
+  static class BrokenEquals {
+    @Override
+    public boolean equals(Object o) {
+      return true; // broken implementation
     }
   }
 }

--- a/src/test/java/org/testng/AssertTest.java
+++ b/src/test/java/org/testng/AssertTest.java
@@ -381,6 +381,12 @@ public class AssertTest {
     Assert.assertSame(object2, object);
   }
 
+  @Test(description = "GITHUB-2490")
+  public void testAssertNotEqualsWithNullObject() {
+    Assert.assertNotEquals(null, new Object());
+    Assert.assertNotEquals(new Object(), null);
+  }
+
   class Contrived {
 
     int integer;


### PR DESCRIPTION
GitHub #2490 - Added a condition to check equals method even if any of actual/expected is null as part of this feature request.
