### PR TITLE
Allow data providers to be non cacheable

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current (7.10.0)
+Fixed: GITHUB-3041: TestNG 7.x DataProvider works in opposite to TestNG 6.x when retrying tests. (Krishnan Mahadevan)
 Fixed: GITHUB-3066: How to dynamically adjust the number of TestNG threads after IExecutorFactory is deprecated? (Krishnan Mahadevan)
 New:   GITHUB-2874: Allow users to define ordering for TestNG listeners (Krishnan Mahadevan)
 Fixed: GITHUB-3033: Moved ant support under own repository https://github.com/testng-team/testng-ant (Julien Herr)

--- a/testng-core-api/src/main/java/org/testng/IDataProviderMethod.java
+++ b/testng-core-api/src/main/java/org/testng/IDataProviderMethod.java
@@ -38,4 +38,12 @@ public interface IDataProviderMethod {
   default Class<? extends IRetryDataProvider> retryUsing() {
     return IRetryDataProvider.DisableDataProviderRetries.class;
   }
+
+  /**
+   * @return - <code>true</code> if TestNG should use data returned by the original data provider
+   *     invocation, when a test method fails and is configured to be retried.
+   */
+  default boolean cacheDataForTestRetries() {
+    return true;
+  }
 }

--- a/testng-core-api/src/main/java/org/testng/annotations/DataProvider.java
+++ b/testng-core-api/src/main/java/org/testng/annotations/DataProvider.java
@@ -58,6 +58,12 @@ public @interface DataProvider {
   boolean propagateFailureAsTestFailure() default false;
 
   /**
+   * @return - <code>true</code> if TestNG should use data returned by the original data provider
+   *     invocation, when a test method fails and is configured to be retried.
+   */
+  boolean cacheDataForTestRetries() default true;
+
+  /**
    * @return - An Class which implements {@link IRetryDataProvider} and which can be used to retry a
    *     data provider.
    */

--- a/testng-core-api/src/main/java/org/testng/annotations/IDataProviderAnnotation.java
+++ b/testng-core-api/src/main/java/org/testng/annotations/IDataProviderAnnotation.java
@@ -40,4 +40,16 @@ public interface IDataProviderAnnotation extends IAnnotation {
    *     data provider.
    */
   Class<? extends IRetryDataProvider> retryUsing();
+
+  /**
+   * @param cache - when set to <code>true</code>, TestNG does not invoke the data provider again
+   *     when retrying failed tests using a retry analyzer.
+   */
+  void cacheDataForTestRetries(boolean cache);
+
+  /**
+   * @return - <code>true</code> if TestNG should use data returned by the original data provider
+   *     invocation, when a test method fails and is configured to be retried.
+   */
+  boolean isCacheDataForTestRetries();
 }

--- a/testng-core/src/main/java/org/testng/internal/DataProviderMethod.java
+++ b/testng-core/src/main/java/org/testng/internal/DataProviderMethod.java
@@ -53,4 +53,9 @@ class DataProviderMethod implements IDataProviderMethod {
   public Class<? extends IRetryDataProvider> retryUsing() {
     return annotation.retryUsing();
   }
+
+  @Override
+  public boolean cacheDataForTestRetries() {
+    return annotation.isCacheDataForTestRetries();
+  }
 }

--- a/testng-core/src/main/java/org/testng/internal/Parameters.java
+++ b/testng-core/src/main/java/org/testng/internal/Parameters.java
@@ -442,7 +442,7 @@ public class Parameters {
         throw new TestNGException(
             errPrefix
                 + ".\nFor more information on native dependency injection please refer to "
-                + "https://testng.org/doc/documentation-main.html#native-dependency-injection");
+                + "https://testng.org/#_dependency_injection");
       }
     }
 

--- a/testng-core/src/main/java/org/testng/internal/annotations/DataProviderAnnotation.java
+++ b/testng-core/src/main/java/org/testng/internal/annotations/DataProviderAnnotation.java
@@ -13,6 +13,8 @@ public class DataProviderAnnotation extends BaseAnnotation implements IDataProvi
   private boolean m_bubbleUpFailures = false;
   private Class<? extends IRetryDataProvider> retryUsing;
 
+  private boolean cachedDataForTestRetries = true;
+
   @Override
   public boolean isParallel() {
     return m_parallel;
@@ -61,5 +63,14 @@ public class DataProviderAnnotation extends BaseAnnotation implements IDataProvi
   @Override
   public Class<? extends IRetryDataProvider> retryUsing() {
     return retryUsing;
+  }
+
+  public void cacheDataForTestRetries(boolean cache) {
+    this.cachedDataForTestRetries = cache;
+  }
+
+  @Override
+  public boolean isCacheDataForTestRetries() {
+    return cachedDataForTestRetries;
   }
 }

--- a/testng-core/src/main/java/org/testng/internal/annotations/JDK15TagFactory.java
+++ b/testng-core/src/main/java/org/testng/internal/annotations/JDK15TagFactory.java
@@ -483,6 +483,7 @@ public class JDK15TagFactory {
       result.propagateFailureAsTestFailure();
     }
     result.setRetryUsing(c.retryUsing());
+    result.cacheDataForTestRetries(c.cacheDataForTestRetries());
     return result;
   }
 

--- a/testng-core/src/test/java/test/dataprovider/DataProviderTest.java
+++ b/testng-core/src/test/java/test/dataprovider/DataProviderTest.java
@@ -55,11 +55,20 @@ import test.dataprovider.issue2934.TestCaseSample;
 import test.dataprovider.issue2934.TestCaseSample.CoreListener;
 import test.dataprovider.issue2934.TestCaseSample.ToggleDataProvider;
 import test.dataprovider.issue2980.LoggingListener;
+import test.dataprovider.issue3041.SampleTestCase;
 import test.dataprovider.issue3045.DataProviderListener;
 import test.dataprovider.issue3045.DataProviderTestClassSample;
 import test.dataprovider.issue3045.DataProviderWithoutListenerTestClassSample;
 
 public class DataProviderTest extends SimpleBaseTest {
+
+  @Test(description = "GITHUB-3041")
+  public void ensureDataProvidersCanBeInstructedNotToCacheDataForFailedTestRetries() {
+    TestNG testng = create(SampleTestCase.class);
+    testng.setVerbose(2);
+    testng.run();
+    assertThat(SampleTestCase.invocationCount.get()).isEqualTo(2);
+  }
 
   @Test(description = "GITHUB-2819")
   public void testDataProviderCanBeRetriedOnFailures() {

--- a/testng-core/src/test/java/test/dataprovider/issue3041/SampleTestCase.java
+++ b/testng-core/src/test/java/test/dataprovider/issue3041/SampleTestCase.java
@@ -1,0 +1,41 @@
+package test.dataprovider.issue3041;
+
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.testng.IRetryAnalyzer;
+import org.testng.ITestResult;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class SampleTestCase {
+
+  public static final AtomicInteger invocationCount = new AtomicInteger(0);
+  private static final Random random = new Random();
+
+  @Test(dataProvider = "dp", retryAnalyzer = MyRetry.class)
+  public void testMethod(int i) {
+    if (invocationCount.get() != 2) {
+      throw new RuntimeException("Failed for " + i);
+    }
+  }
+
+  @DataProvider(name = "dp", cacheDataForTestRetries = false)
+  public Object[][] getData() {
+    invocationCount.incrementAndGet();
+    return new Object[][] {{next()}, {next()}};
+  }
+
+  private static int next() {
+    return random.nextInt();
+  }
+
+  public static class MyRetry implements IRetryAnalyzer {
+
+    private final AtomicInteger counter = new AtomicInteger(1);
+
+    @Override
+    public boolean retry(ITestResult result) {
+      return counter.getAndIncrement() != 2;
+    }
+  }
+}


### PR DESCRIPTION
Closes #3041

We can now configure TestNG to enable/disable 
caching of test data produced by a data provider
when TestNG is retrying a failed test method using the attribute “cacheDataForTestRetries” on the 
“@DataProvider” annotation.

Below is a sample, which forces TestNG to re-invoke the data provider when a test method fails and it  needs to be retried.

```
@DataProvider(name = "dp", cacheDataForTestRetries = false)
public Object[][] getData() {
  return new Object[][] {{1}, {2}};
}
```

Fixes #3041 

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`
- [X] Auto applied styling via `./gradlew autostyleApply`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.

**Note:** For more information on contribution guidelines  please make sure you refer our [Contributing](.github/CONTRIBUTING.md) section for detailed set of steps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Users can now define the order for TestNG listeners.
- **Bug Fixes**
	- Aligned TestNG 7.x DataProvider behavior with TestNG 6.x for test retries.
	- Restored the ability to dynamically adjust the number of TestNG threads.
	- Moved Ant support to its own repository for better management.
	- Introduced caching control for data used in test retries, improving efficiency in test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->