### PR TITLE
assertEquals(Set,Set) now ignores ordering as it did before, fixes #2643

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-2643: assertEquals(Set,Set) now ignores ordering as it did before. (Elis Edlund)
 Fixed: GITHUB-2653: Assert methods requires casting since TestNg 7.0 for mixed boxed and unboxed primitives in assertEquals.
 Fixed: GITHUB-2229: Restore @BeforeGroups and @AfterGroups Annotations functionality (Krishnan Mahadevan)
 Fixed: GITHUB-2563: Skip test if its data provider provides no data (Krishnan Mahadevan)

--- a/testng-asserts/src/main/java/org/testng/Assert.java
+++ b/testng-asserts/src/main/java/org/testng/Assert.java
@@ -1795,7 +1795,7 @@ public class Assert {
   }
 
   private static String getNotEqualReason(Set<?> actual, Set<?> expected) {
-    if (actual == expected) { // We don't use Arrays.equals here because order is checked
+    if (actual == expected) {
       return null;
     }
 
@@ -1807,7 +1807,7 @@ public class Assert {
     if (!Objects.equals(actual, expected)) {
       return "Sets differ: expected " + expected + " but got " + actual;
     }
-    return getNotEqualReason(actual.iterator(), expected.iterator());
+    return null;
   }
 
   /**

--- a/testng-asserts/src/test/java/test/asserttests/AssertTest.java
+++ b/testng-asserts/src/test/java/test/asserttests/AssertTest.java
@@ -373,8 +373,8 @@ public class AssertTest {
     assertNotEquals(iterator1, iterator2);
   }
 
-  @Test(description = "GITHUB-2540", expectedExceptions = AssertionError.class)
-  public void checkSetEqualsFailsWhenDifferentOrder() {
+  @Test(description = "GITHUB-2643")
+  public void checkSetEqualsWhenDifferentOrder() {
 
     Set<String> set1 = new LinkedHashSet<>(Arrays.asList("a", "b", "c"));
     Set<String> set2 = new LinkedHashSet<>(Arrays.asList("a", "c", "b"));
@@ -400,8 +400,8 @@ public class AssertTest {
     assertEquals(set1, set2);
   }
 
-  @Test(description = "GITHUB-2540")
-  public void checkSetNotEquals() {
+  @Test(description = "GITHUB-2643", expectedExceptions = AssertionError.class)
+  public void checkSetNotEqualsFailsWhenDifferentOrder() {
 
     Set<String> set1 = new LinkedHashSet<>(Arrays.asList("a", "b", "c"));
     Set<String> set2 = new LinkedHashSet<>(Arrays.asList("a", "c", "b"));
@@ -409,13 +409,31 @@ public class AssertTest {
     assertNotEquals(set1, set2);
   }
 
-  @Test(description = "GITHUB-2540", expectedExceptions = AssertionError.class)
-  public void checkSetNotEqualsFailsWhenDifferentOrder() {
+  @Test(description = "GITHUB-2643", expectedExceptions = AssertionError.class)
+  public void checkSetNotEqualsFailsWhenSameOrder() {
 
     Set<String> set1 = new LinkedHashSet<>(Arrays.asList("a", "b", "c"));
     Set<String> set2 = new LinkedHashSet<>(Arrays.asList("a", "b", "c"));
 
     assertNotEquals(set1, set2);
+  }
+
+  @Test(description = "GITHUB-2643")
+  public void checkSetNotEqualsWhenNotSameSets() {
+
+    Set<String> set1 = new LinkedHashSet<>(Arrays.asList("a", "b"));
+    Set<String> set2 = new LinkedHashSet<>(Arrays.asList("a", "b", "c"));
+
+    assertNotEquals(set1, set2);
+  }
+
+  @Test(description = "GITHUB-2643", expectedExceptions = AssertionError.class)
+  public void checkSetEqualsFailsWhenNotSameSets() {
+
+    Set<String> set1 = new LinkedHashSet<>(Arrays.asList("a", "b", "c"));
+    Set<String> set2 = new LinkedHashSet<>(Arrays.asList("a", "b"));
+
+    assertEquals(set1, set2);
   }
 
   @Test(description = "GITHUB-2540", expectedExceptions = AssertionError.class)


### PR DESCRIPTION
see #2643

the https://github.com/cbeust/testng/blob/master/CONTRIBUTING.md is linked from the readme.md but does not exist from what I can see, (so excuse me if I didn't follow the correct WoW) 
