### PR TITLE
Add config key for callback discrepancy behavior

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB2818: Add configuration key for callback discrepancy behavior (Krishnan Mahadevan)
 Fixed: GITHUB-2819: Ability to retry a data provider in case of failures (Krishnan Mahadevan)
 Fixed: GITHUB-2308: StringIndexOutOfBoundsException in findClassesInPackage - Surefire/Maven - JDK 11 fails (Krishnan Mahadevan)
 Fixed: GITHUB:2788: TestResult.isSuccess() is TRUE when test fails due to expectedExceptions (Krishnan Mahadevan)

--- a/testng-core-api/src/main/java/org/testng/internal/RuntimeBehavior.java
+++ b/testng-core-api/src/main/java/org/testng/internal/RuntimeBehavior.java
@@ -14,8 +14,13 @@ public final class RuntimeBehavior {
   private static final String MEMORY_FRIENDLY_MODE = "testng.memory.friendly";
   public static final String STRICTLY_HONOUR_PARALLEL_MODE = "testng.strict.parallel";
   public static final String TESTNG_DEFAULT_VERBOSE = "testng.default.verbose";
+  public static final String IGNORE_CALLBACK_INVOCATION_SKIPS = "testng.ignore.callback.skip";
 
   private RuntimeBehavior() {}
+
+  public static boolean ignoreCallbackInvocationSkips() {
+    return Boolean.getBoolean(IGNORE_CALLBACK_INVOCATION_SKIPS);
+  }
 
   public static boolean strictParallelism() {
     return Boolean.getBoolean(STRICTLY_HONOUR_PARALLEL_MODE);

--- a/testng-core/src/main/java/org/testng/internal/invokers/ConfigInvoker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/ConfigInvoker.java
@@ -362,7 +362,11 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
             tm, method, targetInstance, params, testResult);
       }
       boolean testStatusRemainedUnchanged = testResult.isNotRunning();
-      if (usesConfigurableInstance && willfullyIgnored && testStatusRemainedUnchanged) {
+      boolean throwException = !RuntimeBehavior.ignoreCallbackInvocationSkips();
+      if (throwException
+          && usesConfigurableInstance
+          && willfullyIgnored
+          && testStatusRemainedUnchanged) {
         throw new ConfigurationNotInvokedException(tm);
       }
       testResult.setStatus(ITestResult.SUCCESS);

--- a/testng-core/src/main/java/org/testng/internal/invokers/TestInvoker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/TestInvoker.java
@@ -691,7 +691,11 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
                 hookableInstance);
       }
       boolean testStatusRemainedUnchanged = testResult.isNotRunning();
-      if (usesHookableInstance && willfullyIgnored && testStatusRemainedUnchanged) {
+      boolean throwException = !RuntimeBehavior.ignoreCallbackInvocationSkips();
+      if (throwException
+          && usesHookableInstance
+          && willfullyIgnored
+          && testStatusRemainedUnchanged) {
         TestNotInvokedException tn = new TestNotInvokedException(arguments.tm);
         testResult.setThrowable(tn);
         setTestStatus(testResult, ITestResult.FAILURE);

--- a/testng-core/src/test/java/test/hook/samples/CallBackSample.java
+++ b/testng-core/src/test/java/test/hook/samples/CallBackSample.java
@@ -1,0 +1,32 @@
+package test.hook.samples;
+
+import org.testng.IConfigurable;
+import org.testng.IConfigureCallBack;
+import org.testng.IHookCallBack;
+import org.testng.IHookable;
+import org.testng.ITestResult;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class CallBackSample {
+
+  public static class ConfigCallBackSkipTestCase implements IConfigurable {
+
+    @Override
+    public void run(IConfigureCallBack callBack, ITestResult testResult) {}
+
+    @BeforeMethod
+    public void beforeMethod() {}
+
+    @Test
+    public void testMethod() {}
+  }
+
+  public static class TestCallBackSkipTestCase implements IHookable {
+    @Override
+    public void run(IHookCallBack callBack, ITestResult testResult) {}
+
+    @Test
+    public void testMethod() {}
+  }
+}


### PR DESCRIPTION
Closes #2818

Fixes #2818 .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`
- [X] Auto applied styling via `./gradlew autostyleApply`

With this PR we can now disable TestNG from throwing exceptions when there are callbacks ( `IHookable` && `IConfigurable` ) defined but are not invoked by setting the JVM argument `-Dtestng.ignore.callback.skip=true`
