### PR TITLE
Draft implementation  of IListenerSetupReporter

### DIFF
--- a/testng-core-api/src/main/java/org/testng/IListenerSetupReporter.java
+++ b/testng-core-api/src/main/java/org/testng/IListenerSetupReporter.java
@@ -1,0 +1,17 @@
+package org.testng;
+
+
+public interface IListenerSetupReporter extends ITestNGListener {
+
+  default void onListenerSetupStart() {
+    // not implemented
+  }
+
+  default void onListenerSetupFailure(Throwable e) {
+    // not implemented
+  }
+
+  default void onListenerSetupFinish() {
+    // not implemented
+  }
+}

--- a/testng-core/src/main/java/org/testng/internal/Configuration.java
+++ b/testng-core/src/main/java/org/testng/internal/Configuration.java
@@ -7,6 +7,7 @@ import org.testng.IConfigurationListener;
 import org.testng.IExecutionListener;
 import org.testng.IHookable;
 import org.testng.IInjectorFactory;
+import org.testng.IListenerSetupReporter;
 import org.testng.ITestObjectFactory;
 import org.testng.collections.Lists;
 import org.testng.collections.Maps;
@@ -36,6 +37,9 @@ public class Configuration implements IConfiguration {
   private boolean includeAllDataDrivenTestsWhenSkipping;
 
   private boolean propagateDataProviderFailureAsTestFailure;
+
+  private final Map<Class<? extends IListenerSetupReporter>, IListenerSetupReporter>
+      listenerSetupReporters = Maps.newLinkedHashMap();;
 
   public Configuration() {
     init(new JDK15AnnotationFinder(new DefaultAnnotationTransformer()));
@@ -92,6 +96,16 @@ public class Configuration implements IConfiguration {
   @Override
   public List<IExecutionListener> getExecutionListeners() {
     return Lists.newArrayList(m_executionListeners.values());
+  }
+
+  @Override
+  public List<IListenerSetupReporter> getListenerSetupReporters() {
+    return Lists.newArrayList(listenerSetupReporters.values());
+  }
+
+  @Override
+  public boolean addListenerSetupReporters(IListenerSetupReporter l) {
+    return listenerSetupReporters.putIfAbsent(l.getClass(), l) == null;
   }
 
   @Override

--- a/testng-core/src/main/java/org/testng/internal/IConfiguration.java
+++ b/testng-core/src/main/java/org/testng/internal/IConfiguration.java
@@ -24,6 +24,10 @@ public interface IConfiguration {
 
   List<IExecutionListener> getExecutionListeners();
 
+  List<IListenerSetupReporter> getListenerSetupReporters();
+
+  boolean addListenerSetupReporters(IListenerSetupReporter l);
+
   default void addExecutionListener(IExecutionListener l) {}
 
   default boolean addExecutionListenerIfAbsent(IExecutionListener l) {

--- a/testng-core/src/test/java/org/testng/xml/XmlSuiteTest.java
+++ b/testng-core/src/test/java/org/testng/xml/XmlSuiteTest.java
@@ -2,6 +2,7 @@ package org.testng.xml;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
+import static org.testng.xml.issue2937.ListenerSetupReporter.isListenerSetupFailureReported;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -22,6 +23,7 @@ import org.testng.xml.internal.Parser;
 import org.testng.xml.issue2866.ATestClassSample;
 import org.testng.xml.issue2866.BTestClassSample;
 import org.testng.xml.issue2866.ThreadCountingSuiteAlteringListener;
+import org.testng.xml.issue2937.ListenerSetupReporter;
 import test.SimpleBaseTest;
 
 public class XmlSuiteTest extends SimpleBaseTest {
@@ -212,6 +214,23 @@ public class XmlSuiteTest extends SimpleBaseTest {
     assertEquals(suite5_0.getName(), "Child Suite 5");
     assertEquals(suite5_0.getTests().size(), 1);
   }
+
+  @Test()
+  public void ensureSuiteLevelTests() throws IOException {
+    PrintStream current = System.out;
+    try {
+      Parser parser = new Parser("src/test/java/org/testng/xml/issue2937/suite.xml");
+      List<XmlSuite> suites = parser.parseToList();
+      TestNG testNG = new TestNG();
+      testNG.setXmlSuites(suites);
+//      testNG.addListener(new ListenerSetupReporter());
+      testNG.run();
+    } finally {
+
+      assertThat(isListenerSetupFailureReported).isEqualTo(true);
+    }
+  }
+
 
   private static void runTests(
       String suiteFile, int childSuitesCount, int suiteCounter, String... suiteNames) {

--- a/testng-core/src/test/java/org/testng/xml/issue2937/BasicTest.java
+++ b/testng-core/src/test/java/org/testng/xml/issue2937/BasicTest.java
@@ -1,0 +1,34 @@
+package org.testng.xml.issue2937;
+
+import org.junit.jupiter.api.Test;
+import org.testng.TestNG;
+//import org.testng.annotations.Test;
+import org.testng.xml.XmlSuite;
+import org.testng.xml.internal.Parser;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BasicTest {
+
+  @Test()
+  public void ensureSuiteLevelBeanshellIsAppliedToAllTests() throws IOException {
+    PrintStream current = System.out;
+    try {
+      Parser parser = new Parser("testng-core/src/test/java/org/testng/xml/issue2937/suite.xml");
+      List<XmlSuite> suites = parser.parseToList();
+      XmlSuite xmlsuite = suites.get(0);
+      assertThat(xmlsuite.getTests().get(0).getMethodSelectors().size()).isEqualTo(0);
+      TestNG testNG = new TestNG();
+      testNG.setXmlSuites(suites);
+      testNG.addListener(new ListenerSetupReporter());
+      testNG.run();
+      assertThat(xmlsuite.getTests().get(0).getMethodSelectors().size()).isEqualTo(1);
+    } finally {
+      System.setOut(current);
+    }
+  }
+}

--- a/testng-core/src/test/java/org/testng/xml/issue2937/ListenerSetupReporter.java
+++ b/testng-core/src/test/java/org/testng/xml/issue2937/ListenerSetupReporter.java
@@ -1,0 +1,24 @@
+package org.testng.xml.issue2937;
+
+import org.testng.IListenerSetupReporter;
+
+public class ListenerSetupReporter implements IListenerSetupReporter {
+  public static boolean isListenerSetupFailureReported = false;
+
+  @Override
+   public void onListenerSetupStart() {
+    System.out.println("onListenerSetupStart");
+  }
+
+  @Override
+  public void onListenerSetupFailure(Throwable e) {
+    isListenerSetupFailureReported = true;
+    System.out.println("onListenerSetupFailure");
+  }
+
+  @Override
+  public void onListenerSetupFinish() {
+
+    System.out.println("onListenerSetupFinish");
+  }
+}

--- a/testng-core/src/test/java/org/testng/xml/issue2937/SuitListenerWithRuntimeError.java
+++ b/testng-core/src/test/java/org/testng/xml/issue2937/SuitListenerWithRuntimeError.java
@@ -1,0 +1,50 @@
+package org.testng.xml.issue2937;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.testng.IAlterSuiteListener;
+import org.testng.IInvokedMethod;
+import org.testng.IInvokedMethodListener;
+import org.testng.ITestContext;
+import org.testng.ITestListener;
+import org.testng.ITestResult;
+import org.testng.xml.XmlSuite;
+import org.testng.xml.XmlTest;
+
+public class SuitListenerWithRuntimeError
+    implements IInvokedMethodListener, IAlterSuiteListener, ITestListener {
+
+  public SuitListenerWithRuntimeError() {
+    throw new RuntimeException();
+  }
+
+  private final Map<String, Set<Long>> mappings = new ConcurrentHashMap<>();
+
+  @Override
+  public void alter(List<XmlSuite> suites) {
+    XmlSuite xmlSuite = suites.get(0);
+    XmlTest xmlTest = xmlSuite.getTests().get(0);
+    XmlTest clonedTest = (XmlTest) xmlTest.clone();
+    clonedTest.setName(xmlTest.getName() + "_cloned");
+  }
+
+  @Override
+  public void onStart(ITestContext context) {
+    mappings.put(context.getName(), Collections.synchronizedSet(new HashSet<>()));
+  }
+
+  @Override
+  public void beforeInvocation(IInvokedMethod method, ITestResult testResult) {
+    Set<Long> threadIds = mappings.get(testResult.getTestContext().getName());
+    threadIds.add(Thread.currentThread().getId());
+  }
+
+  public Set<Long> getThreadIds(String testName) {
+    return mappings.get(testName);
+  }
+}

--- a/testng-core/src/test/java/org/testng/xml/issue2937/XmlTestTest.java
+++ b/testng-core/src/test/java/org/testng/xml/issue2937/XmlTestTest.java
@@ -1,0 +1,55 @@
+package org.testng.xml.issue2937;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.testng.collections.Maps;
+import org.testng.xml.Issue1716TestSample;
+import org.testng.xml.XmlSuite;
+import org.testng.xml.XmlTest;
+import test.SimpleBaseTest;
+import test.junitreports.SimpleTestSample;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class XmlTestTest extends SimpleBaseTest {
+  @Test
+  public void testNameMatchesAny() {
+    XmlSuite xmlSuite = createDummySuiteWithTestNamesAs("test1");
+    XmlTest xmlTest = xmlSuite.getTests().get(0);
+    assertThat(xmlTest.nameMatchesAny(Collections.singletonList("test1"))).isTrue();
+    assertThat(xmlTest.nameMatchesAny(Collections.singletonList("test2"))).isFalse();
+  }
+
+  @Test(dataProvider = "dp", description = "GITHUB-1716")
+  public void testNullOrEmptyParameter(Map<String, String> data) {
+    XmlTest test = createXmlTest("suite", "test", Issue1716TestSample.class);
+    test.setParameters(data);
+    test.toXml("   ");
+    Assert.assertTrue(true, "No exceptions should have been thrown");
+  }
+
+  @DataProvider(name = "dp")
+  public Object[][] getData() {
+    return new Object[][] {{newSetOfParameters(null, "value")}, {newSetOfParameters("foo", null)}};
+  }
+
+  @Test(description = "GITHUB-2467")
+  public void testXMLClassesInCloneMethod() {
+    XmlSuite xmlSuite = createXmlSuite("suite");
+    XmlTest xmlTest = createXmlTest(xmlSuite, "test");
+    createXmlClass(xmlTest, SimpleTestSample.class);
+    XmlTest copyXmlTest = (XmlTest) xmlTest.clone();
+    Assert.assertNotNull(copyXmlTest);
+    Assert.assertNotNull(copyXmlTest.getXmlClasses());
+    Assert.assertEquals(xmlTest.getXmlClasses().size(), copyXmlTest.getXmlClasses().size());
+  }
+
+  private static Map<String, String> newSetOfParameters(String key, String value) {
+    Map<String, String> map = Maps.newHashMap();
+    map.put(key, value);
+    return map;
+  }
+}

--- a/testng-core/src/test/java/org/testng/xml/issue2937/suite.xml
+++ b/testng-core/src/test/java/org/testng/xml/issue2937/suite.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd">
+<suite name="GitHub1533_Suite">
+  <listeners>
+    <listener class-name="org.testng.xml.issue2937.SuitListenerWithRuntimeError"/>
+  </listeners>
+  <test name="GitHub1533_Test">
+      <classes>
+          <class name="org.testng.xml.github1533.SampleTestClassSample"/>
+      </classes>
+  </test>
+</suite>


### PR DESCRIPTION
**Note:** Just for future reference, as TestTG commitee not persuaded to the idea of having new listener would solve the problem completely.

**Problem statement:**
- TestNG's lifecycle includes various listeners to notify about Tests, Suites, execution failures and statistics but not for `Listeners`. Given that Listeners are an integral part of this lifecycle, it's reasonable to expect a dedicated one for handling Listener failures as well.

**What is it?**
- Draft implementation of introducing `IListenerSetupReporter`, to report failures of Listener configuration. 

- More details can be found here https://github.com/testng-team/testng/issues/2937

**How to use?**

1.  Gradle: Register listener as part of `useTestNG` build script
```groovy
 tasks.test {
    useTestNG {
        listeners.add("com.listeners.ListenerSetupReporter")

        suites("src/test/kotlin/config/functional_tests.xml")
    }
}
```
2. TestNG runner

```kotlin
    val testNg = TestNG()
    testNg.addListener(ListenerSetupReporter())
    testNg.setTestSuites(suites)

    testNg.run()
```



