### PR TITLE
Include all data driven tests for reporting skips

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-2674: Run onTestSkipped for each value from data provider (Krishnan Mahadevan)
 Fixed: GITHUB-2672: Log real stacktrace when test times out. (cdalexndr)
 Fixed: GITHUB-2669: A failed retry with ITestContext will lose the ITestContext. (Nan Liang)
 Fixed: GITHUB-2643: assertEquals(Set,Set) now ignores ordering as it did before. (Elis Edlund)

--- a/testng-core/src/main/java/org/testng/CommandLineArgs.java
+++ b/testng-core/src/main/java/org/testng/CommandLineArgs.java
@@ -242,4 +242,13 @@ public class CommandLineArgs {
       description =
           "Comma separated fully qualified class names of listeners that should be skipped from being wired in via Service Loaders.")
   public Boolean overrideIncludedMethods = false;
+
+  public static final String INCLUDE_ALL_DATA_DRIVEN_TESTS_WHEN_SKIPPING =
+      "-includeAllDataDrivenTestsWhenSkipping";
+
+  @Parameter(
+      names = INCLUDE_ALL_DATA_DRIVEN_TESTS_WHEN_SKIPPING,
+      description =
+          "Should TestNG report all iterations of a data driven test as individual skips, in-case of upstream failures.")
+  public Boolean includeAllDataDrivenTestsWhenSkipping = false;
 }

--- a/testng-core/src/main/java/org/testng/TestNG.java
+++ b/testng-core/src/main/java/org/testng/TestNG.java
@@ -582,6 +582,14 @@ public class TestNG {
     m_selectors.add(selector);
   }
 
+  public void setReportAllDataDrivenTestsAsSkipped(boolean reportAllDataDrivenTestsAsSkipped) {
+    this.m_configuration.setReportAllDataDrivenTestsAsSkipped(reportAllDataDrivenTestsAsSkipped);
+  }
+
+  public boolean getReportAllDataDrivenTestsAsSkipped() {
+    return this.m_configuration.getReportAllDataDrivenTestsAsSkipped();
+  }
+
   /**
    * Set the suites file names to be run by this TestNG object. This method tries to load and parse
    * the specified TestNG suite xml files. If a file is missing, it is ignored.
@@ -1404,6 +1412,7 @@ public class TestNG {
    * @param cla The command line parameters
    */
   protected void configure(CommandLineArgs cla) {
+    setReportAllDataDrivenTestsAsSkipped(cla.includeAllDataDrivenTestsWhenSkipping);
     if (cla.verbose != null) {
       setVerbose(cla.verbose);
     }
@@ -1613,6 +1622,10 @@ public class TestNG {
     result.xmlPathInJar = (String) cmdLineArgs.get(CommandLineArgs.XML_PATH_IN_JAR);
     result.junit = (Boolean) cmdLineArgs.get(CommandLineArgs.JUNIT);
     result.mixed = (Boolean) cmdLineArgs.get(CommandLineArgs.MIXED);
+    Object tmpValue = cmdLineArgs.get(CommandLineArgs.INCLUDE_ALL_DATA_DRIVEN_TESTS_WHEN_SKIPPING);
+    if (tmpValue != null) {
+      result.includeAllDataDrivenTestsWhenSkipping = Boolean.parseBoolean(tmpValue.toString());
+    }
     result.skipFailedInvocationCounts =
         (Boolean) cmdLineArgs.get(CommandLineArgs.SKIP_FAILED_INVOCATION_COUNTS);
     result.failIfAllTestsSkipped =

--- a/testng-core/src/main/java/org/testng/internal/Configuration.java
+++ b/testng-core/src/main/java/org/testng/internal/Configuration.java
@@ -33,6 +33,8 @@ public class Configuration implements IConfiguration {
   private IInjectorFactory injectorFactory = new GuiceBackedInjectorFactory();
   private boolean overrideIncludedMethods = false;
 
+  private boolean includeAllDataDrivenTestsWhenSkipping;
+
   public Configuration() {
     init(new JDK15AnnotationFinder(new DefaultAnnotationTransformer()));
   }
@@ -143,5 +145,15 @@ public class Configuration implements IConfiguration {
   @Override
   public void setOverrideIncludedMethods(boolean overrideIncludedMethods) {
     this.overrideIncludedMethods = overrideIncludedMethods;
+  }
+
+  @Override
+  public void setReportAllDataDrivenTestsAsSkipped(boolean reportAllDataDrivenTestsAsSkipped) {
+    this.includeAllDataDrivenTestsWhenSkipping = reportAllDataDrivenTestsAsSkipped;
+  }
+
+  @Override
+  public boolean getReportAllDataDrivenTestsAsSkipped() {
+    return this.includeAllDataDrivenTestsWhenSkipping;
   }
 }

--- a/testng-core/src/main/java/org/testng/internal/IConfiguration.java
+++ b/testng-core/src/main/java/org/testng/internal/IConfiguration.java
@@ -49,4 +49,10 @@ public interface IConfiguration {
   boolean getOverrideIncludedMethods();
 
   void setOverrideIncludedMethods(boolean overrideIncludedMethods);
+
+  default void setReportAllDataDrivenTestsAsSkipped(boolean reportAllDataDrivenTestsAsSkipped) {}
+
+  default boolean getReportAllDataDrivenTestsAsSkipped() {
+    return false;
+  }
 }

--- a/testng-core/src/test/java/test/skip/ReasonForSkipTest.java
+++ b/testng-core/src/test/java/test/skip/ReasonForSkipTest.java
@@ -5,13 +5,16 @@ import static org.assertj.core.api.Assertions.entry;
 
 import java.util.Arrays;
 import java.util.Map;
+import org.testng.CommandLineArgs;
 import org.testng.ITestResult;
 import org.testng.TestNG;
 import org.testng.annotations.Test;
 import org.testng.collections.Maps;
 import org.testng.xml.XmlSuite;
+import test.InvokedMethodNameListener;
 import test.SimpleBaseTest;
 import test.skip.github1967.TestClassSample;
+import test.skip.issue2674.ConfigAwareTestNG;
 
 public class ReasonForSkipTest extends SimpleBaseTest {
 
@@ -101,6 +104,31 @@ public class ReasonForSkipTest extends SimpleBaseTest {
     expected.put("test2min", ITestResult.SKIP);
     expected.put("setup", ITestResult.FAILURE);
     assertThat(actual).containsAllEntriesOf(expected);
+  }
+
+  @Test(description = "GITHUB-2674")
+  public void ensureUpstreamFailuresTriggerSkipsForAllDataProviderValues() {
+    TestNG testng = create(test.skip.issue2674.TestClassSample.class);
+    testng.setReportAllDataDrivenTestsAsSkipped(true);
+    InvokedMethodNameListener listener = new InvokedMethodNameListener();
+    testng.addListener(listener);
+    testng.run();
+    assertThat(listener.getSkippedMethodNames())
+        .containsExactly("test2(iPhone,13)", "test2(iPhone-Pro,12)");
+  }
+
+  @Test(description = "GITHUB-2674")
+  public void ensureUpstreamFailuresTriggerSkipsForAllDataProviderValuesViaCmdLineArgs() {
+    CommandLineArgs cli = new CommandLineArgs();
+    cli.includeAllDataDrivenTestsWhenSkipping = true;
+    ConfigAwareTestNG testng = new ConfigAwareTestNG();
+    testng.setTestClasses(new Class<?>[] {test.skip.issue2674.TestClassSample.class});
+    testng.configure(cli);
+    InvokedMethodNameListener listener = new InvokedMethodNameListener();
+    testng.addListener(listener);
+    testng.run();
+    assertThat(listener.getSkippedMethodNames())
+        .containsExactly("test2(iPhone,13)", "test2(iPhone-Pro,12)");
   }
 
   private static void runTest(Map<String, String> expected, Class<?>... clazz) {

--- a/testng-core/src/test/java/test/skip/issue2674/ConfigAwareTestNG.java
+++ b/testng-core/src/test/java/test/skip/issue2674/ConfigAwareTestNG.java
@@ -1,0 +1,12 @@
+package test.skip.issue2674;
+
+import org.testng.CommandLineArgs;
+import org.testng.TestNG;
+
+public class ConfigAwareTestNG extends TestNG {
+
+  @Override
+  public void configure(CommandLineArgs cla) {
+    super.configure(cla);
+  }
+}

--- a/testng-core/src/test/java/test/skip/issue2674/TestClassSample.java
+++ b/testng-core/src/test/java/test/skip/issue2674/TestClassSample.java
@@ -1,0 +1,22 @@
+package test.skip.issue2674;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class TestClassSample {
+  @Test
+  void test1() {
+    Assert.fail();
+  }
+
+  @Test(
+      dataProvider = "items",
+      dependsOnMethods = {"test1"})
+  void test2(String model, int variant) {}
+
+  @DataProvider(name = "items")
+  Object[][] items() {
+    return new Object[][] {{"iPhone", 13}, {"iPhone-Pro", 12}};
+  }
+}


### PR DESCRIPTION
Closes #2674

We now have a new configuration parameter named
“-includeAllDataDrivenTestsWhenSkipping” which 
when used would cause a data driven test to report
All its iterations as skipped when there is a failure
in its upstream dependencies.

Fixes #2674  .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`
- [X] Auto applied styling via `./gradlew autostyleApply`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.

**Note:** For more information on contribution guidelines  please make sure you refer our [Contributing](.github/CONTRIBUTING.md) section for detailed set of steps.
