### PR TITLE
Feature: Check that specific object present in List

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+New: Added assertListContains and assertListContainsObject methods to check if specific object present in List (Dmytro Budym)
 Fixed: GITHUB-2888: Skipped Tests with DataProvider appear as failed (Joaquin Moreira)
 Fixed: GITHUB-2884: Discrepancies with DataProvider and Retry of failed tests (Krishnan Mahadevan)
 Fixed: GITHUB-2879: Test listeners specified in parent testng.xml file are not included in testng-failed.xml file (Krishnan Mahadevan)

--- a/testng-asserts/src/main/java/org/testng/Assert.java
+++ b/testng-asserts/src/main/java/org/testng/Assert.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.testng.collections.Lists;
@@ -2454,5 +2455,59 @@ public class Assert {
         String.format(
             "Expected %s to be thrown, but nothing was thrown", throwableClass.getSimpleName());
     throw new AssertionError(message != null ? message : nothingThrownMessage);
+  }
+
+  /**
+   * Asserts that List contains object. Uses java.util.List#contains method, be sure that equals and
+   * hashCode of tested object are overridden.
+   *
+   * @param list the list to search in
+   * @param object the object to search in list
+   * @param message the fail message
+   * @param <T> type of object
+   */
+  public static <T> void assertListContainsObject(List<T> list, T object, String message) {
+    assertTrue(list.contains(object), "List NOT contains: [" + message + "]");
+  }
+
+  /**
+   * Asserts that List not contains object. Opposite to assertListContainsObject() Uses
+   * java.util.List#contains method, be sure that equals and hashCode of tested object are
+   * overridden.
+   *
+   * @param list the list to search in
+   * @param object to search in list
+   * @param message the fail message
+   * @param <T> type of object
+   */
+  public static <T> void assertListNotContainsObject(List<T> list, T object, String message) {
+    assertFalse(list.contains(object), "List contains: [" + message + "]");
+  }
+
+  /**
+   * Asserts that List contains object by specific Predicate. Uses
+   * java.util.stream.Stream#anyMatch(java.util.function.Predicate) method.
+   *
+   * @param list the list to search in
+   * @param predicate the Predicate to match object
+   * @param message the fail message
+   * @param <T> type of object
+   */
+  public static <T> void assertListContains(List<T> list, Predicate<T> predicate, String message) {
+    assertTrue(list.stream().anyMatch(predicate), "List NOT contains: [" + message + "]");
+  }
+
+  /**
+   * Asserts that List not contains object by specific Predicate. Opposite to assertListContains()
+   * method. Uses java.util.stream.Stream#noneMatch(java.util.function.Predicate) method.
+   *
+   * @param list the list to search in
+   * @param predicate the Predicate to match object
+   * @param message the fail message
+   * @param <T> type of object
+   */
+  public static <T> void assertListNotContains(
+      List<T> list, Predicate<T> predicate, String message) {
+    assertTrue(list.stream().noneMatch(predicate), "List contains: [" + message + "]");
   }
 }

--- a/testng-asserts/src/test/java/test/assertion/AssertionListContainsTest.java
+++ b/testng-asserts/src/test/java/test/assertion/AssertionListContainsTest.java
@@ -1,0 +1,66 @@
+package test.assertion;
+
+import com.google.common.base.Objects;
+import java.util.List;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class AssertionListContainsTest {
+
+  private User userJack = new User("Jack", 22);
+  private User userJohn = new User("John", 32);
+  private List<User> users = List.of(userJack, userJohn);
+
+  @Test
+  public void assertListContainsObject() {
+    Assert.assertListContainsObject(users, userJack, "user Jack");
+  }
+
+  @Test
+  public void assertListNotContainsObject() {
+    Assert.assertListNotContainsObject(users, new User("NoName", 34), "user NoName");
+  }
+
+  @Test
+  public void testAssertListContainsByPredicate() {
+    Assert.assertListContains(users, user -> user.age.equals(22), "user with age 22");
+  }
+
+  @Test
+  public void testAssertListNotContainsByPredicate() {
+    Assert.assertListNotContains(users, user -> user.age.equals(19), "user with age 19");
+  }
+
+  private class User {
+
+    private String name;
+    private Integer age;
+
+    public User(String name, Integer age) {
+      this.name = name;
+      this.age = age;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      User user = (User) o;
+      return Objects.equal(name, user.name) && Objects.equal(age, user.age);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(name, age);
+    }
+
+    @Override
+    public String toString() {
+      final StringBuilder sb = new StringBuilder("User{");
+      sb.append("name='").append(name).append('\'');
+      sb.append(", age=").append(age);
+      sb.append('}');
+      return sb.toString();
+    }
+  }
+}


### PR DESCRIPTION
### **Feature: Check that specific object present in List**

**Motivation**
It's a common use case to check if some object present in list. There are objects with overridden and not overridden `equals()` & `hashCode()`. 

So is very repeating operation to write code as:
`Assert.assertTrue(list.stream().anyMatch(user -> user.name.equals(userName)), "list not contains user");`
`Assert.assertTrue(list.contains(user), "list not contains user");`

**I propose to add methods to simplify this action and convenient use:**
`Assert.assertListContains(users, user -> user.name.equals(userName), "user " + userName);`
`Assert.assertListContainsObject(users, user, "user " + user.name);`

`assertListContains` uses a Predicate 
`assertListContainsObject` uses `contains()` method of `List`

### Did you remember to?

- [x] Add test case(s)
- [x] Update `CHANGES.txt`
- [x] Auto applied styling via `./gradlew autostyleApply`


