### PR TITLE
Adding issue management workflows

### DIFF
--- a/.github/label-commenter-config.yml
+++ b/.github/label-commenter-config.yml
@@ -1,0 +1,35 @@
+# Configuration for Label Commenter - https://github.com/peaceiris/actions-label-commenter
+labels:
+  - name: needs-sample
+    labeled:
+      issue:
+        body: |
+          Hi, @{{ issue.user.login }}.
+          We need more information to reproduce the issue.
+
+          Please help share a [Minimal, Reproducible Example](https://stackoverflow.com/help/minimal-reproducible-example) that can be used to recreate the issue.
+
+          In addition to sharing a sample, please also add the following details:
+
+          * TestNG version being used.
+          * JDK version being used.
+          * How was the test run (IDE/Build Tools)?
+          * How does your build file (`pom.xml` | `build.gradle` | `build.gradle.kts`) look like ?
+
+          It would be better if you could share a sample project that can be directly used to reproduce the problem.
+          Reply to this issue when all information is provided, thank you.
+  - name: question
+    labeled:
+      issue:
+        body: |
+          💬 Please ask questions at:
+          * 📫 The [TestNG user group](https://groups.google.com/forum/#!forum/testng-users)
+          * 📮 [StackOverflow](https://stackoverflow.com/questions/tagged/testng)
+        action: close
+  - name: help-wanted
+    labeled:
+      issue:
+        body: |
+          This issue is looking for contributors.
+
+          Please comment below if you are interested.

--- a/.github/workflows/label-commenter.yml
+++ b/.github/workflows/label-commenter.yml
@@ -1,0 +1,18 @@
+name: Label Commenter
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  comment:
+    if: github.repository_owner == 'testng-team'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Label Commenter
+        uses: peaceiris/actions-label-commenter@v1


### PR DESCRIPTION
We can now add the below labels to issues 
And the workflow will automatically add the required text that will be instructions to the issue submitter.

* `needs-sample`
* `question` 
* `help-wanted`

These labels should be added to the repository 
And we can perhaps get rid of the other labels
that intend to convey the same thing.

More details available at: https://github.com/peaceiris/actions-label-commenter



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a Label Commenter tool to automatically add specific comments to issues based on their labels, enhancing communication on issues labeled as needing more information, questions, and help-wanted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->