### PR TITLE
Abort for invalid combinations

### DIFF
--- a/testng-core/src/main/java/org/testng/TestNG.java
+++ b/testng-core/src/main/java/org/testng/TestNG.java
@@ -1209,9 +1209,11 @@ public class TestNG {
     // Create a map with XmlSuite as key and corresponding SuiteRunner as value
     for (XmlSuite xmlSuite : m_suites) {
       if (m_configuration.isShareThreadPoolForDataProviders()) {
+        abortIfUsingGraphThreadPoolExecutor("Shared thread-pool for data providers");
         xmlSuite.setShareThreadPoolForDataProviders(true);
       }
       if (m_configuration.useGlobalThreadPool()) {
+        abortIfUsingGraphThreadPoolExecutor("Global thread-pool");
         xmlSuite.shouldUseGlobalThreadPool(true);
       }
       createSuiteRunners(suiteRunnerMap, xmlSuite);
@@ -1260,6 +1262,13 @@ public class TestNG {
 
   private static void error(String s) {
     LOGGER.error(s);
+  }
+
+  private static void abortIfUsingGraphThreadPoolExecutor(String prefix) {
+    if (RuntimeBehavior.favourCustomThreadPoolExecutor()) {
+      throw new UnsupportedOperationException(
+          prefix + " is NOT COMPATIBLE with TestNG's custom thread pool executor");
+    }
   }
 
   /**

--- a/testng-core/src/test/java/test/dataprovider/DataProviderTest.java
+++ b/testng-core/src/test/java/test/dataprovider/DataProviderTest.java
@@ -18,6 +18,7 @@ import org.testng.TestNGException;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.testng.collections.Lists;
+import org.testng.internal.RuntimeBehavior;
 import org.testng.internal.collections.Pair;
 import org.testng.internal.reflect.MethodMatcherException;
 import org.testng.xml.XmlClass;
@@ -607,6 +608,20 @@ public class DataProviderTest extends SimpleBaseTest {
   @Test(description = "GITHUB-2934")
   public void ensureSequentialDataProviderWithRetryAnalyserWorks() {
     runTest(false);
+  }
+
+  @Test(
+      description = "GITHUB-2980",
+      expectedExceptions = UnsupportedOperationException.class,
+      expectedExceptionsMessageRegExp =
+          "Shared thread-pool for data providers is NOT COMPATIBLE with TestNG's custom thread pool executor")
+  public void ensureErrorShownWhenUsedWithGraphThreadPoolExecutor() {
+    try {
+      System.setProperty(RuntimeBehavior.FAVOR_CUSTOM_THREAD_POOL_EXECUTOR, "true");
+      runDataProviderTest(true);
+    } finally {
+      System.setProperty(RuntimeBehavior.FAVOR_CUSTOM_THREAD_POOL_EXECUTOR, "false");
+    }
   }
 
   @Test(description = "GITHUB-2980", dataProvider = "dataProviderForIssue2980")

--- a/testng-core/src/test/java/test/thread/SharedThreadPoolTest.java
+++ b/testng-core/src/test/java/test/thread/SharedThreadPoolTest.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 import org.testng.TestNG;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
+import org.testng.internal.RuntimeBehavior;
 import org.testng.xml.XmlSuite;
 import test.SimpleBaseTest;
 import test.thread.issue2019.TestClassSample;
@@ -35,6 +36,20 @@ public class SharedThreadPoolTest extends SimpleBaseTest {
     assertThat(list)
         .withFailMessage("Expecting the regular and data driven tests to run in at-least 3 threads")
         .hasSizeGreaterThanOrEqualTo(3);
+  }
+
+  @Test(
+      description = "GITHUB-2019",
+      expectedExceptions = UnsupportedOperationException.class,
+      expectedExceptionsMessageRegExp =
+          "Global thread-pool is NOT COMPATIBLE with TestNG's custom thread pool executor")
+  public void ensureErrorShownWhenUsedWithGraphThreadPoolExecutor() {
+    try {
+      System.setProperty(RuntimeBehavior.FAVOR_CUSTOM_THREAD_POOL_EXECUTOR, "true");
+      runSimpleTest(true);
+    } finally {
+      System.setProperty(RuntimeBehavior.FAVOR_CUSTOM_THREAD_POOL_EXECUTOR, "false");
+    }
   }
 
   private static List<Long> runSimpleTest(boolean useSharedGlobalThreadPool) {


### PR DESCRIPTION
GraphThreadPoolExecutor will NOT work if user is
trying to use a shared thread pool for just their
data driven tests (or) for all tests (both regular and data driven) .

So if these combinations are found, abort execution.


