### PR TITLE
Fix `assertEqualsDeep(Set, Set, String)` wrong comparison and add variant without message

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,7 @@ Current (7.11.0)
 Fixed: GITHUB-3028: Execution stalls when using "use-global-thread-pool" (Krishnan Mahadevan)
 Fixed: GITHUB-3122: Update JCommander to 1.83 (Antoine Dessaigne)
 Fixed: GITHUB-3135: assertEquals on arrays - Failure message is missing information about the array index when an array element is unexpectedly null or non-null (Albert Choi)
+Fixed: GITHUB-3140: assertEqualsDeep on Sets - Deep comparison was using the wrong expected value
 
 7.10.2
 Fixed: GITHUB-3117: ListenerComparator doesn't work (Krishnan Mahadevan)

--- a/testng-asserts/src/main/java/org/testng/Assert.java
+++ b/testng-asserts/src/main/java/org/testng/Assert.java
@@ -2067,12 +2067,16 @@ public class Assert {
           return arrayNotEqualReason;
         }
       } else {
-        if (!areEqualImpl(value, expected)) {
+        if (!areEqualImpl(value, expectedValue)) {
           return "Sets not equal: expected: " + expectedValue + " and actual: " + value;
         }
       }
     }
     return null;
+  }
+
+  public static void assertEqualsDeep(Set<?> actual, Set<?> expected) {
+    assertEqualsDeep(actual, expected, null);
   }
 
   public static void assertEqualsDeep(Set<?> actual, Set<?> expected, String message) {

--- a/testng-asserts/src/test/java/org/testng/AssertTest.java
+++ b/testng-asserts/src/test/java/org/testng/AssertTest.java
@@ -580,6 +580,28 @@ public class AssertTest {
     Assert.assertNotEquals(obj, obj);
   }
 
+  @Test(description = "GITHUB-3140")
+  public void testAssertEqualsDeepSet() {
+    var expectedSet = new HashSet<>();
+    expectedSet.add(new Contrived(1));
+    expectedSet.add(new Contrived[] {new Contrived(1)});
+    var actualSet = new HashSet<>();
+    actualSet.add(new Contrived(1));
+    actualSet.add(new Contrived[] {new Contrived(1)});
+    Assert.assertEqualsDeep(actualSet, expectedSet);
+  }
+
+  @Test(description = "GITHUB-3140", expectedExceptions = AssertionError.class)
+  public void testAssertEqualsDeepSetFail() {
+    var expectedSet = new HashSet<>();
+    expectedSet.add(new Contrived(1));
+    expectedSet.add(new Contrived[] {new Contrived(1)});
+    var actualSet = new HashSet<>();
+    actualSet.add(new Contrived(1));
+    actualSet.add(new Contrived[] {new Contrived(2)});
+    Assert.assertEqualsDeep(actualSet, expectedSet);
+  }
+
   static class Contrived {
 
     int integer;


### PR DESCRIPTION
Fixes #3140.

This PR intends to fix the error reported in #3140, while also introducing another method `assertEqualsDeep(Set, Set)`, in the same fashion as other methods in the class.

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`
- [X] Auto applied styling via `./gradlew autostyleApply`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.

**Note:** For more information on contribution guidelines  please make sure you refer our [Contributing](.github/CONTRIBUTING.md) section for detailed set of steps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the deep comparison issue in `assertEqualsDeep` for Sets to ensure accurate expected value matching.

- **New Features**
  - Introduced new `assertEqualsDeep` methods for Sets with optional custom error messages to improve assertion capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->