### PR TITLE
Streamline adding listeners

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-2638: "[WARN] Ignoring duplicate listener" appears when running .xml suite with <listeners> and <suite-files> (Krishnan Mahadevan)
 Fixed: GITHUB-1297: Passed configuration methods appear in testng-failed.xml, when failure was after passed test (Dzmitry Sankouski)
 New: Decouple configuration unit tests from main suite (Dzmitry Sankouski).
 Fixed: GITHUB-2536: Problems with Nested Test Classes (Krishnan Mahadevan)

--- a/testng-core-api/src/main/java/org/testng/xml/XmlSuite.java
+++ b/testng-core-api/src/main/java/org/testng/xml/XmlSuite.java
@@ -417,15 +417,10 @@ public class XmlSuite implements Cloneable {
   /** @return The parameters defined in this suite and all its XmlTests. */
   public Map<String, String> getAllParameters() {
     Map<String, String> result = Maps.newHashMap();
-    for (Map.Entry<String, String> entry : m_parameters.entrySet()) {
-      result.put(entry.getKey(), entry.getValue());
-    }
+    result.putAll(m_parameters);
 
     for (XmlTest test : getTests()) {
-      Map<String, String> tp = test.getLocalParameters();
-      for (Map.Entry<String, String> entry : tp.entrySet()) {
-        result.put(entry.getKey(), entry.getValue());
-      }
+      result.putAll(test.getLocalParameters());
     }
 
     return result;
@@ -657,14 +652,6 @@ public class XmlSuite implements Cloneable {
   }
 
   public List<String> getListeners() {
-    if (m_parentSuite != null) {
-      List<String> listeners = m_parentSuite.getListeners();
-      for (String listener : listeners) {
-        if (!m_listeners.contains(listener)) {
-          m_listeners.add(listener);
-        }
-      }
-    }
     return m_listeners;
   }
 

--- a/testng-core/src/test/java/test/listeners/ListenersTest.java
+++ b/testng-core/src/test/java/test/listeners/ListenersTest.java
@@ -1,0 +1,139 @@
+package test.listeners;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.testng.TestNG;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.testng.xml.XmlSuite;
+import test.SimpleBaseTest;
+import test.listeners.issue2638.DummyInvokedMethodListener;
+import test.listeners.issue2638.TestClassASample;
+import test.listeners.issue2638.TestClassBSample;
+
+public class ListenersTest extends SimpleBaseTest {
+
+  private static final String[] github2638ExpectedList =
+      new String[] {
+        "test.listeners.issue2638.TestClassASample.testMethod",
+        "test.listeners.issue2638.TestClassBSample.testMethod"
+      };
+
+  @Test(description = "GITHUB-2638", dataProvider = "suiteProvider")
+  public void ensureDuplicateListenersAreNotWiredInAcrossSuites(
+      XmlSuite xmlSuite, Map<String, String[]> expected) {
+    TestNG testng = create(xmlSuite);
+    testng.run();
+
+    assertThat(DummyInvokedMethodListener.getMethods("Container_Suite"))
+        .containsExactly(expected.get("Container_Suite"));
+    assertThat(DummyInvokedMethodListener.getMethods("Inner_Suite1"))
+        .containsExactly(expected.get("Inner_Suite1"));
+    assertThat(DummyInvokedMethodListener.getMethods("Inner_Suite2"))
+        .containsExactly(expected.get("Inner_Suite2"));
+    DummyInvokedMethodListener.reset();
+  }
+
+  @DataProvider(name = "suiteProvider")
+  public Object[][] getSuites() throws IOException {
+    return new Object[][] {
+      new Object[] {getNestedSuitesViaXmlFiles(), getExpectations()},
+      new Object[] {getNestedSuitesViaApis(), getExpectations()},
+      new Object[] {getNestedSuitesViaXmlFilesWithListenerInChildSuite(), getExpectations()},
+      new Object[] {getNestedSuitesViaApisWithListenerInChildSuite(), getExpectations()}
+    };
+  }
+
+  private static Map<String, String[]> getExpectations() {
+    Map<String, String[]> expected = new HashMap<>();
+    expected.put("Container_Suite", new String[] {});
+    expected.put("Inner_Suite1", github2638ExpectedList);
+    expected.put("Inner_Suite2", github2638ExpectedList);
+    return expected;
+  }
+
+  private static XmlSuite getNestedSuitesViaXmlFiles() throws IOException {
+    XmlSuite containerSuite = createXmlSuite("Container_Suite");
+    containerSuite.setListeners(
+        Collections.singletonList(DummyInvokedMethodListener.class.getName()));
+
+    XmlSuite innerSuite1 = createXmlSuite("Inner_Suite1");
+    createXmlTest(innerSuite1, "Inner_Test_1", TestClassASample.class);
+    createXmlTest(innerSuite1, "Inner_Test_2", TestClassBSample.class);
+    Path s1 = Files.createTempFile("testng", ".xml");
+    Files.write(s1, Collections.singletonList(innerSuite1.toXml()));
+
+    XmlSuite innerSuite2 = createXmlSuite("Inner_Suite2");
+    createXmlTest(innerSuite2, "Inner_Test_1", TestClassASample.class);
+    createXmlTest(innerSuite2, "Inner_Test_2", TestClassBSample.class);
+    Path s2 = Files.createTempFile("testng", ".xml");
+    Files.write(s2, Collections.singletonList(innerSuite2.toXml()));
+
+    containerSuite.setSuiteFiles(
+        Arrays.asList(s1.toFile().getAbsolutePath(), s2.toFile().getAbsolutePath()));
+    return containerSuite;
+  }
+
+  private static XmlSuite getNestedSuitesViaXmlFilesWithListenerInChildSuite() throws IOException {
+    XmlSuite containerSuite = createXmlSuite("Container_Suite");
+
+    XmlSuite innerSuite1 = createXmlSuite("Inner_Suite1");
+    innerSuite1.setListeners(Collections.singletonList(DummyInvokedMethodListener.class.getName()));
+    createXmlTest(innerSuite1, "Inner_Test_1", TestClassASample.class);
+    createXmlTest(innerSuite1, "Inner_Test_2", TestClassBSample.class);
+    Path s1 = Files.createTempFile("testng", ".xml");
+    Files.write(s1, Collections.singletonList(innerSuite1.toXml()));
+
+    XmlSuite innerSuite2 = createXmlSuite("Inner_Suite2");
+    createXmlTest(innerSuite2, "Inner_Test_1", TestClassASample.class);
+    createXmlTest(innerSuite2, "Inner_Test_2", TestClassBSample.class);
+    Path s2 = Files.createTempFile("testng", ".xml");
+    Files.write(s2, Collections.singletonList(innerSuite2.toXml()));
+
+    containerSuite.setSuiteFiles(
+        Arrays.asList(s1.toFile().getAbsolutePath(), s2.toFile().getAbsolutePath()));
+    return containerSuite;
+  }
+
+  private static XmlSuite getNestedSuitesViaApisWithListenerInChildSuite() {
+    XmlSuite containerSuite = createXmlSuite("Container_Suite");
+
+    XmlSuite innerSuite1 = createXmlSuite("Inner_Suite1");
+    innerSuite1.setListeners(Collections.singletonList(DummyInvokedMethodListener.class.getName()));
+    createXmlTest(innerSuite1, "Inner_Test_1", TestClassASample.class);
+    createXmlTest(innerSuite1, "Inner_Test_2", TestClassBSample.class);
+    containerSuite.getChildSuites().add(innerSuite1);
+    innerSuite1.setParentSuite(containerSuite);
+
+    XmlSuite innerSuite2 = createXmlSuite("Inner_Suite2");
+    createXmlTest(innerSuite2, "Inner_Test_1", TestClassASample.class);
+    createXmlTest(innerSuite2, "Inner_Test_2", TestClassBSample.class);
+    containerSuite.getChildSuites().add(innerSuite2);
+    innerSuite2.setParentSuite(containerSuite);
+    return containerSuite;
+  }
+
+  private static XmlSuite getNestedSuitesViaApis() {
+    XmlSuite containerSuite = createXmlSuite("Container_Suite");
+    containerSuite.setListeners(
+        Collections.singletonList(DummyInvokedMethodListener.class.getName()));
+    XmlSuite innerSuite1 = createXmlSuite("Inner_Suite1");
+    createXmlTest(innerSuite1, "Inner_Test_1", TestClassASample.class);
+    createXmlTest(innerSuite1, "Inner_Test_2", TestClassBSample.class);
+    XmlSuite innerSuite2 = createXmlSuite("Inner_Suite2");
+    createXmlTest(innerSuite2, "Inner_Test_1", TestClassASample.class);
+    createXmlTest(innerSuite2, "Inner_Test_2", TestClassBSample.class);
+    containerSuite.getChildSuites().add(innerSuite1);
+    containerSuite.getChildSuites().add(innerSuite2);
+    innerSuite1.setParentSuite(containerSuite);
+    innerSuite2.setParentSuite(containerSuite);
+    return containerSuite;
+  }
+}

--- a/testng-core/src/test/java/test/listeners/issue2638/DummyInvokedMethodListener.java
+++ b/testng-core/src/test/java/test/listeners/issue2638/DummyInvokedMethodListener.java
@@ -1,0 +1,30 @@
+package test.listeners.issue2638;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.testng.IInvokedMethod;
+import org.testng.IInvokedMethodListener;
+import org.testng.ITestResult;
+import org.testng.collections.Lists;
+import org.testng.collections.Maps;
+
+public class DummyInvokedMethodListener implements IInvokedMethodListener {
+  private static final Map<String, List<String>> methods = Maps.newHashMap();
+
+  @Override
+  public void beforeInvocation(IInvokedMethod method, ITestResult testResult) {
+    String suiteName = testResult.getTestContext().getSuite().getName();
+    methods
+        .computeIfAbsent(suiteName, k -> Lists.newArrayList())
+        .add(method.getTestMethod().getQualifiedName());
+  }
+
+  public static List<String> getMethods(String suiteName) {
+    return methods.getOrDefault(suiteName, Collections.emptyList());
+  }
+
+  public static void reset() {
+    methods.clear();
+  }
+}

--- a/testng-core/src/test/java/test/listeners/issue2638/TestClassASample.java
+++ b/testng-core/src/test/java/test/listeners/issue2638/TestClassASample.java
@@ -1,0 +1,9 @@
+package test.listeners.issue2638;
+
+import org.testng.annotations.Test;
+
+public class TestClassASample {
+
+  @Test
+  public void testMethod() {}
+}

--- a/testng-core/src/test/java/test/listeners/issue2638/TestClassBSample.java
+++ b/testng-core/src/test/java/test/listeners/issue2638/TestClassBSample.java
@@ -1,0 +1,9 @@
+package test.listeners.issue2638;
+
+import org.testng.annotations.Test;
+
+public class TestClassBSample {
+
+  @Test
+  public void testMethod() {}
+}

--- a/testng-core/src/test/resources/testng.xml
+++ b/testng-core/src/test/resources/testng.xml
@@ -189,6 +189,7 @@
       <class name="test.listeners.github1735.ExecutionListenerTest"/>
       <class name="test.listeners.github1602.IssueTest"/>
       <class name="test.listeners.issue1777.IssueTest"/>
+      <class name="test.listeners.ListenersTest"/>
       <class name="test.skip.github1632.IssueTest"/>
       <class name="test.listeners.issue2220.IssueTest"/>
       <class name="test.listeners.issue2328.IssueTest"/>


### PR DESCRIPTION
Closes #2638 

When dealing with a suite, we don’t need to 
get hold of its parent’s listeners and add them
as well to the current suite because our execution
model allows us to run tests only in the following
two modes:

1. Current suite wherein a suite doesn’t have
nested suite.
2. Suite of suites wherein the current suite 
would not have a parent suite.

Fixes #2638  .

### Did you remember to?

- [ ] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
