### PR TITLE
DataProvider: possibility to unload dataprovider class, when done with it

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 Current
 7.6.0
+New: GITHUB-2724: DataProvider: possibility to unload dataprovider class, when done with it (Dzmitry Sankouski)
 Fixed: GITHUB-217: Configure TestNG to fail when there's a failure in data provider (Krishnan Mahadevan)
 Fixed: GITHUB-2743: SuiteRunner could not be initial by default Configuration (Nan Liang)
 Fixed: GITHUB-2729: beforeConfiguration() listener method should be invoked for skipped configurations as well(Nan Liang)

--- a/testng-core-api/src/main/java/org/testng/annotations/ITestAnnotation.java
+++ b/testng-core-api/src/main/java/org/testng/annotations/ITestAnnotation.java
@@ -72,6 +72,10 @@ public interface ITestAnnotation extends ITestOrConfiguration, IDataProvidable {
 
   void setDataProviderClass(Class<?> v);
 
+  String getDataProviderDynamicClass();
+
+  void setDataProviderDynamicClass(String v);
+
   void setRetryAnalyzer(Class<? extends IRetryAnalyzer> c);
 
   Class<? extends IRetryAnalyzer> getRetryAnalyzerClass();

--- a/testng-core-api/src/main/java/org/testng/annotations/Test.java
+++ b/testng-core-api/src/main/java/org/testng/annotations/Test.java
@@ -104,6 +104,8 @@ public @interface Test {
    */
   Class<?> dataProviderClass() default Object.class;
 
+  String dataProviderDynamicClass() default "";
+
   /**
    * If set to true, this test method will always be run even if it depends on a method that failed.
    * This attribute will be ignored if this test doesn't depend on any method or group.

--- a/testng-core-api/src/main/java/org/testng/internal/annotations/IDataProvidable.java
+++ b/testng-core-api/src/main/java/org/testng/internal/annotations/IDataProvidable.java
@@ -9,4 +9,8 @@ public interface IDataProvidable {
   Class<?> getDataProviderClass();
 
   void setDataProviderClass(Class<?> v);
+
+  String getDataProviderDynamicClass();
+
+  void setDataProviderDynamicClass(String v);
 }

--- a/testng-core/src/main/java/org/testng/internal/DataProviderLoader.java
+++ b/testng-core/src/main/java/org/testng/internal/DataProviderLoader.java
@@ -1,0 +1,43 @@
+package org.testng.internal;
+
+import java.io.IOException;
+import java.io.InputStream;
+import org.testng.log4testng.Logger;
+
+public class DataProviderLoader extends ClassLoader {
+  private static final int BUFFER_SIZE = 1 << 20;
+  private static final Logger log = Logger.getLogger(DataProviderLoader.class);
+
+  public Class loadClazz(String path) throws ClassNotFoundException {
+    Class clazz = findLoadedClass(path);
+    if (clazz == null) {
+      byte[] bt = loadClassData(path);
+      clazz = defineClass(path, bt, 0, bt.length);
+    }
+
+    return clazz;
+  }
+
+  private byte[] loadClassData(String className) throws ClassNotFoundException {
+    InputStream in =
+        this.getClass()
+            .getClassLoader()
+            .getResourceAsStream(className.replace(".", "/") + ".class");
+    if (in == null) {
+      throw new ClassNotFoundException("Cannot load resource input stream: " + className);
+    }
+
+    byte[] classBytes;
+    try {
+      classBytes = in.readAllBytes();
+    } catch (IOException e) {
+      throw new ClassNotFoundException("ERROR reading class file" + e);
+    }
+
+    if (classBytes == null) {
+      throw new ClassNotFoundException("Cannot load class: " + className);
+    }
+
+    return classBytes;
+  }
+}

--- a/testng-core/src/main/java/org/testng/internal/DataProviderMethod.java
+++ b/testng-core/src/main/java/org/testng/internal/DataProviderMethod.java
@@ -8,8 +8,8 @@ import org.testng.annotations.IDataProviderAnnotation;
 /** Represents an @{@link org.testng.annotations.DataProvider} annotated method. */
 class DataProviderMethod implements IDataProviderMethod {
 
-  private final Object instance;
-  private final Method method;
+  protected Object instance;
+  protected Method method;
   private final IDataProviderAnnotation annotation;
 
   DataProviderMethod(Object instance, Method method, IDataProviderAnnotation annotation) {

--- a/testng-core/src/main/java/org/testng/internal/DataProviderMethodRemovable.java
+++ b/testng-core/src/main/java/org/testng/internal/DataProviderMethodRemovable.java
@@ -1,0 +1,20 @@
+package org.testng.internal;
+
+import java.lang.reflect.Method;
+import org.testng.annotations.IDataProviderAnnotation;
+
+/** Represents an @{@link org.testng.annotations.DataProvider} annotated method. */
+class DataProviderMethodRemovable extends DataProviderMethod {
+
+  DataProviderMethodRemovable(Object instance, Method method, IDataProviderAnnotation annotation) {
+    super(instance, method, annotation);
+  }
+
+  public void setInstance(Object instance) {
+    this.instance = instance;
+  }
+
+  public void setMethod(Method method) {
+    this.method = method;
+  }
+}

--- a/testng-core/src/main/java/org/testng/internal/annotations/FactoryAnnotation.java
+++ b/testng-core/src/main/java/org/testng/internal/annotations/FactoryAnnotation.java
@@ -8,6 +8,7 @@ public class FactoryAnnotation extends BaseAnnotation implements IFactoryAnnotat
 
   private String m_dataProvider = null;
   private Class<?> m_dataProviderClass;
+  private String m_dataProviderDynamicClass;
   private boolean m_enabled = true;
   private List<Integer> m_indices;
 
@@ -28,6 +29,16 @@ public class FactoryAnnotation extends BaseAnnotation implements IFactoryAnnotat
   @Override
   public Class<?> getDataProviderClass() {
     return m_dataProviderClass;
+  }
+
+  @Override
+  public String getDataProviderDynamicClass() {
+    return m_dataProviderDynamicClass;
+  }
+
+  @Override
+  public void setDataProviderDynamicClass(String v) {
+    m_dataProviderDynamicClass = v;
   }
 
   @Override

--- a/testng-core/src/main/java/org/testng/internal/annotations/JDK15AnnotationFinder.java
+++ b/testng-core/src/main/java/org/testng/internal/annotations/JDK15AnnotationFinder.java
@@ -48,7 +48,7 @@ public class JDK15AnnotationFinder implements IAnnotationFinder {
   private final JDK15TagFactory m_tagFactory = new JDK15TagFactory();
   private final Map<Class<? extends IAnnotation>, Class<? extends Annotation>> m_annotationMap =
       new ConcurrentHashMap<>();
-  private final Map<Pair<Annotation, ?>, IAnnotation> m_annotations = new ConcurrentHashMap<>();
+  private final Map<String, IAnnotation> m_annotations = new ConcurrentHashMap<>();
 
   private final IAnnotationTransformer m_transformer;
 
@@ -273,7 +273,7 @@ public class JDK15AnnotationFinder implements IAnnotationFinder {
 
     IAnnotation result =
         m_annotations.computeIfAbsent(
-            p,
+            p.toString(),
             key -> {
               IAnnotation obj = m_tagFactory.createTag(cls, testMethod, a, annotationClass);
               transform(obj, testClass, testConstructor, testMethod, whichClass);

--- a/testng-core/src/main/java/org/testng/internal/annotations/JDK15TagFactory.java
+++ b/testng-core/src/main/java/org/testng/internal/annotations/JDK15TagFactory.java
@@ -484,6 +484,7 @@ public class JDK15TagFactory {
     result.setDataProviderClass(
         findInherited(
             test.dataProviderClass(), cls, Test.class, "dataProviderClass", DEFAULT_CLASS));
+    result.setDataProviderDynamicClass(test.dataProviderDynamicClass());
     result.setAlwaysRun(test.alwaysRun());
     result.setDescription(
         findInherited(test.description(), cls, Test.class, "description", DEFAULT_STRING));

--- a/testng-core/src/main/java/org/testng/internal/annotations/TestAnnotation.java
+++ b/testng-core/src/main/java/org/testng/internal/annotations/TestAnnotation.java
@@ -19,6 +19,7 @@ public class TestAnnotation extends TestOrConfiguration implements ITestAnnotati
   private String m_testName = "";
   private boolean m_singleThreaded = false;
   private Class<?> m_dataProviderClass = null;
+  private String m_dataProviderDynamicClass = null;
   private Class<? extends IRetryAnalyzer> m_retryAnalyzerClass = null;
   private boolean m_skipFailedInvocations = false;
   private boolean m_ignoreMissingDependencies = false;
@@ -64,6 +65,16 @@ public class TestAnnotation extends TestOrConfiguration implements ITestAnnotati
   @Override
   public void setDataProviderClass(Class<?> dataProviderClass) {
     m_dataProviderClass = dataProviderClass;
+  }
+
+  @Override
+  public String getDataProviderDynamicClass() {
+    return m_dataProviderDynamicClass;
+  }
+
+  @Override
+  public void setDataProviderDynamicClass(String v) {
+    m_dataProviderDynamicClass = v;
   }
 
   @Override

--- a/testng-core/src/test/kotlin/org/testng/dataprovider/DynamicDataProviderLoadingTest.kt
+++ b/testng-core/src/test/kotlin/org/testng/dataprovider/DynamicDataProviderLoadingTest.kt
@@ -1,0 +1,126 @@
+package org.testng.dataprovider
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.SoftAssertions
+import org.netbeans.lib.profiler.heap.HeapFactory2
+import org.netbeans.lib.profiler.heap.Instance
+import org.netbeans.lib.profiler.heap.JavaClass
+import org.testng.Reporter
+import org.testng.annotations.Test
+import org.testng.dataprovider.sample.issue2724.*
+import test.SimpleBaseTest
+import java.io.File
+import java.nio.file.Files
+
+const val CLASS_NAME_DP = "org.testng.dataprovider.sample.issue2724.DataProviders"
+const val CLASS_NAME_DP_LOADER = "org.testng.internal.DataProviderLoader"
+
+class DynamicDataProviderLoadingTest : SimpleBaseTest() {
+
+    @Test
+    fun testDynamicDataProviderPasses() {
+        val listener = run(SampleDynamicDP::class.java)
+        assertThat(listener.failedMethodNames).isEmpty()
+        assertThat(listener.succeedMethodNames).containsExactly(
+            "testDynamicDataProvider(Mike,34,student)",
+            "testDynamicDataProvider(Mike,23,driver)",
+            "testDynamicDataProvider(Paul,20,director)",
+        )
+        assertThat(listener.skippedMethodNames).isEmpty()
+    }
+
+    @Test
+    fun testDynamicDataProviderUnloaded() {
+        val tempDirectory = Files.createTempDirectory("temp-testng-")
+        val dumpPath = "%s/%s".format(tempDirectory.toAbsolutePath().toString(), "dump.hprof")
+        val dumpPathBeforeSample =
+            "%s/%s".format(tempDirectory.toAbsolutePath().toString(), "dump-before-sample.hprof")
+        System.setProperty("memdump.path", dumpPath)
+
+        saveMemDump(dumpPathBeforeSample)
+        val heapDumpBeforeSampleFile = File(dumpPathBeforeSample)
+        assertThat(heapDumpBeforeSampleFile).exists()
+        var heap = HeapFactory2.createHeap(heapDumpBeforeSampleFile, null)
+        val beforeSampleDPClassDump: JavaClass? = heap.getJavaClassByName(CLASS_NAME_DP)
+        assertThat(beforeSampleDPClassDump)
+            .describedAs(
+                "Class $CLASS_NAME_DP shouldn't be loaded, before test sample started. "
+            )
+            .isNull()
+
+        run(SampleDPUnloaded::class.java)
+
+        val heapDumpFile = File(dumpPath)
+        assertThat(heapDumpFile).exists()
+        heap = HeapFactory2.createHeap(heapDumpFile, null)
+
+        with(SoftAssertions()) {
+            val dpLoaderClassDump: JavaClass? = heap.getJavaClassByName(CLASS_NAME_DP_LOADER)
+            val dpClassDump: JavaClass? = heap.getJavaClassByName(CLASS_NAME_DP)
+            val dpLoaderMessage = dpLoaderClassDump?.instances?.joinToString("\n") {
+                getGCPath(it)
+            }
+            val dpMessage = dpLoaderClassDump?.instances?.joinToString("\n") {
+                getGCPath(it)
+            }
+
+            this.assertThat(dpLoaderClassDump?.instances)
+                .describedAs(
+                    """
+                    All instances of class $CLASS_NAME_DP_LOADER should be garbage collected, but was not.
+                    Path to GC root is:
+                    $dpLoaderMessage
+                    """.trimIndent()
+                )
+                .isEmpty()
+            this.assertThat(dpClassDump)
+                .describedAs(
+                    """
+                    Class $CLASS_NAME_DP shouldn't be loaded, but it was.
+                    Path to GC root is:
+                    $dpMessage
+                    """.trimIndent()
+                )
+                .isNull()
+            this.assertAll()
+        }
+    }
+
+    @Test
+    fun comparePerformanceAgainstCsvFiles() {
+        val simpleDPSuite = create().apply {
+            setTestClasses(arrayOf(SampleSimpleDP::class.java))
+            setListenerClasses(listOf(TestTimeListener::class.java))
+        }
+        val csvSuite = create().apply {
+            setTestClasses(arrayOf(SampleWithCSVData::class.java))
+            setListenerClasses(listOf(TestTimeListener::class.java))
+        }
+        val dataAsCodeSuite = create().apply {
+            setTestClasses(arrayOf(SampleDynamicDP::class.java))
+            setListenerClasses(listOf(TestTimeListener::class.java))
+        }
+
+        Reporter.log("Test execution time:\n")
+        for (suite in listOf(
+            Pair("simple dataprovider", simpleDPSuite),
+            Pair("dataprovider as code", dataAsCodeSuite),
+            Pair("csv dataprovider", csvSuite),
+        )) {
+            run(false, suite.second)
+            Reporter.log(
+                "${suite.first} execution times: %d milliseconds."
+                    .format(TestTimeListener.testRunTime),
+                true
+            )
+        }
+    }
+
+    fun getGCPath(instance: Instance): String {
+        var result = ""
+        if (!instance.isGCRoot) {
+            result += getGCPath(instance.nearestGCRootPointer)
+        }
+        return result + "${instance.javaClass.name}\n"
+    }
+}

--- a/testng-core/src/test/kotlin/org/testng/dataprovider/sample/issue2724/DataProviders.kt
+++ b/testng-core/src/test/kotlin/org/testng/dataprovider/sample/issue2724/DataProviders.kt
@@ -1,0 +1,14 @@
+package org.testng.dataprovider.sample.issue2724
+
+import org.testng.annotations.DataProvider
+
+class DataProviders {
+    @DataProvider
+    fun data() : Array<Array<Any>> {
+        return arrayOf(
+            arrayOf("Mike", 34, "student"),
+            arrayOf("Mike", 23, "driver"),
+            arrayOf("Paul", 20, "director")
+        )
+    }
+}

--- a/testng-core/src/test/kotlin/org/testng/dataprovider/sample/issue2724/SampleDPUnloaded.kt
+++ b/testng-core/src/test/kotlin/org/testng/dataprovider/sample/issue2724/SampleDPUnloaded.kt
@@ -1,0 +1,23 @@
+package org.testng.dataprovider.sample.issue2724
+
+import jlibs.core.lang.RuntimeUtil
+import org.testng.annotations.AfterClass
+import org.testng.annotations.Test
+import test.SimpleBaseTest
+
+class SampleDPUnloaded {
+    @Suppress("UNUSED_PARAMETER")
+    @Test(
+        dataProviderDynamicClass = "org.testng.dataprovider.sample.issue2724.DataProviders",
+        dataProvider = "data"
+    )
+    fun testDynamicDataProvider(name: String, age: Int, status: String) {
+
+    }
+
+    @AfterClass
+    fun afterTest() {
+        RuntimeUtil.gc(10)
+        SimpleBaseTest.saveMemDump(System.getProperty("memdump.path"))
+    }
+}

--- a/testng-core/src/test/kotlin/org/testng/dataprovider/sample/issue2724/SampleDynamicDP.kt
+++ b/testng-core/src/test/kotlin/org/testng/dataprovider/sample/issue2724/SampleDynamicDP.kt
@@ -1,0 +1,15 @@
+package org.testng.dataprovider.sample.issue2724
+
+import org.testng.annotations.Test
+
+class SampleDynamicDP {
+
+    @Suppress("UNUSED_PARAMETER")
+    @Test(
+        dataProviderDynamicClass = "org.testng.dataprovider.sample.issue2724.DataProviders",
+        dataProvider = "data"
+    )
+    fun testDynamicDataProvider(name: String, age: Int, status: String) {
+
+    }
+}

--- a/testng-core/src/test/kotlin/org/testng/dataprovider/sample/issue2724/SampleSimpleDP.kt
+++ b/testng-core/src/test/kotlin/org/testng/dataprovider/sample/issue2724/SampleSimpleDP.kt
@@ -1,0 +1,21 @@
+package org.testng.dataprovider.sample.issue2724
+
+import org.testng.annotations.DataProvider
+import org.testng.annotations.Test
+
+class SampleSimpleDP {
+    @Suppress("UNUSED_PARAMETER")
+    @Test(dataProvider = "data")
+    fun testDynamicDataProvider(name: String, age: Int, status: String) {
+
+    }
+
+    @DataProvider
+    fun data() : Array<Array<Any>> {
+        return arrayOf(
+            arrayOf("Mike", 34, "student"),
+            arrayOf("Mike", 23, "driver"),
+            arrayOf("Paul", 20, "director")
+        )
+    }
+}

--- a/testng-core/src/test/kotlin/org/testng/dataprovider/sample/issue2724/SampleWithCSVData.kt
+++ b/testng-core/src/test/kotlin/org/testng/dataprovider/sample/issue2724/SampleWithCSVData.kt
@@ -1,0 +1,21 @@
+package org.testng.dataprovider.sample.issue2724
+
+import org.testng.annotations.DataProvider
+import org.testng.annotations.Test
+
+class SampleWithCSVData {
+    @Suppress("UNUSED_PARAMETER")
+    @Test(dataProvider = "data")
+    fun testDynamicDataProvider(name: String, age: Int, status: String) {
+
+    }
+
+    @DataProvider
+    fun data() : Array<Array<Any>> {
+        val fileInputStream = this::class.java.classLoader
+            .getResourceAsStream("test/issue2724/data.csv")
+        return fileInputStream.reader().readLines().map {
+            it.split(",").toTypedArray<Any>()
+        }.toTypedArray()
+    }
+}

--- a/testng-core/src/test/kotlin/org/testng/dataprovider/sample/issue2724/TestTimeListener.kt
+++ b/testng-core/src/test/kotlin/org/testng/dataprovider/sample/issue2724/TestTimeListener.kt
@@ -1,0 +1,20 @@
+package org.testng.dataprovider.sample.issue2724
+
+import org.testng.ITestContext
+import org.testng.ITestListener
+
+class TestTimeListener : ITestListener {
+    private var startTime: Long = 0
+
+    override fun onStart(context: ITestContext?) {
+        startTime = System.currentTimeMillis()
+    }
+
+    override fun onFinish(context: ITestContext?) {
+        testRunTime = System.currentTimeMillis() - startTime
+    }
+
+    companion object {
+        var testRunTime: Long = 0
+    }
+}

--- a/testng-core/src/test/kotlin/test/SimpleBaseTest.kt
+++ b/testng-core/src/test/kotlin/test/SimpleBaseTest.kt
@@ -1,5 +1,6 @@
 package test
 
+import com.sun.management.HotSpotDiagnosticMXBean
 import org.assertj.core.api.Assertions.assertThat
 import org.testng.*
 import org.testng.annotations.ITestAnnotation
@@ -10,6 +11,7 @@ import org.testng.internal.annotations.JDK15AnnotationFinder
 import org.testng.xml.*
 import org.testng.xml.internal.Parser
 import java.io.*
+import java.lang.management.ManagementFactory
 import java.nio.file.FileVisitResult
 import java.nio.file.Files
 import java.nio.file.Path
@@ -28,7 +30,7 @@ open class SimpleBaseTest {
         fun run(vararg testClasses: Class<*>) = run(false, *testClasses)
 
         @JvmStatic
-        private fun run(skipConfiguration: Boolean, tng: TestNG) =
+        fun run(skipConfiguration: Boolean, tng: TestNG) =
             InvokedMethodNameListener(skipConfiguration).apply {
                 tng.addListener(this)
                 tng.run()
@@ -381,6 +383,26 @@ open class SimpleBaseTest {
                 }
                 .collect(Collectors.joining("\n"))
             return "Failed methods should pass: \n $methods"
+        }
+
+        @JvmStatic
+        fun saveMemDump(path: String) {
+            val jvmName = System.getProperty("java.vm.name")
+            val isHotSpot = jvmName.contains("hotspot", true)
+            if (!isHotSpot) {
+                throw SkipException("Taking memory dump is not implemented for $jvmName JVM")
+            }
+            try {
+                val server = ManagementFactory.getPlatformMBeanServer()
+                val mxBean = ManagementFactory.newPlatformMXBeanProxy(
+                    server,
+                    "com.sun.management:type=HotSpotDiagnostic",
+                    HotSpotDiagnosticMXBean::class.java
+                )
+                mxBean.dumpHeap(path, true)
+            } catch (e: IOException) {
+                throw TestNGException("Failed to save memory dump", e)
+            }
         }
     }
 

--- a/testng-core/src/test/resources/test/issue2724/data.csv
+++ b/testng-core/src/test/resources/test/issue2724/data.csv
@@ -1,0 +1,3 @@
+Mike, 34, student
+Mike, 23, driver
+Paul, 20, director

--- a/testng-core/src/test/resources/testng.xml
+++ b/testng-core/src/test/resources/testng.xml
@@ -992,6 +992,7 @@
   <test name="Kotlin">
     <classes>
       <class name="org.testng.BasicTest"/>
+      <class name="org.testng.dataprovider.DynamicDataProviderLoadingTest" />
     </classes>
   </test>
 </suite>

--- a/testng-core/testng-core-build.gradle.kts
+++ b/testng-core/testng-core-build.gradle.kts
@@ -46,6 +46,9 @@ dependencies {
     testImplementation("org.jboss.shrinkwrap:shrinkwrap-api:_")
     testImplementation("org.jboss.shrinkwrap:shrinkwrap-impl-base:_")
     testImplementation("org.xmlunit:xmlunit-assertj:_")
+    testImplementation("in.jlibs:jlibs-core:_")
+    testImplementation("org.gridkit.jvmtool:heaplib:_")
+    testImplementation("org.gridkit.lab:jvm-attach-api:_")
     testImplementation("commons-io:commons-io:_")
 }
 

--- a/versions.properties
+++ b/versions.properties
@@ -25,6 +25,8 @@ version.com.google.inject..guice-bom=5.0.1
 
 version.commons-io..commons-io=2.11.0
 
+version.in.jlibs..jlibs-core=3.0.1
+
 version.javax..javaee-api=8.0.1
 
 version.junit.junit=4.13.2
@@ -42,6 +44,10 @@ version.org.apache.felix..org.apache.felix.framework=7.0.0
 version.org.assertj..assertj-core=3.22.0
 
 version.org.codehaus.groovy..groovy-all=2.4.7
+
+version.org.gridkit.jvmtool..heaplib=0.2
+
+version.org.gridkit.lab..jvm-attach-api=1.5
 
 version.org.jboss.shrinkwrap..shrinkwrap-api=1.2.6
 


### PR DESCRIPTION
With current Data providers implementation, it's code will stick around
in method area (JVM spec $2.5.4) for entire test run.

By specifying dataprovider class with it's full qualified name, and
by using new custom classloader to load it, when needed, JVM gets a
chance to unload dataprovider class, when we're done and deleted
all links to it

Fixes #2724 .

### Did you remember to?

- [x] Add test case(s)
- [x] Update `CHANGES.txt`
- [x] Auto applied styling via `./gradlew autostyleApply`
