### PR TITLE
Report deadlocks when running in sharedthreadpool

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current (7.11.0)
+Fixed: GITHUB-3028: Execution stalls when using "use-global-thread-pool" (Krishnan Mahadevan)
 
 7.10.2
 Fixed: GITHUB-3117: ListenerComparator doesn't work (Krishnan Mahadevan)

--- a/testng-core-api/src/main/java/org/testng/internal/TestNGDeadLockException.java
+++ b/testng-core-api/src/main/java/org/testng/internal/TestNGDeadLockException.java
@@ -1,0 +1,10 @@
+package org.testng.internal;
+
+import org.testng.TestNGException;
+
+/** Represents a deadlock condition in TestNG wherein execution can get stalled. */
+public class TestNGDeadLockException extends TestNGException {
+  public TestNGDeadLockException(String string) {
+    super(string);
+  }
+}

--- a/testng-core/src/test/java/test/thread/issue3028/AnotherDataDrivenTestSample.java
+++ b/testng-core/src/test/java/test/thread/issue3028/AnotherDataDrivenTestSample.java
@@ -1,0 +1,30 @@
+package test.thread.issue3028;
+
+import org.testng.ITestResult;
+import org.testng.Reporter;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class AnotherDataDrivenTestSample {
+
+  @Test(dataProvider = "dp")
+  public void a(int ignored) {
+    log();
+  }
+
+  @Test(dataProvider = "dp")
+  public void b(int ignored) {
+    log();
+  }
+
+  private void log() {
+    ITestResult itr = Reporter.getCurrentTestResult();
+    long id = Thread.currentThread().getId();
+    Reporter.log("Running " + itr.toString() + " on Thread " + id);
+  }
+
+  @DataProvider(name = "dp", parallel = true)
+  public Object[][] getData() {
+    return new Object[][] {{1}, {2}, {3}, {4}, {5}};
+  }
+}

--- a/testng-core/src/test/java/test/thread/issue3028/DataDrivenTestSample.java
+++ b/testng-core/src/test/java/test/thread/issue3028/DataDrivenTestSample.java
@@ -1,0 +1,29 @@
+package test.thread.issue3028;
+
+import org.testng.ITestResult;
+import org.testng.Reporter;
+import org.testng.annotations.*;
+
+public class DataDrivenTestSample {
+
+  @Test(dataProvider = "dp")
+  public void a(int ignored) {
+    log();
+  }
+
+  @Test(dataProvider = "dp")
+  public void b(int ignored) {
+    log();
+  }
+
+  private void log() {
+    ITestResult itr = Reporter.getCurrentTestResult();
+    long id = Thread.currentThread().getId();
+    Reporter.log("Running " + itr.toString() + " on Thread " + id);
+  }
+
+  @DataProvider(name = "dp", parallel = true)
+  public Object[][] getData() {
+    return new Object[][] {{1}, {2}, {3}, {4}, {5}};
+  }
+}

--- a/testng-core/src/test/java/test/thread/issue3028/FactoryPoweredDataDrivenTestSample.java
+++ b/testng-core/src/test/java/test/thread/issue3028/FactoryPoweredDataDrivenTestSample.java
@@ -1,0 +1,38 @@
+package test.thread.issue3028;
+
+import org.testng.ITestResult;
+import org.testng.Reporter;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+
+public class FactoryPoweredDataDrivenTestSample {
+
+  @Factory
+  public static Object[] objects() {
+    return new Object[] {
+      new FactoryPoweredDataDrivenTestSample(), new FactoryPoweredDataDrivenTestSample()
+    };
+  }
+
+  @Test(dataProvider = "dp")
+  public void a(int ignored) {
+    log();
+  }
+
+  @Test(dataProvider = "dp")
+  public void b(int ignored) {
+    log();
+  }
+
+  private void log() {
+    ITestResult itr = Reporter.getCurrentTestResult();
+    long id = Thread.currentThread().getId();
+    Reporter.log("Running " + itr.toString() + " on Thread " + id);
+  }
+
+  @DataProvider(name = "dp", parallel = true)
+  public Object[][] getData() {
+    return new Object[][] {{1}, {2}, {3}, {4}, {5}};
+  }
+}


### PR DESCRIPTION
Closes #3028

Fixes #3028 

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`
- [X] Auto applied styling via `./gradlew autostyleApply`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.

**Note:** For more information on contribution guidelines  please make sure you refer our [Contributing](.github/CONTRIBUTING.md) section for detailed set of steps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed a stalling issue when using "use-global-thread-pool" in version 7.11.0.
	- Resolved a malfunction with ListenerComparator in version 7.10.2.
- **New Features**
	- Introduced deadlock detection for data-driven tests running in parallel to enhance reliability.
- **Tests**
	- Added tests to ensure deadlock conditions are detected in data-driven tests running in parallel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->