### PR TITLE
Support suite level thread pools for data provider

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 Current
 Fixed: GITHUB-3006: ITestResult injected at @AfterMethod incorrect when a configuration method failed (Krishnan Mahadevan)
+Fixed: GITHUB-2980: Data Provider Threads configuration in the suite don't match the documentation (Krishnan Mahadevan)
 Fixed: GITHUB-3003: BeforeClass|AfterClass with inheritedGroups triggers cyclic dependencies (Krishnan Mahadevan)
 New:   Added @Inherited to the Listeners annotation, allowing it to be used in forming meta-annotations. (Pavlo Glushchenko)
 Fixed: GITHUB-2991: Suite attributes map should be thread safe (Krishnan Mahadevan)

--- a/testng-core-api/src/main/java/org/testng/xml/XmlSuite.java
+++ b/testng-core-api/src/main/java/org/testng/xml/XmlSuite.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import org.testng.ITestObjectFactory;
 import org.testng.collections.Lists;
 import org.testng.collections.Maps;
@@ -123,6 +124,9 @@ public class XmlSuite implements Cloneable {
   private String m_parentModule = "";
   private String m_guiceStage = "";
 
+  /** Represents a unique id for this suite. Can be used for uniquely identifying the xml suite. */
+  public final UUID SUITE_ID = UUID.randomUUID();
+
   /** Whether to SKIP or CONTINUE to re-attempt failed configuration methods. */
   public static final FailurePolicy DEFAULT_CONFIG_FAILURE_POLICY = FailurePolicy.SKIP;
 
@@ -138,6 +142,8 @@ public class XmlSuite implements Cloneable {
 
   public static final Boolean DEFAULT_SKIP_FAILED_INVOCATION_COUNTS = Boolean.FALSE;
   private Boolean m_skipFailedInvocationCounts = DEFAULT_SKIP_FAILED_INVOCATION_COUNTS;
+
+  private boolean shareThreadPoolForDataProviders = false;
 
   /** The thread count. */
   public static final Integer DEFAULT_THREAD_COUNT = 5;
@@ -241,6 +247,14 @@ public class XmlSuite implements Cloneable {
 
   public Class<? extends ITestObjectFactory> getObjectFactoryClass() {
     return m_objectFactoryClass;
+  }
+
+  public void setShareThreadPoolForDataProviders(boolean shareThreadPoolForDataProviders) {
+    this.shareThreadPoolForDataProviders = shareThreadPoolForDataProviders;
+  }
+
+  public boolean isShareThreadPoolForDataProviders() {
+    return shareThreadPoolForDataProviders;
   }
 
   @Deprecated

--- a/testng-core/src/main/java/org/testng/CommandLineArgs.java
+++ b/testng-core/src/main/java/org/testng/CommandLineArgs.java
@@ -274,4 +274,13 @@ public class CommandLineArgs {
       names = GENERATE_RESULTS_PER_SUITE,
       description = "Should TestNG consider failures in Data Providers  as test failures.")
   public Boolean generateResultsPerSuite = false;
+
+  public static final String SHARE_THREAD_POOL_FOR_DATA_PROVIDERS =
+      "-shareThreadPoolForDataProviders";
+
+  @Parameter(
+      names = SHARE_THREAD_POOL_FOR_DATA_PROVIDERS,
+      description =
+          "Should TestNG use a global Shared ThreadPool (At suite level) for running data providers.")
+  public Boolean shareThreadPoolForDataProviders = false;
 }

--- a/testng-core/src/main/java/org/testng/internal/Configuration.java
+++ b/testng-core/src/main/java/org/testng/internal/Configuration.java
@@ -23,6 +23,8 @@ public class Configuration implements IConfiguration {
   private ITestObjectFactory m_objectFactory;
   private IHookable m_hookable;
   private IConfigurable m_configurable;
+
+  private boolean shareThreadPoolForDataProviders = false;
   private final Map<Class<? extends IExecutionListener>, IExecutionListener> m_executionListeners =
       Maps.newLinkedHashMap();
   private final Map<Class<? extends IConfigurationListener>, IConfigurationListener>
@@ -167,5 +169,15 @@ public class Configuration implements IConfiguration {
   @Override
   public boolean isPropagateDataProviderFailureAsTestFailure() {
     return propagateDataProviderFailureAsTestFailure;
+  }
+
+  @Override
+  public boolean isShareThreadPoolForDataProviders() {
+    return this.shareThreadPoolForDataProviders;
+  }
+
+  @Override
+  public void shareThreadPoolForDataProviders(boolean flag) {
+    this.shareThreadPoolForDataProviders = flag;
   }
 }

--- a/testng-core/src/main/java/org/testng/internal/IConfiguration.java
+++ b/testng-core/src/main/java/org/testng/internal/IConfiguration.java
@@ -59,4 +59,8 @@ public interface IConfiguration {
   void propagateDataProviderFailureAsTestFailure();
 
   boolean isPropagateDataProviderFailureAsTestFailure();
+
+  boolean isShareThreadPoolForDataProviders();
+
+  void shareThreadPoolForDataProviders(boolean flag);
 }

--- a/testng-core/src/main/java/org/testng/internal/ObjectBag.java
+++ b/testng-core/src/main/java/org/testng/internal/ObjectBag.java
@@ -1,0 +1,57 @@
+package org.testng.internal;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+import org.testng.ISuite;
+import org.testng.log4testng.Logger;
+
+/**
+ * A simple bean bag that is intended to help share objects during the lifetime of TestNG without
+ * needing it to be a singleton.
+ */
+public final class ObjectBag {
+
+  private static final Logger logger = Logger.getLogger(ObjectBag.class);
+  private final Map<Class<?>, Object> bag = new ConcurrentHashMap<>();
+
+  private static final Map<UUID, ObjectBag> instances = new ConcurrentHashMap<>();
+
+  public static ObjectBag getInstance(ISuite suite) {
+    return instances.computeIfAbsent(suite.getXmlSuite().SUITE_ID, k -> new ObjectBag());
+  }
+
+  public static void cleanup(ISuite suite) {
+    UUID uid = suite.getXmlSuite().SUITE_ID;
+    Optional.ofNullable(instances.get(uid)).ifPresent(ObjectBag::cleanup);
+    instances.remove(uid);
+  }
+
+  /**
+   * @param type - The type of the object to be created
+   * @param supplier - A {@link Supplier} that should be used to produce a new instance
+   * @return - Either the newly produced instance or the existing instance.
+   */
+  public Object createIfRequired(Class<?> type, Supplier<Object> supplier) {
+    return bag.computeIfAbsent(type, t -> supplier.get());
+  }
+
+  public void cleanup() {
+    bag.values().stream()
+        .filter(it -> it instanceof Closeable)
+        .map(it -> (Closeable) it)
+        .forEach(
+            it -> {
+              try {
+                it.close();
+              } catch (IOException e) {
+                logger.debug("Could not clean-up " + it, e);
+              }
+            });
+    bag.clear();
+  }
+}

--- a/testng-core/src/main/java/org/testng/xml/TestNGContentHandler.java
+++ b/testng-core/src/main/java/org/testng/xml/TestNGContentHandler.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Stack;
 import org.testng.ITestObjectFactory;
 import org.testng.TestNGException;
@@ -267,6 +268,15 @@ public class TestNGContentHandler extends DefaultHandler {
       if (null != dataProviderThreadCount) {
         m_currentSuite.setDataProviderThreadCount(Integer.parseInt(dataProviderThreadCount));
       }
+
+      String shareThreadPoolForDataProviders =
+          attributes.getValue("share-thread-pool-for-data-providers");
+      Optional.ofNullable(shareThreadPoolForDataProviders)
+          .ifPresent(
+              it ->
+                  m_currentSuite.setShareThreadPoolForDataProviders(
+                      Boolean.parseBoolean(shareThreadPoolForDataProviders)));
+
       String timeOut = attributes.getValue("time-out");
       if (null != timeOut) {
         m_currentSuite.setTimeOut(timeOut);

--- a/testng-core/src/main/resources/testng-1.0.dtd
+++ b/testng-core/src/main/resources/testng-1.0.dtd
@@ -56,11 +56,13 @@ Cedric Beust & Alexandru Popescu
 @attr  skipfailedinvocationcounts Whether to skip failed invocations.
 @attr  data-provider-thread-count An integer giving the size of the thread pool to use
        for parallel data providers.
+@attr share-thread-pool-for-data-providers - Whether TestNG should use a common thread pool
+      for running parallel data providers. (Works only with TestNG versions 7.9.0 or higher)
 @attr  object-factory A class that implements IObjectFactory that will be used to
        instantiate the test objects.
 @attr allow-return-values If true, tests that return a value will be run as well
 -->
-<!ATTLIST suite 
+<!ATTLIST suite
     name CDATA #REQUIRED
     junit (true | false) "false"
     verbose CDATA #IMPLIED
@@ -73,6 +75,7 @@ Cedric Beust & Alexandru Popescu
     time-out CDATA #IMPLIED
     skipfailedinvocationcounts (true | false) "false"
     data-provider-thread-count CDATA "10"
+    share-thread-pool-for-data-providers (true | false) "false"
     object-factory CDATA #IMPLIED
     group-by-instances (true | false) "false"
     preserve-order (true | false) "true"

--- a/testng-core/src/test/java/test/dataprovider/issue2980/LoggingListener.java
+++ b/testng-core/src/test/java/test/dataprovider/issue2980/LoggingListener.java
@@ -1,0 +1,36 @@
+package test.dataprovider.issue2980;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.testng.IReporter;
+import org.testng.ISuite;
+import org.testng.ISuiteResult;
+import org.testng.internal.collections.Pair;
+import org.testng.xml.XmlSuite;
+
+public class LoggingListener implements IReporter {
+
+  private List<Pair<String, Integer>> pairs;
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public void generateReport(
+      List<XmlSuite> xmlSuites, List<ISuite> suites, String outputDirectory) {
+    pairs =
+        suites.stream()
+            .flatMap(it -> it.getResults().values().stream())
+            .map(ISuiteResult::getTestContext)
+            .flatMap(it -> it.getPassedTests().getAllResults().stream())
+            .map(it -> it.getAttribute(TestClassSample.THREAD_ID))
+            .map(it -> (Pair<String, Integer>) it)
+            .collect(Collectors.toList());
+  }
+
+  public final List<Integer> getThreadIds() {
+    return pairs.stream().map(Pair::second).distinct().collect(Collectors.toList());
+  }
+
+  public final List<String> getMethodNames() {
+    return pairs.stream().map(Pair::first).distinct().collect(Collectors.toList());
+  }
+}

--- a/testng-core/src/test/java/test/dataprovider/issue2980/TestClassSample.java
+++ b/testng-core/src/test/java/test/dataprovider/issue2980/TestClassSample.java
@@ -1,0 +1,42 @@
+package test.dataprovider.issue2980;
+
+import java.util.Arrays;
+import org.testng.ITestResult;
+import org.testng.Reporter;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.testng.internal.collections.Pair;
+
+public class TestClassSample {
+
+  static final String THREAD_ID = "thread_id";
+
+  @Test(dataProvider = "dp")
+  public void testMethod(int ignored) {
+    recordThreadId();
+  }
+
+  @Test(dataProvider = "dp1")
+  public void anotherTestMethod(String ignored) {
+    recordThreadId();
+  }
+
+  private static void recordThreadId() {
+    ITestResult itr = Reporter.getCurrentTestResult();
+    itr.setAttribute(
+        THREAD_ID,
+        new Pair<>(
+            itr.getMethod().getMethodName() + "_" + Arrays.toString(itr.getParameters()),
+            Thread.currentThread().getId()));
+  }
+
+  @DataProvider(name = "dp", parallel = true)
+  public Object[][] getTestData() {
+    return new Object[][] {{1}, {2}, {3}, {4}, {5}};
+  }
+
+  @DataProvider(name = "dp1", parallel = true)
+  public Object[][] getTestData1() {
+    return new Object[][] {{"A"}, {"B"}, {"C"}, {"D"}, {"E"}};
+  }
+}

--- a/testng-core/src/test/resources/2980_with_shared_threadpool_disabled.xml
+++ b/testng-core/src/test/resources/2980_with_shared_threadpool_disabled.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suite SYSTEM "src/main/resources/testng-1.0.dtd">
+<suite name="suite" share-thread-pool-for-data-providers="false" data-provider-thread-count="5">
+    <test name="test">
+        <classes>
+            <class name="test.dataprovider.issue2980.TestClassSample"/>
+        </classes>
+    </test> <!-- test -->
+</suite> <!-- suite -->

--- a/testng-core/src/test/resources/2980_with_shared_threadpool_enabled.xml
+++ b/testng-core/src/test/resources/2980_with_shared_threadpool_enabled.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suite SYSTEM "src/main/resources/testng-1.0.dtd">
+<suite name="suite" share-thread-pool-for-data-providers="true" data-provider-thread-count="5">
+    <test name="test">
+        <classes>
+            <class name="test.dataprovider.issue2980.TestClassSample"/>
+        </classes>
+    </test> <!-- test -->
+</suite> <!-- suite -->


### PR DESCRIPTION
Closes #2980

We can now configure TestNG such that it uses a
Suite level thread pool when running data driven
Tests in parallel.

This can be enabled via the configuration 

“-shareThreadPoolForDataProviders” 
with a value of “true”

Alternatively one can also use the suite level 
attribute “share-thread-pool-for-data-providers”

Fixes #2980 .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`
- [X] Auto applied styling via `./gradlew autostyleApply`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.

**Note:** For more information on contribution guidelines  please make sure you refer our [Contributing](.github/CONTRIBUTING.md) section for detailed set of steps.
