### PR TITLE
Make listener finished method work with reverse insertion order

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 Current
 Fixed: GITHUB-2536: Problems with Nested Test Classes (Krishnan Mahadevan)
+Fixed: GITHUB-2558:Make IExecutionListener, ITestListener, IInvokedMethodListener, IConfigurationListener, ISuiteListener finish method with reverse order (dianny)
 Fixed: GITHUB-2532: Apply commandline switches for suites in jar files (Dzmitry Sankouski).
 Fixed: GITHUB-2558: Make IExecutionListener, ITestListener, IInvokedMethodListener, IConfigurationListener, ISuiteListener execute in the order of insertion (Krishnan Mahadevan)
 Fixed: GITHUB-2611: Config Failures not included in testng-failed.xml when its part of a different test class (Krishnan Mahadevan)

--- a/testng-collections/src/main/java/org/testng/collections/Lists.java
+++ b/testng-collections/src/main/java/org/testng/collections/Lists.java
@@ -76,4 +76,10 @@ public final class Lists {
             });
     return result;
   }
+
+  public static <K> List<K> newReversedArrayList(Collection<K> c) {
+    List<K> list = newArrayList(c);
+    Collections.reverse(list);
+    return list;
+  }
 }

--- a/testng-core/src/main/java/org/testng/SuiteRunner.java
+++ b/testng-core/src/main/java/org/testng/SuiteRunner.java
@@ -252,10 +252,13 @@ public class SuiteRunner implements ISuite, IInvokedMethodListener {
   }
 
   private void invokeListeners(boolean start) {
-    for (ISuiteListener sl : Lists.newArrayList(listeners.values())) {
-      if (start) {
+    if (start) {
+      for (ISuiteListener sl : Lists.newArrayList(listeners.values())) {
         sl.onStart(this);
-      } else {
+      }
+    } else {
+      List<ISuiteListener> suiteListenersReversed = Lists.newReversedArrayList(listeners.values());
+      for (ISuiteListener sl : suiteListenersReversed) {
         sl.onFinish(this);
       }
     }

--- a/testng-core/src/main/java/org/testng/TestNG.java
+++ b/testng-core/src/main/java/org/testng/TestNG.java
@@ -1083,10 +1083,15 @@ public class TestNG {
   }
 
   private void runExecutionListeners(boolean start) {
-    for (IExecutionListener l : m_configuration.getExecutionListeners()) {
-      if (start) {
+    List<IExecutionListener> executionListeners = m_configuration.getExecutionListeners();
+    if (start) {
+      for (IExecutionListener l : executionListeners) {
         l.onExecutionStart();
-      } else {
+      }
+    } else {
+      List<IExecutionListener> executionListenersReversed =
+          Lists.newReversedArrayList(executionListeners);
+      for (IExecutionListener l : executionListenersReversed) {
         l.onExecutionFinish();
       }
     }

--- a/testng-core/src/main/java/org/testng/TestRunner.java
+++ b/testng-core/src/main/java/org/testng/TestRunner.java
@@ -91,7 +91,7 @@ public class TestRunner
   /** ITestListeners support. */
   private final List<ITestListener> m_testListeners = Lists.newArrayList();
 
-  private final Set<IConfigurationListener> m_configurationListeners = Sets.newHashSet();
+  private final Set<IConfigurationListener> m_configurationListeners = Sets.newLinkedHashSet();
   private final Set<IExecutionVisualiser> visualisers = Sets.newHashSet();
 
   private final IConfigurationListener m_confListener = new ConfigurationListener();
@@ -933,10 +933,14 @@ public class TestRunner
    *     finish
    */
   private void fireEvent(boolean isStart) {
-    for (ITestListener itl : m_testListeners) {
-      if (isStart) {
+    if (isStart) {
+      for (ITestListener itl : m_testListeners) {
         itl.onStart(this);
-      } else {
+      }
+
+    } else {
+      List<ITestListener> testListenersReversed = Lists.newReversedArrayList(m_testListeners);
+      for (ITestListener itl : testListenersReversed) {
         itl.onFinish(this);
       }
     }

--- a/testng-core/src/main/java/org/testng/internal/TestListenerHelper.java
+++ b/testng-core/src/main/java/org/testng/internal/TestListenerHelper.java
@@ -35,7 +35,8 @@ public final class TestListenerHelper {
 
   public static void runPostConfigurationListeners(
       ITestResult tr, ITestNGMethod tm, List<IConfigurationListener> listeners) {
-    for (IConfigurationListener icl : listeners) {
+    List<IConfigurationListener> listenersreversed = Lists.newReversedArrayList(listeners);
+    for (IConfigurationListener icl : listenersreversed) {
       switch (tr.getStatus()) {
         case ITestResult.SKIP:
           icl.onConfigurationSkip(tr);

--- a/testng-core/src/main/java/org/testng/internal/invokers/BaseInvoker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/BaseInvoker.java
@@ -10,6 +10,7 @@ import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
 import org.testng.SkipException;
 import org.testng.SuiteRunState;
+import org.testng.collections.Lists;
 import org.testng.collections.Maps;
 import org.testng.internal.IConfiguration;
 import org.testng.internal.ITestResultNotifier;
@@ -54,7 +55,14 @@ class BaseInvoker {
 
     InvokedMethodListenerInvoker invoker =
         new InvokedMethodListenerInvoker(listenerMethod, testResult, testResult.getTestContext());
-    for (IInvokedMethodListener currentListener : m_invokedMethodListeners) {
+    // For BEFORE_INVOCATION method, still run as insert order, but regarding AFTER_INVOCATION, it
+    // should be reverse order
+    boolean isAfterInvocation = InvokedMethodListenerMethod.AFTER_INVOCATION == listenerMethod;
+    Collection<IInvokedMethodListener> listeners =
+        isAfterInvocation
+            ? Lists.newReversedArrayList(m_invokedMethodListeners)
+            : m_invokedMethodListeners;
+    for (IInvokedMethodListener currentListener : listeners) {
       try {
         invoker.invokeListener(currentListener, invokedMethod);
       } catch (SkipException e) {

--- a/testng-core/src/main/java/org/testng/internal/invokers/TestInvoker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/TestInvoker.java
@@ -28,6 +28,7 @@ import org.testng.IRetryAnalyzer;
 import org.testng.ISuite;
 import org.testng.ITestClass;
 import org.testng.ITestContext;
+import org.testng.ITestListener;
 import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
 import org.testng.Reporter;
@@ -232,7 +233,15 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
   }
 
   public void runTestResultListener(ITestResult tr) {
-    TestListenerHelper.runTestListeners(tr, m_notifier.getTestListeners());
+    // For onTestStart method, still run as insert order
+    // but regarding
+    // onTestSkipped/onTestFailedButWithinSuccessPercentage/onTestFailedWithTimeout/onTestFailure/onTestSuccess, it should be reverse order.
+    boolean isFinished = tr.getStatus() != ITestResult.STARTED;
+    List<ITestListener> listeners =
+        isFinished
+            ? Lists.newReversedArrayList(m_notifier.getTestListeners())
+            : m_notifier.getTestListeners();
+    TestListenerHelper.runTestListeners(tr, listeners);
   }
 
   private Collection<IDataProviderListener> dataProviderListeners() {

--- a/testng-core/src/main/java/org/testng/junit/JUnitTestRunner.java
+++ b/testng-core/src/main/java/org/testng/junit/JUnitTestRunner.java
@@ -15,9 +15,6 @@ import junit.framework.TestListener;
 import junit.framework.TestResult;
 import junit.framework.TestSuite;
 import org.testng.*;
-import org.testng.ITestNGMethod;
-import org.testng.ITestResult;
-import org.testng.TestNGException;
 import org.testng.collections.Lists;
 import org.testng.internal.ITestResultNotifier;
 import org.testng.internal.TestListenerHelper;
@@ -86,8 +83,15 @@ public class JUnitTestRunner implements TestListener, IJUnitTestRunner {
     }
 
     org.testng.internal.TestResult tr = recordResults(test, tri);
-
-    TestListenerHelper.runTestListeners(tr, m_parentRunner.getTestListeners());
+    // For onTestStart method, still run as insert order
+    // but regarding
+    // onTestSkipped/onTestFailedButWithinSuccessPercentage/onTestFailedWithTimeout/onTestFailure/onTestSuccess, it should be reverse order.
+    boolean isFinished = tr.getStatus() != ITestResult.STARTED;
+    List<ITestListener> listeners =
+        isFinished
+            ? Lists.newReversedArrayList(m_parentRunner.getTestListeners())
+            : m_parentRunner.getTestListeners();
+    TestListenerHelper.runTestListeners(tr, listeners);
   }
 
   public void setInvokedMethodListeners(Collection<IInvokedMethodListener> listeners) {

--- a/testng-core/src/test/java/test/listeners/ListenerTest.java
+++ b/testng-core/src/test/java/test/listeners/ListenerTest.java
@@ -380,26 +380,26 @@ public class ListenerTest extends SimpleBaseTest {
           prefix + "ClassMethodListenersHolder$ClassMethodListenerA.onBeforeClass()",
           prefix + "ClassMethodListenersHolder$ClassMethodListenerB.beforeInvocation()",
           prefix + "ClassMethodListenersHolder$ClassMethodListenerA.beforeInvocation()",
-          prefix + "ClassMethodListenersHolder$ClassMethodListenerB.afterInvocation()",
           prefix + "ClassMethodListenersHolder$ClassMethodListenerA.afterInvocation()",
+          prefix + "ClassMethodListenersHolder$ClassMethodListenerB.afterInvocation()",
           prefix + "ClassMethodListenersHolder$ClassMethodListenerB.onBeforeClass()",
           prefix + "ClassMethodListenersHolder$ClassMethodListenerA.onBeforeClass()",
           prefix + "ClassMethodListenersHolder$ClassMethodListenerB.onBeforeClass()",
           prefix + "ClassMethodListenersHolder$ClassMethodListenerA.onBeforeClass()",
           prefix + "ClassMethodListenersHolder$ClassMethodListenerB.beforeInvocation()",
           prefix + "ClassMethodListenersHolder$ClassMethodListenerA.beforeInvocation()",
-          prefix + "ClassMethodListenersHolder$ClassMethodListenerB.afterInvocation()",
           prefix + "ClassMethodListenersHolder$ClassMethodListenerA.afterInvocation()",
+          prefix + "ClassMethodListenersHolder$ClassMethodListenerB.afterInvocation()",
           prefix + "ClassMethodListenersHolder$ClassMethodListenerB.onBeforeClass()",
           prefix + "ClassMethodListenersHolder$ClassMethodListenerA.onBeforeClass()",
-          prefix + "TestListenersHolder$TestListenerB.onFinish(ctx)",
           prefix + "TestListenersHolder$TestListenerA.onFinish(ctx)",
-          prefix + "SuiteListenersHolder$SuiteListenerB.onFinish()",
+          prefix + "TestListenersHolder$TestListenerB.onFinish(ctx)",
           prefix + "SuiteListenersHolder$SuiteListenerA.onFinish()",
+          prefix + "SuiteListenersHolder$SuiteListenerB.onFinish()",
           prefix + "ReportersHolder$ReporterB.generateReport()",
           prefix + "ReportersHolder$ReporterA.generateReport()",
-          prefix + "ExecutionListenersHolder$ExecutionListenerB.onExecutionFinish()",
-          prefix + "ExecutionListenersHolder$ExecutionListenerA.onExecutionFinish()"
+          prefix + "ExecutionListenersHolder$ExecutionListenerA.onExecutionFinish()",
+          prefix + "ExecutionListenersHolder$ExecutionListenerB.onExecutionFinish()"
         };
     List<Class<?>> listeners =
         Arrays.asList(


### PR DESCRIPTION
Now the listener start method and finished method worked with insertion
order, this commit changes the finished method worked with reverse
order.

Fixes #2558 .




