### PR TITLE
Corrected javadoc typo in ITestContext

### DIFF
--- a/testng-core-api/src/main/java/org/testng/ITestContext.java
+++ b/testng-core-api/src/main/java/org/testng/ITestContext.java
@@ -35,7 +35,7 @@ public interface ITestContext extends IAttributes {
   IResultMap getFailedButWithinSuccessPercentageTests();
 
   /**
-   * @return A map of all the tests that passed, indexed by their ITextMethor.
+   * @return A map of all the tests that failed, indexed by their ITestNGMethod.
    * @see org.testng.ITestNGMethod
    */
   IResultMap getFailedTests();


### PR DESCRIPTION
Fixed incorrect javadoc that indicated getFailedTests() returned a list of passing tests, corrected typo in ITestNGMethod type

Fixes # .

### Did you remember to?

- [ ] Add test case(s)
- [ ] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
