### PR TITLE
Fix sporadic failure for “firstTimeOnly” methods

### DIFF
--- a/testng-core-api/src/main/java/org/testng/ITestResult.java
+++ b/testng-core-api/src/main/java/org/testng/ITestResult.java
@@ -116,6 +116,13 @@ public interface ITestResult extends IAttributes, Comparable<ITestResult> {
   String id();
 
   /**
+   * @return <code>true</code> if the current method (test|configuration) was executed by TestNG.
+   */
+  default boolean wasExecuted() {
+    return !isNotRunning();
+  }
+
+  /**
    * @return - <code>true</code> if the current test result is either {@link ITestResult#STARTED} or
    *     {@link ITestResult#CREATED}
    */

--- a/testng-core/src/main/java/org/testng/internal/invokers/ConfigInvoker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/ConfigInvoker.java
@@ -285,18 +285,23 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
                 arguments.getTestMethodResult());
         testResult.setParameters(parameters);
 
-        runConfigurationListeners(testResult, arguments.getTestMethod(), true /* before */);
-
         Object newInstance = computeInstance(arguments.getInstance(), inst, tm);
         if (isConfigMethodEligibleForScrutiny(tm)) {
           if (m_executedConfigMethods.add(arguments.getTestMethod())) {
+            runConfigurationListeners(testResult, arguments.getTestMethod(), true /* before */);
             invokeConfigurationMethod(newInstance, tm, parameters, testResult);
           }
         } else {
+          runConfigurationListeners(testResult, arguments.getTestMethod(), true /* before */);
           invokeConfigurationMethod(newInstance, tm, parameters, testResult);
         }
         copyAttributesFromNativelyInjectedTestResult(parameters, arguments.getTestMethodResult());
-        runConfigurationListeners(testResult, arguments.getTestMethod(), false /* after */);
+
+        if (testResult.wasExecuted()) {
+          // When it comes to "firstTimeOnly" configurations, some of them would NOT be run
+          // by TestNG. For those occurrences, DONOT run the listener.
+          runConfigurationListeners(testResult, arguments.getTestMethod(), false /* after */);
+        }
         if (testResult.getStatus() == ITestResult.SKIP) {
           Throwable t = testResult.getThrowable();
           if (t != null) {


### PR DESCRIPTION
Ensure that the listeners for “firstTimeOnly” 
methods are executed ONLY if the config method
was run else skip listener execution as well.

The test was failing because it relied on config
listeners

Fixes the sporadic failure in https://github.com/krmahadevan/testng/actions/runs/3611418844/jobs/6085892554