### PR TITLE
hidden spotbugs in release #2829

### DIFF
--- a/testng-core-api/testng-core-api-build.gradle.kts
+++ b/testng-core-api/testng-core-api-build.gradle.kts
@@ -10,7 +10,7 @@ java {
 
 dependencies {
     api(projects.testngCollections)
-    api("com.github.spotbugs:spotbugs:_")
+    compileOnly("com.github.spotbugs:spotbugs:_")
     "guiceApi"(platform("com.google.inject:guice-bom:_"))
     "guiceApi"("com.google.inject:guice")
 

--- a/testng-core/testng-core-build.gradle.kts
+++ b/testng-core/testng-core-build.gradle.kts
@@ -25,7 +25,7 @@ java {
 dependencies {
     api(projects.testngCoreApi)
     // Annotations have to be available on the compile classpath for the proper compilation
-    api("com.github.spotbugs:spotbugs:_")
+    compileOnly("com.github.spotbugs:spotbugs:_")
     api("com.beust:jcommander:_")
 
     "guiceApi"(platform("com.google.inject:guice-bom:_"))

--- a/testng-runner-api/testng-runner-api-build.gradle.kts
+++ b/testng-runner-api/testng-runner-api-build.gradle.kts
@@ -4,4 +4,5 @@ plugins {
 
 dependencies {
     api(projects.testngCoreApi)
+    compileOnly("com.github.spotbugs:spotbugs:_")
 }


### PR DESCRIPTION
org.w3c.dom is accessible from more than one module: <unnamed>, java.xml during building cbeust#2829

Signed-off-by: Bob Shi <bob.shi@ericsson.com>

Fixes # .

### Did you remember to?

- [ ] Add test case(s)
- [ ] Update `CHANGES.txt`
- [ ] Auto applied styling via `./gradlew autostyleApply`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.

**Note:** For more information on contribution guidelines  please make sure you refer our [Contributing](.github/CONTRIBUTING.md) section for detailed set of steps.
