### PR TITLE
Ability to retry a data provider during failures

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-2819: Ability to retry a data provider in case of failures (Krishnan Mahadevan)
 Fixed: GITHUB-2308: StringIndexOutOfBoundsException in findClassesInPackage - Surefire/Maven - JDK 11 fails (Krishnan Mahadevan)
 Fixed: GITHUB:2788: TestResult.isSuccess() is TRUE when test fails due to expectedExceptions (Krishnan Mahadevan)
 Fixed: GITHUB-2800: Running Test Classes with Inherited @Factory and @DataProvider Annotated Non-Static Methods Fail (Krishnan Mahadevan)

--- a/testng-core-api/src/main/java/org/testng/IDataProviderMethod.java
+++ b/testng-core-api/src/main/java/org/testng/IDataProviderMethod.java
@@ -30,4 +30,12 @@ public interface IDataProviderMethod {
   default boolean propagateFailureAsTestFailure() {
     return false;
   }
+
+  /**
+   * @return - An Class which implements {@link IRetryDataProvider} and which can be used to retry a
+   *     data provider.
+   */
+  default Class<? extends IRetryDataProvider> retryUsing() {
+    return IRetryDataProvider.DisableDataProviderRetries.class;
+  }
 }

--- a/testng-core-api/src/main/java/org/testng/IRetryDataProvider.java
+++ b/testng-core-api/src/main/java/org/testng/IRetryDataProvider.java
@@ -1,0 +1,21 @@
+package org.testng;
+
+/** Represents the ability to retry a data provider. */
+public interface IRetryDataProvider {
+
+  /**
+   * @param dataProvider - The {@link IDataProviderMethod} object which represents the data provider
+   *     to be invoked.
+   * @return - <code>true</code> if the data provider should be invoked again.
+   */
+  boolean retry(IDataProviderMethod dataProvider);
+
+  /** A dummy implementation which disables retrying of a failed data provider. */
+  class DisableDataProviderRetries implements IRetryDataProvider {
+
+    @Override
+    public boolean retry(IDataProviderMethod dataProvider) {
+      return false;
+    }
+  }
+}

--- a/testng-core-api/src/main/java/org/testng/annotations/DataProvider.java
+++ b/testng-core-api/src/main/java/org/testng/annotations/DataProvider.java
@@ -5,6 +5,7 @@ import static java.lang.annotation.ElementType.METHOD;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
+import org.testng.IRetryDataProvider;
 
 /**
  * Mark a method as supplying data for a test method.
@@ -55,4 +56,11 @@ public @interface DataProvider {
    * @return the value
    */
   boolean propagateFailureAsTestFailure() default false;
+
+  /**
+   * @return - An Class which implements {@link IRetryDataProvider} and which can be used to retry a
+   *     data provider.
+   */
+  Class<? extends IRetryDataProvider> retryUsing() default
+      IRetryDataProvider.DisableDataProviderRetries.class;
 }

--- a/testng-core-api/src/main/java/org/testng/annotations/IDataProviderAnnotation.java
+++ b/testng-core-api/src/main/java/org/testng/annotations/IDataProviderAnnotation.java
@@ -1,6 +1,7 @@
 package org.testng.annotations;
 
 import java.util.List;
+import org.testng.IRetryDataProvider;
 
 /** Encapsulate the @DataProvider / @testng.data-provider annotation */
 public interface IDataProviderAnnotation extends IAnnotation {
@@ -27,4 +28,16 @@ public interface IDataProviderAnnotation extends IAnnotation {
 
   /** @return - <code>true</code>If data provider failures should be propagated as test failures */
   boolean isPropagateFailureAsTestFailure();
+
+  /**
+   * @param retry - A Class that implements {@link IRetryDataProvider} and which can be used to
+   *     retry a data provider.
+   */
+  void setRetryUsing(Class<? extends IRetryDataProvider> retry);
+
+  /**
+   * @return - An Class which implements {@link IRetryDataProvider} and which can be used to retry a
+   *     data provider.
+   */
+  Class<? extends IRetryDataProvider> retryUsing();
 }

--- a/testng-core/src/main/java/org/testng/internal/DataProviderMethod.java
+++ b/testng-core/src/main/java/org/testng/internal/DataProviderMethod.java
@@ -3,6 +3,7 @@ package org.testng.internal;
 import java.lang.reflect.Method;
 import java.util.List;
 import org.testng.IDataProviderMethod;
+import org.testng.IRetryDataProvider;
 import org.testng.annotations.IDataProviderAnnotation;
 
 /** Represents an @{@link org.testng.annotations.DataProvider} annotated method. */
@@ -46,5 +47,10 @@ class DataProviderMethod implements IDataProviderMethod {
   @Override
   public boolean propagateFailureAsTestFailure() {
     return annotation.isPropagateFailureAsTestFailure();
+  }
+
+  @Override
+  public Class<? extends IRetryDataProvider> retryUsing() {
+    return annotation.retryUsing();
   }
 }

--- a/testng-core/src/main/java/org/testng/internal/FilteredParameters.java
+++ b/testng-core/src/main/java/org/testng/internal/FilteredParameters.java
@@ -1,0 +1,62 @@
+package org.testng.internal;
+
+import java.util.Iterator;
+import java.util.List;
+import org.testng.ITestNGMethod;
+import org.testng.TestNGException;
+
+class FilteredParameters implements Iterator<Object[]> {
+
+  private int index = 0;
+  private boolean hasWarn = false;
+  private final Iterator<Object[]> parameters;
+  private final ITestNGMethod testMethod;
+  private final String dataProviderName;
+  private final List<Integer> indices;
+
+  public FilteredParameters(
+      Iterator<Object[]> parameters,
+      ITestNGMethod testMethod,
+      String dataProviderName,
+      List<Integer> indices) {
+    this.parameters = parameters;
+    this.testMethod = testMethod;
+    this.dataProviderName = dataProviderName;
+    this.indices = indices;
+  }
+
+  @Override
+  public boolean hasNext() {
+    if (index == 0 && !parameters.hasNext() && !hasWarn) {
+      hasWarn = true;
+      String msg =
+          String.format(
+              "The test method '%s' will be skipped since its "
+                  + "data provider '%s' "
+                  + "returned an empty array or iterator. ",
+              testMethod.getQualifiedName(), dataProviderName);
+      Utils.warn(msg);
+    }
+    return parameters.hasNext();
+  }
+
+  @Override
+  public Object[] next() {
+    testMethod.setParameterInvocationCount(index);
+    Object[] next = parameters.next();
+    if (next == null) {
+      throw new TestNGException("Parameters must not be null");
+    }
+    if (!indices.isEmpty() && !indices.contains(index)) {
+      // Skip parameters
+      next = null;
+    }
+    index++;
+    return next;
+  }
+
+  @Override
+  public void remove() {
+    throw new UnsupportedOperationException("remove");
+  }
+}

--- a/testng-core/src/main/java/org/testng/internal/annotations/DataProviderAnnotation.java
+++ b/testng-core/src/main/java/org/testng/internal/annotations/DataProviderAnnotation.java
@@ -1,6 +1,7 @@
 package org.testng.internal.annotations;
 
 import java.util.List;
+import org.testng.IRetryDataProvider;
 import org.testng.annotations.IDataProviderAnnotation;
 
 /** An implementation of IDataProvider. */
@@ -10,6 +11,7 @@ public class DataProviderAnnotation extends BaseAnnotation implements IDataProvi
   private boolean m_parallel;
   private List<Integer> m_indices;
   private boolean m_bubbleUpFailures = false;
+  private Class<? extends IRetryDataProvider> retryUsing;
 
   @Override
   public boolean isParallel() {
@@ -49,5 +51,15 @@ public class DataProviderAnnotation extends BaseAnnotation implements IDataProvi
   @Override
   public boolean isPropagateFailureAsTestFailure() {
     return m_bubbleUpFailures;
+  }
+
+  @Override
+  public void setRetryUsing(Class<? extends IRetryDataProvider> retry) {
+    this.retryUsing = retry;
+  }
+
+  @Override
+  public Class<? extends IRetryDataProvider> retryUsing() {
+    return retryUsing;
   }
 }

--- a/testng-core/src/main/java/org/testng/internal/annotations/JDK15TagFactory.java
+++ b/testng-core/src/main/java/org/testng/internal/annotations/JDK15TagFactory.java
@@ -417,17 +417,17 @@ public class JDK15TagFactory {
   private IAnnotation createDataProviderTag(Method method, Annotation a) {
     DataProviderAnnotation result = new DataProviderAnnotation();
     DataProvider c = (DataProvider) a;
+    String name = c.name();
     if (c.name().isEmpty()) {
-      result.setName(method.getName());
-    } else {
-      result.setName(c.name());
+      name = method.getName();
     }
+    result.setName(name);
     result.setParallel(c.parallel());
     result.setIndices(Ints.asList(c.indices()));
     if (c.propagateFailureAsTestFailure()) {
       result.propagateFailureAsTestFailure();
     }
-
+    result.setRetryUsing(c.retryUsing());
     return result;
   }
 

--- a/testng-core/src/test/java/test/dataprovider/issue2819/DataProviderListenerForRetryAwareTests.java
+++ b/testng-core/src/test/java/test/dataprovider/issue2819/DataProviderListenerForRetryAwareTests.java
@@ -1,0 +1,42 @@
+package test.dataprovider.issue2819;
+
+import org.testng.IDataProviderListener;
+import org.testng.IDataProviderMethod;
+import org.testng.ITestContext;
+import org.testng.ITestNGMethod;
+
+public class DataProviderListenerForRetryAwareTests implements IDataProviderListener {
+
+  private int beforeInvocations = 0;
+  private int afterInvocations = 0;
+  private int failureInvocations = 0;
+
+  public int getBeforeInvocations() {
+    return beforeInvocations;
+  }
+
+  public int getFailureInvocations() {
+    return failureInvocations;
+  }
+
+  public int getAfterInvocations() {
+    return afterInvocations;
+  }
+
+  @Override
+  public void beforeDataProviderExecution(
+      IDataProviderMethod dp, ITestNGMethod tm, ITestContext ctx) {
+    beforeInvocations++;
+  }
+
+  @Override
+  public void afterDataProviderExecution(
+      IDataProviderMethod dp, ITestNGMethod tm, ITestContext ctx) {
+    afterInvocations++;
+  }
+
+  @Override
+  public void onDataProviderFailure(ITestNGMethod method, ITestContext ctx, RuntimeException t) {
+    failureInvocations++;
+  }
+}

--- a/testng-core/src/test/java/test/dataprovider/issue2819/SimpleRetry.java
+++ b/testng-core/src/test/java/test/dataprovider/issue2819/SimpleRetry.java
@@ -1,0 +1,27 @@
+package test.dataprovider.issue2819;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import org.testng.IDataProviderMethod;
+import org.testng.IRetryDataProvider;
+
+public class SimpleRetry implements IRetryDataProvider {
+
+  private static final Set<Integer> hashCodes = new HashSet<>();
+
+  public static Set<Integer> getHashCodes() {
+    return Collections.unmodifiableSet(hashCodes);
+  }
+
+  public SimpleRetry() {
+    hashCodes.add(hashCode());
+  }
+
+  private int counter = 0;
+
+  @Override
+  public boolean retry(IDataProviderMethod dataProvider) {
+    return counter++ < 2;
+  }
+}

--- a/testng-core/src/test/java/test/dataprovider/issue2819/TestClassSample.java
+++ b/testng-core/src/test/java/test/dataprovider/issue2819/TestClassSample.java
@@ -1,0 +1,34 @@
+package test.dataprovider.issue2819;
+
+import java.lang.reflect.Method;
+import org.testng.IAnnotationTransformer;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.IDataProviderAnnotation;
+import org.testng.annotations.Test;
+
+public class TestClassSample {
+
+  private int counter = 0;
+
+  @Test(dataProvider = "dp")
+  public void sampleTest(int ignored) {}
+
+  @DataProvider(name = "dp")
+  public Object[][] getTestData() {
+    if (shouldSimulateFailure()) {
+      throw new RuntimeException("Simulating a failure");
+    }
+    return new Object[][] {{1}};
+  }
+
+  private boolean shouldSimulateFailure() {
+    return counter++ < 2;
+  }
+
+  public static class EnableRetryForDataProvider implements IAnnotationTransformer {
+    @Override
+    public void transform(IDataProviderAnnotation annotation, Method method) {
+      annotation.setRetryUsing(SimpleRetry.class);
+    }
+  }
+}

--- a/testng-core/src/test/java/test/dataprovider/issue2819/TestClassUsingDataProviderRetrySample.java
+++ b/testng-core/src/test/java/test/dataprovider/issue2819/TestClassUsingDataProviderRetrySample.java
@@ -1,0 +1,24 @@
+package test.dataprovider.issue2819;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class TestClassUsingDataProviderRetrySample {
+
+  private int counter = 0;
+
+  @Test(dataProvider = "dp")
+  public void sampleTest(int ignored) {}
+
+  @DataProvider(name = "dp", retryUsing = SimpleRetry.class)
+  public Object[][] getTestData() {
+    if (shouldSimulateFailure()) {
+      throw new RuntimeException("Simulating a failure");
+    }
+    return new Object[][] {{1}};
+  }
+
+  private boolean shouldSimulateFailure() {
+    return counter++ < 2;
+  }
+}

--- a/testng-core/src/test/java/test/dataprovider/issue2819/TestClassWithMultipleRetryImplSample.java
+++ b/testng-core/src/test/java/test/dataprovider/issue2819/TestClassWithMultipleRetryImplSample.java
@@ -1,0 +1,41 @@
+package test.dataprovider.issue2819;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class TestClassWithMultipleRetryImplSample {
+
+  @Test(dataProvider = "dp")
+  public void sampleTest(int ignored) {}
+
+  @DataProvider(name = "dp", retryUsing = SimpleRetry.class)
+  public Object[][] getTestData() {
+    if (shouldSimulateFailureForGetTestData()) {
+      throw new RuntimeException("Simulating a failure");
+    }
+    return new Object[][] {{1}};
+  }
+
+  @Test(dataProvider = "anotherDP")
+  public void anotherSampleTest(int ignored) {}
+
+  @DataProvider(name = "anotherDP", retryUsing = SimpleRetry.class)
+  public Object[][] getMoreTestData() {
+    if (shouldSimulateFailureForMoreTestData()) {
+      throw new RuntimeException("Simulating another failure");
+    }
+    return new Object[][] {{200}};
+  }
+
+  private int moreTestDataCounter = 0;
+
+  private boolean shouldSimulateFailureForMoreTestData() {
+    return moreTestDataCounter++ < 2;
+  }
+
+  private int testDataCounter = 0;
+
+  private boolean shouldSimulateFailureForGetTestData() {
+    return testDataCounter++ < 2;
+  }
+}


### PR DESCRIPTION
Closes #2819

Fixes #2819  .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`
- [X] Auto applied styling via `./gradlew autostyleApply`

**Sample test case**

```java
import org.testng.annotations.DataProvider;
import org.testng.annotations.Test;

public class TestClassUsingDataProviderRetrySample {

  private int counter = 0;

  @Test(dataProvider = "dp")
  public void sampleTest(int ignored) {}

  @DataProvider(name = "dp", retryUsing = SimpleRetry.class)
  public Object[][] getTestData() {
    if (counter++ < 2) {
      throw new RuntimeException("Simulating a failure");
    }
    return new Object[][] {{1}};
  }
}
```

**Sample retry mechanism implementation**

```java
import org.testng.IDataProviderMethod;
import org.testng.IRetryDataProvider;

public class SimpleRetry implements IRetryDataProvider {

  private int counter = 0;

  @Override
  public boolean retry(IDataProviderMethod dataProvider) {
    return counter++ < 2;
  }
}
```