### PR TITLE
Fix and unit tests for #2532

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-2532: Apply commandline switches for suites in jar files (Dzmitry Sankouski).
 Fixed: GITHUB-2611: Config Failures not included in testng-failed.xml when its part of a different test class (Krishnan Mahadevan)
 Fixed: GITHUB-2613: Ignored Tests are not retrieved for a mixed test class (test with enabled, disabled and ignored test method) (Krishnan Mahadevan)
 Fixed: GITHUB-849: Performance improvement by fixing hashCode (testn & Vladimir Sitnikov)

--- a/src/test/resources/2532.xml
+++ b/src/test/resources/2532.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd">
+<suite name="suite" parallel="methods" verbose="2">
+    <test name="test">
+        <classes>
+            <class name="test.thread.Github1636Sample"/>
+        </classes>
+    </test> <!-- test -->
+</suite> <!-- suite -->

--- a/testng-core/build.gradle.kts
+++ b/testng-core/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     testImplementation("org.jboss.shrinkwrap:shrinkwrap-api:_")
     testImplementation("org.jboss.shrinkwrap:shrinkwrap-impl-base:_")
     testImplementation("org.xmlunit:xmlunit-assertj:_")
+    testImplementation("commons-io:commons-io:_")
 }
 
 tasks.test {

--- a/testng-core/src/main/java/org/testng/TestNG.java
+++ b/testng-core/src/main/java/org/testng/TestNG.java
@@ -381,8 +381,7 @@ public class TestNG {
     // Parse the suites that were passed on the command line
     //
     for (String suitePath : m_stringSuites) {
-      Collection<XmlSuite> allSuites;
-      allSuites = parseSuite(suitePath);
+      Collection<XmlSuite> allSuites = parseSuite(suitePath);
       m_suites.addAll(processCommandLineArgs(allSuites));
     }
 
@@ -412,10 +411,8 @@ public class TestNG {
     JarFileUtils utils =
         new JarFileUtils(getProcessor(), m_xmlPathInJar, m_testNames, m_parallelMode);
 
-    Collection<XmlSuite> allSuites;
-    allSuites = utils.extractSuitesFrom(jarFile);
-    allSuites = processCommandLineArgs(allSuites);
-    m_suites.addAll(allSuites);
+    Collection<XmlSuite> allSuites = utils.extractSuitesFrom(jarFile);
+    m_suites.addAll(processCommandLineArgs(allSuites));
   }
 
   /** @param threadCount Define the number of threads in the thread pool. */

--- a/testng-core/src/main/java/org/testng/TestNG.java
+++ b/testng-core/src/main/java/org/testng/TestNG.java
@@ -321,9 +321,8 @@ public class TestNG {
     if (LOGGER.isDebugEnabled()) {
       LOGGER.debug("suiteXmlPath: \"" + suitePath + "\"");
     }
-    Collection<XmlSuite> allSuites = null;
     try {
-      allSuites = Parser.parse(suitePath, getProcessor());
+      return Parser.parse(suitePath, getProcessor());
     } catch (IOException e) {
       e.printStackTrace(System.out);
     } catch (Exception ex) {
@@ -338,7 +337,7 @@ public class TestNG {
       throw new TestNGException(t);
     }
 
-    return allSuites;
+    return Collections.emptySet();
   }
 
   private Collection<XmlSuite> processCommandLineArgs(Collection<XmlSuite> allSuites) {
@@ -384,8 +383,7 @@ public class TestNG {
     for (String suitePath : m_stringSuites) {
       Collection<XmlSuite> allSuites;
       allSuites = parseSuite(suitePath);
-      allSuites = processCommandLineArgs(allSuites);
-      m_suites.addAll(allSuites);
+      m_suites.addAll(processCommandLineArgs(allSuites));
     }
 
     //

--- a/testng-core/src/test/java/test/thread/ParallelTestTest.java
+++ b/testng-core/src/test/java/test/thread/ParallelTestTest.java
@@ -17,6 +17,7 @@ import java.util.zip.ZipOutputStream;
 import org.apache.commons.io.IOUtils;
 import org.testng.SkipException;
 import org.testng.TestNG;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.testng.collections.Lists;
@@ -168,5 +169,10 @@ public class ParallelTestTest extends BaseTest {
     } catch (IOException e) {
       throw new SkipException(String.format("Error writing zip to %s", targetFilePath), e);
     }
+  }
+
+  @AfterMethod
+  private void clearThreadCount() {
+    Github1636Sample.threads.clear();
   }
 }

--- a/testng-core/src/test/java/test/thread/ParallelTestTest.java
+++ b/testng-core/src/test/java/test/thread/ParallelTestTest.java
@@ -2,12 +2,20 @@ package test.thread;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import org.apache.commons.io.IOUtils;
+import org.testng.SkipException;
 import org.testng.TestNG;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -73,6 +81,35 @@ public class ParallelTestTest extends BaseTest {
     assertThat(Github1636Sample.threads).hasSize(3);
   }
 
+  @Test
+  public void testJarXmlSuiteObeyCommandLine() {
+    final String file = "build/resources/test/2532.zip";
+    final String suiteFileName = "2532.xml";
+    final int threadCount = 3;
+    zipResource(suiteFileName, file);
+
+    TestNG tng = new TestNG();
+    tng.setXmlPathInJar(suiteFileName);
+    tng.setTestJar(file);
+    tng.setThreadCount(threadCount);
+    tng.setParallel(XmlSuite.ParallelMode.METHODS);
+    tng.run();
+    assertThat(Github1636Sample.threads).hasSize(threadCount);
+  }
+
+  @Test
+  public void testXmlSuiteObeyCommandLine() {
+    final String file = "build/resources/test/2532.xml";
+    final int threadCount = 3;
+
+    TestNG tng = new TestNG();
+    tng.setTestSuites(Collections.singletonList(file));
+    tng.setThreadCount(threadCount);
+    tng.setParallel(XmlSuite.ParallelMode.METHODS);
+    tng.run();
+    assertThat(Github1636Sample.threads).hasSize(threadCount);
+  }
+
   private void createTest(XmlSuite xmlSuite, Class<?> clazz) {
     XmlTest result = new XmlTest(xmlSuite);
     List<XmlClass> classes = result.getXmlClasses();
@@ -114,5 +151,22 @@ public class ParallelTestTest extends BaseTest {
     }
 
     assertThat(mergedMap).hasSize(expectedThreadCount);
+  }
+
+  private void zipResource(String resourceName, String targetFilePath) {
+    InputStream suiteStream = this.getClass().getClassLoader().getResourceAsStream(resourceName);
+    try {
+      File targetFile = new File(targetFilePath);
+      FileOutputStream targetFileStream = new FileOutputStream(targetFile);
+      ZipOutputStream zipSuiteStream = new ZipOutputStream(targetFileStream);
+      zipSuiteStream.putNextEntry(new ZipEntry(resourceName));
+
+      byte[] suiteByteData = IOUtils.toByteArray(suiteStream);
+      zipSuiteStream.write(suiteByteData, 0, suiteByteData.length);
+      zipSuiteStream.closeEntry();
+      zipSuiteStream.close();
+    } catch (IOException e) {
+      throw new SkipException(String.format("Error writing zip to %s", targetFilePath), e);
+    }
   }
 }

--- a/testng-core/src/test/resources/2532.xml
+++ b/testng-core/src/test/resources/2532.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd">
+<suite name="suite">
+    <test name="test">
+        <classes>
+            <class name="test.thread.Github1636Sample"/>
+        </classes>
+    </test> <!-- test -->
+</suite> <!-- suite -->

--- a/versions.properties
+++ b/versions.properties
@@ -25,6 +25,8 @@ version.com.google.code.findbugs..jsr305=3.0.1
 
 version.com.google.inject..guice-bom=5.0.1
 
+version.commons-io..commons-io=2.11.0
+
 version.javax..javaee-api=8.0.1
 
 version.junit.junit=4.13.2


### PR DESCRIPTION
This closes #2532. Treat suites from jar same as suites, from filesystem.

Divide parseSuite method into 2 parts: reading suites from files, and processing it.
Apply processing part for suites in jar files, too.

- [x] Add test case(s)
- [x] Update `CHANGES.txt`

`testExclusionOfPassedConfigsInvolvingGroups*` tests fails occasionally.  Failure occurs due to incorrect instance detection in upstreamConfigFailures in org.testng.reporters.FailedReporter#generateXmlTest method. That seems not related to this PR.
UPDATE: this should be fixed in #2620

#2532 