### PR TITLE
Don’t use null objects

### DIFF
--- a/testng-core/src/main/java/org/testng/internal/invokers/BaseInvoker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/BaseInvoker.java
@@ -28,6 +28,11 @@ class BaseInvoker {
   /** Class failures must be synced as the Invoker is accessed concurrently */
   protected final Map<Class<?>, Set<Object>> m_classInvocationResults = Maps.newConcurrentMap();
 
+  // This object essentially represents the instance to which a BeforeTest|AfterTest
+  // method belongs to. Currently TestNG handles this with a null value.
+  // Instead we now would be using this special object.
+  protected final Object NULL_OBJECT = new Object();
+
   public BaseInvoker(
       ITestResultNotifier notifier,
       Collection<IInvokedMethodListener> invokedMethodListeners,

--- a/testng-core/src/main/java/org/testng/internal/invokers/ConfigInvoker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/ConfigInvoker.java
@@ -482,7 +482,7 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
             classSetEntry -> {
               Set<Object> obj = classSetEntry.getValue();
               Class<?> c = classSetEntry.getKey();
-              boolean containsBeforeTestOrBeforeSuiteFailure = obj.contains(null);
+              boolean containsBeforeTestOrBeforeSuiteFailure = obj.contains(NULL_OBJECT);
               return c == cls
                   || c.isAssignableFrom(cls)
                       && (obj.contains(instance) || containsBeforeTestOrBeforeSuiteFailure);
@@ -513,7 +513,8 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
     synchronized (m_classInvocationResults) {
       Set<Object> instances =
           m_classInvocationResults.computeIfAbsent(clazz, k -> Sets.newHashSet());
-      instances.add(instance);
+      Object objectToAdd = instance == null ? NULL_OBJECT : instance;
+      instances.add(objectToAdd);
     }
   }
 


### PR DESCRIPTION
Currently when dealing with a BeforeTest config 
method, TestNG quietly slips in a null instance 
into the set. The Set interface states that it 
would throw a NPE if a null value is inserted but  HashSet (which is what we use) seems to allow null values into it.

So changing this to start dealing with a special 
object which represents a null.

