### PR TITLE
Minor code clean-ups

### DIFF
--- a/testng-core-api/src/main/java/org/testng/Reporter.java
+++ b/testng-core-api/src/main/java/org/testng/Reporter.java
@@ -1,9 +1,8 @@
 package org.testng;
 
-import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Vector;
 import org.testng.collections.Lists;
 import org.testng.collections.Maps;
 import org.testng.internal.Utils;
@@ -32,9 +31,9 @@ public class Reporter {
       new InheritableThreadLocal<>();
 
   /** All output logged in a sequential order. */
-  private static final List<String> m_output = new Vector<>();
+  private static final List<String> m_output = new LinkedList<>();
 
-  private static final Map<String, List<Integer>> m_methodOutputMap = Maps.newHashMap();
+  private static final Map<String, List<Integer>> m_methodOutputMap = Maps.newConcurrentMap();
 
   private static boolean m_escapeHtml = false;
   // This variable is responsible for persisting all output that is yet to be associated with any
@@ -77,7 +76,7 @@ public class Reporter {
     if (m == null) {
       // Persist the output temporarily into a ThreadLocal String list.
       if (m_orphanedOutput.get() == null) {
-        m_orphanedOutput.set(new ArrayList<>());
+        m_orphanedOutput.set(new LinkedList<>());
       }
       m_orphanedOutput.get().add(s);
       return;
@@ -86,7 +85,7 @@ public class Reporter {
     // Synchronization needed to ensure the line number and m_output are updated atomically.
     int n = getOutput().size();
 
-    List<Integer> lines = m_methodOutputMap.computeIfAbsent(m.id(), k -> Lists.newArrayList());
+    List<Integer> lines = m_methodOutputMap.computeIfAbsent(m.id(), k -> Lists.newLinkedList());
 
     // Check if there was already some orphaned output for the current thread.
     if (m_orphanedOutput.get() != null) {

--- a/testng-core/src/main/java/org/testng/TestNG.java
+++ b/testng-core/src/main/java/org/testng/TestNG.java
@@ -55,7 +55,6 @@ import org.testng.reporters.EmailableReporter2;
 import org.testng.reporters.FailedReporter;
 import org.testng.reporters.JUnitReportReporter;
 import org.testng.reporters.PerSuiteXMLReporter;
-import org.testng.reporters.SuiteHTMLReporter;
 import org.testng.reporters.VerboseReporter;
 import org.testng.reporters.XMLReporter;
 import org.testng.reporters.jq.Main;
@@ -937,7 +936,6 @@ public class TestNG {
       this.exitCodeListener.failIfAllTestsSkipped();
     }
     if (m_useDefaultListeners) {
-      addReporter(SuiteHTMLReporter.class);
       addReporter(Main.class);
       addReporter(FailedReporter.class);
       if (m_generateResultsPerSuite) {

--- a/testng-core/src/main/java/org/testng/reporters/EmailableReporter.java
+++ b/testng-core/src/main/java/org/testng/reporters/EmailableReporter.java
@@ -33,8 +33,10 @@ import org.testng.xml.XmlSuite;
 /**
  * Reported designed to render self-contained HTML top down view of a testing suite.
  *
+ * @deprecated - This reporter is being deprecated in favour of the newer {@link EmailableReporter2}
  * @since 5.2
  */
+@Deprecated
 public class EmailableReporter implements IReporter {
   private static final Logger L = Logger.getLogger(EmailableReporter.class);
 

--- a/testng-core/src/main/java/org/testng/reporters/SuiteHTMLReporter.java
+++ b/testng-core/src/main/java/org/testng/reporters/SuiteHTMLReporter.java
@@ -27,9 +27,12 @@ import org.testng.xml.XmlSuite;
 /**
  * This class implements an HTML reporter for suites.
  *
+ * @deprecated - This reporter is deprecated as of TestNG <code>7.9.0</code> in favour of {@link
+ *     org.testng.reporters.jq.Main}
  * @author cbeust
  * @author <a href='mailto:the_mindstorm@evolva.ro'>Alexandru Popescu</a>
  */
+@Deprecated
 public class SuiteHTMLReporter implements IReporter {
   public static final String METHODS_CHRONOLOGICAL = "methods.html";
   public static final String METHODS_ALPHABETICAL = "methods-alphabetical.html";


### PR DESCRIPTION
* Reporter.log() to use LinkedList instead of  using “Vector” so that we are a bit more memory 
efficient.
* Deprecated the old SuiteHTMLReporter since its  being generated in a “old” folder and we have a new  jquery backed newer report.
* Removed SuiteHTMLReporter from being generated  by default. If a user wants, they can refer to it  explicitly as a listener
* Deprecated the old EmailableReporter which is not even being generated in favour of EmailableReporter2