### PR TITLE
Yaml parser: implement loadClasses flag

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,5 @@
 Current
-New: Yaml parser: implement loadClasses flag (Dzmitry Sankouski)
+Fixed: GITHUB-2689: Yaml parser: implement loadClasses flag (Dzmitry Sankouski)
 Fixed: GITHUB-2676: NPE is triggered when working with ITestObjectFactory (Krishnan Mahadevan)
 Fixed: GITHUB-2674: Run onTestSkipped for each value from data provider (Krishnan Mahadevan)
 Fixed: GITHUB-2672: Log real stacktrace when test times out. (cdalexndr)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+New: Yaml parser: implement loadClasses flag (Dzmitry Sankouski)
 Fixed: GITHUB-2676: NPE is triggered when working with ITestObjectFactory (Krishnan Mahadevan)
 Fixed: GITHUB-2674: Run onTestSkipped for each value from data provider (Krishnan Mahadevan)
 Fixed: GITHUB-2672: Log real stacktrace when test times out. (cdalexndr)

--- a/testng-core/src/main/java/org/testng/internal/Yaml.java
+++ b/testng-core/src/main/java/org/testng/internal/Yaml.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import org.testng.TestNGException;
+import org.testng.internal.objects.InstanceCreator;
 import org.testng.util.Strings;
 import org.testng.xml.XmlClass;
 import org.testng.xml.XmlInclude;
@@ -378,13 +379,13 @@ public final class Yaml {
                           nodeTuple ->
                               ((ScalarNode) nodeTuple.getKeyNode()).getValue().equals("name"))
                       .findFirst()
-                      .orElseThrow(RuntimeException::new)
+                      .orElseThrow(() -> new TestNGException("Node 'name' not found"))
                       .getValueNode();
           className = ((ScalarNode) valueNode).getValue();
         } else {
           className = ((ScalarNode) node).getValue();
         }
-        return c.newInstance(className, loadClasses);
+        return InstanceCreator.newInstance(c, className, loadClasses);
       } catch (Exception e) {
         throw new TestNGException("Failed to instantiate class", e);
       }

--- a/testng-core/src/main/java/org/testng/internal/Yaml.java
+++ b/testng-core/src/main/java/org/testng/internal/Yaml.java
@@ -7,6 +7,7 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
+import org.testng.TestNGException;
 import org.testng.util.Strings;
 import org.testng.xml.XmlClass;
 import org.testng.xml.XmlInclude;
@@ -27,7 +28,8 @@ public final class Yaml {
 
   private Yaml() {}
 
-  public static XmlSuite parse(String filePath, InputStream is) throws FileNotFoundException {
+  public static XmlSuite parse(String filePath, InputStream is, boolean loadClasses)
+      throws FileNotFoundException {
     Constructor constructor = new TestNGConstructor(XmlSuite.class);
     {
       TypeDescription suiteDescription = new TypeDescription(XmlSuite.class);
@@ -45,6 +47,9 @@ public final class Yaml {
       testDescription.addPropertyParameters("method-selectors", XmlMethodSelector.class);
       constructor.addTypeDescription(testDescription);
     }
+
+    TypeDescription xmlClassDescription = new XmlClassTypeDescriptor(loadClasses);
+    constructor.addTypeDescription(xmlClassDescription);
 
     org.yaml.snakeyaml.Yaml y = new org.yaml.snakeyaml.Yaml(constructor);
     if (is == null) {
@@ -344,6 +349,44 @@ public final class Yaml {
           return XmlSuite.FailurePolicy.getValidPolicy(failurePolicy);
         }
         return super.construct(node);
+      }
+    }
+  }
+
+  private static class XmlClassTypeDescriptor extends TypeDescription {
+
+    private final boolean loadClasses;
+
+    public XmlClassTypeDescriptor(boolean loadClasses) {
+      super(XmlClass.class);
+      this.loadClasses = loadClasses;
+    }
+
+    @Override
+    public Object newInstance(Node node) {
+      String className;
+
+      try {
+        java.lang.reflect.Constructor<?> c =
+            XmlClass.class.getDeclaredConstructor(String.class, boolean.class);
+        c.setAccessible(true);
+        if (node instanceof MappingNode) {
+          Node valueNode =
+              ((MappingNode) node)
+                  .getValue().stream()
+                      .filter(
+                          nodeTuple ->
+                              ((ScalarNode) nodeTuple.getKeyNode()).getValue().equals("name"))
+                      .findFirst()
+                      .orElseThrow(RuntimeException::new)
+                      .getValueNode();
+          className = ((ScalarNode) valueNode).getValue();
+        } else {
+          className = ((ScalarNode) node).getValue();
+        }
+        return c.newInstance(className, loadClasses);
+      } catch (Exception e) {
+        throw new TestNGException("Failed to instantiate class", e);
       }
     }
   }

--- a/testng-core/src/main/java/org/testng/internal/YamlParser.java
+++ b/testng-core/src/main/java/org/testng/internal/YamlParser.java
@@ -13,7 +13,7 @@ public class YamlParser implements ISuiteParser {
   public XmlSuite parse(String filePath, InputStream is, boolean loadClasses)
       throws TestNGException {
     try {
-      return Yaml.parse(filePath, is);
+      return Yaml.parse(filePath, is, loadClasses);
     } catch (FileNotFoundException e) {
       throw new TestNGException(e);
     }

--- a/testng-core/src/test/java/test/yaml/YamlTest.java
+++ b/testng-core/src/test/java/test/yaml/YamlTest.java
@@ -72,7 +72,7 @@ public class YamlTest extends SimpleBaseTest {
     assertThat(Yaml.toYaml(actualXmlSuite).toString()).isEqualToNormalizingNewlines(expectedYaml);
   }
 
-  @Test
+  @Test(description = "GITHUB-2689")
   public void testLoadClassesFlag() throws IOException {
     YamlParser yamlParser = new YamlParser();
     String yamlSuiteFile = "src/test/resources/yaml/suiteWithNonExistentTest.yaml";

--- a/testng-core/src/test/java/test/yaml/YamlTest.java
+++ b/testng-core/src/test/java/test/yaml/YamlTest.java
@@ -14,6 +14,7 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.testng.internal.Yaml;
+import org.testng.internal.YamlParser;
 import org.testng.reporters.Files;
 import org.testng.xml.SuiteXmlParser;
 import org.testng.xml.XmlSuite;
@@ -21,6 +22,7 @@ import org.testng.xml.internal.Parser;
 import test.SimpleBaseTest;
 
 public class YamlTest extends SimpleBaseTest {
+  public static final String CLASS_NOT_FOUND_MESSAGE = "Cannot find class in classpath";
 
   @DataProvider
   public Object[][] dp() {
@@ -68,5 +70,27 @@ public class YamlTest extends SimpleBaseTest {
         new String(
             java.nio.file.Files.readAllBytes(Paths.get(expectedYamlFile)), StandardCharsets.UTF_8);
     assertThat(Yaml.toYaml(actualXmlSuite).toString()).isEqualToNormalizingNewlines(expectedYaml);
+  }
+
+  @Test
+  public void testLoadClassesFlag() throws IOException {
+    YamlParser yamlParser = new YamlParser();
+    String yamlSuiteFile = "src/test/resources/yaml/suiteWithNonExistentTest.yaml";
+
+    try {
+      yamlParser.parse(yamlSuiteFile, new FileInputStream(yamlSuiteFile), false);
+    } catch (Throwable throwable) {
+      Throwable rootCause = getRootCause(throwable);
+      String rootCauseMessage = rootCause.getMessage();
+      if (rootCauseMessage.contains(CLASS_NOT_FOUND_MESSAGE)) {
+        throw new AssertionError("TestNG shouldn't attempt to load test class", throwable);
+      }
+
+      throw new AssertionError("Yaml parser failed to parse suite", throwable);
+    }
+  }
+
+  private Throwable getRootCause(Throwable throwable) {
+    return throwable.getCause() != null ? getRootCause(throwable.getCause()) : throwable;
   }
 }

--- a/testng-core/src/test/resources/yaml/suiteWithNonExistentTest.yaml
+++ b/testng-core/src/test/resources/yaml/suiteWithNonExistentTest.yaml
@@ -1,0 +1,5 @@
+name: My_Suite
+tests:
+  - name: My_test
+    classes:
+      - this.class.does.not.Exists


### PR DESCRIPTION
Parser loadClasses flag controls, whether test classes will be loaded during
suite parsing. Setting it to false allow to load yaml suite with non-existent
classes, whereas true will fail parsing on test class loading.

### Did you remember to?

- [x] Add test case(s)
- [x] Update `CHANGES.txt`
- [x] Auto applied styling via `./gradlew autostyleApply`

* Add new features to TestNG