### PR TITLE
Restore BeforeGroups|AfterGroups functionality back

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 Current
 Fixed: GITHUB-2653: Assert methods requires casting since TestNg 7.0 for mixed boxed and unboxed primitives in assertEquals.
+Fixed: GITHUB-2229: Restore @BeforeGroups and @AfterGroups Annotations functionality (Krishnan Mahadevan)
 Fixed: GITHUB-2563: Skip test if its data provider provides no data (Krishnan Mahadevan)
 Fixed: GITHUB-2535: TestResult.getEndMillis() returns 0 for skipped configuration - after upgrading testng to 7.0 + (Krishnan Mahadevan)
 Fixed: GITHUB-2638: "[WARN] Ignoring duplicate listener" appears when running .xml suite with <listeners> and <suite-files> (Krishnan Mahadevan)

--- a/testng-core/src/main/java/org/testng/internal/invokers/ConfigInvoker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/ConfigInvoker.java
@@ -110,10 +110,6 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
    * @param arguments - A {@link GroupConfigMethodArguments} object.
    */
   public void invokeBeforeGroupsConfigurations(GroupConfigMethodArguments arguments) {
-    if (arguments.isGroupFilteringDisabled()) {
-      return;
-    }
-
     List<ITestNGMethod> filteredMethods = Lists.newArrayList();
     String[] groups = arguments.getTestMethod().getGroups();
 
@@ -165,10 +161,6 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
     // (only a method that belongs to a group can trigger the invocation
     // of afterGroups methods)
     if (arguments.getTestMethod().getGroups().length == 0) {
-      return;
-    }
-
-    if (arguments.isGroupFilteringDisabled()) {
       return;
     }
 

--- a/testng-core/src/main/java/org/testng/internal/invokers/GroupConfigMethodArguments.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/GroupConfigMethodArguments.java
@@ -34,10 +34,6 @@ public class GroupConfigMethodArguments extends Arguments {
     return instance;
   }
 
-  public boolean isGroupFilteringDisabled() {
-    return getTestMethod().getXmlTest().isGroupFilteringDisabled();
-  }
-
   public static class Builder {
 
     private ITestNGMethod testMethod;

--- a/testng-core/src/test/java/test/beforegroups/BeforeGroupsTest.java
+++ b/testng-core/src/test/java/test/beforegroups/BeforeGroupsTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -23,6 +24,8 @@ import test.InvokedMethodNameListener;
 import test.SimpleBaseTest;
 import test.beforegroups.issue118.TestclassSample;
 import test.beforegroups.issue1694.BaseClassWithBeforeGroups;
+import test.beforegroups.issue2229.AnotherTestClassSample;
+import test.beforegroups.issue2229.TestClassSample;
 import test.beforegroups.issue346.SampleTestClass;
 
 public class BeforeGroupsTest extends SimpleBaseTest {
@@ -63,6 +66,38 @@ public class BeforeGroupsTest extends SimpleBaseTest {
     expected.put(TEST_1, Collections.singletonList("beforeGroups:" + TEST_1 + TEST_1));
     expected.put(TEST_2, Collections.singletonList("afterGroups:" + TEST_2 + TEST_2));
     assertThat(SampleTestClass.logs).isEqualTo(expected);
+  }
+
+  @Test(description = "GITHUB-2229")
+  public void ensureBeforeGroupsAreInvokedByDefaultEvenWithoutGrouping() {
+    TestNG testng = create(TestClassSample.class, AnotherTestClassSample.class);
+    testng.run();
+    assertThat(testng.getStatus()).isEqualTo(0);
+    List<String> expectedLogs =
+        Arrays.asList(
+            "TestA",
+            "TestB",
+            "TestC",
+            "beforeGroupA",
+            "testGroupA1",
+            "testGroupA2",
+            "testGroupA3",
+            "afterGroupA",
+            "beforeGroupB",
+            "testGroupB",
+            "afterGroupB");
+    assertThat(TestClassSample.logs).containsExactlyElementsOf(expectedLogs);
+    expectedLogs =
+        Arrays.asList(
+            "beforeGroups1",
+            "test1_testGroup1",
+            "beforeGroups2",
+            "test2_testGroup2",
+            "test3_testGroup1",
+            "afterGroups1",
+            "test4_testGroup2",
+            "afterGroups2");
+    assertThat(AnotherTestClassSample.logs).containsExactlyElementsOf(expectedLogs);
   }
 
   private static void createXmlTest(XmlSuite xmlSuite, String name, String group) {

--- a/testng-core/src/test/java/test/beforegroups/issue2229/AnotherTestClassSample.java
+++ b/testng-core/src/test/java/test/beforegroups/issue2229/AnotherTestClassSample.java
@@ -1,0 +1,52 @@
+package test.beforegroups.issue2229;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.testng.annotations.AfterGroups;
+import org.testng.annotations.BeforeGroups;
+import org.testng.annotations.Test;
+
+public class AnotherTestClassSample {
+
+  public static List<String> logs = new ArrayList<>();
+
+  @BeforeGroups(groups = "testGroup1")
+  public void beforeGroups1() {
+    logs.add("beforeGroups1");
+  }
+
+  @BeforeGroups(groups = "testGroup2")
+  public void beforeGroups2() {
+    logs.add("beforeGroups2");
+  }
+
+  @AfterGroups(groups = "testGroup1")
+  public void afterGroups1() {
+    logs.add("afterGroups1");
+  }
+
+  @AfterGroups(groups = "testGroup2")
+  public void afterGroups2() {
+    logs.add("afterGroups2");
+  }
+
+  @Test(groups = "testGroup1")
+  public void test1() {
+    logs.add("test1_testGroup1");
+  }
+
+  @Test(groups = "testGroup2")
+  public void test2() {
+    logs.add("test2_testGroup2");
+  }
+
+  @Test(groups = "testGroup1")
+  public void test3() {
+    logs.add("test3_testGroup1");
+  }
+
+  @Test(groups = "testGroup2")
+  public void test4() {
+    logs.add("test4_testGroup2");
+  }
+}

--- a/testng-core/src/test/java/test/beforegroups/issue2229/TestClassSample.java
+++ b/testng-core/src/test/java/test/beforegroups/issue2229/TestClassSample.java
@@ -1,0 +1,93 @@
+package test.beforegroups.issue2229;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterGroups;
+import org.testng.annotations.BeforeGroups;
+import org.testng.annotations.Test;
+
+public class TestClassSample {
+
+  public static List<String> logs = new ArrayList<>();
+
+  boolean valueA = false;
+  boolean valueB = false;
+
+  @BeforeGroups(groups = "groupA")
+  public void beforeGroupA() {
+    logs.add("beforeGroupA");
+    valueA = true;
+  }
+
+  @BeforeGroups(groups = "groupB")
+  public void beforeGroupB() {
+    valueB = true;
+    logs.add("beforeGroupB");
+  }
+
+  @BeforeGroups(groups = "groupC")
+  public void beforeGroupC() {
+    logs.add("beforeGroupC No Test exist, should not run.");
+  }
+
+  @Test
+  public void testA() {
+    logs.add("TestA");
+  }
+
+  @Test
+  public void testB() {
+    logs.add("TestB");
+  }
+
+  @Test
+  public void testC() {
+    logs.add("TestC");
+  }
+
+  @Test(groups = "groupA")
+  public void testGroupA1() {
+    logs.add("testGroupA1");
+    assertTrue(valueA, "BeforeGroupA was not executed");
+  }
+
+  @Test(groups = "groupA")
+  public void testGroupA2() {
+    logs.add("testGroupA2");
+    assertTrue(valueA, "BeforeGroupA was not executed");
+  }
+
+  @Test(groups = "groupA")
+  public void testGroupA3() {
+    logs.add("testGroupA3");
+    assertTrue(valueA, "BeforeGroupA was not executed");
+  }
+
+  @Test(groups = "groupB")
+  public void testGroupB() {
+    logs.add("testGroupB");
+    assertTrue(valueB, "BeforeGroupB was not executed");
+  }
+
+  @AfterGroups(groups = "groupA")
+  public void afterGroupA() {
+    logs.add("afterGroupA");
+    valueA = false;
+  }
+
+  @AfterGroups(groups = "groupB")
+  public void afterGroupB() {
+    logs.add("afterGroupB");
+    valueB = false;
+  }
+
+  @AfterClass
+  public void afterClass() {
+    assertFalse(valueA, "AfterGroupsA was not executed");
+    assertFalse(valueB, "AfterGroupsB was not executed");
+  }
+}


### PR DESCRIPTION
Closes #2229

Ensure that BeforeGroups and AfterGroups config
Methods always get invoked irrespective of whether
Group level filtering being done by users.

Fixes #2229  .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
