### PR TITLE
Update github actions versions

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -6,5 +6,5 @@ jobs:
     name: "Validation"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: actions/checkout@v3.5.0
+      - uses: gradle/wrapper-validation-action@v1.0.6

--- a/.github/workflows/publish-maven-central.yml
+++ b/.github/workflows/publish-maven-central.yml
@@ -21,10 +21,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3.5.0
 
     - name: Gradle wrapper validation
-      uses: gradle/wrapper-validation-action@v1
+      uses: gradle/wrapper-validation-action@v1.0.6
 
     # Runs a single command using the runners shell
     - name: Install gpg secret key

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -16,10 +16,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3.5.0
 
     - name: Gradle wrapper validation
-      uses: gradle/wrapper-validation-action@v1
+      uses: gradle/wrapper-validation-action@v1.0.6
 
     - name: Publish to GitHub
       run: |

--- a/.github/workflows/release-maven-central.yml
+++ b/.github/workflows/release-maven-central.yml
@@ -24,12 +24,12 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v3.5.0
       with:
         fetch-depth: 0
 
     - name: Gradle wrapper validation
-      uses: gradle/wrapper-validation-action@v1
+      uses: gradle/wrapper-validation-action@v1.0.6
 
     # Runs a single command using the runners shell
     - name: Install gpg secret key

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       # Ask matrix.js to produce 7 jobs
       MATRIX_JOBS: 7
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.5.0
         with:
           fetch-depth: 1
       - id: set-matrix
@@ -37,12 +37,12 @@ jobs:
     env:
       TZ: ${{ matrix.tz }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.5.0
         with:
           fetch-depth: 10
       # Install built-in JDK
       - name: 'Set up JDK ${{ matrix.jdk.version }} / ${{ matrix.jdk.distribution }}'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3.11.0
         if: ${{ matrix.jdk.distribution != 'jdkfile' }}
         with:
           distribution: ${{ matrix.jdk.distribution }}


### PR DESCRIPTION
# Fixes
 
The purpose of this PR is to update the github actions versions to run the actions with node 16 because after april the actions with node 12 will fail.
Currently we have this warning:
```
 [build](https://github.com/cbeust/testng/actions/runs/4511856639/jobs/7944533841)
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```
### Did you remember to?

- [NA] Add test case(s)
- [NA] Update `CHANGES.txt`
- [NA] Auto applied styling via `./gradlew autostyleApply`



* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.

**Note:** For more information on contribution guidelines  please make sure you refer our [Contributing](.github/CONTRIBUTING.md) section for detailed set of steps.
