### PR TITLE
Fix possible StringIndexOutOfBoundsException exception in XmlReporter

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,7 @@ Fixed: GITHUB-2704: IHookable and IConfigurable callback discrepancy (Krishnan M
 Fixed: GITHUB-2637: Upgrade to JDK11 as the minimum JDK requirements (Krishnan Mahadevan)
 Fixed: GITHUB-2734: Keep the initial order of listeners (Andrei Solntsev)
 Fixed: GITHUB-2359: Testng @BeforeGroups is running in parallel with testcases in the group (Anton Velma)
+Fixed: Possible StringIndexOutOfBoundsException in XmlReporter (Anton Velma)
 
 7.5
 Fixed: GITHUB-2701: Bump gradle version to 7.3.3 to support java17 build (ZhangJian He)

--- a/testng-core/src/main/java/org/testng/internal/WrappedTestNGMethod.java
+++ b/testng-core/src/main/java/org/testng/internal/WrappedTestNGMethod.java
@@ -373,4 +373,9 @@ public class WrappedTestNGMethod implements ITestNGMethod {
   public int hashCode() {
     return multiplicationFactor * testNGMethod.hashCode();
   }
+
+  @Override
+  public String toString() {
+    return testNGMethod.toString();
+  }
 }


### PR DESCRIPTION
Fixes possible StringIndexOutOfBoundsException exception in XmlReporter on processing WrappedTestNGMethod

### Did you remember to?

- [x] Add test case(s)
- [x] Update `CHANGES.txt`
- [x] Auto applied styling via `./gradlew autostyleApply`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.

**Note:** For more information on contribution guidelines  please make sure you refer our [Contributing](.github/CONTRIBUTING.md) section for detailed set of steps.
