### PR TITLE
Tweaks around accessing SuiteResult

### DIFF
--- a/testng-core/src/main/java/org/testng/SuiteRunner.java
+++ b/testng-core/src/main/java/org/testng/SuiteRunner.java
@@ -34,8 +34,7 @@ public class SuiteRunner implements ISuite, ISuiteRunnerListener {
 
   private static final String DEFAULT_OUTPUT_DIR = "test-output";
 
-  private final Map<String, ISuiteResult> suiteResults =
-      Collections.synchronizedMap(Maps.newLinkedHashMap());
+  private final Map<String, ISuiteResult> suiteResults = Maps.newLinkedHashMap();
   private final List<TestRunner> testRunners = Lists.newArrayList();
   private final Map<Class<? extends ISuiteListener>, ISuiteListener> listeners =
       Maps.newLinkedHashMap();
@@ -514,7 +513,9 @@ public class SuiteRunner implements ISuite, ISuiteRunnerListener {
 
   @Override
   public Map<String, ISuiteResult> getResults() {
-    return suiteResults;
+    // Just to ensure that we guard the internals of the suite results we now wrap it
+    // around with an unmodifiable map.
+    return Collections.unmodifiableMap(suiteResults);
   }
 
   /**


### PR DESCRIPTION
Closes #3078

Following changes were made:

* Removed the lock based synchronization around  SuiteResult because it’s already backed by a 
SynchronizedMap from Collections.
* Altered the getter such that it returns back a regular linkedHashMap (without the synchronisation Because users are expected ONLY to iterate on it and NOT change its state)
* Also just to ensure that users don’t garble the  Suite result, wrapping it with an UnModifiableMap

Fixes #3078  .




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved thread safety in test suite execution by modifying synchronization mechanisms.
	- Enhanced the integrity of test results by ensuring the results map is unmodifiable.
	- Concealed internal implementation details for enhanced security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->