### PR TITLE
BeforeGroups should run before any matched test

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,7 @@ Fixed: GITHUB-2709: Testnames not working together with suites in suite (Martin 
 Fixed: GITHUB-2704: IHookable and IConfigurable callback discrepancy (Krishnan Mahadevan)
 Fixed: GITHUB-2637: Upgrade to JDK11 as the minimum JDK requirements (Krishnan Mahadevan)
 Fixed: GITHUB-2734: Keep the initial order of listeners (Andrei Solntsev)
+Fixed: GITHUB-2359: Testng @BeforeGroups is running in parallel with testcases in the group (Anton Velma)
 
 7.5
 Fixed: GITHUB-2701: Bump gradle version to 7.3.3 to support java17 build (ZhangJian He)

--- a/testng-core/src/test/java/test/beforegroups/issue2359/ListenerAdapter.java
+++ b/testng-core/src/test/java/test/beforegroups/issue2359/ListenerAdapter.java
@@ -1,0 +1,21 @@
+package test.beforegroups.issue2359;
+
+import java.util.Collection;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import org.testng.ITestResult;
+import org.testng.TestListenerAdapter;
+
+public class ListenerAdapter extends TestListenerAdapter {
+
+  private final Collection<ITestResult> passedConfiguration = new ConcurrentLinkedQueue<>();
+
+  @Override
+  public void onConfigurationSuccess(ITestResult itr) {
+    super.onConfigurationSuccess(itr);
+    this.passedConfiguration.add(itr);
+  }
+
+  public Collection<ITestResult> getPassedConfiguration() {
+    return passedConfiguration;
+  }
+}

--- a/testng-core/src/test/java/test/beforegroups/issue2359/SampleFor2359.java
+++ b/testng-core/src/test/java/test/beforegroups/issue2359/SampleFor2359.java
@@ -1,0 +1,26 @@
+package test.beforegroups.issue2359;
+
+import java.util.concurrent.TimeUnit;
+import org.testng.annotations.BeforeGroups;
+import org.testng.annotations.Test;
+
+public class SampleFor2359 {
+
+  @BeforeGroups(groups = "testng2359")
+  public void beforeGroup() {
+    try {
+      TimeUnit.SECONDS.sleep(2);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  @Test(groups = "testng2359")
+  public void sampleTest1() {}
+
+  @Test(groups = "testng2359")
+  public void sampleTest2() {}
+
+  @Test(groups = "testng2359")
+  public void sampleTest3() {}
+}


### PR DESCRIPTION
Closes #2359 

Fixes #2359 .

There is possibility that BeforeGroups method will be run in parallel with test(s) that have this group assigned (see test case), this pull request fixed this situation

### Did you remember to?

- [x] Add test case(s)
- [x] Update `CHANGES.txt`
- [x] Auto applied styling via `./gradlew autostyleApply`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.

**Note:** For more information on contribution guidelines  please make sure you refer our [Contributing](.github/CONTRIBUTING.md) section for detailed set of steps.
