### PR TITLE
Streamline Inheritance + dependsOnMethods

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-2658: Inheritance + dependsOnMethods (Krishnan Mahadevan)
 Fixed: GITHUB-2664: Order for DependsOnGroups has changed after TestNg 7.4.0 (Krishnan Mahadevan)
 Fixed: GITHUB-2501: TestNG 7.4.0 throws an exception "sun.net.www.protocol.file.FileURLConnection cannot be cast to java.net.HttpURLConnection" when xml file contain "ENTITY SYSTEM" grammer (Krishnan Mahadevan)
 Fixed: GITHUB-2693: TestNG ignores 'dataproviderthreadcount' CLA (Krishnan Mahadevan)

--- a/testng-core/src/main/java/org/testng/internal/invokers/TestInvoker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/TestInvoker.java
@@ -8,6 +8,7 @@ import static org.testng.internal.invokers.ParameterHandler.*;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -344,7 +345,13 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
       ITestNGMethod[] methods = MethodHelper.findDependedUponMethods(testMethod, allTestMethods);
 
       if (failuresPresentInUpstreamDependency(testMethod, methods)) {
-        return "Method " + testMethod + " depends on not successfully finished methods";
+        String methodsInfo =
+            Arrays.stream(methods)
+                .map(tm -> tm.getQualifiedName() + "() on instance " + tm.getInstance().toString())
+                .collect(Collectors.joining("\n"));
+        return String.format(
+            "Method %s() on instance %s depends on not successfully finished methods \n[%s]",
+            testMethod.getQualifiedName(), testMethod.getInstance().toString(), methodsInfo);
       }
     }
 
@@ -437,11 +444,19 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
         .parallelStream()
         .filter(
             r -> {
-              // Keep this instance if 1) It's on a different class or 2) It's on the same class
-              // and on the same instance
               Object instance =
-                  r.getInstance() != null ? r.getInstance() : r.getMethod().getInstance();
-              return r.getTestClass() != method.getTestClass() || instance == method.getInstance();
+                  Optional.ofNullable(r.getInstance()).orElse(r.getMethod().getInstance());
+              if (method.getGroupsDependedUpon().length == 0) {
+                // Consider equality of objects alone if we are NOT dealing with group dependency.
+                return instance == method.getInstance();
+              }
+              // Keep this instance if
+              // 1) It's on a different class or
+              // 2) It's on the same class and on the same instance
+              boolean unEqualTestClasses =
+                  !r.getTestClass().getRealClass().equals(method.getTestClass().getRealClass());
+              boolean sameInstance = instance == method.getInstance();
+              return sameInstance || unEqualTestClasses;
             })
         .collect(Collectors.toSet());
   }

--- a/testng-core/src/test/java/test/dependent/issue2658/BaseClassSample.java
+++ b/testng-core/src/test/java/test/dependent/issue2658/BaseClassSample.java
@@ -1,0 +1,12 @@
+package test.dependent.issue2658;
+
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.Test;
+
+public class BaseClassSample {
+  @Test
+  public void test() {
+    assertEquals(getClass(), PassingClassSample.class);
+  }
+}

--- a/testng-core/src/test/java/test/dependent/issue2658/FailingClassSample.java
+++ b/testng-core/src/test/java/test/dependent/issue2658/FailingClassSample.java
@@ -1,0 +1,8 @@
+package test.dependent.issue2658;
+
+import org.testng.annotations.Test;
+
+public class FailingClassSample extends BaseClassSample {
+  @Test(dependsOnMethods = "test")
+  void failingMethod() {}
+}

--- a/testng-core/src/test/java/test/dependent/issue2658/PassingClassSample.java
+++ b/testng-core/src/test/java/test/dependent/issue2658/PassingClassSample.java
@@ -1,0 +1,8 @@
+package test.dependent.issue2658;
+
+import org.testng.annotations.Test;
+
+public class PassingClassSample extends BaseClassSample {
+  @Test(dependsOnMethods = "test")
+  public void passingMethod() {}
+}


### PR DESCRIPTION
Closes #2658

Refactored logic to group test results based on 
Instances depending upon whether 

1. Test has group dependency (or)
2. Test has method dependency

Also refactored the tests to move away from different
Base class flavours into converging on SimpleBaseTest

Fixes #2658  .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`
- [X] Auto applied styling via `./gradlew autostyleApply`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.

**Note:** For more information on contribution guidelines  please make sure you refer our [Contributing](.github/CONTRIBUTING.md) section for detailed set of steps.
