### PR TITLE
Replace FindBugs by SpotBugs

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-2780: Use SpotBugs instead of abandoned FindBugs
 
 7.6.1
 Fixed: GITHUB-2761: Exception: ERROR java.nio.file.NoSuchFileException: /tmp/testngXmlPathInJar-15086412835569336174 (Krishnan Mahadevan)

--- a/testng-core-api/testng-core-api-build.gradle.kts
+++ b/testng-core-api/testng-core-api-build.gradle.kts
@@ -10,7 +10,7 @@ java {
 
 dependencies {
     api(projects.testngCollections)
-    api("com.google.code.findbugs:jsr305:_")
+    api("com.github.spotbugs:spotbugs:_")
     "guiceApi"(platform("com.google.inject:guice-bom:_"))
     "guiceApi"("com.google.inject:guice")
 

--- a/testng-core/testng-core-build.gradle.kts
+++ b/testng-core/testng-core-build.gradle.kts
@@ -25,7 +25,7 @@ java {
 dependencies {
     api(projects.testngCoreApi)
     // Annotations have to be available on the compile classpath for the proper compilation
-    api("com.google.code.findbugs:jsr305:_")
+    api("com.github.spotbugs:spotbugs:_")
     api("com.beust:jcommander:_")
 
     "guiceApi"(platform("com.google.inject:guice-bom:_"))

--- a/versions.properties
+++ b/versions.properties
@@ -45,7 +45,7 @@ version.ch.qos.logback..logback-core=1.2.11
 
 version.com.beust..jcommander=1.82
 
-version.com.google.code.findbugs..jsr305=3.0.2
+version.com.github.spotbugs..spotbugs=4.7.1
 
 version.com.google.inject..guice-bom=5.1.0
 


### PR DESCRIPTION
Replace FindBugs by SpotBugs. The current SpotBugs version is 4.7.1

FindBugs is abandoned.

Fixes #2780 .

### Did you remember to?

- [x] Update `CHANGES.txt`
