### PR TITLE
IHookable and IConfigurable callback discrepancy

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 Current
 7.6.0
 Fixed: GITHUB-2709: Testnames not working together with suites in suite (Martin Aldrin)
+Fixed: GITHUB-2704: IHookable and IConfigurable callback discrepancy (Krishnan Mahadevan)
 Fixed: GITHUB-2637: Upgrade to JDK11 as the minimum JDK requirements(Krishnan Mahadevan)
 
 7.5

--- a/testng-core-api/src/main/java/org/testng/ConfigurationNotInvokedException.java
+++ b/testng-core-api/src/main/java/org/testng/ConfigurationNotInvokedException.java
@@ -1,0 +1,25 @@
+package org.testng;
+
+/**
+ * Represents an exception that is thrown when a configuration method is not invoked. One of the
+ * use-cases when this can happen is when the user does the following:
+ *
+ * <ul>
+ *   <li>User defines a configuration method
+ *   <li>The class that houses the configuration method defines support for callbacks via {@link
+ *       IConfigurable} implementation
+ *   <li>User willfully skips invoking the callback and also fails at altering the configuration
+ *       method's status via {@link ITestResult#setStatus(int)}
+ * </ul>
+ */
+public class ConfigurationNotInvokedException extends TestNGException {
+
+  public ConfigurationNotInvokedException(ITestNGMethod tm) {
+    super(
+        tm.getQualifiedName()
+            + " defines a callback via "
+            + IConfigurable.class.getName()
+            + " but neither the callback was invoked nor the status was altered to "
+            + String.join("|", ITestResult.finalStatuses()));
+  }
+}

--- a/testng-core-api/src/main/java/org/testng/ITestResult.java
+++ b/testng-core-api/src/main/java/org/testng/ITestResult.java
@@ -1,5 +1,6 @@
 package org.testng;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.testng.internal.thread.ThreadTimeoutException;
@@ -113,6 +114,27 @@ public interface ITestResult extends IAttributes, Comparable<ITestResult> {
    *     specific test method's result.
    */
   String id();
+
+  /**
+   * @return - <code>true</code> if the current test result is either {@link ITestResult#STARTED} or
+   *     {@link ITestResult#CREATED}
+   */
+  default boolean isNotRunning() {
+    return getStatus() == STARTED || getStatus() == CREATED;
+  }
+
+  /**
+   * @return - A list of all user facing statuses viz.,
+   *     <ul>
+   *       <li>{@link ITestResult#SUCCESS}
+   *       <li>{@link ITestResult#SUCCESS_PERCENTAGE_FAILURE}
+   *       <li>{@link ITestResult#FAILURE}
+   *       <li>{@link ITestResult#SKIP}
+   *     </ul>
+   */
+  static List<String> finalStatuses() {
+    return Arrays.asList("SUCCESS", "FAILURE", "SKIP", "SUCCESS_PERCENTAGE_FAILURE");
+  }
 
   /**
    * @param result - The test result of a method

--- a/testng-core-api/src/main/java/org/testng/TestNotInvokedException.java
+++ b/testng-core-api/src/main/java/org/testng/TestNotInvokedException.java
@@ -1,0 +1,24 @@
+package org.testng;
+
+/**
+ * Represents an exception that is thrown when a test method is not invoked. One of the use-cases
+ * when this can happen is when the user does the following:
+ *
+ * <ul>
+ *   <li>User defines a test method
+ *   <li>The class that houses the test method defines support for callbacks via {@link IHookable}
+ *       implementation
+ *   <li>User willfully skips invoking the callback and also fails at altering the test method's
+ *       status via {@link ITestResult#setStatus(int)}
+ * </ul>
+ */
+public class TestNotInvokedException extends TestNGException {
+  public TestNotInvokedException(ITestNGMethod tm) {
+    super(
+        tm.getQualifiedName()
+            + " defines a callback via "
+            + IHookable.class.getName()
+            + " but neither the callback was invoked nor the status was altered to "
+            + String.join("|", ITestResult.finalStatuses()));
+  }
+}

--- a/testng-core/src/main/java/org/testng/internal/MethodHelper.java
+++ b/testng-core/src/main/java/org/testng/internal/MethodHelper.java
@@ -484,11 +484,8 @@ public class MethodHelper {
       String thisMethodName = thisMethod.getName();
       String methodName = usePackage ? calculateMethodCanonicalName(method) : thisMethodName;
       Pair<String, String> cacheKey = Pair.create(regexp, methodName);
-      Boolean match = MATCH_CACHE.get(cacheKey);
-      if (match == null) {
-        match = pattern.matcher(methodName).matches();
-        MATCH_CACHE.put(cacheKey, match);
-      }
+      boolean match =
+          MATCH_CACHE.computeIfAbsent(cacheKey, key -> pattern.matcher(methodName).matches());
       if (match) {
         results.matchedMethods.add(method);
         results.foundAtLeastAMethod = true;

--- a/testng-core/src/main/java/org/testng/internal/invokers/ConfigInvoker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/ConfigInvoker.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import org.testng.ConfigurationNotInvokedException;
 import org.testng.IClass;
 import org.testng.IConfigurable;
 import org.testng.IInvokedMethodListener;
@@ -374,15 +375,24 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
         testResult.setStatus(ITestResult.SUCCESS);
         return;
       }
-      if (configurableInstance != null) {
-        MethodInvocationHelper.invokeConfigurable(
-            targetInstance, params, configurableInstance, method.getMethod(), testResult);
+      boolean willfullyIgnored = false;
+      boolean usesConfigurableInstance = configurableInstance != null;
+      if (usesConfigurableInstance) {
+        willfullyIgnored =
+            !MethodInvocationHelper.invokeConfigurable(
+                targetInstance, params, configurableInstance, method.getMethod(), testResult);
       } else {
         MethodInvocationHelper.invokeMethodConsideringTimeout(
             tm, method, targetInstance, params, testResult);
       }
+      boolean testStatusRemainedUnchanged = testResult.isNotRunning();
+      if (usesConfigurableInstance && willfullyIgnored && testStatusRemainedUnchanged) {
+        throw new ConfigurationNotInvokedException(tm);
+      }
       testResult.setStatus(ITestResult.SUCCESS);
-    } catch (InvocationTargetException | IllegalAccessException ex) {
+    } catch (ConfigurationNotInvokedException
+        | InvocationTargetException
+        | IllegalAccessException ex) {
       throwConfigurationFailure(testResult, ex);
       testResult.setStatus(ITestResult.FAILURE);
       throw ex;

--- a/testng-core/src/test/java/test/hook/samples/ConfigurableFailureWithStatusAlteredSample.java
+++ b/testng-core/src/test/java/test/hook/samples/ConfigurableFailureWithStatusAlteredSample.java
@@ -1,0 +1,20 @@
+package test.hook.samples;
+
+import static test.hook.HookableTest.HOOK_INVOKED_ATTRIBUTE;
+
+import org.testng.IConfigureCallBack;
+import org.testng.ITestResult;
+import org.testng.annotations.Test;
+
+public class ConfigurableFailureWithStatusAlteredSample extends BaseConfigurableSample {
+
+  @Override
+  public void run(IConfigureCallBack callBack, ITestResult testResult) {
+    testResult.setAttribute(HOOK_INVOKED_ATTRIBUTE, "true");
+    // Not calling the callback
+    testResult.setStatus(ITestResult.SUCCESS);
+  }
+
+  @Test
+  public void hookWasNotRun() {}
+}

--- a/testng-core/src/test/java/test/hook/samples/HookFailureWithStatusAlteredSample.java
+++ b/testng-core/src/test/java/test/hook/samples/HookFailureWithStatusAlteredSample.java
@@ -2,26 +2,24 @@ package test.hook.samples;
 
 import static test.hook.HookableTest.HOOK_INVOKED_ATTRIBUTE;
 import static test.hook.HookableTest.HOOK_METHOD_INVOKED_ATTRIBUTE;
-import static test.hook.HookableTest.HOOK_METHOD_PARAMS_ATTRIBUTE;
 
-import java.util.UUID;
 import org.testng.IHookCallBack;
 import org.testng.IHookable;
 import org.testng.ITestResult;
 import org.testng.Reporter;
 import org.testng.annotations.Test;
 
-public class HookSuccessTimeoutSample implements IHookable {
+public class HookFailureWithStatusAlteredSample implements IHookable {
 
   @Override
   public void run(IHookCallBack callBack, ITestResult testResult) {
     testResult.setAttribute(HOOK_INVOKED_ATTRIBUTE, "true");
-    testResult.setAttribute(HOOK_METHOD_PARAMS_ATTRIBUTE, callBack.getParameters());
-    callBack.runTestMethod(testResult);
+    // Not invoking the callback:  the method should not be run
+    testResult.setStatus(ITestResult.SUCCESS);
   }
 
-  @Test(timeOut = 100)
+  @Test
   public void verify() {
-    Reporter.getCurrentTestResult().setAttribute(HOOK_METHOD_INVOKED_ATTRIBUTE, UUID.randomUUID());
+    Reporter.getCurrentTestResult().setAttribute(HOOK_METHOD_INVOKED_ATTRIBUTE, "true");
   }
 }

--- a/testng-core/src/test/java/test/hook/samples/HookSuccessTimeoutWithDataProviderSample.java
+++ b/testng-core/src/test/java/test/hook/samples/HookSuccessTimeoutWithDataProviderSample.java
@@ -1,17 +1,16 @@
 package test.hook.samples;
 
-import static test.hook.HookableTest.HOOK_INVOKED_ATTRIBUTE;
-import static test.hook.HookableTest.HOOK_METHOD_INVOKED_ATTRIBUTE;
-import static test.hook.HookableTest.HOOK_METHOD_PARAMS_ATTRIBUTE;
+import static test.hook.HookableTest.*;
 
 import java.util.UUID;
 import org.testng.IHookCallBack;
 import org.testng.IHookable;
 import org.testng.ITestResult;
 import org.testng.Reporter;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-public class HookSuccessTimeoutSample implements IHookable {
+public class HookSuccessTimeoutWithDataProviderSample implements IHookable {
 
   @Override
   public void run(IHookCallBack callBack, ITestResult testResult) {
@@ -20,8 +19,13 @@ public class HookSuccessTimeoutSample implements IHookable {
     callBack.runTestMethod(testResult);
   }
 
-  @Test(timeOut = 100)
-  public void verify() {
-    Reporter.getCurrentTestResult().setAttribute(HOOK_METHOD_INVOKED_ATTRIBUTE, UUID.randomUUID());
+  @DataProvider
+  public Object[][] dp() {
+    return new Object[][] {new Object[] {UUID.randomUUID()}};
+  }
+
+  @Test(dataProvider = "dp", timeOut = 100)
+  public void verify(UUID uuid) {
+    Reporter.getCurrentTestResult().setAttribute(HOOK_METHOD_INVOKED_ATTRIBUTE, uuid);
   }
 }


### PR DESCRIPTION
Closes #2704

Ensure that TestNG reports scenarios wherein 
User defines callbacks for configurations/test methods
But fails to invoke those callbacks explicitly 
And also fails in changing test status to a user
recognized status (PASS|FAILURE|SKIP)

Fixes #2704  .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`
- [X] Auto applied styling via `./gradlew autostyleApply`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.

**Note:** For more information on contribution guidelines  please make sure you refer our [Contributing](.github/CONTRIBUTING.md) section for detailed set of steps.
