### PR TITLE
configfailurepolicy=continue only works for BeforeTest when using TestNG XML file

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 Current
 7.6.0
+Fixed: GITHUB-2731: configfailurepolicy=continue only works for BeforeTest when using TestNG XML file (Nan Liang)
 Fixed: GITHUB-2729: beforeConfiguration() listener method should be invoked for skipped configurations as well(Nan Liang)
 Fixed: assertEqualsNoOrder for Collection and Iterators size check was missing (Adam Kaczmarek)
 Fixed: GITHUB-2709: Testnames not working together with suites in suite (Martin Aldrin)

--- a/testng-core/src/main/java/org/testng/internal/invokers/ConfigInvoker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/ConfigInvoker.java
@@ -274,7 +274,8 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
                 tm.getGroups(),
                 arguments.getTestClass(),
                 arguments.getInstance())
-            && !alwaysRun) {
+            && !alwaysRun
+            && !m_continueOnFailedConfiguration) {
           log(3, "Skipping " + Utils.detailedMethodName(tm, true));
           InvokedMethod invokedMethod = new InvokedMethod(System.currentTimeMillis(), testResult);
           runConfigurationListeners(testResult, arguments.getTestMethod(), true /* before */);

--- a/testng-core/src/main/java/org/testng/internal/invokers/TestInvoker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/TestInvoker.java
@@ -597,7 +597,8 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
             arguments.getTestMethod(),
             arguments.getTestMethod().getGroups(),
             arguments.getTestClass(),
-            arguments.getInstance())) {
+            arguments.getInstance())
+        && suite.getConfigFailurePolicy() == XmlSuite.FailurePolicy.SKIP) {
       Throwable exception =
           ExceptionUtils.getExceptionDetails(m_testContext, arguments.getInstance());
       ITestResult result =

--- a/testng-core/src/test/java/test/configurationfailurepolicy/issue2731/ConfigFailTestSample.java
+++ b/testng-core/src/test/java/test/configurationfailurepolicy/issue2731/ConfigFailTestSample.java
@@ -1,0 +1,33 @@
+package test.configurationfailurepolicy.issue2731;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+public class ConfigFailTestSample {
+  @BeforeSuite
+  public void beforeSuite() {
+    Assert.fail("This before suite is fail");
+  }
+
+  @BeforeTest
+  public void beforeTest() {
+    Assert.fail("This before test is fail");
+  }
+
+  @BeforeClass
+  public void beforeClass() {
+    Assert.fail("This before class is fail");
+  }
+
+  @BeforeMethod
+  public void beforeMethod() {
+    Assert.fail("This before method is fail");
+  }
+
+  @Test
+  public void test() {}
+}

--- a/testng-core/src/test/java/test/listeners/github1602/IssueTest.java
+++ b/testng-core/src/test/java/test/listeners/github1602/IssueTest.java
@@ -38,16 +38,24 @@ public class IssueTest extends SimpleBaseTest {
         Arrays.asList(
             "BeforeInvocation_beforeMethod_STARTED",
             "AfterInvocation_beforeMethod_FAILURE",
+            "BeforeInvocation_testMethod_STARTED",
+            "AfterInvocation_testMethod_SUCCESS",
+            "BeforeInvocation_afterMethod_STARTED");
+    List<String> commonSkipList =
+        Arrays.asList(
+            "BeforeInvocation_beforeMethod_STARTED",
+            "AfterInvocation_beforeMethod_FAILURE",
             "BeforeInvocation_testMethod_SKIP",
             "AfterInvocation_testMethod_SKIP",
-            "BeforeInvocation_afterMethod_STARTED");
+            "BeforeInvocation_afterMethod_STARTED",
+            "AfterInvocation_afterMethod_SKIP");
     List<String> skipList = Lists.newArrayList(baseList);
     skipList.add("AfterInvocation_afterMethod_SKIP");
     List<String> failList = Lists.newArrayList(baseList);
     failList.add("AfterInvocation_afterMethod_FAILURE");
     return new Object[][] {
       {TestClassWithPassingConfigsSample.class, XmlSuite.FailurePolicy.SKIP, passList},
-      {TestClassWithFailingConfigsSample.class, XmlSuite.FailurePolicy.SKIP, skipList},
+      {TestClassWithFailingConfigsSample.class, XmlSuite.FailurePolicy.SKIP, commonSkipList},
       {TestClassWithPassingConfigsSample.class, XmlSuite.FailurePolicy.CONTINUE, passList},
       {TestClassWithFailingConfigsSample.class, XmlSuite.FailurePolicy.CONTINUE, failList}
     };

--- a/testng-core/src/test/java/test/listeners/issue1777/IssueTest.java
+++ b/testng-core/src/test/java/test/listeners/issue1777/IssueTest.java
@@ -28,7 +28,7 @@ public class IssueTest extends SimpleBaseTest {
             "before_test_method: test1",
             "after_test_method: test1",
             "after_test_method: test1",
-            "testSkipped_test_method: test1",
+            "testSuccess_test_method: test1",
             "testStart_test_method: test2",
             "before_test_method: test2",
             "before_test_method: test2",

--- a/testng-core/src/test/resources/testng.xml
+++ b/testng-core/src/test/resources/testng.xml
@@ -784,6 +784,7 @@
   <test name="ConfigFailurePolicy">
     <classes>
       <class name="test.configurationfailurepolicy.FailurePolicyTest" />
+      <class name="test.configurationfailurepolicy.FailureContinuePolicyTest"></class>
     </classes>
   </test>
 


### PR DESCRIPTION
configfailurepolicy=continue only works for BeforeTest when using TestNG XML file

Fixes #2731

### Did you remember to?

- [x] Add test case(s)
- [x] Update `CHANGES.txt`
- [x] Auto applied styling via `./gradlew autostyleApply`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.

**Note:** For more information on contribution guidelines  please make sure you refer our [Contributing](.github/CONTRIBUTING.md) section for detailed set of steps.
