### PR TITLE
Support ordering of listeners

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 Current (7.10.0)
-Fixed: GITHUB-3033: Moved ant support under own repository https://github.com/testng-team/testng-ant
+New:   GITHUB-2916: Allow users to define ordering for TestNG listeners (Krishnan Mahadevan)
+Fixed: GITHUB-3033: Moved ant support under own repository https://github.com/testng-team/testng-ant (Julien Herr)
 Fixed: GITHUB-3064: TestResult lost if failure creating RetryAnalyzer (Krishnan Mahadevan)
 Fixed: GITHUB-3048: ConcurrentModificationException when injecting values (Krishnan Mahadevan)
 Fixed: GITHUB-3050: Race condition when creating Guice Modules (Krishnan Mahadevan)

--- a/testng-core/src/main/java/org/testng/CommandLineArgs.java
+++ b/testng-core/src/main/java/org/testng/CommandLineArgs.java
@@ -54,6 +54,14 @@ public class CommandLineArgs {
               + " implementing ITestListener or ISuiteListener")
   public String listener;
 
+  public static final String LISTENER_COMPARATOR = "-listenercomparator";
+
+  @Parameter(
+      names = LISTENER_COMPARATOR,
+      description =
+          "An implementation of ListenerComparator that will be used by TestNG to determine order of execution for listeners")
+  public String listenerComparator;
+
   public static final String METHOD_SELECTORS = "-methodselectors";
 
   @Parameter(

--- a/testng-core/src/main/java/org/testng/DataProviderHolder.java
+++ b/testng-core/src/main/java/org/testng/DataProviderHolder.java
@@ -2,9 +2,13 @@ package org.testng;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import org.testng.collections.Lists;
 import org.testng.collections.Maps;
 import org.testng.collections.Sets;
+import org.testng.internal.IConfiguration;
 
 /**
  * A holder class that is aimed at acting as a container for holding various different aspects of a
@@ -15,12 +19,32 @@ public class DataProviderHolder {
   private final Map<Class<?>, IDataProviderListener> listeners = Maps.newConcurrentMap();
   private final Collection<IDataProviderInterceptor> interceptors = Sets.newHashSet();
 
+  private final IConfiguration configuration;
+
+  public DataProviderHolder(IConfiguration configuration) {
+    this.configuration = configuration;
+  }
+
   public Collection<IDataProviderListener> getListeners() {
-    return Collections.unmodifiableCollection(listeners.values());
+    List<IDataProviderListener> original = Lists.newArrayList(listeners.values());
+    ListenerComparator comparator = getConfiguration().getListenerComparator();
+    if (comparator != null) {
+      original.sort(comparator::compare);
+    }
+    return Collections.unmodifiableCollection(original);
+  }
+
+  public IConfiguration getConfiguration() {
+    return Objects.requireNonNull(configuration);
   }
 
   public Collection<IDataProviderInterceptor> getInterceptors() {
-    return Collections.unmodifiableCollection(interceptors);
+    List<IDataProviderInterceptor> original = Lists.newArrayList(interceptors);
+    ListenerComparator comparator = getConfiguration().getListenerComparator();
+    if (comparator != null) {
+      original.sort(comparator::compare);
+    }
+    return Collections.unmodifiableCollection(original);
   }
 
   public void addListeners(Collection<IDataProviderListener> listeners) {

--- a/testng-core/src/main/java/org/testng/DataProviderHolder.java
+++ b/testng-core/src/main/java/org/testng/DataProviderHolder.java
@@ -1,11 +1,10 @@
 package org.testng;
 
+import static org.testng.ListenerComparator.*;
+
 import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import org.testng.collections.Lists;
 import org.testng.collections.Maps;
 import org.testng.collections.Sets;
 import org.testng.internal.IConfiguration;
@@ -18,33 +17,18 @@ public class DataProviderHolder {
 
   private final Map<Class<?>, IDataProviderListener> listeners = Maps.newConcurrentMap();
   private final Collection<IDataProviderInterceptor> interceptors = Sets.newHashSet();
-
-  private final IConfiguration configuration;
+  private final ListenerComparator listenerComparator;
 
   public DataProviderHolder(IConfiguration configuration) {
-    this.configuration = configuration;
+    this.listenerComparator = Objects.requireNonNull(configuration).getListenerComparator();
   }
 
   public Collection<IDataProviderListener> getListeners() {
-    List<IDataProviderListener> original = Lists.newArrayList(listeners.values());
-    ListenerComparator comparator = getConfiguration().getListenerComparator();
-    if (comparator != null) {
-      original.sort(comparator::compare);
-    }
-    return Collections.unmodifiableCollection(original);
-  }
-
-  public IConfiguration getConfiguration() {
-    return Objects.requireNonNull(configuration);
+    return sort(listeners.values(), listenerComparator);
   }
 
   public Collection<IDataProviderInterceptor> getInterceptors() {
-    List<IDataProviderInterceptor> original = Lists.newArrayList(interceptors);
-    ListenerComparator comparator = getConfiguration().getListenerComparator();
-    if (comparator != null) {
-      original.sort(comparator::compare);
-    }
-    return Collections.unmodifiableCollection(original);
+    return sort(interceptors, listenerComparator);
   }
 
   public void addListeners(Collection<IDataProviderListener> listeners) {

--- a/testng-core/src/main/java/org/testng/ListenerComparator.java
+++ b/testng-core/src/main/java/org/testng/ListenerComparator.java
@@ -1,5 +1,11 @@
 package org.testng;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import org.testng.collections.Lists;
+
 /**
  * Listener interface that can be used to determine listener execution order. This interface will
  * NOT be used to determine execution order for {@link IReporter} implementations.
@@ -14,13 +20,23 @@ package org.testng;
  * </ol>
  */
 @FunctionalInterface
-public interface ListenerComparator {
+public interface ListenerComparator extends Comparator<ITestNGListener> {
+  static <T extends ITestNGListener> List<T> sort(List<T> list, ListenerComparator comparator) {
+    if (comparator == null) {
+      return Collections.unmodifiableList(list);
+    }
+    List<T> original = Lists.newArrayList(list);
+    original.sort(comparator);
+    return Collections.unmodifiableList(original);
+  }
 
-  /**
-   * @param l1 - First {@link ITestNGListener} object to be compared.
-   * @param l2 - Second {@link ITestNGListener} object to be compared.
-   * @return - a negative integer, zero, or a positive integer as the first argument is less than,
-   *     equal to, or greater than the second.
-   */
-  int compare(ITestNGListener l1, ITestNGListener l2);
+  static <T extends ITestNGListener> Collection<T> sort(
+      Collection<T> list, ListenerComparator comparator) {
+    if (comparator == null) {
+      return Collections.unmodifiableCollection(list);
+    }
+    List<T> original = Lists.newArrayList(list);
+    original.sort(comparator);
+    return Collections.unmodifiableCollection(original);
+  }
 }

--- a/testng-core/src/main/java/org/testng/ListenerComparator.java
+++ b/testng-core/src/main/java/org/testng/ListenerComparator.java
@@ -1,0 +1,26 @@
+package org.testng;
+
+/**
+ * Listener interface that can be used to determine listener execution order. This interface will
+ * NOT be used to determine execution order for {@link IReporter} implementations.
+ *
+ * <p>An implementation can be plugged into TestNG either via:
+ *
+ * <ol>
+ *   <li>{@link TestNG#setListenerComparator(ListenerComparator)} if you are using the {@link
+ *       TestNG} APIs.
+ *   <li>Via the configuration parameter <code>-listenercomparator</code> if you are using a build
+ *       tool
+ * </ol>
+ */
+@FunctionalInterface
+public interface ListenerComparator {
+
+  /**
+   * @param l1 - First {@link ITestNGListener} object to be compared.
+   * @param l2 - Second {@link ITestNGListener} object to be compared.
+   * @return - a negative integer, zero, or a positive integer as the first argument is less than,
+   *     equal to, or greater than the second.
+   */
+  int compare(ITestNGListener l1, ITestNGListener l2);
+}

--- a/testng-core/src/main/java/org/testng/SuiteRunner.java
+++ b/testng-core/src/main/java/org/testng/SuiteRunner.java
@@ -1,5 +1,6 @@
 package org.testng;
 
+import static org.testng.ListenerComparator.sort;
 import static org.testng.internal.Utils.isStringBlank;
 
 import com.google.inject.Injector;
@@ -236,11 +237,8 @@ public class SuiteRunner implements ISuite, ISuiteRunnerListener {
   }
 
   private void invokeListeners(boolean start) {
-    List<ISuiteListener> original = Lists.newArrayList(listeners.values());
-    ListenerComparator comparator = this.configuration.getListenerComparator();
-    if (comparator != null) {
-      original.sort(comparator::compare);
-    }
+    Collection<ISuiteListener> original =
+        sort(listeners.values(), this.configuration.getListenerComparator());
     if (start) {
       for (ISuiteListener sl : ListenerOrderDeterminer.order(original)) {
         sl.onStart(this);

--- a/testng-core/src/main/java/org/testng/SuiteRunner.java
+++ b/testng-core/src/main/java/org/testng/SuiteRunner.java
@@ -1,6 +1,5 @@
 package org.testng;
 
-import static org.testng.ListenerComparator.sort;
 import static org.testng.internal.Utils.isStringBlank;
 
 import com.google.inject.Injector;
@@ -237,14 +236,16 @@ public class SuiteRunner implements ISuite, ISuiteRunnerListener {
   }
 
   private void invokeListeners(boolean start) {
-    Collection<ISuiteListener> original =
-        sort(listeners.values(), this.configuration.getListenerComparator());
     if (start) {
-      for (ISuiteListener sl : ListenerOrderDeterminer.order(original)) {
+      for (ISuiteListener sl :
+          ListenerOrderDeterminer.order(
+              listeners.values(), this.configuration.getListenerComparator())) {
         sl.onStart(this);
       }
     } else {
-      List<ISuiteListener> suiteListenersReversed = ListenerOrderDeterminer.reversedOrder(original);
+      List<ISuiteListener> suiteListenersReversed =
+          ListenerOrderDeterminer.reversedOrder(
+              listeners.values(), this.configuration.getListenerComparator());
       for (ISuiteListener sl : suiteListenersReversed) {
         sl.onFinish(this);
       }

--- a/testng-core/src/main/java/org/testng/SuiteRunner.java
+++ b/testng-core/src/main/java/org/testng/SuiteRunner.java
@@ -41,14 +41,14 @@ public class SuiteRunner implements ISuite, ISuiteRunnerListener {
       Maps.newLinkedHashMap();
 
   private String outputDir;
-  private XmlSuite xmlSuite;
+  private final XmlSuite xmlSuite;
   private Injector parentInjector;
 
   private final List<ITestListener> testListeners = Lists.newArrayList();
   private final Map<Class<? extends IClassListener>, IClassListener> classListeners =
       Maps.newLinkedHashMap();
-  private ITestRunnerFactory tmpRunnerFactory;
-  private final DataProviderHolder holder = new DataProviderHolder();
+  private final ITestRunnerFactory tmpRunnerFactory;
+  private final DataProviderHolder holder;
 
   private boolean useDefaultListeners = true;
 
@@ -57,19 +57,19 @@ public class SuiteRunner implements ISuite, ISuiteRunnerListener {
 
   // The configuration
   // Note: adjust test.multiplelisteners.SimpleReporter#generateReport test if renaming the field
-  private IConfiguration configuration;
+  private final IConfiguration configuration;
 
   private ITestObjectFactory objectFactory;
   private Boolean skipFailedInvocationCounts = Boolean.FALSE;
   private final List<IReporter> reporters = Lists.newArrayList();
 
-  private Map<Class<? extends IInvokedMethodListener>, IInvokedMethodListener>
+  private final Map<Class<? extends IInvokedMethodListener>, IInvokedMethodListener>
       invokedMethodListeners;
 
   private final SuiteRunState suiteState = new SuiteRunState();
   private final IAttributes attributes = new Attributes();
   private final Set<IExecutionVisualiser> visualisers = Sets.newHashSet();
-  private ITestListener exitCodeListener;
+  private final ITestListener exitCodeListener;
 
   public SuiteRunner(
       IConfiguration configuration,
@@ -97,7 +97,7 @@ public class SuiteRunner implements ISuite, ISuiteRunnerListener {
         null /* invoked method listeners */,
         new TestListenersContainer() /* test listeners */,
         null /* class listeners */,
-        new DataProviderHolder(),
+        new DataProviderHolder(configuration),
         comparator);
   }
 
@@ -108,41 +108,15 @@ public class SuiteRunner implements ISuite, ISuiteRunnerListener {
       ITestRunnerFactory runnerFactory,
       boolean useDefaultListeners,
       List<IMethodInterceptor> methodInterceptors,
-      Collection<IInvokedMethodListener> invokedMethodListeners,
+      Collection<IInvokedMethodListener> invokedMethodListener,
       TestListenersContainer container,
       Collection<IClassListener> classListeners,
       DataProviderHolder holder,
       Comparator<ITestNGMethod> comparator) {
-    init(
-        configuration,
-        suite,
-        outputDir,
-        runnerFactory,
-        useDefaultListeners,
-        methodInterceptors,
-        invokedMethodListeners,
-        container,
-        classListeners,
-        holder,
-        comparator);
-  }
-
-  private void init(
-      IConfiguration configuration,
-      XmlSuite suite,
-      String outputDir,
-      ITestRunnerFactory runnerFactory,
-      boolean useDefaultListeners,
-      List<IMethodInterceptor> methodInterceptors,
-      Collection<IInvokedMethodListener> invokedMethodListener,
-      TestListenersContainer container,
-      Collection<IClassListener> classListeners,
-      DataProviderHolder attribs,
-      Comparator<ITestNGMethod> comparator) {
     if (comparator == null) {
       throw new IllegalArgumentException("comparator must not be null");
     }
-    this.holder.merge(attribs);
+    this.holder = holder;
     this.configuration = configuration;
     this.xmlSuite = suite;
     this.useDefaultListeners = useDefaultListeners;
@@ -262,14 +236,17 @@ public class SuiteRunner implements ISuite, ISuiteRunnerListener {
   }
 
   private void invokeListeners(boolean start) {
+    List<ISuiteListener> original = Lists.newArrayList(listeners.values());
+    ListenerComparator comparator = this.configuration.getListenerComparator();
+    if (comparator != null) {
+      original.sort(comparator::compare);
+    }
     if (start) {
-      for (ISuiteListener sl :
-          ListenerOrderDeterminer.order(Lists.newArrayList(listeners.values()))) {
+      for (ISuiteListener sl : ListenerOrderDeterminer.order(original)) {
         sl.onStart(this);
       }
     } else {
-      List<ISuiteListener> suiteListenersReversed =
-          ListenerOrderDeterminer.reversedOrder(listeners.values());
+      List<ISuiteListener> suiteListenersReversed = ListenerOrderDeterminer.reversedOrder(original);
       for (ISuiteListener sl : suiteListenersReversed) {
         sl.onFinish(this);
       }
@@ -298,7 +275,8 @@ public class SuiteRunner implements ISuite, ISuiteRunnerListener {
               this);
     } else {
       factory =
-          new ProxyTestRunnerFactory(testListeners.toArray(new ITestListener[0]), tmpRunnerFactory);
+          new ProxyTestRunnerFactory(
+              testListeners.toArray(new ITestListener[0]), tmpRunnerFactory, configuration);
     }
 
     return factory;
@@ -627,7 +605,7 @@ public class SuiteRunner implements ISuite, ISuiteRunnerListener {
         Collection<IInvokedMethodListener> listeners,
         List<IClassListener> classListeners,
         Map<Class<? extends IDataProviderListener>, IDataProviderListener> dataProviderListeners) {
-      DataProviderHolder holder = new DataProviderHolder();
+      DataProviderHolder holder = new DataProviderHolder(this.configuration);
       holder.addListeners(dataProviderListeners.values());
       return newTestRunner(suite, test, listeners, classListeners, holder);
     }
@@ -684,9 +662,13 @@ public class SuiteRunner implements ISuite, ISuiteRunnerListener {
     private final ITestListener[] failureGenerators;
     private final ITestRunnerFactory target;
 
-    public ProxyTestRunnerFactory(ITestListener[] failureListeners, ITestRunnerFactory target) {
+    private final IConfiguration configuration;
+
+    public ProxyTestRunnerFactory(
+        ITestListener[] failureListeners, ITestRunnerFactory target, IConfiguration configuration) {
       failureGenerators = failureListeners;
       this.target = target;
+      this.configuration = configuration;
     }
 
     @Override
@@ -705,7 +687,7 @@ public class SuiteRunner implements ISuite, ISuiteRunnerListener {
         Collection<IInvokedMethodListener> listeners,
         List<IClassListener> classListeners,
         Map<Class<? extends IDataProviderListener>, IDataProviderListener> dataProviderListeners) {
-      DataProviderHolder holder = new DataProviderHolder();
+      DataProviderHolder holder = new DataProviderHolder(configuration);
       holder.addListeners(dataProviderListeners.values());
       return newTestRunner(suite, test, listeners, classListeners, holder);
     }

--- a/testng-core/src/main/java/org/testng/TestNG.java
+++ b/testng-core/src/main/java/org/testng/TestNG.java
@@ -1147,9 +1147,9 @@ public class TestNG {
   }
 
   private void runExecutionListeners(boolean start) {
-    List<IExecutionListener> original =
-        sort(m_configuration.getExecutionListeners(), m_configuration.getListenerComparator());
-    List<IExecutionListener> executionListeners = ListenerOrderDeterminer.order(original);
+    List<IExecutionListener> executionListeners =
+        ListenerOrderDeterminer.order(
+            m_configuration.getExecutionListeners(), m_configuration.getListenerComparator());
     if (start) {
       for (IExecutionListener l : executionListeners) {
         l.onExecutionStart();
@@ -1158,7 +1158,8 @@ public class TestNG {
       exitCodeListener.onExecutionStart();
     } else {
       List<IExecutionListener> executionListenersReversed =
-          ListenerOrderDeterminer.reversedOrder(executionListeners);
+          ListenerOrderDeterminer.reversedOrder(
+              m_configuration.getExecutionListeners(), m_configuration.getListenerComparator());
       for (IExecutionListener l : executionListenersReversed) {
         l.onExecutionFinish();
       }

--- a/testng-core/src/main/java/org/testng/TestNG.java
+++ b/testng-core/src/main/java/org/testng/TestNG.java
@@ -1,5 +1,6 @@
 package org.testng;
 
+import static org.testng.ListenerComparator.sort;
 import static org.testng.internal.Utils.defaultIfStringEmpty;
 import static org.testng.internal.Utils.isStringEmpty;
 import static org.testng.internal.Utils.isStringNotEmpty;
@@ -1138,20 +1139,16 @@ public class TestNG {
   }
 
   private void runSuiteAlterationListeners() {
-    List<IAlterSuiteListener> original = Lists.newArrayList(m_alterSuiteListeners.values());
-    Optional.ofNullable(m_configuration.getListenerComparator())
-        .ifPresent(it -> original.sort(it::compare));
-
+    Collection<IAlterSuiteListener> original =
+        sort(m_alterSuiteListeners.values(), m_configuration.getListenerComparator());
     for (IAlterSuiteListener l : original) {
       l.alter(m_suites);
     }
   }
 
   private void runExecutionListeners(boolean start) {
-    List<IExecutionListener> original = m_configuration.getExecutionListeners();
-    Optional.ofNullable(m_configuration.getListenerComparator())
-        .ifPresent(it -> original.sort(it::compare));
-
+    List<IExecutionListener> original =
+        sort(m_configuration.getExecutionListeners(), m_configuration.getListenerComparator());
     List<IExecutionListener> executionListeners = ListenerOrderDeterminer.order(original);
     if (start) {
       for (IExecutionListener l : executionListeners) {

--- a/testng-core/src/main/java/org/testng/TestRunner.java
+++ b/testng-core/src/main/java/org/testng/TestRunner.java
@@ -852,15 +852,17 @@ public class TestRunner
    *     finish
    */
   private void fireEvent(boolean isStart) {
-    List<ITestListener> original = sort(m_testListeners, m_configuration.getListenerComparator());
     if (isStart) {
-      for (ITestListener itl : ListenerOrderDeterminer.order(original)) {
+      for (ITestListener itl :
+          ListenerOrderDeterminer.order(m_testListeners, m_configuration.getListenerComparator())) {
         itl.onStart(this);
       }
       this.exitCodeListener.onStart(this);
 
     } else {
-      List<ITestListener> testListenersReversed = ListenerOrderDeterminer.reversedOrder(original);
+      List<ITestListener> testListenersReversed =
+          ListenerOrderDeterminer.reversedOrder(
+              m_testListeners, m_configuration.getListenerComparator());
       for (ITestListener itl : testListenersReversed) {
         itl.onFinish(this);
       }

--- a/testng-core/src/main/java/org/testng/TestRunner.java
+++ b/testng-core/src/main/java/org/testng/TestRunner.java
@@ -1,5 +1,6 @@
 package org.testng;
 
+import static org.testng.ListenerComparator.sort;
 import static org.testng.internal.MethodHelper.fixMethodsWithClass;
 
 import java.lang.reflect.Method;
@@ -695,12 +696,8 @@ public class TestRunner
       }
     }
 
-    List<IExecutionVisualiser> original = Lists.newArrayList(this.visualisers);
-    ListenerComparator listenerComparator = m_configuration.getListenerComparator();
-    if (listenerComparator != null) {
-      original.sort(listenerComparator::compare);
-    }
-
+    Collection<IExecutionVisualiser> original =
+        sort(this.visualisers, m_configuration.getListenerComparator());
     graph.setVisualisers(Sets.newLinkedHashSet(original));
     // In some cases, additional sorting is needed to make sure tests run in the appropriate order.
     // If the user specified a method interceptor, or if we have any methods that have a non-default
@@ -745,12 +742,8 @@ public class TestRunner
     List<IMethodInstance> methodInstances =
         MethodHelper.methodsToMethodInstances(Arrays.asList(methods));
 
-    List<IMethodInterceptor> original = Lists.newArrayList(m_methodInterceptors);
-    ListenerComparator listenerComparator = m_configuration.getListenerComparator();
-    if (listenerComparator != null) {
-      original.sort(listenerComparator::compare);
-    }
-
+    List<IMethodInterceptor> original =
+        sort(m_methodInterceptors, m_configuration.getListenerComparator());
     for (IMethodInterceptor m_methodInterceptor : original) {
       methodInstances = m_methodInterceptor.intercept(methodInstances, this);
     }
@@ -859,11 +852,7 @@ public class TestRunner
    *     finish
    */
   private void fireEvent(boolean isStart) {
-    List<ITestListener> original = Lists.newArrayList(m_testListeners);
-    ListenerComparator listenerComparator = m_configuration.getListenerComparator();
-    if (listenerComparator != null) {
-      original.sort(listenerComparator::compare);
-    }
+    List<ITestListener> original = sort(m_testListeners, m_configuration.getListenerComparator());
     if (isStart) {
       for (ITestListener itl : ListenerOrderDeterminer.order(original)) {
         itl.onStart(this);

--- a/testng-core/src/main/java/org/testng/internal/Configuration.java
+++ b/testng-core/src/main/java/org/testng/internal/Configuration.java
@@ -9,6 +9,7 @@ import org.testng.IHookable;
 import org.testng.IInjectorFactory;
 import org.testng.ITestNGListenerFactory;
 import org.testng.ITestObjectFactory;
+import org.testng.ListenerComparator;
 import org.testng.collections.Lists;
 import org.testng.collections.Maps;
 import org.testng.internal.annotations.DefaultAnnotationTransformer;
@@ -36,6 +37,8 @@ public class Configuration implements IConfiguration {
   private IExecutorFactory m_executorFactory = new DefaultThreadPoolExecutorFactory();
 
   private IInjectorFactory injectorFactory = new GuiceBackedInjectorFactory();
+
+  private ListenerComparator listenerComparator;
   private boolean overrideIncludedMethods = false;
 
   private boolean includeAllDataDrivenTestsWhenSkipping;
@@ -74,6 +77,16 @@ public class Configuration implements IConfiguration {
   @Override
   public ITestNGListenerFactory getListenerFactory() {
     return m_listenerFactory;
+  }
+
+  @Override
+  public void setListenerComparator(ListenerComparator comparator) {
+    this.listenerComparator = comparator;
+  }
+
+  @Override
+  public ListenerComparator getListenerComparator() {
+    return listenerComparator;
   }
 
   @Override

--- a/testng-core/src/main/java/org/testng/internal/IConfiguration.java
+++ b/testng-core/src/main/java/org/testng/internal/IConfiguration.java
@@ -14,6 +14,10 @@ public interface IConfiguration {
 
   ITestNGListenerFactory getListenerFactory();
 
+  void setListenerComparator(ListenerComparator comparator);
+
+  ListenerComparator getListenerComparator();
+
   ITestObjectFactory getObjectFactory();
 
   void setObjectFactory(ITestObjectFactory m_objectFactory);

--- a/testng-core/src/main/java/org/testng/internal/ListenerOrderDeterminer.java
+++ b/testng-core/src/main/java/org/testng/internal/ListenerOrderDeterminer.java
@@ -1,5 +1,7 @@
 package org.testng.internal;
 
+import static org.testng.ListenerComparator.sort;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -7,6 +9,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import org.testng.ITestNGListener;
+import org.testng.ListenerComparator;
 import org.testng.collections.Lists;
 import org.testng.internal.collections.Pair;
 
@@ -43,7 +47,9 @@ public final class ListenerOrderDeterminer {
    * @param original - The original collection of listeners
    * @return - A re-ordered collection wherein preferential listeners are added at the end
    */
-  public static <T> List<T> order(Collection<T> original) {
+  public static <T extends ITestNGListener> List<T> order(
+      Collection<T> original, ListenerComparator comparator) {
+    original = sort(original, comparator);
     Pair<List<T>, List<T>> ordered = arrange(original);
     List<T> ideListeners = ordered.first();
     List<T> regularListeners = ordered.second();
@@ -55,7 +61,9 @@ public final class ListenerOrderDeterminer {
    * @return - A reversed ordered list wherein the user listeners are found in reverse order
    *     followed by preferential listeners also in reverse order.
    */
-  public static <T> List<T> reversedOrder(Collection<T> original) {
+  public static <T extends ITestNGListener> List<T> reversedOrder(
+      Collection<T> original, ListenerComparator comparator) {
+    original = sort(original, comparator);
     Pair<List<T>, List<T>> ordered = arrange(original);
     List<T> preferentialListeners = ordered.first();
     List<T> regularListeners = ordered.second();

--- a/testng-core/src/main/java/org/testng/internal/TestListenerHelper.java
+++ b/testng-core/src/main/java/org/testng/internal/TestListenerHelper.java
@@ -10,6 +10,7 @@ import org.testng.ITestNGListenerFactory;
 import org.testng.ITestNGMethod;
 import org.testng.ITestObjectFactory;
 import org.testng.ITestResult;
+import org.testng.ListenerComparator;
 import org.testng.TestNGException;
 import org.testng.annotations.IListenersAnnotation;
 import org.testng.collections.Lists;
@@ -25,9 +26,12 @@ public final class TestListenerHelper {
       ITestResult tr,
       ITestNGMethod tm,
       List<IConfigurationListener> listeners,
-      IConfigurationListener internal) {
+      IConfigurationListener internal,
+      ListenerComparator comparator) {
     internal.beforeConfiguration(tr);
-    for (IConfigurationListener icl : listeners) {
+    List<IConfigurationListener> original = ListenerOrderDeterminer.order(listeners, comparator);
+
+    for (IConfigurationListener icl : original) {
       icl.beforeConfiguration(tr);
       try {
         icl.beforeConfiguration(tr, tm);
@@ -41,9 +45,10 @@ public final class TestListenerHelper {
       ITestResult tr,
       ITestNGMethod tm,
       List<IConfigurationListener> listeners,
-      IConfigurationListener internal) {
+      IConfigurationListener internal,
+      ListenerComparator comparator) {
     List<IConfigurationListener> listenersreversed =
-        ListenerOrderDeterminer.reversedOrder(listeners);
+        ListenerOrderDeterminer.reversedOrder(listeners, comparator);
     listenersreversed.add(internal);
     for (IConfigurationListener icl : listenersreversed) {
       switch (tr.getStatus()) {

--- a/testng-core/src/main/java/org/testng/internal/TestNGClassFinder.java
+++ b/testng-core/src/main/java/org/testng/internal/TestNGClassFinder.java
@@ -144,7 +144,11 @@ public class TestNGClassFinder extends BaseClassFinder {
 
     TestNGClassFinder finder =
         new TestNGClassFinder(
-            moreClasses, m_instanceMap, configuration, m_testContext, new DataProviderHolder());
+            moreClasses,
+            m_instanceMap,
+            configuration,
+            m_testContext,
+            new DataProviderHolder(configuration));
 
     for (IClass ic2 : finder.findTestClasses()) {
       putIClass(ic2.getRealClass(), ic2);

--- a/testng-core/src/main/java/org/testng/internal/invokers/BaseInvoker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/BaseInvoker.java
@@ -1,6 +1,7 @@
 package org.testng.internal.invokers;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.testng.IInvokedMethod;
@@ -9,8 +10,10 @@ import org.testng.ISuiteRunnerListener;
 import org.testng.ITestContext;
 import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
+import org.testng.ListenerComparator;
 import org.testng.SkipException;
 import org.testng.SuiteRunState;
+import org.testng.collections.Lists;
 import org.testng.collections.Maps;
 import org.testng.internal.IConfiguration;
 import org.testng.internal.ITestResultNotifier;
@@ -68,10 +71,15 @@ class BaseInvoker {
     // For BEFORE_INVOCATION method, still run as insert order, but regarding AFTER_INVOCATION, it
     // should be reverse order
     boolean isAfterInvocation = InvokedMethodListenerMethod.AFTER_INVOCATION == listenerMethod;
+    List<IInvokedMethodListener> original = Lists.newArrayList(m_invokedMethodListeners);
+    ListenerComparator comparator = m_configuration.getListenerComparator();
+    if (comparator != null) {
+      original.sort(comparator::compare);
+    }
     Collection<IInvokedMethodListener> listeners =
         isAfterInvocation
-            ? ListenerOrderDeterminer.reversedOrder(m_invokedMethodListeners)
-            : ListenerOrderDeterminer.order(m_invokedMethodListeners);
+            ? ListenerOrderDeterminer.reversedOrder(original)
+            : ListenerOrderDeterminer.order(original);
     if (!isAfterInvocation) {
       suiteRunner.beforeInvocation(invokedMethod, testResult);
     }

--- a/testng-core/src/main/java/org/testng/internal/invokers/BaseInvoker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/BaseInvoker.java
@@ -1,7 +1,5 @@
 package org.testng.internal.invokers;
 
-import static org.testng.ListenerComparator.sort;
-
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -70,12 +68,12 @@ class BaseInvoker {
     // For BEFORE_INVOCATION method, still run as insert order, but regarding AFTER_INVOCATION, it
     // should be reverse order
     boolean isAfterInvocation = InvokedMethodListenerMethod.AFTER_INVOCATION == listenerMethod;
-    Collection<IInvokedMethodListener> original =
-        sort(m_invokedMethodListeners, m_configuration.getListenerComparator());
     Collection<IInvokedMethodListener> listeners =
         isAfterInvocation
-            ? ListenerOrderDeterminer.reversedOrder(original)
-            : ListenerOrderDeterminer.order(original);
+            ? ListenerOrderDeterminer.reversedOrder(
+                m_invokedMethodListeners, m_configuration.getListenerComparator())
+            : ListenerOrderDeterminer.order(
+                m_invokedMethodListeners, m_configuration.getListenerComparator());
     if (!isAfterInvocation) {
       suiteRunner.beforeInvocation(invokedMethod, testResult);
     }

--- a/testng-core/src/main/java/org/testng/internal/invokers/BaseInvoker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/BaseInvoker.java
@@ -1,7 +1,8 @@
 package org.testng.internal.invokers;
 
+import static org.testng.ListenerComparator.sort;
+
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.testng.IInvokedMethod;
@@ -10,10 +11,8 @@ import org.testng.ISuiteRunnerListener;
 import org.testng.ITestContext;
 import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
-import org.testng.ListenerComparator;
 import org.testng.SkipException;
 import org.testng.SuiteRunState;
-import org.testng.collections.Lists;
 import org.testng.collections.Maps;
 import org.testng.internal.IConfiguration;
 import org.testng.internal.ITestResultNotifier;
@@ -71,11 +70,8 @@ class BaseInvoker {
     // For BEFORE_INVOCATION method, still run as insert order, but regarding AFTER_INVOCATION, it
     // should be reverse order
     boolean isAfterInvocation = InvokedMethodListenerMethod.AFTER_INVOCATION == listenerMethod;
-    List<IInvokedMethodListener> original = Lists.newArrayList(m_invokedMethodListeners);
-    ListenerComparator comparator = m_configuration.getListenerComparator();
-    if (comparator != null) {
-      original.sort(comparator::compare);
-    }
+    Collection<IInvokedMethodListener> original =
+        sort(m_invokedMethodListeners, m_configuration.getListenerComparator());
     Collection<IInvokedMethodListener> listeners =
         isAfterInvocation
             ? ListenerOrderDeterminer.reversedOrder(original)

--- a/testng-core/src/main/java/org/testng/internal/invokers/ConfigInvoker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/ConfigInvoker.java
@@ -8,6 +8,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -21,10 +22,12 @@ import org.testng.ITestClass;
 import org.testng.ITestContext;
 import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
+import org.testng.ListenerComparator;
 import org.testng.Reporter;
 import org.testng.SuiteRunState;
 import org.testng.TestNGException;
 import org.testng.annotations.IConfigurationAnnotation;
+import org.testng.collections.Lists;
 import org.testng.collections.Maps;
 import org.testng.collections.Sets;
 import org.testng.internal.ClassHelper;
@@ -75,6 +78,11 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
         testContext.getSuite().getXmlSuite().getConfigFailurePolicy()
             == XmlSuite.FailurePolicy.CONTINUE;
     this.internalConfigurationListener = internalConfigurationListener;
+  }
+
+  @Override
+  public IConfiguration getConfiguration() {
+    return this.m_configuration;
   }
 
   /**
@@ -433,12 +441,18 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
   }
 
   private void runConfigurationListeners(ITestResult tr, ITestNGMethod tm, boolean before) {
+    List<IConfigurationListener> original =
+        Lists.newArrayList(m_notifier.getConfigurationListeners());
+    ListenerComparator comparator = m_configuration.getListenerComparator();
+    if (comparator != null) {
+      original.sort(comparator::compare);
+    }
     if (before) {
       TestListenerHelper.runPreConfigurationListeners(
-          tr, tm, m_notifier.getConfigurationListeners(), internalConfigurationListener);
+          tr, tm, original, internalConfigurationListener);
     } else {
       TestListenerHelper.runPostConfigurationListeners(
-          tr, tm, m_notifier.getConfigurationListeners(), internalConfigurationListener);
+          tr, tm, original, internalConfigurationListener);
     }
   }
 

--- a/testng-core/src/main/java/org/testng/internal/invokers/ConfigInvoker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/ConfigInvoker.java
@@ -1,5 +1,6 @@
 package org.testng.internal.invokers;
 
+import static org.testng.ListenerComparator.sort;
 import static org.testng.internal.invokers.InvokedMethodListenerMethod.AFTER_INVOCATION;
 import static org.testng.internal.invokers.InvokedMethodListenerMethod.BEFORE_INVOCATION;
 import static org.testng.internal.invokers.Invoker.SAME_CLASS;
@@ -22,12 +23,10 @@ import org.testng.ITestClass;
 import org.testng.ITestContext;
 import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
-import org.testng.ListenerComparator;
 import org.testng.Reporter;
 import org.testng.SuiteRunState;
 import org.testng.TestNGException;
 import org.testng.annotations.IConfigurationAnnotation;
-import org.testng.collections.Lists;
 import org.testng.collections.Maps;
 import org.testng.collections.Sets;
 import org.testng.internal.ClassHelper;
@@ -442,11 +441,7 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
 
   private void runConfigurationListeners(ITestResult tr, ITestNGMethod tm, boolean before) {
     List<IConfigurationListener> original =
-        Lists.newArrayList(m_notifier.getConfigurationListeners());
-    ListenerComparator comparator = m_configuration.getListenerComparator();
-    if (comparator != null) {
-      original.sort(comparator::compare);
-    }
+        sort(m_notifier.getConfigurationListeners(), m_configuration.getListenerComparator());
     if (before) {
       TestListenerHelper.runPreConfigurationListeners(
           tr, tm, original, internalConfigurationListener);

--- a/testng-core/src/main/java/org/testng/internal/invokers/ConfigInvoker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/ConfigInvoker.java
@@ -1,6 +1,5 @@
 package org.testng.internal.invokers;
 
-import static org.testng.ListenerComparator.sort;
 import static org.testng.internal.invokers.InvokedMethodListenerMethod.AFTER_INVOCATION;
 import static org.testng.internal.invokers.InvokedMethodListenerMethod.BEFORE_INVOCATION;
 import static org.testng.internal.invokers.Invoker.SAME_CLASS;
@@ -9,7 +8,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -23,6 +21,7 @@ import org.testng.ITestClass;
 import org.testng.ITestContext;
 import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
+import org.testng.ListenerComparator;
 import org.testng.Reporter;
 import org.testng.SuiteRunState;
 import org.testng.TestNGException;
@@ -440,14 +439,21 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
   }
 
   private void runConfigurationListeners(ITestResult tr, ITestNGMethod tm, boolean before) {
-    List<IConfigurationListener> original =
-        sort(m_notifier.getConfigurationListeners(), m_configuration.getListenerComparator());
+    ListenerComparator comparator = m_configuration.getListenerComparator();
     if (before) {
       TestListenerHelper.runPreConfigurationListeners(
-          tr, tm, original, internalConfigurationListener);
+          tr,
+          tm,
+          m_notifier.getConfigurationListeners(),
+          internalConfigurationListener,
+          comparator);
     } else {
       TestListenerHelper.runPostConfigurationListeners(
-          tr, tm, original, internalConfigurationListener);
+          tr,
+          tm,
+          m_notifier.getConfigurationListeners(),
+          internalConfigurationListener,
+          comparator);
     }
   }
 

--- a/testng-core/src/main/java/org/testng/internal/invokers/IConfigInvoker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/IConfigInvoker.java
@@ -2,6 +2,7 @@ package org.testng.internal.invokers;
 
 import org.testng.IClass;
 import org.testng.ITestNGMethod;
+import org.testng.internal.IConfiguration;
 
 public interface IConfigInvoker {
 
@@ -20,4 +21,6 @@ public interface IConfigInvoker {
   void invokeAfterGroupsConfigurations(GroupConfigMethodArguments arguments);
 
   void invokeConfigurations(ConfigMethodArguments arguments);
+
+  IConfiguration getConfiguration();
 }

--- a/testng-core/src/main/java/org/testng/internal/invokers/TestInvoker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/TestInvoker.java
@@ -1,5 +1,6 @@
 package org.testng.internal.invokers;
 
+import static org.testng.ListenerComparator.sort;
 import static org.testng.internal.invokers.InvokedMethodListenerMethod.AFTER_INVOCATION;
 import static org.testng.internal.invokers.InvokedMethodListenerMethod.BEFORE_INVOCATION;
 import static org.testng.internal.invokers.Invoker.CAN_RUN_FROM_CLASS;
@@ -34,7 +35,6 @@ import org.testng.ITestContext;
 import org.testng.ITestListener;
 import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
-import org.testng.ListenerComparator;
 import org.testng.Reporter;
 import org.testng.SkipException;
 import org.testng.SuiteRunState;
@@ -257,11 +257,8 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
     // but regarding
     // onTestSkipped/onTestFailedButWithinSuccessPercentage/onTestFailedWithTimeout/onTestFailure/onTestSuccess, it should be reverse order.
     boolean isFinished = tr.getStatus() != ITestResult.STARTED;
-    List<ITestListener> original = m_notifier.getTestListeners();
-    ListenerComparator comparator = m_configuration.getListenerComparator();
-    if (comparator != null) {
-      original.sort(comparator::compare);
-    }
+    List<ITestListener> original =
+        sort(m_notifier.getTestListeners(), m_configuration.getListenerComparator());
     List<ITestListener> listeners =
         isFinished
             ? ListenerOrderDeterminer.reversedOrder(original)

--- a/testng-core/src/main/java/org/testng/internal/invokers/TestInvoker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/TestInvoker.java
@@ -1,6 +1,5 @@
 package org.testng.internal.invokers;
 
-import static org.testng.ListenerComparator.sort;
 import static org.testng.internal.invokers.InvokedMethodListenerMethod.AFTER_INVOCATION;
 import static org.testng.internal.invokers.InvokedMethodListenerMethod.BEFORE_INVOCATION;
 import static org.testng.internal.invokers.Invoker.CAN_RUN_FROM_CLASS;
@@ -257,12 +256,12 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
     // but regarding
     // onTestSkipped/onTestFailedButWithinSuccessPercentage/onTestFailedWithTimeout/onTestFailure/onTestSuccess, it should be reverse order.
     boolean isFinished = tr.getStatus() != ITestResult.STARTED;
-    List<ITestListener> original =
-        sort(m_notifier.getTestListeners(), m_configuration.getListenerComparator());
     List<ITestListener> listeners =
         isFinished
-            ? ListenerOrderDeterminer.reversedOrder(original)
-            : ListenerOrderDeterminer.order(original);
+            ? ListenerOrderDeterminer.reversedOrder(
+                m_notifier.getTestListeners(), m_configuration.getListenerComparator())
+            : ListenerOrderDeterminer.order(
+                m_notifier.getTestListeners(), m_configuration.getListenerComparator());
     TestListenerHelper.runTestListeners(tr, listeners);
     TestListenerHelper.runTestListeners(
         tr, Collections.singletonList(m_notifier.getExitCodeListener()));

--- a/testng-core/src/main/java/org/testng/internal/invokers/TestMethodWorker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/TestMethodWorker.java
@@ -13,6 +13,7 @@ import org.testng.ITestClass;
 import org.testng.ITestContext;
 import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
+import org.testng.ListenerComparator;
 import org.testng.collections.Lists;
 import org.testng.collections.Sets;
 import org.testng.internal.*;
@@ -165,7 +166,12 @@ public class TestMethodWorker implements IWorker<ITestNGMethod> {
     Object instance = mi.getInstance();
     if (!instances.contains(instance)) {
       instances.add(instance);
-      for (IClassListener listener : m_listeners) {
+      List<IClassListener> original = Lists.newArrayList(m_listeners);
+      ListenerComparator comparator = m_configInvoker.getConfiguration().getListenerComparator();
+      if (comparator != null) {
+        original.sort(comparator::compare);
+      }
+      for (IClassListener listener : original) {
         listener.onBeforeClass(testClass);
       }
       ConfigMethodArguments attributes =
@@ -231,7 +237,12 @@ public class TestMethodWorker implements IWorker<ITestNGMethod> {
   }
 
   private void invokeListenersOnAfterClass(ITestClass testClass, List<IClassListener> listeners) {
-    for (IClassListener listener : listeners) {
+    List<IClassListener> original = Lists.newArrayList(listeners);
+    ListenerComparator comparator = m_configInvoker.getConfiguration().getListenerComparator();
+    if (comparator != null) {
+      original.sort(comparator::compare);
+    }
+    for (IClassListener listener : original) {
       listener.onAfterClass(testClass);
     }
   }

--- a/testng-core/src/main/java/org/testng/internal/invokers/TestMethodWorker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/TestMethodWorker.java
@@ -1,5 +1,7 @@
 package org.testng.internal.invokers;
 
+import static org.testng.ListenerComparator.sort;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -13,7 +15,6 @@ import org.testng.ITestClass;
 import org.testng.ITestContext;
 import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
-import org.testng.ListenerComparator;
 import org.testng.collections.Lists;
 import org.testng.collections.Sets;
 import org.testng.internal.*;
@@ -166,11 +167,8 @@ public class TestMethodWorker implements IWorker<ITestNGMethod> {
     Object instance = mi.getInstance();
     if (!instances.contains(instance)) {
       instances.add(instance);
-      List<IClassListener> original = Lists.newArrayList(m_listeners);
-      ListenerComparator comparator = m_configInvoker.getConfiguration().getListenerComparator();
-      if (comparator != null) {
-        original.sort(comparator::compare);
-      }
+      List<IClassListener> original =
+          sort(m_listeners, m_configInvoker.getConfiguration().getListenerComparator());
       for (IClassListener listener : original) {
         listener.onBeforeClass(testClass);
       }
@@ -237,11 +235,8 @@ public class TestMethodWorker implements IWorker<ITestNGMethod> {
   }
 
   private void invokeListenersOnAfterClass(ITestClass testClass, List<IClassListener> listeners) {
-    List<IClassListener> original = Lists.newArrayList(listeners);
-    ListenerComparator comparator = m_configInvoker.getConfiguration().getListenerComparator();
-    if (comparator != null) {
-      original.sort(comparator::compare);
-    }
+    List<IClassListener> original =
+        sort(listeners, m_configInvoker.getConfiguration().getListenerComparator());
     for (IClassListener listener : original) {
       listener.onAfterClass(testClass);
     }

--- a/testng-core/src/test/java/org/testng/internal/TestListenerHelperTest.java
+++ b/testng-core/src/test/java/org/testng/internal/TestListenerHelperTest.java
@@ -64,7 +64,7 @@ public class TestListenerHelperTest {
     configuration.setObjectFactory(objectFactory);
     TestNGClassFinder finder =
         new TestNGClassFinder(
-            classMap, Maps.newHashMap(), configuration, ctx, new DataProviderHolder());
+            classMap, Maps.newHashMap(), configuration, ctx, new DataProviderHolder(configuration));
     ITestNGListenerFactory factory =
         TestListenerHelper.createListenerFactory(objectFactory, finder, listenerClazz, ctx);
     assertThat(factory).isNotNull();

--- a/testng-core/src/test/java/org/testng/internal/invokers/ParameterHandlerTest.java
+++ b/testng-core/src/test/java/org/testng/internal/invokers/ParameterHandlerTest.java
@@ -12,6 +12,7 @@ import org.testng.ITestObjectFactory;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.testng.collections.Maps;
+import org.testng.internal.Configuration;
 import org.testng.internal.annotations.DefaultAnnotationTransformer;
 import org.testng.internal.annotations.IAnnotationFinder;
 import org.testng.internal.annotations.JDK15AnnotationFinder;
@@ -30,7 +31,8 @@ public class ParameterHandlerTest extends SimpleBaseTest {
   public void beforeClass() {
     IAnnotationFinder finder = new JDK15AnnotationFinder(new DefaultAnnotationTransformer());
     handler =
-        new ParameterHandler(new ITestObjectFactory() {}, finder, new DataProviderHolder(), 0);
+        new ParameterHandler(
+            new ITestObjectFactory() {}, finder, new DataProviderHolder(new Configuration()), 0);
   }
 
   @Test

--- a/testng-core/src/test/java/test/listeners/ListenersTest.java
+++ b/testng-core/src/test/java/test/listeners/ListenersTest.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.assertj.core.api.Assertions;
+import org.testng.ITestNGListener;
 import org.testng.TestNG;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -28,16 +29,411 @@ import test.listeners.issue2771.TestCaseSample;
 import test.listeners.issue2880.ListenerForIssue2880;
 import test.listeners.issue2880.TestClassWithFailingConfigsSample;
 import test.listeners.issue2880.TestClassWithPassingConfigsSample;
+import test.listeners.issue2916.AlterSuiteListenerHolder;
+import test.listeners.issue2916.AnnotatedTestCaseSamplesHolder;
+import test.listeners.issue2916.AnnotationBackedListenerComparator;
+import test.listeners.issue2916.ClassListenerHolder;
+import test.listeners.issue2916.ConfigurationListenerHolder;
+import test.listeners.issue2916.DataProviderInterceptorHolder;
+import test.listeners.issue2916.DataProviderListenerHolder;
+import test.listeners.issue2916.DataProviderSampleTestCase;
+import test.listeners.issue2916.ElaborateSampleTestCase;
+import test.listeners.issue2916.ExecutionListenerHolder;
+import test.listeners.issue2916.ExecutionVisualiserHolder;
+import test.listeners.issue2916.InvokedMethodListenerHolder;
+import test.listeners.issue2916.MethodInterceptorHolder;
+import test.listeners.issue2916.NormalSampleTestCase;
+import test.listeners.issue2916.SimpleConfigTestCase;
+import test.listeners.issue2916.SuiteListenerHolder;
+import test.listeners.issue2916.TestListenerHolder;
 import test.listeners.issue3064.EvidenceListener;
 import test.listeners.issue3064.SampleTestCase;
 
 public class ListenersTest extends SimpleBaseTest {
-
-  private static final String[] github2638ExpectedList =
+  public static final String[] github2638ExpectedList =
       new String[] {
         "test.listeners.issue2638.TestClassASample.testMethod",
         "test.listeners.issue2638.TestClassBSample.testMethod"
       };
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForExecutionListenersViaApi() {
+    Ensure.orderingViaApi(
+        ExecutionListenerHolder.LOGS,
+        ExecutionListenerHolder.ALL,
+        ExecutionListenerHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForAlterSuiteListenersViaApi() {
+    Ensure.orderingViaApi(
+        AlterSuiteListenerHolder.LOGS,
+        AlterSuiteListenerHolder.ALL,
+        AlterSuiteListenerHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForSuiteListenersViaApi() {
+    Ensure.orderingViaApi(
+        SuiteListenerHolder.LOGS, SuiteListenerHolder.ALL, SuiteListenerHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForTestListenersViaApi() {
+    Ensure.orderingViaApi(
+        ElaborateSampleTestCase.class,
+        TestListenerHolder.LOGS,
+        TestListenerHolder.ALL,
+        TestListenerHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForInvokedListenersViaApi() {
+    Ensure.orderingViaApi(
+        InvokedMethodListenerHolder.LOGS,
+        InvokedMethodListenerHolder.ALL,
+        InvokedMethodListenerHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForConfigurationListenersViaApi() {
+    Ensure.orderingViaApi(
+        SimpleConfigTestCase.class,
+        ConfigurationListenerHolder.LOGS,
+        ConfigurationListenerHolder.ALL,
+        ConfigurationListenerHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForClassListenersViaApi() {
+    Ensure.orderingViaApi(
+        ClassListenerHolder.LOGS, ClassListenerHolder.ALL, ClassListenerHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForDataProviderListenersViaApi() {
+    Ensure.orderingViaApi(
+        DataProviderSampleTestCase.class,
+        DataProviderListenerHolder.LOGS,
+        DataProviderListenerHolder.ALL,
+        DataProviderListenerHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForDataProviderInterceptorsViaApi() {
+    Ensure.orderingViaApi(
+        DataProviderSampleTestCase.class,
+        DataProviderInterceptorHolder.LOGS,
+        DataProviderInterceptorHolder.ALL,
+        DataProviderInterceptorHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForExecutionVisualisersViaApi() {
+    Ensure.orderingViaApi(
+        ExecutionVisualiserHolder.LOGS,
+        ExecutionVisualiserHolder.ALL,
+        ExecutionVisualiserHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForMethodInterceptorsViaApi() {
+    Ensure.orderingViaApi(
+        MethodInterceptorHolder.LOGS,
+        MethodInterceptorHolder.ALL,
+        MethodInterceptorHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForExecutionListenersViaXmlTag() {
+    Ensure.orderingViaXmlTag(
+        ExecutionListenerHolder.LOGS,
+        ExecutionListenerHolder.ALL_STRING,
+        ExecutionListenerHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForAlterSuiteListenersViaXmlTag() {
+    Ensure.orderingViaXmlTag(
+        AlterSuiteListenerHolder.LOGS,
+        AlterSuiteListenerHolder.ALL_STRING,
+        AlterSuiteListenerHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForSuiteListenersViaXmlTag() {
+    Ensure.orderingViaXmlTag(
+        SuiteListenerHolder.LOGS,
+        SuiteListenerHolder.ALL_STRING,
+        SuiteListenerHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForTestListenersViaXmlTag() {
+    Ensure.orderingViaXmlTag(
+        ElaborateSampleTestCase.class,
+        TestListenerHolder.LOGS,
+        TestListenerHolder.ALL_STRING,
+        TestListenerHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForInvokedMethodListenersViaXmlTag() {
+    Ensure.orderingViaXmlTag(
+        InvokedMethodListenerHolder.LOGS,
+        InvokedMethodListenerHolder.ALL_STRING,
+        InvokedMethodListenerHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForConfigurationListenersViaXmlTag() {
+    Ensure.orderingViaXmlTag(
+        SimpleConfigTestCase.class,
+        ConfigurationListenerHolder.LOGS,
+        ConfigurationListenerHolder.ALL_STRING,
+        ConfigurationListenerHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForClassListenersViaXmlTag() {
+    Ensure.orderingViaXmlTag(
+        ClassListenerHolder.LOGS,
+        ClassListenerHolder.ALL_STRING,
+        ClassListenerHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForDataProviderListenersViaXmlTag() {
+    Ensure.orderingViaXmlTag(
+        DataProviderSampleTestCase.class,
+        DataProviderListenerHolder.LOGS,
+        DataProviderListenerHolder.ALL_STRING,
+        DataProviderListenerHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForDataProviderInterceptorsViaXmlTag() {
+    Ensure.orderingViaXmlTag(
+        DataProviderSampleTestCase.class,
+        DataProviderInterceptorHolder.LOGS,
+        DataProviderInterceptorHolder.ALL_STRING,
+        DataProviderInterceptorHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForExecutionVisualisersViaXmlTag() {
+    Ensure.orderingViaXmlTag(
+        ExecutionVisualiserHolder.LOGS,
+        ExecutionVisualiserHolder.ALL_STRING,
+        ExecutionVisualiserHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForMethodInterceptorsViaXmlTag() {
+    Ensure.orderingViaXmlTag(
+        MethodInterceptorHolder.LOGS,
+        MethodInterceptorHolder.ALL_STRING,
+        MethodInterceptorHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForExecutionListenersViaCli() {
+    Ensure.orderingViaCli(
+        ExecutionListenerHolder.LOGS,
+        ExecutionListenerHolder.ALL_STRING,
+        ExecutionListenerHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForAlterSuiteListenersViaCli() {
+    Ensure.orderingViaCli(
+        AlterSuiteListenerHolder.LOGS,
+        AlterSuiteListenerHolder.ALL_STRING,
+        AlterSuiteListenerHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForSuiteListenersViaCli() {
+    Ensure.orderingViaCli(
+        SuiteListenerHolder.LOGS,
+        SuiteListenerHolder.ALL_STRING,
+        SuiteListenerHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForTestListenersViaCli() {
+    Ensure.orderingViaCli(
+        ElaborateSampleTestCase.class, TestListenerHolder.LOGS,
+        TestListenerHolder.ALL_STRING, TestListenerHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForInvokedMethodListenersViaCli() {
+    Ensure.orderingViaCli(
+        InvokedMethodListenerHolder.LOGS,
+        InvokedMethodListenerHolder.ALL_STRING,
+        InvokedMethodListenerHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForConfigurationListenersViaCli() {
+    Ensure.orderingViaCli(
+        SimpleConfigTestCase.class,
+        ConfigurationListenerHolder.LOGS,
+        ConfigurationListenerHolder.ALL_STRING,
+        ConfigurationListenerHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForClassListenersViaCli() {
+    Ensure.orderingViaCli(
+        ClassListenerHolder.LOGS,
+        ClassListenerHolder.ALL_STRING,
+        ClassListenerHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForDataProviderListenersViaCli() {
+    Ensure.orderingViaCli(
+        DataProviderSampleTestCase.class,
+        DataProviderListenerHolder.LOGS,
+        DataProviderListenerHolder.ALL_STRING,
+        DataProviderListenerHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForDataProviderInterceptorsViaCli() {
+    Ensure.orderingViaCli(
+        DataProviderSampleTestCase.class,
+        DataProviderInterceptorHolder.LOGS,
+        DataProviderInterceptorHolder.ALL_STRING,
+        DataProviderInterceptorHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForExecutionVisualisersViaCli() {
+    Ensure.orderingViaCli(
+        ExecutionVisualiserHolder.LOGS,
+        ExecutionVisualiserHolder.ALL_STRING,
+        ExecutionVisualiserHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForMethodInterceptorsViaCli() {
+    Ensure.orderingViaCli(
+        MethodInterceptorHolder.LOGS,
+        MethodInterceptorHolder.ALL_STRING,
+        MethodInterceptorHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForExecutionListenersViaAnnotation() {
+    // This is a special case scenario and so the expected value order is different from the
+    // other two test cases from above.
+    // This is because, when TestNG discovers an IExecutionListener implementation via
+    // @Listeners annotation (which is the case with ExecutionListenerSampleTestCase) it would have
+    // already invoked the first set of listeners found via <listeners> tag or service loaders or
+    // via the TestNG API. So the IExecutionListener implementation is invoked as and when it's
+    // discovered
+    // That's why MasterOogway is listed at the 3rd position instead of it being at the first
+    // position
+    // But the onExecutionFinish() adheres to the proper order in symmetric order.
+    String[] expected =
+        new String[] {
+          "MasterShifu.onExecutionStart",
+          "DragonWarrior.onExecutionStart",
+          "MasterOogway.onExecutionStart",
+          "DragonWarrior.onExecutionFinish",
+          "MasterShifu.onExecutionFinish",
+          "MasterOogway.onExecutionFinish"
+        };
+    Ensure.orderingViaAnnotation(
+        AnnotatedTestCaseSamplesHolder.ExecutionListenerSampleTestCase.class,
+        ExecutionListenerHolder.LOGS,
+        ExecutionListenerHolder.SUBSET,
+        expected);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForSuiteListenersViaAnnotation() {
+    Ensure.orderingViaAnnotation(
+        AnnotatedTestCaseSamplesHolder.SuiteListenerSampleTestCase.class,
+        SuiteListenerHolder.LOGS,
+        SuiteListenerHolder.SUBSET,
+        SuiteListenerHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForTestListenersViaAnnotation() {
+    Ensure.orderingViaAnnotation(
+        AnnotatedTestCaseSamplesHolder.TestListenerSampleTestCase.class,
+        TestListenerHolder.LOGS,
+        TestListenerHolder.SUBSET,
+        TestListenerHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForInvokedMethodListenersViaAnnotation() {
+    Ensure.orderingViaAnnotation(
+        AnnotatedTestCaseSamplesHolder.InvokedMethodListenerSampleTestCase.class,
+        InvokedMethodListenerHolder.LOGS,
+        InvokedMethodListenerHolder.SUBSET,
+        InvokedMethodListenerHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForConfigurationListenersViaAnnotation() {
+    Ensure.orderingViaAnnotation(
+        AnnotatedTestCaseSamplesHolder.ConfigurationListenerSampleTestCase.class,
+        ConfigurationListenerHolder.LOGS,
+        ConfigurationListenerHolder.SUBSET,
+        ConfigurationListenerHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForClassListenersViaAnnotation() {
+    Ensure.orderingViaAnnotation(
+        AnnotatedTestCaseSamplesHolder.ClassListenerSampleTestCase.class,
+        ClassListenerHolder.LOGS,
+        ClassListenerHolder.SUBSET,
+        ClassListenerHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForDataProviderListenersViaAnnotation() {
+    Ensure.orderingViaAnnotation(
+        AnnotatedTestCaseSamplesHolder.DataProviderListenerSampleTestCase.class,
+        DataProviderListenerHolder.LOGS,
+        DataProviderListenerHolder.SUBSET,
+        DataProviderListenerHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForDataProviderInterceptorsViaAnnotation() {
+    Ensure.orderingViaAnnotation(
+        AnnotatedTestCaseSamplesHolder.DataProviderInterceptorSampleTestCase.class,
+        DataProviderInterceptorHolder.LOGS,
+        DataProviderInterceptorHolder.SUBSET,
+        DataProviderInterceptorHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForExecutionVisualisersViaAnnotation() {
+    Ensure.orderingViaAnnotation(
+        AnnotatedTestCaseSamplesHolder.ExecutionVisualiserSampleTestCase.class,
+        ExecutionVisualiserHolder.LOGS,
+        ExecutionVisualiserHolder.SUBSET,
+        ExecutionVisualiserHolder.EXPECTED_LOGS);
+  }
+
+  @Test(description = "GITHUB-2916")
+  public void ensureOrderingForMethodInterceptorsViaAnnotation() {
+    Ensure.orderingViaAnnotation(
+        AnnotatedTestCaseSamplesHolder.MethodInterceptorSampleTestCase.class,
+        MethodInterceptorHolder.LOGS,
+        MethodInterceptorHolder.SUBSET,
+        MethodInterceptorHolder.EXPECTED_LOGS);
+  }
 
   @Test(description = "GITHUB-3064")
   public void ensureTestResultAttributesAreCarriedForward() {
@@ -272,5 +668,71 @@ public class ListenersTest extends SimpleBaseTest {
       {TestClassWithPassingConfigsSample.class, XmlSuite.FailurePolicy.CONTINUE, passList},
       {TestClassWithFailingConfigsSample.class, XmlSuite.FailurePolicy.CONTINUE, failList}
     };
+  }
+
+  private static class Ensure {
+
+    private Ensure() {}
+
+    static void orderingViaAnnotation(
+        Class<?> testClass, List<String> logs, List<ITestNGListener> listeners, String[] expected) {
+      logs.clear();
+      TestNG testng = create(testClass);
+      listeners.forEach(testng::addListener);
+      testng.setUseDefaultListeners(false);
+      testng.setListenerComparator(new AnnotationBackedListenerComparator());
+      testng.run();
+      assertThat(logs).containsExactly(expected);
+    }
+
+    static void orderingViaCli(List<String> logs, List<String> listeners, String[] expected) {
+      orderingViaCli(NormalSampleTestCase.class, logs, listeners, expected);
+    }
+
+    static void orderingViaCli(
+        Class<?> clazz, List<String> logs, List<String> listeners, String[] expected) {
+      logs.clear();
+      String[] args =
+          new String[] {
+            "-listener", String.join(",", listeners),
+            "-usedefaultlisteners", "false",
+            "-testclass", clazz.getName(),
+            "-listenercomparator", AnnotationBackedListenerComparator.class.getName()
+          };
+      TestNG.privateMain(args, null);
+      assertThat(logs).containsExactly(expected);
+    }
+
+    static void orderingViaXmlTag(List<String> logs, List<String> listeners, String[] expected) {
+      orderingViaXmlTag(NormalSampleTestCase.class, logs, listeners, expected);
+    }
+
+    static void orderingViaXmlTag(
+        Class<?> clazz, List<String> logs, List<String> listeners, String[] expected) {
+      logs.clear();
+      XmlSuite xmlSuite = createXmlSuite("suite", "test", clazz);
+      listeners.forEach(xmlSuite::addListener);
+      TestNG testng = create(xmlSuite);
+      testng.setUseDefaultListeners(false);
+      testng.setListenerComparator(new AnnotationBackedListenerComparator());
+      testng.run();
+      assertThat(logs).containsExactly(expected);
+    }
+
+    static void orderingViaApi(
+        List<String> logs, List<ITestNGListener> listeners, String[] expected) {
+      orderingViaApi(NormalSampleTestCase.class, logs, listeners, expected);
+    }
+
+    static void orderingViaApi(
+        Class<?> clazz, List<String> logs, List<ITestNGListener> listeners, String[] expected) {
+      logs.clear();
+      TestNG testng = create(clazz);
+      listeners.forEach(testng::addListener);
+      testng.setUseDefaultListeners(false);
+      testng.setListenerComparator(new AnnotationBackedListenerComparator());
+      testng.run();
+      assertThat(logs).containsExactly(expected);
+    }
   }
 }

--- a/testng-core/src/test/java/test/listeners/issue2916/AlterSuiteListenerHolder.java
+++ b/testng-core/src/test/java/test/listeners/issue2916/AlterSuiteListenerHolder.java
@@ -1,0 +1,39 @@
+package test.listeners.issue2916;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.testng.IAlterSuiteListener;
+import org.testng.ITestNGListener;
+import org.testng.xml.XmlSuite;
+
+public class AlterSuiteListenerHolder {
+
+  public static final String[] EXPECTED_LOGS =
+      new String[] {"MasterOogway.alter", "MasterShifu.alter", "DragonWarrior.alter"};
+  public static List<String> LOGS = new ArrayList<>();
+  private static final String PREFIX = AlterSuiteListenerHolder.class.getName() + "$";
+
+  public static final List<ITestNGListener> ALL =
+      List.of(
+          new AlterSuiteListenerHolder.DragonWarrior(),
+          new AlterSuiteListenerHolder.MasterShifu(),
+          new AlterSuiteListenerHolder.MasterOogway());
+
+  public static final List<String> ALL_STRING =
+      List.of(PREFIX + "DragonWarrior", PREFIX + "MasterShifu", PREFIX + "MasterOogway");
+
+  public abstract static class KungFuWarrior implements IAlterSuiteListener {
+    @Override
+    public void alter(List<XmlSuite> suites) {
+      LOGS.add(getClass().getSimpleName() + ".alter");
+    }
+  }
+
+  @RunOrder(1)
+  public static class MasterOogway extends KungFuWarrior {}
+
+  @RunOrder(2)
+  public static class MasterShifu extends KungFuWarrior {}
+
+  public static class DragonWarrior extends KungFuWarrior {}
+}

--- a/testng-core/src/test/java/test/listeners/issue2916/AnnotatedTestCaseSamplesHolder.java
+++ b/testng-core/src/test/java/test/listeners/issue2916/AnnotatedTestCaseSamplesHolder.java
@@ -1,0 +1,36 @@
+package test.listeners.issue2916;
+
+import org.testng.annotations.Listeners;
+
+public class AnnotatedTestCaseSamplesHolder {
+
+  @Listeners(ExecutionListenerHolder.MasterOogway.class)
+  public static class ExecutionListenerSampleTestCase extends NormalSampleTestCase {}
+
+  @Listeners(SuiteListenerHolder.MasterOogway.class)
+  public static class SuiteListenerSampleTestCase extends NormalSampleTestCase {}
+
+  @Listeners(TestListenerHolder.MasterOogway.class)
+  public static class TestListenerSampleTestCase extends ElaborateSampleTestCase {}
+
+  @Listeners(InvokedMethodListenerHolder.MasterOogway.class)
+  public static class InvokedMethodListenerSampleTestCase extends NormalSampleTestCase {}
+
+  @Listeners(ConfigurationListenerHolder.MasterOogway.class)
+  public static class ConfigurationListenerSampleTestCase extends SimpleConfigTestCase {}
+
+  @Listeners(ClassListenerHolder.MasterOogway.class)
+  public static class ClassListenerSampleTestCase extends NormalSampleTestCase {}
+
+  @Listeners(DataProviderListenerHolder.MasterOogway.class)
+  public static class DataProviderListenerSampleTestCase extends DataProviderSampleTestCase {}
+
+  @Listeners(DataProviderInterceptorHolder.MasterOogway.class)
+  public static class DataProviderInterceptorSampleTestCase extends DataProviderSampleTestCase {}
+
+  @Listeners(ExecutionVisualiserHolder.MasterOogway.class)
+  public static class ExecutionVisualiserSampleTestCase extends NormalSampleTestCase {}
+
+  @Listeners(MethodInterceptorHolder.MasterOogway.class)
+  public static class MethodInterceptorSampleTestCase extends NormalSampleTestCase {}
+}

--- a/testng-core/src/test/java/test/listeners/issue2916/AnnotationBackedListenerComparator.java
+++ b/testng-core/src/test/java/test/listeners/issue2916/AnnotationBackedListenerComparator.java
@@ -1,0 +1,23 @@
+package test.listeners.issue2916;
+
+import java.util.Optional;
+import org.testng.ITestNGListener;
+import org.testng.ListenerComparator;
+
+public class AnnotationBackedListenerComparator implements ListenerComparator {
+
+  @Override
+  public int compare(ITestNGListener l1, ITestNGListener l2) {
+    int first = getRunOrder(l1);
+    int second = getRunOrder(l2);
+    return Integer.compare(first, second);
+  }
+
+  private static int getRunOrder(ITestNGListener listener) {
+    RunOrder runOrder = listener.getClass().getAnnotation(RunOrder.class);
+    return Optional.ofNullable(runOrder)
+        .map(RunOrder::value)
+        .orElse(Integer.MAX_VALUE); // If annotation was not found then return a max value so that
+    // the listener can be plugged in to the end.
+  }
+}

--- a/testng-core/src/test/java/test/listeners/issue2916/ClassListenerHolder.java
+++ b/testng-core/src/test/java/test/listeners/issue2916/ClassListenerHolder.java
@@ -1,0 +1,56 @@
+package test.listeners.issue2916;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.testng.IClassListener;
+import org.testng.ITestClass;
+import org.testng.ITestNGListener;
+
+public class ClassListenerHolder {
+
+  public static List<String> LOGS = new ArrayList<>();
+  private static final String PREFIX = ClassListenerHolder.class.getName() + "$";
+
+  public static final String[] EXPECTED_LOGS =
+      new String[] {
+        "MasterOogway.onBeforeClass",
+        "MasterShifu.onBeforeClass",
+        "DragonWarrior.onBeforeClass",
+        "MasterOogway.onAfterClass",
+        "MasterShifu.onAfterClass",
+        "DragonWarrior.onAfterClass"
+      };
+
+  public static final List<ITestNGListener> ALL =
+      List.of(
+          new ClassListenerHolder.DragonWarrior(),
+          new ClassListenerHolder.MasterShifu(),
+          new ClassListenerHolder.MasterOogway());
+
+  public static final List<ITestNGListener> SUBSET =
+      List.of(new ClassListenerHolder.DragonWarrior(), new ClassListenerHolder.MasterShifu());
+
+  public static final List<String> ALL_STRING =
+      List.of(PREFIX + "DragonWarrior", PREFIX + "MasterShifu", PREFIX + "MasterOogway");
+
+  public abstract static class KungFuWarrior implements IClassListener {
+
+    @Override
+    public void onBeforeClass(ITestClass testClass) {
+      LOGS.add(getClass().getSimpleName() + ".onBeforeClass");
+    }
+
+    @Override
+    public void onAfterClass(ITestClass testClass) {
+      LOGS.add(getClass().getSimpleName() + ".onAfterClass");
+    }
+  }
+
+  @RunOrder(1)
+  public static class MasterOogway extends KungFuWarrior {}
+
+  @RunOrder(2)
+  public static class MasterShifu extends KungFuWarrior {}
+
+  public static class DragonWarrior extends KungFuWarrior {}
+}

--- a/testng-core/src/test/java/test/listeners/issue2916/ConfigurationListenerHolder.java
+++ b/testng-core/src/test/java/test/listeners/issue2916/ConfigurationListenerHolder.java
@@ -1,0 +1,91 @@
+package test.listeners.issue2916;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.testng.IConfigurationListener;
+import org.testng.ITestNGListener;
+import org.testng.ITestNGMethod;
+import org.testng.ITestResult;
+
+public class ConfigurationListenerHolder {
+
+  public static List<String> LOGS = new ArrayList<>();
+  private static final String PREFIX = ConfigurationListenerHolder.class.getName() + "$";
+
+  public static final String[] EXPECTED_LOGS =
+      new String[] {
+        "MasterOogway.beforeConfiguration_beforeSuite",
+        "MasterShifu.beforeConfiguration_beforeSuite",
+        "DragonWarrior.beforeConfiguration_beforeSuite",
+        "DragonWarrior.onConfigurationSuccess_beforeSuite",
+        "MasterShifu.onConfigurationSuccess_beforeSuite",
+        "MasterOogway.onConfigurationSuccess_beforeSuite",
+        "MasterOogway.beforeConfiguration_beforeTest",
+        "MasterShifu.beforeConfiguration_beforeTest",
+        "DragonWarrior.beforeConfiguration_beforeTest",
+        "DragonWarrior.onConfigurationSuccess_beforeTest",
+        "MasterShifu.onConfigurationSuccess_beforeTest",
+        "MasterOogway.onConfigurationSuccess_beforeTest",
+        "MasterOogway.beforeConfiguration_beforeClass",
+        "MasterShifu.beforeConfiguration_beforeClass",
+        "DragonWarrior.beforeConfiguration_beforeClass",
+        "DragonWarrior.onConfigurationSuccess_beforeClass",
+        "MasterShifu.onConfigurationSuccess_beforeClass",
+        "MasterOogway.onConfigurationSuccess_beforeClass",
+        "MasterOogway.beforeConfiguration_beforeMethod",
+        "MasterShifu.beforeConfiguration_beforeMethod",
+        "DragonWarrior.beforeConfiguration_beforeMethod",
+        "DragonWarrior.onConfigurationFailure_beforeMethod",
+        "MasterShifu.onConfigurationFailure_beforeMethod",
+        "MasterOogway.onConfigurationFailure_beforeMethod"
+      };
+
+  public static final List<ITestNGListener> ALL =
+      List.of(
+          new ConfigurationListenerHolder.DragonWarrior(),
+          new ConfigurationListenerHolder.MasterShifu(),
+          new ConfigurationListenerHolder.MasterOogway());
+
+  public static final List<ITestNGListener> SUBSET =
+      List.of(
+          new ConfigurationListenerHolder.DragonWarrior(),
+          new ConfigurationListenerHolder.MasterShifu());
+
+  public static final List<String> ALL_STRING =
+      List.of(PREFIX + "DragonWarrior", PREFIX + "MasterShifu", PREFIX + "MasterOogway");
+
+  public abstract static class KungFuWarrior implements IConfigurationListener {
+
+    @Override
+    public void beforeConfiguration(ITestResult tr, ITestNGMethod tm) {
+      LOGS.add(
+          getClass().getSimpleName() + ".beforeConfiguration_" + tr.getMethod().getMethodName());
+    }
+
+    @Override
+    public void onConfigurationSuccess(ITestResult tr, ITestNGMethod tm) {
+      LOGS.add(
+          getClass().getSimpleName() + ".onConfigurationSuccess_" + tr.getMethod().getMethodName());
+    }
+
+    @Override
+    public void onConfigurationFailure(ITestResult tr, ITestNGMethod tm) {
+      LOGS.add(
+          getClass().getSimpleName() + ".onConfigurationFailure_" + tr.getMethod().getMethodName());
+    }
+
+    @Override
+    public void onConfigurationSkip(ITestResult tr, ITestNGMethod tm) {
+      LOGS.add(
+          getClass().getSimpleName() + ".onConfigurationSkip_" + tr.getMethod().getMethodName());
+    }
+  }
+
+  @RunOrder(1)
+  public static class MasterOogway extends KungFuWarrior {}
+
+  @RunOrder(2)
+  public static class MasterShifu extends KungFuWarrior {}
+
+  public static class DragonWarrior extends KungFuWarrior {}
+}

--- a/testng-core/src/test/java/test/listeners/issue2916/DataProviderInterceptorHolder.java
+++ b/testng-core/src/test/java/test/listeners/issue2916/DataProviderInterceptorHolder.java
@@ -1,0 +1,54 @@
+package test.listeners.issue2916;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import org.testng.*;
+
+public class DataProviderInterceptorHolder {
+
+  public static List<String> LOGS = new ArrayList<>();
+  private static final String PREFIX = DataProviderInterceptorHolder.class.getName() + "$";
+
+  public static final String[] EXPECTED_LOGS =
+      new String[] {
+        "MasterOogway.intercept_getData",
+        "MasterShifu.intercept_getData",
+        "DragonWarrior.intercept_getData"
+      };
+
+  public static final List<ITestNGListener> ALL =
+      List.of(
+          new DataProviderInterceptorHolder.DragonWarrior(),
+          new DataProviderInterceptorHolder.MasterShifu(),
+          new DataProviderInterceptorHolder.MasterOogway());
+
+  public static final List<ITestNGListener> SUBSET =
+      List.of(
+          new DataProviderInterceptorHolder.DragonWarrior(),
+          new DataProviderInterceptorHolder.MasterShifu());
+
+  public static final List<String> ALL_STRING =
+      List.of(PREFIX + "DragonWarrior", PREFIX + "MasterShifu", PREFIX + "MasterOogway");
+
+  public abstract static class KungFuWarrior implements IDataProviderInterceptor {
+
+    @Override
+    public Iterator<Object[]> intercept(
+        Iterator<Object[]> original,
+        IDataProviderMethod dp,
+        ITestNGMethod method,
+        ITestContext iTestContext) {
+      LOGS.add(getClass().getSimpleName() + ".intercept_" + dp.getMethod().getName());
+      return original;
+    }
+  }
+
+  @RunOrder(1)
+  public static class MasterOogway extends KungFuWarrior {}
+
+  @RunOrder(2)
+  public static class MasterShifu extends KungFuWarrior {}
+
+  public static class DragonWarrior extends KungFuWarrior {}
+}

--- a/testng-core/src/test/java/test/listeners/issue2916/DataProviderListenerHolder.java
+++ b/testng-core/src/test/java/test/listeners/issue2916/DataProviderListenerHolder.java
@@ -1,0 +1,82 @@
+package test.listeners.issue2916;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.testng.IDataProviderListener;
+import org.testng.IDataProviderMethod;
+import org.testng.ITestContext;
+import org.testng.ITestNGListener;
+import org.testng.ITestNGMethod;
+
+public class DataProviderListenerHolder {
+
+  public static List<String> LOGS = new ArrayList<>();
+  private static final String PREFIX = DataProviderListenerHolder.class.getName() + "$";
+
+  public static final String[] EXPECTED_LOGS =
+      new String[] {
+        "MasterOogway.beforeDataProviderExecution_getData",
+        "MasterShifu.beforeDataProviderExecution_getData",
+        "DragonWarrior.beforeDataProviderExecution_getData",
+        "MasterOogway.afterDataProviderExecution_getData",
+        "MasterShifu.afterDataProviderExecution_getData",
+        "DragonWarrior.afterDataProviderExecution_getData",
+        "MasterOogway.beforeDataProviderExecution_failingDataProvider",
+        "MasterShifu.beforeDataProviderExecution_failingDataProvider",
+        "DragonWarrior.beforeDataProviderExecution_failingDataProvider",
+        "MasterOogway.onDataProviderFailure_failingDataProvider",
+        "MasterShifu.onDataProviderFailure_failingDataProvider",
+        "DragonWarrior.onDataProviderFailure_failingDataProvider"
+      };
+
+  public static final List<ITestNGListener> ALL =
+      List.of(
+          new DataProviderListenerHolder.DragonWarrior(),
+          new DataProviderListenerHolder.MasterShifu(),
+          new DataProviderListenerHolder.MasterOogway());
+
+  public static final List<ITestNGListener> SUBSET =
+      List.of(
+          new DataProviderListenerHolder.DragonWarrior(),
+          new DataProviderListenerHolder.MasterShifu());
+
+  public static final List<String> ALL_STRING =
+      List.of(PREFIX + "DragonWarrior", PREFIX + "MasterShifu", PREFIX + "MasterOogway");
+
+  public abstract static class KungFuWarrior implements IDataProviderListener {
+
+    @Override
+    public void beforeDataProviderExecution(
+        IDataProviderMethod dataProviderMethod, ITestNGMethod method, ITestContext iTestContext) {
+      LOGS.add(
+          getClass().getSimpleName()
+              + ".beforeDataProviderExecution_"
+              + dataProviderMethod.getMethod().getName());
+    }
+
+    @Override
+    public void afterDataProviderExecution(
+        IDataProviderMethod dataProviderMethod, ITestNGMethod method, ITestContext iTestContext) {
+      LOGS.add(
+          getClass().getSimpleName()
+              + ".afterDataProviderExecution_"
+              + dataProviderMethod.getMethod().getName());
+    }
+
+    @Override
+    public void onDataProviderFailure(ITestNGMethod method, ITestContext ctx, RuntimeException t) {
+      LOGS.add(
+          getClass().getSimpleName()
+              + ".onDataProviderFailure_"
+              + method.getDataProviderMethod().getMethod().getName());
+    }
+  }
+
+  @RunOrder(1)
+  public static class MasterOogway extends KungFuWarrior {}
+
+  @RunOrder(2)
+  public static class MasterShifu extends KungFuWarrior {}
+
+  public static class DragonWarrior extends KungFuWarrior {}
+}

--- a/testng-core/src/test/java/test/listeners/issue2916/DataProviderSampleTestCase.java
+++ b/testng-core/src/test/java/test/listeners/issue2916/DataProviderSampleTestCase.java
@@ -1,0 +1,22 @@
+package test.listeners.issue2916;
+
+import org.testng.annotations.*;
+
+public class DataProviderSampleTestCase {
+
+  @Test(dataProvider = "getData", priority = 1)
+  public void testMethod(int ignored) {}
+
+  @DataProvider
+  public Object[][] getData() {
+    return new Object[][] {{1}};
+  }
+
+  @Test(dataProvider = "failingDataProvider", priority = 2)
+  public void failingTestMethod(int ignored) {}
+
+  @DataProvider
+  public Object[][] failingDataProvider() {
+    throw new IllegalStateException("Failing data provider");
+  }
+}

--- a/testng-core/src/test/java/test/listeners/issue2916/ElaborateSampleTestCase.java
+++ b/testng-core/src/test/java/test/listeners/issue2916/ElaborateSampleTestCase.java
@@ -1,0 +1,30 @@
+package test.listeners.issue2916;
+
+import java.util.concurrent.TimeUnit;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class ElaborateSampleTestCase extends NormalSampleTestCase {
+
+  @Test(priority = 2)
+  public void failingTest() {
+    Assert.fail();
+  }
+
+  @Test(dependsOnMethods = "failingTest")
+  public void skippingTest() {}
+
+  int counter = 1;
+
+  @Test(successPercentage = 40, invocationCount = 4, priority = 3)
+  public void flakyTest() {
+    if (counter != 3) {
+      Assert.fail();
+    }
+  }
+
+  @Test(timeOut = 2, priority = 4)
+  public void timingOutTest() throws InterruptedException {
+    TimeUnit.MILLISECONDS.sleep(10);
+  }
+}

--- a/testng-core/src/test/java/test/listeners/issue2916/ExecutionListenerHolder.java
+++ b/testng-core/src/test/java/test/listeners/issue2916/ExecutionListenerHolder.java
@@ -1,0 +1,54 @@
+package test.listeners.issue2916;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.testng.IExecutionListener;
+import org.testng.ITestNGListener;
+
+public class ExecutionListenerHolder {
+
+  public static final String[] EXPECTED_LOGS =
+      new String[] {
+        "MasterOogway.onExecutionStart",
+        "MasterShifu.onExecutionStart",
+        "DragonWarrior.onExecutionStart",
+        "DragonWarrior.onExecutionFinish",
+        "MasterShifu.onExecutionFinish",
+        "MasterOogway.onExecutionFinish"
+      };
+  public static List<String> LOGS = new ArrayList<>();
+  private static final String PREFIX = ExecutionListenerHolder.class.getName() + "$";
+
+  public static final List<ITestNGListener> ALL =
+      List.of(
+          new ExecutionListenerHolder.DragonWarrior(),
+          new ExecutionListenerHolder.MasterShifu(),
+          new ExecutionListenerHolder.MasterOogway());
+
+  public static final List<ITestNGListener> SUBSET =
+      List.of(
+          new ExecutionListenerHolder.DragonWarrior(), new ExecutionListenerHolder.MasterShifu());
+
+  public static final List<String> ALL_STRING =
+      List.of(PREFIX + "DragonWarrior", PREFIX + "MasterShifu", PREFIX + "MasterOogway");
+
+  public abstract static class KungFuWarrior implements IExecutionListener {
+    @Override
+    public void onExecutionStart() {
+      LOGS.add(getClass().getSimpleName() + ".onExecutionStart");
+    }
+
+    @Override
+    public void onExecutionFinish() {
+      LOGS.add(getClass().getSimpleName() + ".onExecutionFinish");
+    }
+  }
+
+  @RunOrder(1)
+  public static class MasterOogway extends KungFuWarrior {}
+
+  @RunOrder(2)
+  public static class MasterShifu extends KungFuWarrior {}
+
+  public static class DragonWarrior extends KungFuWarrior {}
+}

--- a/testng-core/src/test/java/test/listeners/issue2916/ExecutionVisualiserHolder.java
+++ b/testng-core/src/test/java/test/listeners/issue2916/ExecutionVisualiserHolder.java
@@ -1,0 +1,48 @@
+package test.listeners.issue2916;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.testng.*;
+
+public class ExecutionVisualiserHolder {
+
+  public static List<String> LOGS = new ArrayList<>();
+  private static final String PREFIX = ExecutionVisualiserHolder.class.getName() + "$";
+
+  public static final String[] EXPECTED_LOGS =
+      new String[] {
+        "MasterOogway.consumeDotDefinition",
+        "MasterShifu.consumeDotDefinition",
+        "DragonWarrior.consumeDotDefinition"
+      };
+
+  public static final List<ITestNGListener> ALL =
+      List.of(
+          new ExecutionVisualiserHolder.DragonWarrior(),
+          new ExecutionVisualiserHolder.MasterShifu(),
+          new ExecutionVisualiserHolder.MasterOogway());
+
+  public static final List<ITestNGListener> SUBSET =
+      List.of(
+          new ExecutionVisualiserHolder.DragonWarrior(),
+          new ExecutionVisualiserHolder.MasterShifu());
+
+  public static final List<String> ALL_STRING =
+      List.of(PREFIX + "DragonWarrior", PREFIX + "MasterShifu", PREFIX + "MasterOogway");
+
+  public abstract static class KungFuWarrior implements IExecutionVisualiser {
+
+    @Override
+    public void consumeDotDefinition(String dotDefinition) {
+      LOGS.add(getClass().getSimpleName() + ".consumeDotDefinition");
+    }
+  }
+
+  @RunOrder(1)
+  public static class MasterOogway extends KungFuWarrior {}
+
+  @RunOrder(2)
+  public static class MasterShifu extends KungFuWarrior {}
+
+  public static class DragonWarrior extends KungFuWarrior {}
+}

--- a/testng-core/src/test/java/test/listeners/issue2916/InvokedMethodListenerHolder.java
+++ b/testng-core/src/test/java/test/listeners/issue2916/InvokedMethodListenerHolder.java
@@ -1,0 +1,132 @@
+package test.listeners.issue2916;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.testng.IInvokedMethod;
+import org.testng.IInvokedMethodListener;
+import org.testng.ITestNGListener;
+import org.testng.ITestResult;
+
+public class InvokedMethodListenerHolder {
+
+  public static List<String> LOGS = new ArrayList<>();
+  private static final String PREFIX = InvokedMethodListenerHolder.class.getName() + "$";
+
+  public static final String[] EXPECTED_LOGS =
+      new String[] {
+        "MasterOogway.beforeInvocation_beforeSuite",
+        "MasterShifu.beforeInvocation_beforeSuite",
+        "DragonWarrior.beforeInvocation_beforeSuite",
+        "DragonWarrior.afterInvocation_beforeSuite",
+        "MasterShifu.afterInvocation_beforeSuite",
+        "MasterOogway.afterInvocation_beforeSuite",
+        "MasterOogway.beforeInvocation_beforeTest",
+        "MasterShifu.beforeInvocation_beforeTest",
+        "DragonWarrior.beforeInvocation_beforeTest",
+        "DragonWarrior.afterInvocation_beforeTest",
+        "MasterShifu.afterInvocation_beforeTest",
+        "MasterOogway.afterInvocation_beforeTest",
+        "MasterOogway.beforeInvocation_beforeClass",
+        "MasterShifu.beforeInvocation_beforeClass",
+        "DragonWarrior.beforeInvocation_beforeClass",
+        "DragonWarrior.afterInvocation_beforeClass",
+        "MasterShifu.afterInvocation_beforeClass",
+        "MasterOogway.afterInvocation_beforeClass",
+        "MasterOogway.beforeInvocation_beforeMethod",
+        "MasterShifu.beforeInvocation_beforeMethod",
+        "DragonWarrior.beforeInvocation_beforeMethod",
+        "DragonWarrior.afterInvocation_beforeMethod",
+        "MasterShifu.afterInvocation_beforeMethod",
+        "MasterOogway.afterInvocation_beforeMethod",
+        "MasterOogway.beforeInvocation_testMethod",
+        "MasterShifu.beforeInvocation_testMethod",
+        "DragonWarrior.beforeInvocation_testMethod",
+        "DragonWarrior.afterInvocation_testMethod",
+        "MasterShifu.afterInvocation_testMethod",
+        "MasterOogway.afterInvocation_testMethod",
+        "MasterOogway.beforeInvocation_afterMethod",
+        "MasterShifu.beforeInvocation_afterMethod",
+        "DragonWarrior.beforeInvocation_afterMethod",
+        "DragonWarrior.afterInvocation_afterMethod",
+        "MasterShifu.afterInvocation_afterMethod",
+        "MasterOogway.afterInvocation_afterMethod",
+        "MasterOogway.beforeInvocation_beforeMethod",
+        "MasterShifu.beforeInvocation_beforeMethod",
+        "DragonWarrior.beforeInvocation_beforeMethod",
+        "DragonWarrior.afterInvocation_beforeMethod",
+        "MasterShifu.afterInvocation_beforeMethod",
+        "MasterOogway.afterInvocation_beforeMethod",
+        "MasterOogway.beforeInvocation_testMethod",
+        "MasterShifu.beforeInvocation_testMethod",
+        "DragonWarrior.beforeInvocation_testMethod",
+        "DragonWarrior.afterInvocation_testMethod",
+        "MasterShifu.afterInvocation_testMethod",
+        "MasterOogway.afterInvocation_testMethod",
+        "MasterOogway.beforeInvocation_afterMethod",
+        "MasterShifu.beforeInvocation_afterMethod",
+        "DragonWarrior.beforeInvocation_afterMethod",
+        "DragonWarrior.afterInvocation_afterMethod",
+        "MasterShifu.afterInvocation_afterMethod",
+        "MasterOogway.afterInvocation_afterMethod",
+        "MasterOogway.beforeInvocation_afterClass",
+        "MasterShifu.beforeInvocation_afterClass",
+        "DragonWarrior.beforeInvocation_afterClass",
+        "DragonWarrior.afterInvocation_afterClass",
+        "MasterShifu.afterInvocation_afterClass",
+        "MasterOogway.afterInvocation_afterClass",
+        "MasterOogway.beforeInvocation_afterTest",
+        "MasterShifu.beforeInvocation_afterTest",
+        "DragonWarrior.beforeInvocation_afterTest",
+        "DragonWarrior.afterInvocation_afterTest",
+        "MasterShifu.afterInvocation_afterTest",
+        "MasterOogway.afterInvocation_afterTest",
+        "MasterOogway.beforeInvocation_afterSuite",
+        "MasterShifu.beforeInvocation_afterSuite",
+        "DragonWarrior.beforeInvocation_afterSuite",
+        "DragonWarrior.afterInvocation_afterSuite",
+        "MasterShifu.afterInvocation_afterSuite",
+        "MasterOogway.afterInvocation_afterSuite"
+      };
+
+  public static final List<ITestNGListener> ALL =
+      List.of(
+          new InvokedMethodListenerHolder.DragonWarrior(),
+          new InvokedMethodListenerHolder.MasterShifu(),
+          new InvokedMethodListenerHolder.MasterOogway());
+
+  public static final List<ITestNGListener> SUBSET =
+      List.of(
+          new InvokedMethodListenerHolder.DragonWarrior(),
+          new InvokedMethodListenerHolder.MasterShifu());
+
+  public static final List<String> ALL_STRING =
+      List.of(PREFIX + "DragonWarrior", PREFIX + "MasterShifu", PREFIX + "MasterOogway");
+
+  public abstract static class KungFuWarrior implements IInvokedMethodListener {
+
+    @Override
+    public void beforeInvocation(IInvokedMethod method, ITestResult testResult) {
+      IInvokedMethodListener.super.beforeInvocation(method, testResult);
+      LOGS.add(
+          getClass().getSimpleName()
+              + ".beforeInvocation_"
+              + method.getTestMethod().getMethodName());
+    }
+
+    @Override
+    public void afterInvocation(IInvokedMethod method, ITestResult testResult) {
+      LOGS.add(
+          getClass().getSimpleName()
+              + ".afterInvocation_"
+              + method.getTestMethod().getMethodName());
+    }
+  }
+
+  @RunOrder(1)
+  public static class MasterOogway extends KungFuWarrior {}
+
+  @RunOrder(2)
+  public static class MasterShifu extends KungFuWarrior {}
+
+  public static class DragonWarrior extends KungFuWarrior {}
+}

--- a/testng-core/src/test/java/test/listeners/issue2916/MethodInterceptorHolder.java
+++ b/testng-core/src/test/java/test/listeners/issue2916/MethodInterceptorHolder.java
@@ -1,0 +1,47 @@
+package test.listeners.issue2916;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.testng.IMethodInstance;
+import org.testng.IMethodInterceptor;
+import org.testng.ITestContext;
+import org.testng.ITestNGListener;
+
+public class MethodInterceptorHolder {
+
+  public static List<String> LOGS = new ArrayList<>();
+  private static final String PREFIX = MethodInterceptorHolder.class.getName() + "$";
+
+  public static final String[] EXPECTED_LOGS =
+      new String[] {"MasterOogway.intercept", "MasterShifu.intercept", "DragonWarrior.intercept"};
+
+  public static final List<ITestNGListener> ALL =
+      List.of(
+          new MethodInterceptorHolder.DragonWarrior(),
+          new MethodInterceptorHolder.MasterShifu(),
+          new MethodInterceptorHolder.MasterOogway());
+
+  public static final List<ITestNGListener> SUBSET =
+      List.of(
+          new MethodInterceptorHolder.DragonWarrior(), new MethodInterceptorHolder.MasterShifu());
+
+  public static final List<String> ALL_STRING =
+      List.of(PREFIX + "DragonWarrior", PREFIX + "MasterShifu", PREFIX + "MasterOogway");
+
+  public abstract static class KungFuWarrior implements IMethodInterceptor {
+
+    @Override
+    public List<IMethodInstance> intercept(List<IMethodInstance> methods, ITestContext context) {
+      LOGS.add(getClass().getSimpleName() + ".intercept");
+      return methods;
+    }
+  }
+
+  @RunOrder(1)
+  public static class MasterOogway extends KungFuWarrior {}
+
+  @RunOrder(2)
+  public static class MasterShifu extends KungFuWarrior {}
+
+  public static class DragonWarrior extends KungFuWarrior {}
+}

--- a/testng-core/src/test/java/test/listeners/issue2916/NormalSampleTestCase.java
+++ b/testng-core/src/test/java/test/listeners/issue2916/NormalSampleTestCase.java
@@ -1,0 +1,46 @@
+package test.listeners.issue2916;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterSuite;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class NormalSampleTestCase {
+  @BeforeSuite
+  public void beforeSuite() {}
+
+  @BeforeTest
+  public void beforeTest() {}
+
+  @BeforeClass
+  public void beforeClass() {}
+
+  @BeforeMethod
+  public void beforeMethod() {}
+
+  @AfterMethod
+  public void afterMethod() {}
+
+  @Test(dataProvider = "dp", priority = 1)
+  public void testMethod(int ignored) {}
+
+  @DataProvider(name = "dp")
+  public Object[][] getData() {
+    return new Object[][] {{1}, {2}};
+  }
+
+  @AfterClass
+  public void afterClass() {}
+
+  @AfterTest
+  public void afterTest() {}
+
+  @AfterSuite
+  public void afterSuite() {}
+}

--- a/testng-core/src/test/java/test/listeners/issue2916/RunOrder.java
+++ b/testng-core/src/test/java/test/listeners/issue2916/RunOrder.java
@@ -1,0 +1,12 @@
+package test.listeners.issue2916;
+
+import static java.lang.annotation.ElementType.TYPE;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+@Target({TYPE})
+public @interface RunOrder {
+  int value();
+}

--- a/testng-core/src/test/java/test/listeners/issue2916/SimpleConfigTestCase.java
+++ b/testng-core/src/test/java/test/listeners/issue2916/SimpleConfigTestCase.java
@@ -1,0 +1,23 @@
+package test.listeners.issue2916;
+
+import org.testng.Assert;
+import org.testng.annotations.*;
+
+public class SimpleConfigTestCase {
+  @BeforeSuite
+  public void beforeSuite() {}
+
+  @BeforeTest
+  public void beforeTest() {}
+
+  @BeforeClass
+  public void beforeClass() {}
+
+  @BeforeMethod
+  public void beforeMethod() {
+    Assert.fail();
+  }
+
+  @Test
+  public void testMethod() {}
+}

--- a/testng-core/src/test/java/test/listeners/issue2916/SuiteListenerHolder.java
+++ b/testng-core/src/test/java/test/listeners/issue2916/SuiteListenerHolder.java
@@ -1,0 +1,55 @@
+package test.listeners.issue2916;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.testng.ISuite;
+import org.testng.ISuiteListener;
+import org.testng.ITestNGListener;
+
+public class SuiteListenerHolder {
+
+  public static final String[] EXPECTED_LOGS =
+      new String[] {
+        "MasterOogway.onStart",
+        "MasterShifu.onStart",
+        "DragonWarrior.onStart",
+        "DragonWarrior.onFinish",
+        "MasterShifu.onFinish",
+        "MasterOogway.onFinish"
+      };
+  public static List<String> LOGS = new ArrayList<>();
+  private static final String PREFIX = SuiteListenerHolder.class.getName() + "$";
+
+  public static final List<ITestNGListener> ALL =
+      List.of(
+          new SuiteListenerHolder.DragonWarrior(),
+          new SuiteListenerHolder.MasterShifu(),
+          new SuiteListenerHolder.MasterOogway());
+
+  public static final List<ITestNGListener> SUBSET =
+      List.of(new SuiteListenerHolder.DragonWarrior(), new SuiteListenerHolder.MasterShifu());
+
+  public static final List<String> ALL_STRING =
+      List.of(PREFIX + "DragonWarrior", PREFIX + "MasterShifu", PREFIX + "MasterOogway");
+
+  public abstract static class KungFuWarrior implements ISuiteListener {
+
+    @Override
+    public void onStart(ISuite suite) {
+      LOGS.add(getClass().getSimpleName() + ".onStart");
+    }
+
+    @Override
+    public void onFinish(ISuite suite) {
+      LOGS.add(getClass().getSimpleName() + ".onFinish");
+    }
+  }
+
+  @RunOrder(1)
+  public static class MasterOogway extends KungFuWarrior {}
+
+  @RunOrder(2)
+  public static class MasterShifu extends KungFuWarrior {}
+
+  public static class DragonWarrior extends KungFuWarrior {}
+}

--- a/testng-core/src/test/java/test/listeners/issue2916/TestListenerHolder.java
+++ b/testng-core/src/test/java/test/listeners/issue2916/TestListenerHolder.java
@@ -1,0 +1,140 @@
+package test.listeners.issue2916;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.testng.ITestContext;
+import org.testng.ITestListener;
+import org.testng.ITestNGListener;
+import org.testng.ITestResult;
+
+public class TestListenerHolder {
+
+  public static final String[] EXPECTED_LOGS =
+      new String[] {
+        "MasterOogway.onStart_ITestContext",
+        "MasterShifu.onStart_ITestContext",
+        "DragonWarrior.onStart_ITestContext",
+        "MasterOogway.onTestStart",
+        "MasterShifu.onTestStart",
+        "DragonWarrior.onTestStart",
+        "DragonWarrior.onTestSuccess",
+        "MasterShifu.onTestSuccess",
+        "MasterOogway.onTestSuccess",
+        "MasterOogway.onTestStart",
+        "MasterShifu.onTestStart",
+        "DragonWarrior.onTestStart",
+        "DragonWarrior.onTestSuccess",
+        "MasterShifu.onTestSuccess",
+        "MasterOogway.onTestSuccess",
+        "MasterOogway.onTestStart",
+        "MasterShifu.onTestStart",
+        "DragonWarrior.onTestStart",
+        "DragonWarrior.onTestFailure",
+        "MasterShifu.onTestFailure",
+        "MasterOogway.onTestFailure",
+        "MasterOogway.onTestStart",
+        "MasterShifu.onTestStart",
+        "DragonWarrior.onTestStart",
+        "DragonWarrior.onTestSkipped",
+        "MasterShifu.onTestSkipped",
+        "MasterOogway.onTestSkipped",
+        "MasterOogway.onTestStart",
+        "MasterShifu.onTestStart",
+        "DragonWarrior.onTestStart",
+        "DragonWarrior.onTestFailedButWithinSuccessPercentage",
+        "MasterShifu.onTestFailedButWithinSuccessPercentage",
+        "MasterOogway.onTestFailedButWithinSuccessPercentage",
+        "MasterOogway.onTestStart",
+        "MasterShifu.onTestStart",
+        "DragonWarrior.onTestStart",
+        "DragonWarrior.onTestFailedButWithinSuccessPercentage",
+        "MasterShifu.onTestFailedButWithinSuccessPercentage",
+        "MasterOogway.onTestFailedButWithinSuccessPercentage",
+        "MasterOogway.onTestStart",
+        "MasterShifu.onTestStart",
+        "DragonWarrior.onTestStart",
+        "DragonWarrior.onTestFailedButWithinSuccessPercentage",
+        "MasterShifu.onTestFailedButWithinSuccessPercentage",
+        "MasterOogway.onTestFailedButWithinSuccessPercentage",
+        "MasterOogway.onTestStart",
+        "MasterShifu.onTestStart",
+        "DragonWarrior.onTestStart",
+        "DragonWarrior.onTestFailure",
+        "MasterShifu.onTestFailure",
+        "MasterOogway.onTestFailure",
+        "MasterOogway.onTestStart",
+        "MasterShifu.onTestStart",
+        "DragonWarrior.onTestStart",
+        "DragonWarrior.onTestFailedWithTimeout",
+        "MasterShifu.onTestFailedWithTimeout",
+        "MasterOogway.onTestFailedWithTimeout",
+        "DragonWarrior.onFinish_ITestContext",
+        "MasterShifu.onFinish_ITestContext",
+        "MasterOogway.onFinish_ITestContext"
+      };
+  public static List<String> LOGS = new ArrayList<>();
+  private static final String PREFIX = TestListenerHolder.class.getName() + "$";
+
+  public static final List<ITestNGListener> ALL =
+      List.of(
+          new TestListenerHolder.DragonWarrior(),
+          new TestListenerHolder.MasterShifu(),
+          new TestListenerHolder.MasterOogway());
+
+  public static final List<ITestNGListener> SUBSET =
+      List.of(new TestListenerHolder.DragonWarrior(), new TestListenerHolder.MasterShifu());
+
+  public static final List<String> ALL_STRING =
+      List.of(PREFIX + "DragonWarrior", PREFIX + "MasterShifu", PREFIX + "MasterOogway");
+
+  public abstract static class KungFuWarrior implements ITestListener {
+
+    @Override
+    public void onStart(ITestContext context) {
+      LOGS.add(getClass().getSimpleName() + ".onStart_ITestContext");
+    }
+
+    @Override
+    public void onTestStart(ITestResult result) {
+      LOGS.add(getClass().getSimpleName() + ".onTestStart");
+    }
+
+    @Override
+    public void onTestSuccess(ITestResult result) {
+      LOGS.add(getClass().getSimpleName() + ".onTestSuccess");
+    }
+
+    @Override
+    public void onTestFailure(ITestResult result) {
+      LOGS.add(getClass().getSimpleName() + ".onTestFailure");
+    }
+
+    @Override
+    public void onTestSkipped(ITestResult result) {
+      LOGS.add(getClass().getSimpleName() + ".onTestSkipped");
+    }
+
+    @Override
+    public void onTestFailedWithTimeout(ITestResult result) {
+      LOGS.add(getClass().getSimpleName() + ".onTestFailedWithTimeout");
+    }
+
+    @Override
+    public void onTestFailedButWithinSuccessPercentage(ITestResult result) {
+      LOGS.add(getClass().getSimpleName() + ".onTestFailedButWithinSuccessPercentage");
+    }
+
+    @Override
+    public void onFinish(ITestContext context) {
+      LOGS.add(getClass().getSimpleName() + ".onFinish_ITestContext");
+    }
+  }
+
+  @RunOrder(1)
+  public static class MasterOogway extends KungFuWarrior {}
+
+  @RunOrder(2)
+  public static class MasterShifu extends KungFuWarrior {}
+
+  public static class DragonWarrior extends KungFuWarrior {}
+}


### PR DESCRIPTION
Closes #2916

Fixes #2916  .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`
- [X] Auto applied styling via `./gradlew autostyleApply`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.

**Note:** For more information on contribution guidelines  please make sure you refer our [Contributing](.github/CONTRIBUTING.md) section for detailed set of steps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Users can now define the execution order of TestNG listeners.
    - Added support for specifying a `ListenerComparator` for ordering listener execution.
- **Refactor**
    - Restructured listener handling to utilize the new `ListenerComparator`.
    - Enhanced sorting mechanisms for proper listener execution order.
- **Tests**
    - Added multiple test methods to validate listener ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->