### PR TITLE
Streamline data provider listener invocation

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 Current
 7.10.0
 Fixed: GITHUB-3059: Support the ability to inject custom listener factory (Krishnan Mahadevan)
+Fixed: GITHUB-3045: IDataProviderListener - beforeDataProviderExecution and afterDataProviderExecution are called twice in special setup (Krishnan Mahadevan)
 Fixed: GITHUB-3038: java.lang.IllegalStateException: Results per method should NOT have been empty (Krishnan Mahadevan)
 Fixed: GITHUB-3022: Remove deprecated JUnit related support in TestNG (Krishnan Mahadevan)
 

--- a/testng-core/src/main/java/org/testng/DataProviderHolder.java
+++ b/testng-core/src/main/java/org/testng/DataProviderHolder.java
@@ -2,6 +2,8 @@ package org.testng;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
+import org.testng.collections.Maps;
 import org.testng.collections.Sets;
 
 /**
@@ -10,11 +12,11 @@ import org.testng.collections.Sets;
  */
 public class DataProviderHolder {
 
-  private final Collection<IDataProviderListener> listeners = Sets.newHashSet();
+  private final Map<Class<?>, IDataProviderListener> listeners = Maps.newConcurrentMap();
   private final Collection<IDataProviderInterceptor> interceptors = Sets.newHashSet();
 
   public Collection<IDataProviderListener> getListeners() {
-    return Collections.unmodifiableCollection(listeners);
+    return Collections.unmodifiableCollection(listeners.values());
   }
 
   public Collection<IDataProviderInterceptor> getInterceptors() {
@@ -26,7 +28,7 @@ public class DataProviderHolder {
   }
 
   public void addListener(IDataProviderListener listener) {
-    listeners.add(listener);
+    listeners.putIfAbsent(listener.getClass(), listener);
   }
 
   public void addInterceptors(Collection<IDataProviderInterceptor> interceptors) {
@@ -38,7 +40,7 @@ public class DataProviderHolder {
   }
 
   public void merge(DataProviderHolder other) {
-    this.listeners.addAll(other.getListeners());
+    addListeners(other.getListeners());
     this.interceptors.addAll(other.getInterceptors());
   }
 }

--- a/testng-core/src/test/java/test/dataprovider/issue3045/DataProviderListener.java
+++ b/testng-core/src/test/java/test/dataprovider/issue3045/DataProviderListener.java
@@ -1,0 +1,35 @@
+package test.dataprovider.issue3045;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.testng.IDataProviderListener;
+import org.testng.IDataProviderMethod;
+import org.testng.ITestContext;
+import org.testng.ITestNGMethod;
+
+public class DataProviderListener implements IDataProviderListener {
+
+  public static List<String> logs = new ArrayList<>();
+
+  @Override
+  public void beforeDataProviderExecution(
+      IDataProviderMethod dataProviderMethod, ITestNGMethod method, ITestContext iTestContext) {
+    logs.add(
+        testName(iTestContext)
+            + "-beforeDataProviderExecution-"
+            + dataProviderMethod.getMethod().getName());
+  }
+
+  @Override
+  public void afterDataProviderExecution(
+      IDataProviderMethod dataProviderMethod, ITestNGMethod method, ITestContext iTestContext) {
+    logs.add(
+        testName(iTestContext)
+            + "-afterDataProviderExecution-"
+            + dataProviderMethod.getMethod().getName());
+  }
+
+  private static String testName(ITestContext ctx) {
+    return "[" + ctx.getName() + "]";
+  }
+}

--- a/testng-core/src/test/java/test/dataprovider/issue3045/DataProviderTestClassSample.java
+++ b/testng-core/src/test/java/test/dataprovider/issue3045/DataProviderTestClassSample.java
@@ -1,0 +1,20 @@
+package test.dataprovider.issue3045;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+@Listeners({DataProviderListener.class})
+public class DataProviderTestClassSample {
+
+  @DataProvider
+  public Object[][] dataProvider() {
+    return new Object[][] {{"Test_1"}, {"Test_2"}, {"Test_3"}};
+  }
+
+  @Test(dataProvider = "dataProvider")
+  public void dataDrivenTest(String ignored) {}
+
+  @Test
+  public void normalTest() {}
+}

--- a/testng-core/src/test/java/test/dataprovider/issue3045/DataProviderWithoutListenerTestClassSample.java
+++ b/testng-core/src/test/java/test/dataprovider/issue3045/DataProviderWithoutListenerTestClassSample.java
@@ -1,0 +1,18 @@
+package test.dataprovider.issue3045;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class DataProviderWithoutListenerTestClassSample {
+
+  @DataProvider
+  public Object[][] dataProvider() {
+    return new Object[][] {{"Test_1"}, {"Test_2"}, {"Test_3"}};
+  }
+
+  @Test(dataProvider = "dataProvider")
+  public void dataDrivenTest(String ignored) {}
+
+  @Test
+  public void normalTest() {}
+}


### PR DESCRIPTION
Closes #3045

Fixes #3045 .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`
- [X] Auto applied styling via `./gradlew autostyleApply`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.

**Note:** For more information on contribution guidelines  please make sure you refer our [Contributing](.github/CONTRIBUTING.md) section for detailed set of steps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue causing data provider listeners to be called twice under certain conditions.
	- Fixed a crash (`java.lang.IllegalStateException`) occurring when results per method were empty.
	- Removed outdated JUnit support in TestNG, enhancing compatibility and performance.
- **New Features**
	- Improved TestNG's data provider functionality by ensuring listeners are invoked only once per data provider, enhancing test reliability.
- **Tests**
	- Added new tests to validate that data provider listeners are correctly invoked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->