### PR TITLE
Remove extra whitespace in log for Configuration.createMethods()

### DIFF
--- a/testng-core/src/main/java/org/testng/internal/ConfigurationMethod.java
+++ b/testng-core/src/main/java/org/testng/internal/ConfigurationMethod.java
@@ -164,7 +164,7 @@ public class ConfigurationMethod extends BaseTestMethod {
             "Detected a static method ["
                 + method.getQualifiedName()
                 + "()]. Static configuration methods can cause "
-                + " unexpected behavior.";
+                + "unexpected behavior.";
         Logger.getLogger(Configuration.class).warn(msg);
       }
 


### PR DESCRIPTION
This change removes an extra whitespace character that is part of a warning message that is logged when static methods are used for Test suite configuration.

Fixes # .

### Did you remember to?

- [N/A] Add test case(s)
- [N] Update `CHANGES.txt`
- [N/A] Auto applied styling via `./gradlew autostyleApply`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.

**Note:** For more information on contribution guidelines  please make sure you refer our [Contributing](.github/CONTRIBUTING.md) section for detailed set of steps.
