### PR TITLE
2857 xml test index in yaml suite

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-2857: XmlTest index is not set for test suites invoked with YAML
 
 7.7.1
 Fixed: GITHUB-2854: overloaded assertEquals methods do not work from Groovy (Krishnan Mahadevan)

--- a/testng-core-api/src/main/java/org/testng/xml/XmlTest.java
+++ b/testng-core-api/src/main/java/org/testng/xml/XmlTest.java
@@ -505,6 +505,10 @@ public class XmlTest implements Cloneable {
     return m_index;
   }
 
+  public void setIndex(int index) {
+    m_index = index;
+  }
+
   @Override
   public int hashCode() {
     final int prime = 31;

--- a/testng-core/src/main/java/org/testng/internal/Yaml.java
+++ b/testng-core/src/main/java/org/testng/internal/Yaml.java
@@ -60,11 +60,13 @@ public final class Yaml {
     result.setFileName(filePath);
 
     // Adjust XmlTest parents and indices
+    int testIndex = 0;
     for (XmlTest t : result.getTests()) {
+      t.setIndex(testIndex++);
       t.setSuite(result);
-      int index = 0;
+      int classIndex = 0;
       for (XmlClass c : t.getClasses()) {
-        c.setIndex(index++);
+        c.setIndex(classIndex++);
       }
     }
 

--- a/testng-core/src/test/java/test/yaml/YamlTest.java
+++ b/testng-core/src/test/java/test/yaml/YamlTest.java
@@ -9,6 +9,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Collection;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.testng.Assert;
@@ -18,6 +19,7 @@ import org.testng.internal.Yaml;
 import org.testng.internal.YamlParser;
 import org.testng.xml.SuiteXmlParser;
 import org.testng.xml.XmlSuite;
+import org.testng.xml.XmlTest;
 import org.testng.xml.internal.Parser;
 import test.SimpleBaseTest;
 
@@ -97,6 +99,18 @@ public class YamlTest extends SimpleBaseTest {
       }
 
       throw new AssertionError("Yaml parser failed to parse suite", throwable);
+    }
+  }
+
+  @Test(description = "GITHUB-2857")
+  public void testXmlTestIndex() throws IOException {
+    YamlParser yamlParser = new YamlParser();
+    String yamlSuiteFile = "src/test/resources/yaml/testXmlTestIndex.yaml";
+    XmlSuite suite = yamlParser.parse(yamlSuiteFile, new FileInputStream(yamlSuiteFile), false);
+    List<XmlTest> tests = suite.getTests();
+    assertThat(tests.size()).isEqualTo(3);
+    for (int i = 0; i < tests.size(); i++) {
+      assertThat(tests.get(i).getIndex()).isEqualTo(i);
     }
   }
 

--- a/testng-core/src/test/resources/yaml/testXmlTestIndex.yaml
+++ b/testng-core/src/test/resources/yaml/testXmlTestIndex.yaml
@@ -1,0 +1,14 @@
+name: SuiteYaml
+tests:
+  - name: TestYaml-1
+    parameters: { input: yaml_1 }
+    classes:
+      - test.TestNGTest
+  - name: TestYaml-2
+    parameters: { input: yaml_2 }
+    classes:
+      - test.TestNGTest
+  - name: TestYaml-3
+    parameters: { input: yaml_3 }
+    classes:
+      - test.TestNGTest


### PR DESCRIPTION
Fixes #2857.

Set XmlTest indexes after loading test suite from Yaml.
