### PR TITLE
GITHUB-2888 - don't fail test with dataProvider if skipped

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-2888: Skipped Tests with DataProvider appear as failed (Joaquin Moreira)
 Fixed: GITHUB-2884: Discrepancies with DataProvider and Retry of failed tests (Krishnan Mahadevan)
 Fixed: GITHUB-2879: Test listeners specified in parent testng.xml file are not included in testng-failed.xml file (Krishnan Mahadevan)
 Fixed: GITHUB-2866: TestNG.xml doesn't honour Parallel value of a clone (Krishnan Mahadevan)

--- a/testng-core/src/main/java/org/testng/internal/invokers/TestInvoker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/TestInvoker.java
@@ -922,7 +922,8 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
             m_configuration.isPropagateDataProviderFailureAsTestFailure()
                 || bag.isBubbleUpFailures();
 
-        if (throwable instanceof TestNGException || bubbleUpFailures) {
+        if (!(throwable instanceof SkipException)
+            && (throwable instanceof TestNGException || bubbleUpFailures)) {
           tr.setStatus(ITestResult.FAILURE);
           m_notifier.addFailedTest(arguments.getTestMethod(), tr);
         } else {

--- a/testng-core/src/test/java/test/dataprovider/DataProviderTest.java
+++ b/testng-core/src/test/java/test/dataprovider/DataProviderTest.java
@@ -46,6 +46,7 @@ import test.dataprovider.issue2819.TestClassFailingRetrySample;
 import test.dataprovider.issue2819.TestClassSample;
 import test.dataprovider.issue2819.TestClassUsingDataProviderRetrySample;
 import test.dataprovider.issue2819.TestClassWithMultipleRetryImplSample;
+import test.dataprovider.issue2888.SkipDataProviderSample;
 
 public class DataProviderTest extends SimpleBaseTest {
 
@@ -515,7 +516,7 @@ public class DataProviderTest extends SimpleBaseTest {
 
   @Test(description = "GITHUB-2888")
   public void ensureTestNGSkipExceptionWillSkipTestWithDataProvider() {
-    TestNG testng = create(test.dataprovider.issue2888.SkipDataProviderTest.class);
+    TestNG testng = create(SkipDataProviderSample.class);
     testng.propagateDataProviderFailureAsTestFailure();
     testng.run();
     assertThat(testng.getStatus()).isEqualTo(2);

--- a/testng-core/src/test/java/test/dataprovider/DataProviderTest.java
+++ b/testng-core/src/test/java/test/dataprovider/DataProviderTest.java
@@ -513,6 +513,14 @@ public class DataProviderTest extends SimpleBaseTest {
     assertThat(testng.getStatus()).isEqualTo(1);
   }
 
+  @Test(description = "GITHUB-2888")
+  public void ensureTestNGSkipExceptionWillSkipTestWithDataProvider() {
+    TestNG testng = create(test.dataprovider.issue2888.SkipDataProviderTest.class);
+    testng.propagateDataProviderFailureAsTestFailure();
+    testng.run();
+    assertThat(testng.getStatus()).isEqualTo(2);
+  }
+
   @Test(description = "GITHUB-2255")
   public void ensureDataProviderValuesAreVisibleToConfigMethods() {
     TestNG testNG = create(test.dataprovider.issue2255.TestClassSample.class);

--- a/testng-core/src/test/java/test/dataprovider/issue2888/SkipDataProviderListener.java
+++ b/testng-core/src/test/java/test/dataprovider/issue2888/SkipDataProviderListener.java
@@ -1,0 +1,31 @@
+package test.dataprovider.issue2888;
+
+import java.util.Arrays;
+import org.testng.IDataProviderListener;
+import org.testng.IDataProviderMethod;
+import org.testng.ITestContext;
+import org.testng.ITestListener;
+import org.testng.ITestNGMethod;
+import org.testng.ITestResult;
+import org.testng.SkipException;
+
+public class SkipDataProviderListener implements ITestListener, IDataProviderListener {
+  @Override
+  public void onTestStart(ITestResult result) {
+    skipIfSkipMe(result.getMethod());
+  }
+
+  @Override
+  public void onTestSkipped(ITestResult result) {}
+
+  @Override
+  public void beforeDataProviderExecution(
+      IDataProviderMethod dataProviderMethod, ITestNGMethod method, ITestContext iTestContext) {
+    skipIfSkipMe(method);
+  }
+
+  private void skipIfSkipMe(ITestNGMethod testNGMethod) {
+    if (Arrays.asList(testNGMethod.getGroups()).contains("SkipMe"))
+      throw new SkipException("Test was skipped");
+  }
+}

--- a/testng-core/src/test/java/test/dataprovider/issue2888/SkipDataProviderListener.java
+++ b/testng-core/src/test/java/test/dataprovider/issue2888/SkipDataProviderListener.java
@@ -24,7 +24,7 @@ public class SkipDataProviderListener implements ITestListener, IDataProviderLis
     skipIfSkipMe(method);
   }
 
-  private void skipIfSkipMe(ITestNGMethod testNGMethod) {
+  private static void skipIfSkipMe(ITestNGMethod testNGMethod) {
     if (Arrays.asList(testNGMethod.getGroups()).contains("SkipMe"))
       throw new SkipException("Test was skipped");
   }

--- a/testng-core/src/test/java/test/dataprovider/issue2888/SkipDataProviderSample.java
+++ b/testng-core/src/test/java/test/dataprovider/issue2888/SkipDataProviderSample.java
@@ -4,10 +4,9 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
-import test.SimpleBaseTest;
 
 @Listeners({SkipDataProviderListener.class})
-public class SkipDataProviderTest extends SimpleBaseTest {
+public class SkipDataProviderSample {
   @Test(groups = "SkipMe")
   public void testSkip() {
     Assert.fail("This test should not execute, it should be skipped");

--- a/testng-core/src/test/java/test/dataprovider/issue2888/SkipDataProviderTest.java
+++ b/testng-core/src/test/java/test/dataprovider/issue2888/SkipDataProviderTest.java
@@ -1,0 +1,25 @@
+package test.dataprovider.issue2888;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+import test.SimpleBaseTest;
+
+@Listeners({SkipDataProviderListener.class})
+public class SkipDataProviderTest extends SimpleBaseTest {
+  @Test(groups = "SkipMe")
+  public void testSkip() {
+    Assert.fail("This test should not execute, it should be skipped");
+  }
+
+  @DataProvider(name = "dataProvider")
+  private Object[][] dataProvider() {
+    return new Object[][] {new Object[] {"test1"}};
+  }
+
+  @Test(dataProvider = "dataProvider", groups = "SkipMe")
+  public void testSkipWithDataProvider(String a) {
+    Assert.fail("This test should not execute, it should be skipped");
+  }
+}


### PR DESCRIPTION
Fixes #2888

If you want to create a listener that would skip a DataProvider in case a Test will be skipped, the Test was marked as FAILED, instead of SKIPPED

### Did you remember to?

- [x] Add test case(s)
- [x] Update `CHANGES.txt`
- [x] Auto applied styling via `./gradlew autostyleApply`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.

**Note:** For more information on contribution guidelines  please make sure you refer our [Contributing](.github/CONTRIBUTING.md) section for detailed set of steps.
