### PR TITLE
Introduce missing `assertEquals(long, Long, String)` overload

### DIFF
--- a/testng-asserts/src/main/java/org/testng/Assert.java
+++ b/testng-asserts/src/main/java/org/testng/Assert.java
@@ -976,6 +976,18 @@ public class Assert {
    * @param expected the expected value
    * @param message the assertion error message
    */
+  public static void assertEquals(long actual, Long expected, String message) {
+    assertEquals(Long.valueOf(actual), expected, message);
+  }
+
+  /**
+   * Asserts that two longs are equal. If they are not, an AssertionError, with the given message,
+   * is thrown.
+   *
+   * @param actual the actual value
+   * @param expected the expected value
+   * @param message the assertion error message
+   */
   public static void assertEquals(Long actual, Long expected, String message) {
     assertEquals(actual, (Object) expected, message);
   }

--- a/testng-asserts/src/test/java/test/asserttests/AssertTest.java
+++ b/testng-asserts/src/test/java/test/asserttests/AssertTest.java
@@ -51,6 +51,7 @@ public class AssertTest {
     assertEquals(a, b);
     assertEquals(a, b, "");
     assertEquals(b, a);
+    assertEquals(b, a, "");
     assertEquals(Long.valueOf(b), a, "");
   }
 


### PR DESCRIPTION
This reinstates a method that was introduced in
80e02ff41021210415a49c488089f05b1aa3dd12 but accidentally replaced in
89dc5845fcb46c26af187e50ea907a7382d06e72.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new assertion method to compare primitive long values with Long objects.
  
- **Tests**
	- Enhanced test coverage for boxed and unboxed long comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->