### PR TITLE
Disable automatic dependency on kotlin-stdlib since Kotlin is used only for testing for now

### DIFF
--- a/build-logic/jvm/build.gradle.kts
+++ b/build-logic/jvm/build.gradle.kts
@@ -10,5 +10,5 @@ dependencies {
     implementation(project(":basics"))
     implementation(project(":code-quality"))
     implementation("com.github.vlsi.gradle-extensions:com.github.vlsi.gradle-extensions.gradle.plugin:1.74")
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin")
+    implementation("org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin:1.5.10")
 }

--- a/build-logic/jvm/src/main/kotlin/testng.kotlin-library.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/testng.kotlin-library.gradle.kts
@@ -5,8 +5,9 @@ plugins {
     kotlin("jvm")
 }
 
-java {
-    withSourcesJar()
+dependencies {
+    testImplementation(platform("org.jetbrains.kotlin:kotlin-bom:1.5.10"))
+    testImplementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 }
 
 tasks.withType<KotlinCompile>().configureEach {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,9 @@
 org.gradle.parallel=true
 systemProp.org.gradle.kotlin.dsl.precompiled.accessors.strict=true
 kotlin.code.style=official
+# See https://kotlinlang.org/docs/gradle.html#dependency-on-the-standard-library
+# Note: testng.kotlin-library.gradle.kts adds kotlin-stdlib for testImplementation
+kotlin.stdlib.default.dependency=false
 
 testng.version=7.5
 

--- a/testng-core/build.gradle.kts
+++ b/testng-core/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("testng.java-library")
+    id("testng.kotlin-library")
     groovy
-    kotlin("jvm") version "1.5.10"
     id("testng.sonarqube")
 }
 


### PR DESCRIPTION
See https://kotlinlang.org/docs/gradle.html#dependency-on-the-standard-library
