### PR TITLE
fix possibilty that AfterGroups method is invoked before all tests

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,7 +11,7 @@ Fixed: GITHUB-2637: Upgrade to JDK11 as the minimum JDK requirements (Krishnan M
 Fixed: GITHUB-2734: Keep the initial order of listeners (Andrei Solntsev)
 Fixed: GITHUB-2359: Testng @BeforeGroups is running in parallel with testcases in the group (Anton Velma)
 Fixed: Possible StringIndexOutOfBoundsException in XmlReporter (Anton Velma)
-Fixed: AfterGroups methods could be invoked before all tests for defined groups in case of multiple groups for AfterGroups method (Anton Velma)
+Fixed: GITHUB-2754: @AfterGroups is executed for each "finished" group when it has multiple groups defined (Anton Velma)
 
 7.5
 Fixed: GITHUB-2701: Bump gradle version to 7.3.3 to support java17 build (ZhangJian He)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,6 +11,7 @@ Fixed: GITHUB-2637: Upgrade to JDK11 as the minimum JDK requirements (Krishnan M
 Fixed: GITHUB-2734: Keep the initial order of listeners (Andrei Solntsev)
 Fixed: GITHUB-2359: Testng @BeforeGroups is running in parallel with testcases in the group (Anton Velma)
 Fixed: Possible StringIndexOutOfBoundsException in XmlReporter (Anton Velma)
+Fixed: AfterGroups methods could be invoked before all tests for defined groups in case of multiple groups for AfterGroups method (Anton Velma)
 
 7.5
 Fixed: GITHUB-2701: Bump gradle version to 7.3.3 to support java17 build (ZhangJian He)

--- a/testng-core/src/main/java/org/testng/internal/ConfigurationGroupMethods.java
+++ b/testng-core/src/main/java/org/testng/internal/ConfigurationGroupMethods.java
@@ -90,21 +90,23 @@ public class ConfigurationGroupMethods {
           .map(t -> retrieve(afterGroupsThatHaveAlreadyRun, m_afterGroupsMethods, t))
           .filter(Objects::nonNull)
           .flatMap(Collection::stream)
-          .filter(
-              afterGroupMethod -> {
-                String[] afterGroupMethodGroups = afterGroupMethod.getAfterGroups();
-                if (afterGroupMethodGroups.length == 1
-                    || methodGroups.containsAll(Arrays.asList(afterGroupMethodGroups))) {
-                  return true;
-                }
-                return Arrays.stream(afterGroupMethodGroups)
-                    .allMatch(
-                        t ->
-                            methodGroups.contains(t)
-                                || !CollectionUtils.hasElements(m_afterGroupsMap.get(t)));
-              })
+          .filter(t -> isAfterGroupAllowedToRunAfterTestMethod(t, methodGroups))
           .collect(Collectors.toList());
     }
+  }
+
+  private boolean isAfterGroupAllowedToRunAfterTestMethod(
+      ITestNGMethod afterGroupMethod, Set<String> testMethodGroups) {
+    String[] afterGroupMethodGroups = afterGroupMethod.getAfterGroups();
+    if (afterGroupMethodGroups.length == 1
+        || testMethodGroups.containsAll(Arrays.asList(afterGroupMethodGroups))) {
+      return true;
+    }
+    return Arrays.stream(afterGroupMethodGroups)
+        .allMatch(
+            t ->
+                testMethodGroups.contains(t)
+                    || !CollectionUtils.hasElements(m_afterGroupsMap.get(t)));
   }
 
   public void removeBeforeGroups(String[] groups) {

--- a/testng-core/src/test/java/test/aftergroups/AfterGroupsBehaviorTest.java
+++ b/testng-core/src/test/java/test/aftergroups/AfterGroupsBehaviorTest.java
@@ -46,6 +46,7 @@ public class AfterGroupsBehaviorTest extends SimpleBaseTest {
 
     tng.run();
 
+    assertThat(adapter.getPassedConfiguration()).hasSize(1);
     ITestResult afterGroup = adapter.getPassedConfiguration().iterator().next();
     adapter
         .getPassedTests()

--- a/testng-core/src/test/java/test/aftergroups/AfterGroupsBehaviorTest.java
+++ b/testng-core/src/test/java/test/aftergroups/AfterGroupsBehaviorTest.java
@@ -2,6 +2,7 @@ package test.aftergroups;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.testng.ITestResult;
 import org.testng.TestNG;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -12,6 +13,8 @@ import test.aftergroups.issue165.TestclassSampleWithFailedMember;
 import test.aftergroups.issue165.TestclassSampleWithSkippedMember;
 import test.aftergroups.issue1880.LocalConfigListener;
 import test.aftergroups.issue1880.TestClassSample;
+import test.aftergroups.samples.MultipleGroupsSample;
+import test.beforegroups.issue2359.ListenerAdapter;
 
 public class AfterGroupsBehaviorTest extends SimpleBaseTest {
 
@@ -31,6 +34,23 @@ public class AfterGroupsBehaviorTest extends SimpleBaseTest {
       {TestclassSampleWithSkippedMember.class, "afterGroupsMethod"},
       {TestclassSampleWithFailedMember.class, "afterGroupsMethod"},
     };
+  }
+
+  @Test
+  public void ensureAfterGroupsInvokedAfterAllTestsWhenMultipleGroupsDefined() {
+    TestNG tng = new TestNG();
+    tng.setTestClasses(new Class[] {MultipleGroupsSample.class});
+
+    ListenerAdapter adapter = new ListenerAdapter();
+    tng.addListener(adapter);
+
+    tng.run();
+
+    ITestResult afterGroup = adapter.getPassedConfiguration().iterator().next();
+    adapter
+        .getPassedTests()
+        .forEach(
+            t -> assertThat(t.getEndMillis()).isLessThanOrEqualTo(afterGroup.getStartMillis()));
   }
 
   private static void runTest(

--- a/testng-core/src/test/java/test/aftergroups/samples/MultipleGroupsSample.java
+++ b/testng-core/src/test/java/test/aftergroups/samples/MultipleGroupsSample.java
@@ -1,0 +1,18 @@
+package test.aftergroups.samples;
+
+import org.testng.annotations.AfterGroups;
+import org.testng.annotations.Test;
+
+public class MultipleGroupsSample {
+
+  @AfterGroups(groups = {"group-1", "group-2", "not-defined"})
+  public void afterGroup() {}
+
+  @Test(groups = "group-1")
+  public void test1() {}
+
+  @Test(groups = "group-2")
+  public void test2() throws InterruptedException {
+    Thread.sleep(3000);
+  }
+}


### PR DESCRIPTION
Fixes #2754
When AfterGroups method has multiple groups defined then situation was possible that it is invoked not after all tests for all its groups but after the last test of any group

### Did you remember to?

- [x] Add test case(s)
- [x] Update `CHANGES.txt`
- [x] Auto applied styling via `./gradlew autostyleApply`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.

**Note:** For more information on contribution guidelines  please make sure you refer our [Contributing](.github/CONTRIBUTING.md) section for detailed set of steps.
