### PR TITLE
Fix AssertTest not failing for missing exception

### DIFF
--- a/testng-asserts/src/test/java/org/testng/AssertTest.java
+++ b/testng-asserts/src/test/java/org/testng/AssertTest.java
@@ -121,24 +121,28 @@ public class AssertTest {
   public void oneNullMapAssertEquals() {
     Map<?, ?> expected = Maps.newHashMap();
     Map<?, ?> actual = null;
+    boolean failed = true;
     try {
       Assert.assertEquals(actual, expected);
-      Assert.fail("AssertEquals didn't fail");
+      failed = false;
     } catch (AssertionError error) {
       // do nothing
     }
+    Assert.assertTrue(failed, "assertEquals did not fail");
   }
 
   @Test
   public void oneNullSetAssertEquals() {
     Set<?> expected = null;
     Set<?> actual = Sets.newHashSet();
+    boolean failed = true;
     try {
       Assert.assertEquals(actual, expected);
-      Assert.fail("AssertEquals didn't fail");
+      failed = false;
     } catch (AssertionError error) {
       // do nothing
     }
+    Assert.assertTrue(failed, "assertEquals did not fail");
   }
 
   /**


### PR DESCRIPTION
The previous code was incorrect because the `AssertionError` thrown by `Assert.fail` would have been caught by the `catch` clause. So even if `assertEquals` did not behave as expected, the test would still have passed.