### PR TITLE
Add wrapperbot and update workflow order

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,4 +10,5 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-  
+      # Check for npm updates at 00:00 UTC
+      time: "00:00"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,5 +10,5 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-      # Check for npm updates at 00:00 UTC
+      # Check for updates at 00:00 UTC
       time: "00:00"

--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -2,7 +2,7 @@ name: Combine PRs
 
 on:
   schedule:
-    - cron: '0 0 * * *' # Every day at 00:00 UTC
+    - cron: '0 2 * * *' # Every day at 02:00 UTC
   workflow_dispatch: # allows you to manually trigger the workflow
 
 # The minimum permissions required to run this Action
@@ -18,3 +18,5 @@ jobs:
       - name: combine-prs
         id: combine-prs
         uses: github/combine-prs@v5.0.0
+        with:
+          branch_regex: ^(dependa|wrapper)bot\/.*$

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -1,0 +1,15 @@
+name: Update Gradle Wrapper
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Every day at 00:00 UTC
+
+jobs:
+  update-gradle-wrapper:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Update Gradle Wrapper
+        uses: gradle-update/update-gradle-wrapper-action@v1


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Scheduled Dependabot to check updates daily at 00:00 UTC.
	- Adjusted the execution time of the combine PRs workflow to 02:00 UTC and introduced a new input parameter for branch filtering.
	- Implemented a daily workflow to automatically update the Gradle Wrapper at 00:00 UTC.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->