### PR TITLE
Added the link for TestNG Documentation's GitHub Repo in README.md

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current
+Fixed: GITHUB-2904: Add location of docs Github to readme and contributions page (Mohsin Sackeer)
 Fixed: GITHUB-2934: Parallel Dataproviders & retries causes test result count to be skewed (Krishnan Mahadevan)
 Fixed: GITHUB-2925: Issue in ITestcontext.getAllTestMethods() with annotation @BeforeSuite (Krishnan Mahadevan)
 Fixed: GITHUB-2928: The constructor of TestRunner encountered NBC changes in 7.8.0 (Krishnan Mahadevan)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Sonarqube tech debt](https://img.shields.io/sonar/https/sonarqube.com/org.testng:testng/tech_debt.svg?label=Sonarqube%20tech%20debt)](https://sonarqube.com/dashboard/index?id=org.testng:testng)
 [![Sonarqube Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=org.testng%3Atestng&metric=alert_status)](https://sonarcloud.io/dashboard?id=org.testng%3Atestng)
 
-Documentation available at [TestNG's main web site](https://testng.org).
+Documentation available at [TestNG's main web site](https://testng.org). Visit [TestNG Documentation's GitHub Repo](https://github.com/testng-team/testng-team.github.io) to contribute to it.
 
 ### Release Notes
 * [7.8.0](https://groups.google.com/g/testng-users/c/xdldK3VyU_s)


### PR DESCRIPTION
Referring to Github Issue [#2904](https://github.com/testng-team/testng/issues/2904): Add location of docs Github to readme and contributions
