### PR TITLE
Honour inheritance when parsing listener factories

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 Current (7.10.0)
 
+Fixed: GITHUB-3095: Super class annotated with ITestNGListenerFactory makes derived test class throw TestNGException on execution (Krishnan Mahadevan)
 Fixed: GITHUB-3081: Discrepancy with combination of (Shared Thread pool and Method Interceptor) (Krishnan Mahadevan)
 Fixed: GITHUB-2381: Controlling the inclusion of the listener at runtime (Krishnan Mahadevan)
 Fixed: GITHUB-3082: IInvokedMethodListener Iinvoked method does not return correct instance during @BeforeMethod, @AfterMethod and @AfterClass (Krishnan Mahadevan)

--- a/testng-core/src/test/java/org/testng/internal/TestListenerHelperTest.java
+++ b/testng-core/src/test/java/org/testng/internal/TestListenerHelperTest.java
@@ -14,11 +14,11 @@ import org.testng.collections.Maps;
 import org.testng.internal.annotations.DefaultAnnotationTransformer;
 import org.testng.internal.annotations.IAnnotationFinder;
 import org.testng.internal.annotations.JDK15AnnotationFinder;
-import org.testng.internal.listeners.DummyListenerFactory;
+import org.testng.internal.listeners.ListenerFactoryContainer;
+import org.testng.internal.listeners.TestClassContainer;
 import org.testng.internal.listeners.TestClassDoublingupAsListenerFactory;
 import org.testng.internal.listeners.TestClassWithCompositeListener;
 import org.testng.internal.listeners.TestClassWithListener;
-import org.testng.internal.listeners.TestClassWithMultipleListenerFactories;
 import org.testng.internal.paramhandler.FakeTestContext;
 import org.testng.xml.XmlClass;
 import test.SimpleBaseTest;
@@ -45,13 +45,25 @@ public class TestListenerHelperTest {
     };
   }
 
+  @Test(description = "GITHUB-3095")
+  public void testFindAllListenersDuplicateListenerFactories() {
+    TestListenerHelper.ListenerHolder result =
+        TestListenerHelper.findAllListeners(
+            TestClassContainer.TestClassWithDuplicateListenerFactories.class, finder);
+    assertThat(result.getListenerFactoryClass()).isNotNull();
+  }
+
   @Test(
+      description = "GITHUB-3095",
       expectedExceptions = TestNGException.class,
       expectedExceptionsMessageRegExp =
           "\nFound more than one class implementing ITestNGListenerFactory:class "
-              + "org.testng.internal.listeners.DummyListenerFactory and class org.testng.internal.listeners.DummyListenerFactory")
+              + "org.testng.internal.listeners.ListenerFactoryContainer\\$DummyListenerFactory2 "
+              + "and class org.testng.internal.listeners"
+              + ".ListenerFactoryContainer\\$DummyListenerFactory")
   public void testFindAllListenersErrorCondition() {
-    TestListenerHelper.findAllListeners(TestClassWithMultipleListenerFactories.class, finder);
+    TestListenerHelper.findAllListeners(
+        TestClassContainer.TestClassWithMultipleUniqueListenerFactories.class, finder);
   }
 
   @Test(dataProvider = "getFactoryTestData")
@@ -73,7 +85,7 @@ public class TestListenerHelperTest {
   @DataProvider(name = "getFactoryTestData")
   public Object[][] getFactoryTestData() {
     return new Object[][] {
-      {TestClassWithListener.class, DummyListenerFactory.class},
+      {TestClassWithListener.class, ListenerFactoryContainer.DummyListenerFactory.class},
       {TestClassDoublingupAsListenerFactory.class, TestClassDoublingupAsListenerFactory.class}
     };
   }

--- a/testng-core/src/test/java/org/testng/internal/listeners/ListenerFactoryContainer.java
+++ b/testng-core/src/test/java/org/testng/internal/listeners/ListenerFactoryContainer.java
@@ -1,0 +1,21 @@
+package org.testng.internal.listeners;
+
+import org.testng.IExecutionListener;
+import org.testng.ITestNGListener;
+import org.testng.ITestNGListenerFactory;
+
+public class ListenerFactoryContainer {
+  public static class DummyListenerFactory implements ITestNGListenerFactory, IExecutionListener {
+    @Override
+    public ITestNGListener createListener(Class<? extends ITestNGListener> listenerClass) {
+      return this;
+    }
+  }
+
+  public static class DummyListenerFactory2 implements ITestNGListenerFactory, IExecutionListener {
+    @Override
+    public ITestNGListener createListener(Class<? extends ITestNGListener> listenerClass) {
+      return this;
+    }
+  }
+}

--- a/testng-core/src/test/java/org/testng/internal/listeners/TestClassContainer.java
+++ b/testng-core/src/test/java/org/testng/internal/listeners/TestClassContainer.java
@@ -1,0 +1,17 @@
+package org.testng.internal.listeners;
+
+import org.testng.annotations.Listeners;
+
+public class TestClassContainer {
+  @Listeners({
+    ListenerFactoryContainer.DummyListenerFactory.class,
+    ListenerFactoryContainer.DummyListenerFactory.class
+  })
+  public static class TestClassWithDuplicateListenerFactories {}
+
+  @Listeners({
+    ListenerFactoryContainer.DummyListenerFactory.class,
+    ListenerFactoryContainer.DummyListenerFactory2.class
+  })
+  public static class TestClassWithMultipleUniqueListenerFactories {}
+}

--- a/testng-core/src/test/java/org/testng/internal/listeners/TestClassWithCompositeListener.java
+++ b/testng-core/src/test/java/org/testng/internal/listeners/TestClassWithCompositeListener.java
@@ -3,7 +3,7 @@ package org.testng.internal.listeners;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
-@Listeners(DummyListenerFactory.class)
+@Listeners(ListenerFactoryContainer.DummyListenerFactory.class)
 public class TestClassWithCompositeListener {
   @Test
   public void testMethod() {}

--- a/testng-core/src/test/java/org/testng/internal/listeners/TestClassWithMultipleListenerFactories.java
+++ b/testng-core/src/test/java/org/testng/internal/listeners/TestClassWithMultipleListenerFactories.java
@@ -1,6 +1,0 @@
-package org.testng.internal.listeners;
-
-import org.testng.annotations.Listeners;
-
-@Listeners({DummyListenerFactory.class, DummyListenerFactory.class})
-public class TestClassWithMultipleListenerFactories {}

--- a/testng-core/src/test/java/test/listeners/ListenersTest.java
+++ b/testng-core/src/test/java/test/listeners/ListenersTest.java
@@ -54,6 +54,7 @@ import test.listeners.issue3064.EvidenceListener;
 import test.listeners.issue3064.SampleTestCase;
 import test.listeners.issue3082.ObjectRepository;
 import test.listeners.issue3082.ObjectTrackingMethodListener;
+import test.listeners.issue3095.ChildClassSample;
 
 public class ListenersTest extends SimpleBaseTest {
   public static final String[] github2638ExpectedList =
@@ -586,6 +587,13 @@ public class ListenersTest extends SimpleBaseTest {
     ObjectRepository.invocations()
         .forEach(it -> softly.assertThat(it).containsExactlyElementsOf(expected));
     softly.assertAll();
+  }
+
+  @Test(description = "GITHUB-3095")
+  public void ensureInheritanceIsHandledWhenDealingWithListeners() {
+    TestNG testng = create(ChildClassSample.class);
+    testng.run();
+    assertThat(testng.getStatus()).isZero();
   }
 
   private void setupTest(boolean addExplicitListener) {

--- a/testng-core/src/test/java/test/listeners/issue3095/ChildClassSample.java
+++ b/testng-core/src/test/java/test/listeners/issue3095/ChildClassSample.java
@@ -1,0 +1,8 @@
+package test.listeners.issue3095;
+
+import org.testng.annotations.Test;
+
+public class ChildClassSample extends SuperClassSample {
+  @Test
+  public void childTestMethod() {}
+}

--- a/testng-core/src/test/java/test/listeners/issue3095/MyTestNgFactory.java
+++ b/testng-core/src/test/java/test/listeners/issue3095/MyTestNgFactory.java
@@ -1,12 +1,11 @@
-package org.testng.internal.listeners;
+package test.listeners.issue3095;
 
-import org.testng.IExecutionListener;
 import org.testng.ITestNGListener;
 import org.testng.ITestNGListenerFactory;
 
-public class DummyListenerFactory implements ITestNGListenerFactory, IExecutionListener {
+public class MyTestNgFactory implements ITestNGListener, ITestNGListenerFactory {
   @Override
   public ITestNGListener createListener(Class<? extends ITestNGListener> listenerClass) {
-    return this;
+    return null;
   }
 }

--- a/testng-core/src/test/java/test/listeners/issue3095/SuperClassSample.java
+++ b/testng-core/src/test/java/test/listeners/issue3095/SuperClassSample.java
@@ -1,0 +1,6 @@
+package test.listeners.issue3095;
+
+import org.testng.annotations.Listeners;
+
+@Listeners(MyTestNgFactory.class)
+public class SuperClassSample {}


### PR DESCRIPTION
Closes #3095

Fixes #3095  .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`
- [X] Auto applied styling via `./gradlew autostyleApply`

**Root cause:** TestNG was enhanced such that the `@Listeners` annotation was inheritable via the PR https://github.com/testng-team/testng/pull/3002



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Addressed issues with test execution behavior, including test class inheritance and method interception.
- **New Features**
	- Improved handling and uniqueness of listener annotations in test execution.
	- Enhanced management of listener factories for more effective test listener integration.
- **Refactor**
	- Streamlined test listener logic for better efficiency and clarity.
	- Introduced new test classes and methods for improved testing of listener inheritance and factory functionality.
- **Tests**
	- Added new tests to ensure correct handling of listener inheritance and listener factory behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->