### PR TITLE
fix equals implementation for WrappedTestNGMethod

### DIFF
--- a/testng-core/src/main/java/org/testng/internal/WrappedTestNGMethod.java
+++ b/testng-core/src/main/java/org/testng/internal/WrappedTestNGMethod.java
@@ -366,7 +366,7 @@ public class WrappedTestNGMethod implements ITestNGMethod {
 
   @Override
   public boolean equals(Object o) {
-    return testNGMethod.equals(o);
+    return o == this || (o instanceof ITestNGMethod && testNGMethod.equals(o));
   }
 
   @Override

--- a/testng-core/src/test/java/test/aftergroups/AfterGroupsBehaviorTest.java
+++ b/testng-core/src/test/java/test/aftergroups/AfterGroupsBehaviorTest.java
@@ -2,10 +2,15 @@ package test.aftergroups;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.ArrayList;
+import java.util.List;
+import org.testng.IMethodInstance;
 import org.testng.ITestResult;
 import org.testng.TestNG;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.testng.internal.MethodInstance;
+import org.testng.internal.WrappedTestNGMethod;
 import org.testng.xml.XmlSuite;
 import org.testng.xml.XmlSuite.FailurePolicy;
 import test.SimpleBaseTest;
@@ -13,6 +18,7 @@ import test.aftergroups.issue165.TestclassSampleWithFailedMember;
 import test.aftergroups.issue165.TestclassSampleWithSkippedMember;
 import test.aftergroups.issue1880.LocalConfigListener;
 import test.aftergroups.issue1880.TestClassSample;
+import test.aftergroups.samples.AfterGroupsSample;
 import test.aftergroups.samples.MultipleGroupsSample;
 import test.beforegroups.issue2359.ListenerAdapter;
 
@@ -52,6 +58,26 @@ public class AfterGroupsBehaviorTest extends SimpleBaseTest {
         .getPassedTests()
         .forEach(
             t -> assertThat(t.getEndMillis()).isLessThanOrEqualTo(afterGroup.getStartMillis()));
+  }
+
+  @Test
+  public void ensureAfterGroupsInvokedWhenTestMethodIsWrappedWithWrappedTestNGMethod() {
+    TestNG tng = new TestNG();
+    tng.setTestClasses(new Class[] {AfterGroupsSample.class});
+
+    tng.setMethodInterceptor(
+        (methods, context) -> {
+          List<IMethodInstance> result = new ArrayList<>(methods);
+          result.add(new MethodInstance(new WrappedTestNGMethod(result.get(0).getMethod())));
+          return result;
+        });
+
+    ListenerAdapter adapter = new ListenerAdapter();
+    tng.addListener(adapter);
+
+    tng.run();
+
+    assertThat(adapter.getPassedConfiguration()).hasSize(1);
   }
 
   private static void runTest(

--- a/testng-core/src/test/java/test/aftergroups/samples/AfterGroupsSample.java
+++ b/testng-core/src/test/java/test/aftergroups/samples/AfterGroupsSample.java
@@ -1,0 +1,13 @@
+package test.aftergroups.samples;
+
+import org.testng.annotations.AfterGroups;
+import org.testng.annotations.Test;
+
+public class AfterGroupsSample {
+
+  @Test(groups = "group-1")
+  public void someTest() {}
+
+  @AfterGroups(groups = "group-1")
+  public void afterGroupMethod() {}
+}


### PR DESCRIPTION
Fixed implementation of equals method, so after executing method wrapped into WrappedTestNGMethod it can be removed from ConfigurationGroupMethods::m_afterGroupsMap

### Did you remember to?

- [x] Add test case(s)
- [ ] Update `CHANGES.txt`
- [x] Auto applied styling via `./gradlew autostyleApply`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.

**Note:** For more information on contribution guidelines  please make sure you refer our [Contributing](.github/CONTRIBUTING.md) section for detailed set of steps.
