### PR TITLE
Ignore Config skips in xml reports

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,7 @@ Fixed: GITHUB-2862: Allow test classes to define "configfailurepolicy" at a per 
 Fixed: GITHUB-2796: Option for onAfterClass to run after @AfterClass (Oliver Hughes)
 Fixed: GITHUB-2857: XmlTest index is not set for test suites invoked with YAML (Sergei Baranov)
 Fixed: GITHUB-2880: Before configuration and before invocation set 'SKIP' when beforeMethod is 'skip' (Bob Shi)
+Fixed: GITHUB-2886: testng-results xml reports config skips from base classes as ignored (Krishnan Mahadevan)
 
 7.7.1
 Fixed: GITHUB-2854: overloaded assertEquals methods do not work from Groovy (Krishnan Mahadevan)

--- a/testng-core/src/main/java/org/testng/reporters/XMLReporter.java
+++ b/testng-core/src/main/java/org/testng/reporters/XMLReporter.java
@@ -55,7 +55,7 @@ public class XMLReporter implements IReporter, ICustomizeXmlReport {
         }
         skipped += skippedPerTest;
         retried += retriedPerTest;
-        ignored += testContext.getExcludedMethods().size();
+        ignored += testContext.getExcludedMethods().stream().filter(ITestNGMethod::isTest).count();
       }
     }
 

--- a/testng-core/src/test/java/test/reports/issue2886/BaseClassSample.java
+++ b/testng-core/src/test/java/test/reports/issue2886/BaseClassSample.java
@@ -1,0 +1,9 @@
+package test.reports.issue2886;
+
+import org.testng.annotations.BeforeSuite;
+
+public class BaseClassSample {
+
+  @BeforeSuite
+  public void beforeSuite() {}
+}

--- a/testng-core/src/test/java/test/reports/issue2886/HydeTestSample.java
+++ b/testng-core/src/test/java/test/reports/issue2886/HydeTestSample.java
@@ -1,0 +1,9 @@
+package test.reports.issue2886;
+
+import org.testng.annotations.Test;
+
+public class HydeTestSample extends BaseClassSample {
+
+  @Test
+  public void rogueBehaviourTest() {}
+}

--- a/testng-core/src/test/java/test/reports/issue2886/JekyllTestSample.java
+++ b/testng-core/src/test/java/test/reports/issue2886/JekyllTestSample.java
@@ -1,0 +1,8 @@
+package test.reports.issue2886;
+
+import org.testng.annotations.Test;
+
+public class JekyllTestSample extends BaseClassSample {
+  @Test
+  public void gentleBehaviourTest() {}
+}


### PR DESCRIPTION
Closes #2886

TestNG by design excludes suite level configs 
When there is inheritance involved and multiple 
Children of the same base class are included in a suite.  But when reporting the results as xml 
TestNG is not excluding these configs from the reports.

Fixed this discrepancy.

Fixes #2886  .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`
- [X] Auto applied styling via `./gradlew autostyleApply`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.

**Note:** For more information on contribution guidelines  please make sure you refer our [Contributing](.github/CONTRIBUTING.md) section for detailed set of steps.
