### PR TITLE
Favour FutureTask for concurrency support

### DIFF
--- a/testng-core-api/src/main/java/org/testng/internal/RuntimeBehavior.java
+++ b/testng-core-api/src/main/java/org/testng/internal/RuntimeBehavior.java
@@ -20,11 +20,22 @@ public final class RuntimeBehavior {
   public static final String IGNORE_CALLBACK_INVOCATION_SKIPS = "testng.ignore.callback.skip";
   public static final String SYMMETRIC_LISTENER_EXECUTION = "testng.listener.execution.symmetric";
   public static final String PREFERENTIAL_LISTENERS = "testng.preferential.listeners.package";
+  public static final String FAVOR_CUSTOM_THREAD_POOL_EXECUTOR =
+      "testng.favor.custom.thread-pool.executor";
 
   private RuntimeBehavior() {}
 
   public static boolean ignoreCallbackInvocationSkips() {
     return Boolean.getBoolean(IGNORE_CALLBACK_INVOCATION_SKIPS);
+  }
+
+  /**
+   * @return - <code>true</code> if TestNG is to be using its custom implementation of {@link
+   *     java.util.concurrent.ThreadPoolExecutor} for running concurrent tests. Defaults to <code>
+   *     false</code>
+   */
+  public static boolean favourCustomThreadPoolExecutor() {
+    return Boolean.getBoolean(FAVOR_CUSTOM_THREAD_POOL_EXECUTOR);
   }
 
   /**

--- a/testng-core/src/main/java/org/testng/SuiteTaskExecutor.java
+++ b/testng-core/src/main/java/org/testng/SuiteTaskExecutor.java
@@ -1,0 +1,83 @@
+package org.testng;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import org.testng.internal.IConfiguration;
+import org.testng.internal.RuntimeBehavior;
+import org.testng.internal.Utils;
+import org.testng.internal.thread.TestNGThreadFactory;
+import org.testng.internal.thread.graph.GraphOrchestrator;
+import org.testng.log4testng.Logger;
+import org.testng.thread.IExecutorFactory;
+import org.testng.thread.ITestNGThreadPoolExecutor;
+import org.testng.thread.IThreadWorkerFactory;
+
+class SuiteTaskExecutor {
+  private final BlockingQueue<Runnable> queue;
+  private final IDynamicGraph<ISuite> graph;
+  private final IThreadWorkerFactory<ISuite> factory;
+  private final IConfiguration configuration;
+
+  private final int threadPoolSize;
+
+  private ExecutorService service;
+
+  private static final Logger LOGGER = Logger.getLogger(SuiteTaskExecutor.class);
+
+  public SuiteTaskExecutor(
+      IConfiguration configuration,
+      IThreadWorkerFactory<ISuite> factory,
+      BlockingQueue<Runnable> queue,
+      IDynamicGraph<ISuite> graph,
+      int threadPoolSize) {
+    this.configuration = configuration;
+    this.factory = factory;
+    this.queue = queue;
+    this.graph = graph;
+    this.threadPoolSize = threadPoolSize;
+  }
+
+  public void execute() {
+    String name = "suites-";
+    if (RuntimeBehavior.favourCustomThreadPoolExecutor()) {
+      IExecutorFactory execFactory = configuration.getExecutorFactory();
+      ITestNGThreadPoolExecutor executor =
+          execFactory.newSuiteExecutor(
+              name,
+              graph,
+              factory,
+              threadPoolSize,
+              threadPoolSize,
+              Integer.MAX_VALUE,
+              TimeUnit.MILLISECONDS,
+              queue,
+              null);
+      executor.run();
+      service = executor;
+    } else {
+      service =
+          new ThreadPoolExecutor(
+              threadPoolSize,
+              threadPoolSize,
+              Integer.MAX_VALUE,
+              TimeUnit.MILLISECONDS,
+              queue,
+              new TestNGThreadFactory(name));
+      GraphOrchestrator<ISuite> executor = new GraphOrchestrator<>(service, factory, graph, null);
+      executor.run();
+    }
+  }
+
+  public void awaitCompletion() {
+    Utils.log("TestNG", 2, "Starting executor for all suites");
+    try {
+      boolean ignored = service.awaitTermination(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
+      service.shutdownNow();
+    } catch (InterruptedException handled) {
+      Thread.currentThread().interrupt();
+      LOGGER.error(handled.getMessage(), handled);
+    }
+  }
+}

--- a/testng-core/src/main/java/org/testng/TestTaskExecutor.java
+++ b/testng-core/src/main/java/org/testng/TestTaskExecutor.java
@@ -1,0 +1,95 @@
+package org.testng;
+
+import java.util.Comparator;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import org.testng.internal.IConfiguration;
+import org.testng.internal.RuntimeBehavior;
+import org.testng.internal.Utils;
+import org.testng.internal.thread.TestNGThreadFactory;
+import org.testng.internal.thread.graph.GraphOrchestrator;
+import org.testng.log4testng.Logger;
+import org.testng.thread.IExecutorFactory;
+import org.testng.thread.ITestNGThreadPoolExecutor;
+import org.testng.thread.IThreadWorkerFactory;
+import org.testng.xml.XmlTest;
+
+class TestTaskExecutor {
+  private final BlockingQueue<Runnable> queue;
+  private final Comparator<ITestNGMethod> comparator;
+  private final IDynamicGraph<ITestNGMethod> graph;
+  private final XmlTest xmlTest;
+  private final IThreadWorkerFactory<ITestNGMethod> factory;
+  private final IConfiguration configuration;
+  private final long timeOut;
+
+  private ExecutorService service;
+
+  private static final Logger LOGGER = Logger.getLogger(TestTaskExecutor.class);
+
+  public TestTaskExecutor(
+      IConfiguration configuration,
+      XmlTest xmlTest,
+      IThreadWorkerFactory<ITestNGMethod> factory,
+      BlockingQueue<Runnable> queue,
+      IDynamicGraph<ITestNGMethod> graph,
+      Comparator<ITestNGMethod> comparator) {
+    this.configuration = configuration;
+    this.xmlTest = xmlTest;
+    this.factory = factory;
+    this.queue = queue;
+    this.graph = graph;
+    this.comparator = comparator;
+    this.timeOut = xmlTest.getTimeOut(XmlTest.DEFAULT_TIMEOUT_MS);
+  }
+
+  public void execute() {
+    String name = "test-" + xmlTest.getName();
+    int threadCount = xmlTest.getThreadCount();
+    threadCount = Math.max(threadCount, 1);
+    if (RuntimeBehavior.favourCustomThreadPoolExecutor()) {
+      IExecutorFactory execFactory = configuration.getExecutorFactory();
+      ITestNGThreadPoolExecutor executor =
+          execFactory.newTestMethodExecutor(
+              name,
+              graph,
+              factory,
+              threadCount,
+              threadCount,
+              0,
+              TimeUnit.MILLISECONDS,
+              queue,
+              comparator);
+      executor.run();
+      service = executor;
+    } else {
+      service =
+          new ThreadPoolExecutor(
+              threadCount,
+              threadCount,
+              0,
+              TimeUnit.MILLISECONDS,
+              queue,
+              new TestNGThreadFactory(name));
+      GraphOrchestrator<ITestNGMethod> executor =
+          new GraphOrchestrator<>(service, factory, graph, comparator);
+      executor.run();
+    }
+  }
+
+  public void awaitCompletion() {
+    String msg =
+        String.format(
+            "Starting executor test %d with time out: %d milliseconds.", timeOut, timeOut);
+    Utils.log("TestTaskExecutor", 2, msg);
+    try {
+      boolean ignored = service.awaitTermination(timeOut, TimeUnit.MILLISECONDS);
+      service.shutdownNow();
+    } catch (InterruptedException handled) {
+      LOGGER.error(handled.getMessage(), handled);
+      Thread.currentThread().interrupt();
+    }
+  }
+}

--- a/testng-core/src/main/java/org/testng/internal/thread/DefaultThreadPoolExecutorFactory.java
+++ b/testng-core/src/main/java/org/testng/internal/thread/DefaultThreadPoolExecutorFactory.java
@@ -11,6 +11,11 @@ import org.testng.thread.IExecutorFactory;
 import org.testng.thread.ITestNGThreadPoolExecutor;
 import org.testng.thread.IThreadWorkerFactory;
 
+/**
+ * @deprecated - This implementation stands deprecated as of TestNG <code>v7.9.0</code>. There are
+ *     no alternatives for this implementation.
+ */
+@Deprecated
 public class DefaultThreadPoolExecutorFactory implements IExecutorFactory {
 
   @Override

--- a/testng-core/src/main/java/org/testng/internal/thread/graph/GraphOrchestrator.java
+++ b/testng-core/src/main/java/org/testng/internal/thread/graph/GraphOrchestrator.java
@@ -1,0 +1,139 @@
+package org.testng.internal.thread.graph;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.*;
+import org.testng.IDynamicGraph;
+import org.testng.collections.Maps;
+import org.testng.internal.RuntimeBehavior;
+import org.testng.log4testng.Logger;
+import org.testng.thread.IThreadWorkerFactory;
+import org.testng.thread.IWorker;
+
+/**
+ * An orchestrator that works with a {@link IDynamicGraph} graph to execute nodes from the DAG in an
+ * concurrent fashion by using a {@link ThreadPoolExecutor}
+ */
+public class GraphOrchestrator<T> {
+  private final ExecutorService service;
+  private final IDynamicGraph<T> graph;
+  private final Map<T, IWorker<T>> mapping = Maps.newConcurrentMap();
+  private final Map<T, T> upstream = Maps.newConcurrentMap();
+  private final Comparator<T> comparator;
+  private final IThreadWorkerFactory<T> factory;
+
+  public GraphOrchestrator(
+      ExecutorService service,
+      IThreadWorkerFactory<T> factory,
+      IDynamicGraph<T> graph,
+      Comparator<T> comparator) {
+    this.service = service;
+    this.graph = graph;
+    this.comparator = comparator;
+    this.factory = factory;
+  }
+
+  public void run() {
+    synchronized (graph) {
+      List<T> freeNodes = graph.getFreeNodes();
+      if (comparator != null) {
+        freeNodes.sort(comparator);
+      }
+      runNodes(freeNodes);
+    }
+  }
+
+  private void runNodes(List<T> freeNodes) {
+    List<IWorker<T>> workers = factory.createWorkers(freeNodes);
+    mapNodeToWorker(workers, freeNodes);
+
+    for (IWorker<T> worker : workers) {
+      mapNodeToParent(freeNodes);
+      setStatus(worker, IDynamicGraph.Status.RUNNING);
+      try {
+        TestNGFutureTask<T> task = new TestNGFutureTask<>(worker, this::afterExecute);
+        service.execute(task);
+      } catch (Exception ex) {
+        Logger.getLogger(GraphOrchestrator.class).error(ex.getMessage(), ex);
+      }
+    }
+  }
+
+  private void mapNodeToParent(List<T> freeNodes) {
+    if (!RuntimeBehavior.enforceThreadAffinity()) {
+      return;
+    }
+    for (T freeNode : freeNodes) {
+      List<T> nodes = graph.getDependenciesFor(freeNode);
+      nodes.forEach(eachNode -> upstream.put(eachNode, freeNode));
+    }
+  }
+
+  private void afterExecute(IWorker<T> r, Throwable t) {
+    synchronized (graph) {
+      setStatus(r, computeStatus(r));
+      if (graph.getNodeCount() == graph.getNodeCountWithStatus(IDynamicGraph.Status.FINISHED)) {
+        service.shutdown();
+      } else {
+        List<T> freeNodes = graph.getFreeNodes();
+        if (comparator != null) {
+          freeNodes.sort(comparator);
+        }
+        handleThreadAffinity(freeNodes);
+        runNodes(freeNodes);
+      }
+    }
+  }
+
+  private void handleThreadAffinity(List<T> freeNodes) {
+    if (!RuntimeBehavior.enforceThreadAffinity()) {
+      return;
+    }
+    for (T node : freeNodes) {
+      T upstreamNode = upstream.get(node);
+      if (upstreamNode == null) {
+        continue;
+      }
+      IWorker<T> w = mapping.get(upstreamNode);
+      if (w != null) {
+        long threadId = w.getCurrentThreadId();
+        mapping.put(node, new PhoneyWorker<>(threadId));
+      }
+    }
+  }
+
+  private IDynamicGraph.Status computeStatus(IWorker<T> worker) {
+    IDynamicGraph.Status status = IDynamicGraph.Status.FINISHED;
+    if (RuntimeBehavior.enforceThreadAffinity() && !worker.completed()) {
+      status = IDynamicGraph.Status.READY;
+    }
+    return status;
+  }
+
+  private void setStatus(IWorker<T> worker, IDynamicGraph.Status status) {
+    synchronized (graph) {
+      for (T m : worker.getTasks()) {
+        graph.setStatus(m, status);
+      }
+    }
+  }
+
+  private void mapNodeToWorker(List<IWorker<T>> runnables, List<T> freeNodes) {
+    if (!RuntimeBehavior.enforceThreadAffinity()) {
+      return;
+    }
+    for (IWorker<T> runnable : runnables) {
+      for (T freeNode : freeNodes) {
+        IWorker<T> w = mapping.get(freeNode);
+        if (w != null) {
+          long current = w.getThreadIdToRunOn();
+          runnable.setThreadIdToRunOn(current);
+        }
+        if (runnable.toString().contains(freeNode.toString())) {
+          mapping.put(freeNode, runnable);
+        }
+      }
+    }
+  }
+}

--- a/testng-core/src/main/java/org/testng/internal/thread/graph/GraphThreadPoolExecutor.java
+++ b/testng-core/src/main/java/org/testng/internal/thread/graph/GraphThreadPoolExecutor.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nonnull;
 import org.testng.IDynamicGraph;
 import org.testng.IDynamicGraph.Status;
 import org.testng.TestNGException;
@@ -22,7 +21,11 @@ import org.testng.thread.IWorker;
  * An Executor that launches tasks per batches. It takes a {@code DynamicGraph} of tasks to be run
  * and a {@code IThreadWorkerFactory} to initialize/create {@code Runnable} wrappers around those
  * tasks
+ *
+ * @deprecated - This implementation stands deprecated as of TestNG <code>v7.9.0</code>. There are
+ *     no alternatives for this implementation.
  */
+@Deprecated
 public class GraphThreadPoolExecutor<T> extends ThreadPoolExecutor
     implements ITestNGThreadPoolExecutor {
 
@@ -161,44 +164,8 @@ public class GraphThreadPoolExecutor<T> extends ThreadPoolExecutor
       IWorker<T> w = mapping.get(upstreamNode);
       if (w != null) {
         long threadId = w.getCurrentThreadId();
-        mapping.put(node, new PhoneyWorker(threadId));
+        mapping.put(node, new PhoneyWorker<>(threadId));
       }
-    }
-  }
-
-  private class PhoneyWorker implements IWorker<T> {
-    private long threadId;
-
-    public PhoneyWorker(long threadId) {
-      this.threadId = threadId;
-    }
-
-    @Override
-    public List<T> getTasks() {
-      return null;
-    }
-
-    @Override
-    public long getTimeOut() {
-      return 0;
-    }
-
-    @Override
-    public int getPriority() {
-      return 0;
-    }
-
-    @Override
-    public int compareTo(@Nonnull IWorker<T> o) {
-      return 0;
-    }
-
-    @Override
-    public void run() {}
-
-    @Override
-    public long getThreadIdToRunOn() {
-      return threadId;
     }
   }
 }

--- a/testng-core/src/main/java/org/testng/internal/thread/graph/PhoneyWorker.java
+++ b/testng-core/src/main/java/org/testng/internal/thread/graph/PhoneyWorker.java
@@ -1,0 +1,41 @@
+package org.testng.internal.thread.graph;
+
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.testng.thread.IWorker;
+
+class PhoneyWorker<T> implements IWorker<T> {
+  private final long threadId;
+
+  public PhoneyWorker(long threadId) {
+    this.threadId = threadId;
+  }
+
+  @Override
+  public List<T> getTasks() {
+    return null;
+  }
+
+  @Override
+  public long getTimeOut() {
+    return 0;
+  }
+
+  @Override
+  public int getPriority() {
+    return 0;
+  }
+
+  @Override
+  public int compareTo(@Nonnull IWorker<T> o) {
+    return 0;
+  }
+
+  @Override
+  public void run() {}
+
+  @Override
+  public long getThreadIdToRunOn() {
+    return threadId;
+  }
+}

--- a/testng-core/src/main/java/org/testng/internal/thread/graph/TestNGFutureTask.java
+++ b/testng-core/src/main/java/org/testng/internal/thread/graph/TestNGFutureTask.java
@@ -1,0 +1,56 @@
+package org.testng.internal.thread.graph;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
+import java.util.function.BiConsumer;
+import org.testng.thread.IWorker;
+
+public class TestNGFutureTask<T> extends FutureTask<IWorker<T>> implements IWorker<T> {
+
+  private final IWorker<T> worker;
+  private final BiConsumer<IWorker<T>, Throwable> callback;
+
+  public TestNGFutureTask(IWorker<T> worker, BiConsumer<IWorker<T>, Throwable> callback) {
+    super(worker, worker);
+    this.callback = callback;
+    this.worker = worker;
+  }
+
+  @Override
+  public void run() {
+    super.run();
+  }
+
+  @Override
+  protected void done() {
+    Throwable throwable = null;
+    IWorker<T> result = null;
+    try {
+      result = super.get();
+    } catch (InterruptedException | ExecutionException e) {
+      throwable = e;
+    }
+    callback.accept(result, throwable);
+  }
+
+  @Override
+  public List<T> getTasks() {
+    return worker.getTasks();
+  }
+
+  @Override
+  public long getTimeOut() {
+    return worker.getTimeOut();
+  }
+
+  @Override
+  public int getPriority() {
+    return worker.getPriority();
+  }
+
+  @Override
+  public int compareTo(IWorker<T> o) {
+    return this.worker.compareTo(o);
+  }
+}

--- a/testng-core/src/main/java/org/testng/thread/IExecutorFactory.java
+++ b/testng-core/src/main/java/org/testng/thread/IExecutorFactory.java
@@ -10,7 +10,10 @@ import org.testng.ITestNGMethod;
 /**
  * Represents the capabilities to be possessed by any implementation that can be plugged into TestNG
  * to execute nodes from a {@link org.testng.IDynamicGraph} object.
+ *
+ * @deprecated - This interface stands deprecated as of TestNG <code>v7.9.0</code>.
  */
+@Deprecated
 public interface IExecutorFactory {
 
   /**

--- a/testng-core/src/main/java/org/testng/thread/ITestNGThreadPoolExecutor.java
+++ b/testng-core/src/main/java/org/testng/thread/ITestNGThreadPoolExecutor.java
@@ -2,7 +2,12 @@ package org.testng.thread;
 
 import java.util.concurrent.ExecutorService;
 
-/** Represents the capabilities of a TestNG specific {@link ExecutorService} */
+/**
+ * Represents the capabilities of a TestNG specific {@link ExecutorService}
+ *
+ * @deprecated - This interface stands deprecated as of TestNG <code>v7.9.0</code>.
+ */
+@Deprecated
 public interface ITestNGThreadPoolExecutor extends ExecutorService {
 
   /** Helps kick start the execution and is the point of entry for execution. */


### PR DESCRIPTION
TestNG currently has a custom implementation of 
ThreadPoolExecutor named GraphThreadPoolExecutor.

This class was created to facilitate concurrency
in a DAG.

Now that we are on JDK11, we can very well move
over to leveraging FutureTask based implementations and thus decouple ourselves from the Executor 
and just focus on orchestrating the next node retrieval for execution.

Since this is experimental, we are currently providing a JVM based switch that can fall back to the old 
Behaviour in case of any issues.

JVM argument to use “-Dtestng.favor.custom.thread-pool.executor=true”
