### PR TITLE
Allow OnAfterClass listeners to run after AfterClass Configuration Methods

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-2796: Option for onAfterClass to run after @AfterClass
 Fixed: GITHUB-2857: XmlTest index is not set for test suites invoked with YAML
 
 7.7.1

--- a/testng-core-api/src/main/java/org/testng/internal/RuntimeBehavior.java
+++ b/testng-core-api/src/main/java/org/testng/internal/RuntimeBehavior.java
@@ -15,6 +15,7 @@ public final class RuntimeBehavior {
   public static final String STRICTLY_HONOUR_PARALLEL_MODE = "testng.strict.parallel";
   public static final String TESTNG_DEFAULT_VERBOSE = "testng.default.verbose";
   public static final String IGNORE_CALLBACK_INVOCATION_SKIPS = "testng.ignore.callback.skip";
+  public static final String SYMMETRIC_LISTENER_EXECUTION = "testng.listener.execution.symmetric";
 
   private RuntimeBehavior() {}
 
@@ -131,5 +132,18 @@ public final class RuntimeBehavior {
    */
   public static int getDefaultVerboseLevel() {
     return Integer.getInteger(TESTNG_DEFAULT_VERBOSE, 1);
+  }
+
+  /**
+   * @return - <code>true</code> if we would like to invoke AfterClass methods symmetrically to
+   *     BeforeClass. When true, order is:
+   *     <ol>
+   *       <li>Class @afterClass methods
+   *       <li>Listener onAfterClass methods
+   *     </ol>
+   *     When false, order is reversed.
+   */
+  public static boolean useSymmetricListenerExecution() {
+    return Boolean.parseBoolean(System.getProperty(SYMMETRIC_LISTENER_EXECUTION, "false"));
   }
 }

--- a/testng-core/src/main/java/org/testng/internal/invokers/TestMethodWorker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/TestMethodWorker.java
@@ -207,9 +207,16 @@ public class TestMethodWorker implements IWorker<ITestNGMethod> {
       invokeInstances.add(inst);
     }
 
-    for (IClassListener listener : m_listeners) {
-      listener.onAfterClass(testClass);
+    if (RuntimeBehavior.useSymmetricListenerExecution()) {
+      invokeAfterClassConfigurations(testClass, invokeInstances);
+      invokeListenersOnAfterClass(testClass, m_listeners);
+    } else {
+      invokeListenersOnAfterClass(testClass, m_listeners);
+      invokeAfterClassConfigurations(testClass, invokeInstances);
     }
+  }
+
+  private void invokeAfterClassConfigurations(ITestClass testClass, List<Object> invokeInstances) {
     for (Object invokeInstance : invokeInstances) {
       ConfigMethodArguments attributes =
           new Builder()
@@ -220,6 +227,12 @@ public class TestMethodWorker implements IWorker<ITestNGMethod> {
               .usingInstance(invokeInstance)
               .build();
       m_configInvoker.invokeConfigurations(attributes);
+    }
+  }
+
+  private void invokeListenersOnAfterClass(ITestClass testClass, List<IClassListener> listeners) {
+    for (IClassListener listener : listeners) {
+      listener.onAfterClass(testClass);
     }
   }
 

--- a/testng-core/src/test/java/test/listeners/ordering/ListenerInvocationDefaultBehaviorTest.java
+++ b/testng-core/src/test/java/test/listeners/ordering/ListenerInvocationDefaultBehaviorTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.testng.TestNG;
 import org.testng.annotations.Test;
+import org.testng.internal.RuntimeBehavior;
 import test.SimpleBaseTest;
 import test.listeners.issue1952.TestclassSample;
 
@@ -460,6 +461,102 @@ public class ListenerInvocationDefaultBehaviorTest extends SimpleBaseTest {
             IREPORTER_GENERATE_REPORT,
             IEXECUTIONLISTENER_ON_EXECUTION_FINISH);
     runTest(expected, SimpleTestClassWithFailedMethodHasRetryAnalyzer.class, true);
+  }
+
+  @Test(description = "Test Configuration/Listener order NOT using symmetric listener execution")
+  public void testOrderForNonSymmetricOnAfterClass() {
+    List<String> nonSymmetricExpected =
+        Arrays.asList(
+            IEXECUTIONLISTENER_ON_EXECUTION_START,
+            IALTERSUITELISTENER_ALTER,
+            IANNOTATIONTRANSFORMER_TRANSFORM_3_ARGS,
+            IANNOTATIONTRANSFORMER_TRANSFORM_4_ARGS,
+            ISUITELISTENER_ON_START,
+            ITESTLISTENER_ON_START_TEST_TAG,
+            METHODINTERCEPTOR_INTERCEPT,
+            METHODINTERCEPTOR_INTERCEPT,
+            // onBeforeClass
+            ICLASSLISTENER_ON_BEFORE_CLASS,
+            // @beforeClass
+            ICONFIGURATIONLISTENER_BEFORE_CONFIGURATION,
+            IINVOKEDMETHODLISTENER_BEFORE_INVOCATION,
+            IINVOKEDMETHODLISTENER_BEFORE_INVOCATION_WITH_CONTEXT,
+            IINVOKEDMETHODLISTENER_AFTER_INVOCATION,
+            IINVOKEDMETHODLISTENER_AFTER_INVOCATION_WITH_CONTEXT,
+            ICONFIGURATIONLISTENER_ON_CONFIGURATION_SUCCESS,
+            // test method
+            ITESTLISTENER_ON_START_TEST_METHOD,
+            IINVOKEDMETHODLISTENER_BEFORE_INVOCATION,
+            IINVOKEDMETHODLISTENER_BEFORE_INVOCATION_WITH_CONTEXT,
+            IINVOKEDMETHODLISTENER_AFTER_INVOCATION,
+            IINVOKEDMETHODLISTENER_AFTER_INVOCATION_WITH_CONTEXT,
+            ITESTLISTENER_ON_TEST_SUCCESS_TEST_METHOD,
+            // onAfterClass
+            ICLASSLISTENER_ON_AFTER_CLASS,
+            // @afterClass
+            ICONFIGURATIONLISTENER_BEFORE_CONFIGURATION,
+            IINVOKEDMETHODLISTENER_BEFORE_INVOCATION,
+            IINVOKEDMETHODLISTENER_BEFORE_INVOCATION_WITH_CONTEXT,
+            IINVOKEDMETHODLISTENER_AFTER_INVOCATION,
+            IINVOKEDMETHODLISTENER_AFTER_INVOCATION_WITH_CONTEXT,
+            ICONFIGURATIONLISTENER_ON_CONFIGURATION_SUCCESS,
+            IEXECUTION_VISUALISER_CONSUME_DOT_DEFINITION,
+            ITESTLISTENER_ON_FINISH_TEST_TAG,
+            ISUITELISTENER_ON_FINISH,
+            IREPORTER_GENERATE_REPORT,
+            IEXECUTIONLISTENER_ON_EXECUTION_FINISH);
+    runTest(nonSymmetricExpected, SimpleTestClassWithBeforeAndAfterClass.class);
+  }
+
+  @Test(description = "Test Configuration/Listener order using symmetric listener execution")
+  public void testOrderForSymmetricOnAfterClass() {
+    List<String> symmetricExpected =
+        Arrays.asList(
+            IEXECUTIONLISTENER_ON_EXECUTION_START,
+            IALTERSUITELISTENER_ALTER,
+            IANNOTATIONTRANSFORMER_TRANSFORM_3_ARGS,
+            IANNOTATIONTRANSFORMER_TRANSFORM_4_ARGS,
+            ISUITELISTENER_ON_START,
+            ITESTLISTENER_ON_START_TEST_TAG,
+            METHODINTERCEPTOR_INTERCEPT,
+            METHODINTERCEPTOR_INTERCEPT,
+            // onBeforeClass
+            ICLASSLISTENER_ON_BEFORE_CLASS,
+            // @beforeClass
+            ICONFIGURATIONLISTENER_BEFORE_CONFIGURATION,
+            IINVOKEDMETHODLISTENER_BEFORE_INVOCATION,
+            IINVOKEDMETHODLISTENER_BEFORE_INVOCATION_WITH_CONTEXT,
+            IINVOKEDMETHODLISTENER_AFTER_INVOCATION,
+            IINVOKEDMETHODLISTENER_AFTER_INVOCATION_WITH_CONTEXT,
+            ICONFIGURATIONLISTENER_ON_CONFIGURATION_SUCCESS,
+            // test method
+            ITESTLISTENER_ON_START_TEST_METHOD,
+            IINVOKEDMETHODLISTENER_BEFORE_INVOCATION,
+            IINVOKEDMETHODLISTENER_BEFORE_INVOCATION_WITH_CONTEXT,
+            IINVOKEDMETHODLISTENER_AFTER_INVOCATION,
+            IINVOKEDMETHODLISTENER_AFTER_INVOCATION_WITH_CONTEXT,
+            ITESTLISTENER_ON_TEST_SUCCESS_TEST_METHOD,
+            // @afterClass
+            ICONFIGURATIONLISTENER_BEFORE_CONFIGURATION,
+            IINVOKEDMETHODLISTENER_BEFORE_INVOCATION,
+            IINVOKEDMETHODLISTENER_BEFORE_INVOCATION_WITH_CONTEXT,
+            IINVOKEDMETHODLISTENER_AFTER_INVOCATION,
+            IINVOKEDMETHODLISTENER_AFTER_INVOCATION_WITH_CONTEXT,
+            ICONFIGURATIONLISTENER_ON_CONFIGURATION_SUCCESS,
+            // onAfterClass
+            ICLASSLISTENER_ON_AFTER_CLASS,
+            IEXECUTION_VISUALISER_CONSUME_DOT_DEFINITION,
+            ITESTLISTENER_ON_FINISH_TEST_TAG,
+            ISUITELISTENER_ON_FINISH,
+            IREPORTER_GENERATE_REPORT,
+            IEXECUTIONLISTENER_ON_EXECUTION_FINISH);
+
+    try {
+      System.setProperty(RuntimeBehavior.SYMMETRIC_LISTENER_EXECUTION, Boolean.TRUE.toString());
+      runTest(symmetricExpected, SimpleTestClassWithBeforeAndAfterClass.class);
+    } finally {
+      System.setProperty(RuntimeBehavior.SYMMETRIC_LISTENER_EXECUTION, Boolean.FALSE.toString());
+    }
   }
 
   private static void runTest(List<String> expected, Class<?> clazz) {

--- a/testng-core/src/test/java/test/listeners/ordering/SimpleTestClassWithBeforeAndAfterClass.java
+++ b/testng-core/src/test/java/test/listeners/ordering/SimpleTestClassWithBeforeAndAfterClass.java
@@ -1,0 +1,16 @@
+package test.listeners.ordering;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class SimpleTestClassWithBeforeAndAfterClass {
+  @BeforeClass
+  public void beforeClass() {}
+
+  @Test
+  public void testWillPass() {}
+
+  @AfterClass
+  public void afterClass() {}
+}


### PR DESCRIPTION
Fixes #2796 

### Did you remember to?

- [x] Add test case(s)
- [x] Update `CHANGES.txt`
- [x] Auto applied styling via `./gradlew autostyleApply`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.

**Note:** For more information on contribution guidelines  please make sure you refer our [Contributing](.github/CONTRIBUTING.md) section for detailed set of steps.

---

Code change & Tests to allow specifying ordering of \@afterClass and onAfterClass methods to be same as current or symmetrical to \@beforeClass and onBeforeClass

I've left current behaviour as default to avoid breaking existing usage.
