### PR TITLE
Gradle: Drop forUseAtConfigurationTime()

### DIFF
--- a/build-logic/code-quality/src/main/kotlin/testng.testing.gradle.kts
+++ b/build-logic/code-quality/src/main/kotlin/testng.testing.gradle.kts
@@ -11,7 +11,6 @@ dependencies {
 tasks.withType<Test>().configureEach {
     useTestNG()
     providers.gradleProperty("testng.test.extra.jvmargs")
-        .forUseAtConfigurationTime()
         .orNull?.toString()?.trim()
         ?.takeIf { it.isNotEmpty() }
         ?.let {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ println("Building testng $buildVersion")
  */
 
 fun property(name: String) =
-    providers.gradleProperty(name).forUseAtConfigurationTime()
+    providers.gradleProperty(name)
 
 releaseParams {
     tlp.set(property("github.repository"))


### PR DESCRIPTION
It is deprecated and scheduled for removal in Gradle 9.0.
Starting with version 7.4 Gradle will implicitly treat an
external value used at configuration time as a configuration
cache input.
Source: https://docs.gradle.org/current/userguide/upgrading_version_7.html#changes_7.4