### PR TITLE
update slf4j from 1.7.36 to 2.0.16

### DIFF
--- a/testng-core-api/testng-core-api-build.gradle.kts
+++ b/testng-core-api/testng-core-api-build.gradle.kts
@@ -15,6 +15,6 @@ dependencies {
     "guiceApi"("com.google.inject:guice")
 
     implementation(projects.testngReflectionUtils)
-    api("org.slf4j:slf4j-api:1.7.36")
-    testImplementation("org.slf4j:slf4j-simple:1.7.36")
+    api("org.slf4j:slf4j-api:2.0.16")
+    testImplementation("org.slf4j:slf4j-simple:2.0.16")
 }


### PR DESCRIPTION
slf4j 1.7.* is a very old version. 
Many projects use the newer slf4j, but fallback to 1.7.36 because of TestNG transitive dependency.

### Did you remember to?

- [ ] Add test case(s)
- [ ] Update `CHANGES.txt`
- [ ] Auto applied styling via `./gradlew autostyleApply`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.

**Note:** For more information on contribution guidelines  please make sure you refer our [Contributing](.github/CONTRIBUTING.md) section for detailed set of steps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated SLF4J API and SLF4J Simple dependencies to the latest version for improved performance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->