### PR TITLE
Fix array assertEquals failure message when an element is null or non-null

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 Current (7.11.0)
 Fixed: GITHUB-3028: Execution stalls when using "use-global-thread-pool" (Krishnan Mahadevan)
 Fixed: GITHUB-3122: Update JCommander to 1.83 (Antoine Dessaigne)
+Fixed: GITHUB-3135: assertEquals on arrays - Failure message is missing information about the array index when an array element is unexpectedly null or non-null (Albert Choi)
 
 7.10.2
 Fixed: GITHUB-3117: ListenerComparator doesn't work (Krishnan Mahadevan)

--- a/testng-asserts/src/main/java/org/testng/Assert.java
+++ b/testng-asserts/src/main/java/org/testng/Assert.java
@@ -1780,7 +1780,7 @@ public class Assert {
         continue;
       }
       if ((a == null && e != null) || (a != null && e == null)) {
-        failNotEquals(a, e, message);
+        failNotEquals(a, e, errorMessage);
       }
       // Compare by value for multi-dimensional array.
       if (e.getClass().isArray()) {

--- a/testng-asserts/src/test/java/org/testng/AssertTest.java
+++ b/testng-asserts/src/test/java/org/testng/AssertTest.java
@@ -355,6 +355,33 @@ public class AssertTest {
     Assert.assertEquals("x", "y");
   }
 
+  @Test(
+      description = "GITHUB-3135",
+      expectedExceptions = AssertionError.class,
+      expectedExceptionsMessageRegExp =
+          "Arrays differ at element \\[2\\]: 3 != 5 expected \\[3\\] but found \\[5\\]")
+  public void testAssertEqualsArrayElementDiffers() {
+    Assert.assertEquals(new Integer[] {1, 2, 5}, new Integer[] {1, 2, 3});
+  }
+
+  @Test(
+      description = "GITHUB-3135",
+      expectedExceptions = AssertionError.class,
+      expectedExceptionsMessageRegExp =
+          "Arrays differ at element \\[2\\]: 3 != null expected \\[3\\] but found \\[null\\]")
+  public void testAssertEqualsArrayElementIsNull() {
+    Assert.assertEquals(new Integer[] {1, 2, null}, new Integer[] {1, 2, 3});
+  }
+
+  @Test(
+      description = "GITHUB-3135",
+      expectedExceptions = AssertionError.class,
+      expectedExceptionsMessageRegExp =
+          "Arrays differ at element \\[2\\]: null != 5 expected \\[null\\] but found \\[5\\]")
+  public void testAssertEqualsArrayElementIsNotNull() {
+    Assert.assertEquals(new Integer[] {1, 2, 5}, new Integer[] {1, 2, null});
+  }
+
   @Test
   public void testAssertEqualsNoOrder() {
     String[] actual = {"a", "b"};


### PR DESCRIPTION
Fixes #3135 - assertEquals on arrays - Failure message is missing information about the array index when an array element is unexpectedly null or non-null.

Just need to use the `errorMessage` variable instead of `message`.

### Did you remember to?

- [x] Add test case(s)
- [x] Update `CHANGES.txt`
- [x] Auto applied styling via `./gradlew autostyleApply`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.

**Note:** For more information on contribution guidelines  please make sure you refer our [Contributing](.github/CONTRIBUTING.md) section for detailed set of steps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error messages for `assertEquals` on arrays to provide clearer information when an array element is unexpectedly null or non-null.

- **Tests**
	- Added new test cases to ensure better handling and reporting of array element differences in assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->