### PR TITLE
Support to execlude somes test in option of command line

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,7 @@ Fixed: GITHUB-3122: Update JCommander to 1.83 (Antoine Dessaigne)
 Fixed: GITHUB-3135: assertEquals on arrays - Failure message is missing information about the array index when an array element is unexpectedly null or non-null (Albert Choi)
 Fixed: GITHUB-3140: assertEqualsDeep on Sets - Deep comparison was using the wrong expected value
 Fixed: GITHUB-3189: Incorrect number of ignored tests displayed in the XML results
+Fixed: GITHUB-3196: support to execlude somes 'test' in option of command line
 
 7.10.2
 Fixed: GITHUB-3117: ListenerComparator doesn't work (Krishnan Mahadevan)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,7 +6,7 @@ Fixed: GITHUB-3122: Update JCommander to 1.83 (Antoine Dessaigne)
 Fixed: GITHUB-3135: assertEquals on arrays - Failure message is missing information about the array index when an array element is unexpectedly null or non-null (Albert Choi)
 Fixed: GITHUB-3140: assertEqualsDeep on Sets - Deep comparison was using the wrong expected value
 Fixed: GITHUB-3189: Incorrect number of ignored tests displayed in the XML results
-Fixed: GITHUB-3196: support to execlude somes 'test' in option of command line
+Fixed: GITHUB-3196: support to execlude somes tests in option of command line
 
 7.10.2
 Fixed: GITHUB-3117: ListenerComparator doesn't work (Krishnan Mahadevan)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Sonarqube Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=org.testng%3Atestng&metric=alert_status)](https://sonarcloud.io/dashboard?id=org.testng%3Atestng)
 
 Documentation available at [TestNG's main web site](https://testng.org). Visit [TestNG Documentation's GitHub Repo](https://github.com/testng-team/testng-team.github.io) to contribute to it.
-###
 ### Release Notes
 * [7.10.0](https://groups.google.com/g/testng-users/c/6DmFaKUjIxY)
 * [7.9.0](https://groups.google.com/g/testng-users/c/nN7LkuZWO48)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Sonarqube Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=org.testng%3Atestng&metric=alert_status)](https://sonarcloud.io/dashboard?id=org.testng%3Atestng)
 
 Documentation available at [TestNG's main web site](https://testng.org). Visit [TestNG Documentation's GitHub Repo](https://github.com/testng-team/testng-team.github.io) to contribute to it.
-
+###
 ### Release Notes
 * [7.10.0](https://groups.google.com/g/testng-users/c/6DmFaKUjIxY)
 * [7.9.0](https://groups.google.com/g/testng-users/c/nN7LkuZWO48)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Sonarqube Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=org.testng%3Atestng&metric=alert_status)](https://sonarcloud.io/dashboard?id=org.testng%3Atestng)
 
 Documentation available at [TestNG's main web site](https://testng.org). Visit [TestNG Documentation's GitHub Repo](https://github.com/testng-team/testng-team.github.io) to contribute to it.
+
 ### Release Notes
 * [7.10.0](https://groups.google.com/g/testng-users/c/6DmFaKUjIxY)
 * [7.9.0](https://groups.google.com/g/testng-users/c/nN7LkuZWO48)
@@ -39,7 +40,7 @@ Always make sure your issue is happening on the latest TestNG version. Bug repor
 
 ### Have you considered sending a pull request instead of filing an issue?
 The best way to report a bug is to provide the TestNG team with a full test case reproducing the issue.
-Maybe you can write a runnable test case (check the `src/test/` folder for examples) and propose it in a pull request 
+Maybe you can write a runnable test case (check the `src/test/` folder for examples) and propose it in a pull request
 Don't worry if the CI fails because it is the expected behavior.
 This pull request will be a perfect start to find the fix :)
 
@@ -48,12 +49,12 @@ Refer our [Contributing](.github/CONTRIBUTING.md) section for detailed set of st
 
 ### We encourage pull requests that:
 
-  * Add new features to TestNG (or)
-  * Fix bugs in TestNG
+* Add new features to TestNG (or)
+* Fix bugs in TestNG
 
-  If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
-  [TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
-  
+If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the
+[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
+
 ### GPG Keys
 
 #### Getting the keys

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Always make sure your issue is happening on the latest TestNG version. Bug repor
 
 ### Have you considered sending a pull request instead of filing an issue?
 The best way to report a bug is to provide the TestNG team with a full test case reproducing the issue.
-Maybe you can write a runnable test case (check the `src/test/` folder for examples) and propose it in a pull request
+Maybe you can write a runnable test case (check the `src/test/` folder for examples) and propose it in a pull request 
 Don't worry if the CI fails because it is the expected behavior.
 This pull request will be a perfect start to find the fix :)
 
@@ -49,12 +49,12 @@ Refer our [Contributing](.github/CONTRIBUTING.md) section for detailed set of st
 
 ### We encourage pull requests that:
 
-* Add new features to TestNG (or)
-* Fix bugs in TestNG
+  * Add new features to TestNG (or)
+  * Fix bugs in TestNG
 
-If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the
-[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
-
+  If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
+  [TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.
+  
 ### GPG Keys
 
 #### Getting the keys

--- a/testng-core-api/src/main/java/org/testng/xml/XmlTest.java
+++ b/testng-core-api/src/main/java/org/testng/xml/XmlTest.java
@@ -625,6 +625,6 @@ public class XmlTest implements Cloneable {
    * @return <code>true</code> if the current test's name matches with any of the given names.
    */
   public boolean nameMatchesAny(List<String> names) {
-    return names.stream().allMatch(regex -> Pattern.matches(regex, getName()));
+    return names.stream().anyMatch(regex -> Pattern.matches(regex, getName()));
   }
 }

--- a/testng-core-api/src/main/java/org/testng/xml/XmlTest.java
+++ b/testng-core-api/src/main/java/org/testng/xml/XmlTest.java
@@ -1,6 +1,7 @@
 package org.testng.xml;
 
 import java.util.*;
+import java.util.regex.Pattern;
 import org.testng.TestNGException;
 import org.testng.collections.Lists;
 import org.testng.collections.Maps;
@@ -624,6 +625,6 @@ public class XmlTest implements Cloneable {
    * @return <code>true</code> if the current test's name matches with any of the given names.
    */
   public boolean nameMatchesAny(List<String> names) {
-    return names.contains(getName());
+    return names.stream().allMatch(regex -> Pattern.matches(regex, getName()));
   }
 }

--- a/testng-core-api/src/main/java/org/testng/xml/XmlTest.java
+++ b/testng-core-api/src/main/java/org/testng/xml/XmlTest.java
@@ -625,6 +625,15 @@ public class XmlTest implements Cloneable {
    * @return <code>true</code> if the current test's name matches with any of the given names.
    */
   public boolean nameMatchesAny(List<String> names) {
-    return names.stream().anyMatch(regex -> Pattern.matches(regex, getName()));
+    return names.contains(getName())
+        || names.stream()
+            .anyMatch(
+                regex -> {
+                  if (regex.startsWith("/") && regex.endsWith("/")) {
+                    String trimmedRegex = regex.substring(1, regex.length() - 1);
+                    return Pattern.matches(trimmedRegex, getName());
+                  }
+                  return false;
+                });
   }
 }

--- a/testng-core/src/main/java/org/testng/xml/internal/TestNamesMatcher.java
+++ b/testng-core/src/main/java/org/testng/xml/internal/TestNamesMatcher.java
@@ -91,7 +91,17 @@ public final class TestNamesMatcher {
     List<String> missedTestNames = Lists.newArrayList();
     missedTestNames.addAll(testNames);
     missedTestNames.removeIf(
-        regex -> matchedTestNames.stream().anyMatch(testName -> Pattern.matches(regex, testName)));
+        regex ->
+            matchedTestNames.contains(regex)
+                || matchedTestNames.stream()
+                    .anyMatch(
+                        name -> {
+                          if (regex.startsWith("/") && regex.endsWith("/")) {
+                            String trimmedRegex = regex.substring(1, regex.length() - 1);
+                            return Pattern.matches(trimmedRegex, name);
+                          }
+                          return false;
+                        }));
     return missedTestNames;
   }
 

--- a/testng-core/src/main/java/org/testng/xml/internal/TestNamesMatcher.java
+++ b/testng-core/src/main/java/org/testng/xml/internal/TestNamesMatcher.java
@@ -21,6 +21,8 @@ public final class TestNamesMatcher {
   private final List<XmlSuite> cloneSuites = Lists.newArrayList();
   private final List<String> matchedTestNames = Lists.newArrayList();
   private final List<XmlTest> matchedTests = Lists.newArrayList();
+  private final List<String> missedTestNames = Lists.newArrayList();
+  private final List<XmlTest> missedTests = Lists.newArrayList();
   private final List<String> testNames;
   private final boolean ignoreMissedTestNames;
 
@@ -87,9 +89,6 @@ public final class TestNamesMatcher {
   }
 
   public List<String> getMissedTestNames() {
-    List<String> missedTestNames = Lists.newArrayList();
-    missedTestNames.addAll(testNames);
-    missedTestNames.removeIf(matchedTestNames::contains);
     return missedTestNames;
   }
 
@@ -110,6 +109,9 @@ public final class TestNamesMatcher {
         tests.add(xt);
         matchedTestNames.add(xt.getName());
         matchedTests.add(xt);
+      }else{
+        missedTestNames.add(xt.getName());
+        missedTests.add(xt);
       }
     }
     if (tests.isEmpty()) {

--- a/testng-core/src/main/java/org/testng/xml/internal/TestNamesMatcher.java
+++ b/testng-core/src/main/java/org/testng/xml/internal/TestNamesMatcher.java
@@ -109,7 +109,7 @@ public final class TestNamesMatcher {
         tests.add(xt);
         matchedTestNames.add(xt.getName());
         matchedTests.add(xt);
-      }else{
+      } else {
         missedTestNames.add(xt.getName());
         missedTests.add(xt);
       }

--- a/testng-core/src/main/java/org/testng/xml/internal/TestNamesMatcher.java
+++ b/testng-core/src/main/java/org/testng/xml/internal/TestNamesMatcher.java
@@ -90,10 +90,8 @@ public final class TestNamesMatcher {
   public List<String> getMissedTestNames() {
     List<String> missedTestNames = Lists.newArrayList();
     missedTestNames.addAll(testNames);
-    missedTestNames.removeIf(regex ->
-        matchedTestNames.stream()
-            .anyMatch(testName -> Pattern.matches(regex, testName))
-    );
+    missedTestNames.removeIf(
+        regex -> matchedTestNames.stream().anyMatch(testName -> Pattern.matches(regex, testName)));
     return missedTestNames;
   }
 

--- a/testng-core/src/main/java/org/testng/xml/internal/TestNamesMatcher.java
+++ b/testng-core/src/main/java/org/testng/xml/internal/TestNamesMatcher.java
@@ -1,6 +1,7 @@
 package org.testng.xml.internal;
 
 import java.util.List;
+import java.util.regex.Pattern;
 import org.testng.TestNGException;
 import org.testng.collections.Lists;
 import org.testng.log4testng.Logger;
@@ -21,8 +22,6 @@ public final class TestNamesMatcher {
   private final List<XmlSuite> cloneSuites = Lists.newArrayList();
   private final List<String> matchedTestNames = Lists.newArrayList();
   private final List<XmlTest> matchedTests = Lists.newArrayList();
-  private final List<String> missedTestNames = Lists.newArrayList();
-  private final List<XmlTest> missedTests = Lists.newArrayList();
   private final List<String> testNames;
   private final boolean ignoreMissedTestNames;
 
@@ -89,6 +88,12 @@ public final class TestNamesMatcher {
   }
 
   public List<String> getMissedTestNames() {
+    List<String> missedTestNames = Lists.newArrayList();
+    missedTestNames.addAll(testNames);
+    missedTestNames.removeIf(regex ->
+        matchedTestNames.stream()
+            .anyMatch(testName -> Pattern.matches(regex, testName))
+    );
     return missedTestNames;
   }
 
@@ -109,9 +114,6 @@ public final class TestNamesMatcher {
         tests.add(xt);
         matchedTestNames.add(xt.getName());
         matchedTests.add(xt);
-      } else {
-        missedTestNames.add(xt.getName());
-        missedTests.add(xt);
       }
     }
     if (tests.isEmpty()) {

--- a/testng-core/src/test/java/org/testng/xml/XmlTestTest.java
+++ b/testng-core/src/test/java/org/testng/xml/XmlTestTest.java
@@ -21,7 +21,7 @@ public class XmlTestTest extends SimpleBaseTest {
   }
 
   @Test(description = "GITHUB-3196")
-  public void testNameMatchesAnyWithRegex(){
+  public void testNameMatchesAnyWithRegex() {
     XmlSuite xmlSuite = createDummySuiteWithTestNamesAs("test1");
     XmlTest xmlTest = xmlSuite.getTests().get(0);
     assertThat(xmlTest.nameMatchesAny(Collections.singletonList("^(test1$).*"))).isTrue();

--- a/testng-core/src/test/java/org/testng/xml/XmlTestTest.java
+++ b/testng-core/src/test/java/org/testng/xml/XmlTestTest.java
@@ -20,6 +20,14 @@ public class XmlTestTest extends SimpleBaseTest {
     assertThat(xmlTest.nameMatchesAny(Collections.singletonList("test2"))).isFalse();
   }
 
+  @Test(description = "GITHUB-3196")
+  public void testNameMatchesAnyWithRegex(){
+    XmlSuite xmlSuite = createDummySuiteWithTestNamesAs("test1");
+    XmlTest xmlTest = xmlSuite.getTests().get(0);
+    assertThat(xmlTest.nameMatchesAny(Collections.singletonList("^(test1$).*"))).isTrue();
+    assertThat(xmlTest.nameMatchesAny(Collections.singletonList("^(?!test1$).*,"))).isFalse();
+  }
+
   @Test(dataProvider = "dp", description = "GITHUB-1716")
   public void testNullOrEmptyParameter(Map<String, String> data) {
     XmlTest test = createXmlTest("suite", "test", Issue1716TestSample.class);

--- a/testng-core/src/test/java/org/testng/xml/XmlTestTest.java
+++ b/testng-core/src/test/java/org/testng/xml/XmlTestTest.java
@@ -24,8 +24,8 @@ public class XmlTestTest extends SimpleBaseTest {
   public void testNameMatchesAnyWithRegex() {
     XmlSuite xmlSuite = createDummySuiteWithTestNamesAs("test1");
     XmlTest xmlTest = xmlSuite.getTests().get(0);
-    assertThat(xmlTest.nameMatchesAny(Collections.singletonList("^(test1$).*"))).isTrue();
-    assertThat(xmlTest.nameMatchesAny(Collections.singletonList("^(?!test1$).*,"))).isFalse();
+    assertThat(xmlTest.nameMatchesAny(Collections.singletonList("/^(test1$).*/"))).isTrue();
+    assertThat(xmlTest.nameMatchesAny(Collections.singletonList("/^(?!test1$).*/"))).isFalse();
   }
 
   @Test(dataProvider = "dp", description = "GITHUB-1716")

--- a/testng-core/src/test/java/test/methodselectors/CommandLineTest.java
+++ b/testng-core/src/test/java/test/methodselectors/CommandLineTest.java
@@ -170,6 +170,27 @@ public class CommandLineTest extends SimpleBaseTest {
     verifyTests("Failed", failed, tla.getFailedTests());
   }
 
+  @Test(description = "GITHUB-2407")
+  public void testSpecificTestNamesWithRegexCommandLineExclusions() {
+    String[] args =
+        new String[] {
+          "src/test/resources/testnames/main-suite.xml",
+          "-log",
+          "0",
+          "-d",
+          OutputDirectoryPatch.getOutputDirectory(),
+          "-testnames",
+          "/^testGroup1.*/"
+        };
+
+    TestNG.privateMain(args, tla);
+
+    String[] passed = {"sampleOutputTest1"};
+    String[] failed = {};
+    verifyTests("Passed", passed, tla.getPassedTests());
+    verifyTests("Failed", failed, tla.getFailedTests());
+  }
+
   private void verifyTests(String title, String[] expected, List<ITestResult> found) {
 
     Assertions.assertThat(found.stream().map(ITestResult::getName).toArray(String[]::new))


### PR DESCRIPTION
Fixes #3196 .

### Did you remember to?

- [ ] Add test case(s)
- [ ] Update `CHANGES.txt`
- [ ] Auto applied styling via `./gradlew autostyleApply`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.

**Note:** For more information on contribution guidelines  please make sure you refer our [Contributing](.github/CONTRIBUTING.md) section for detailed set of steps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support to exclude certain tests from command line options (GITHUB-3196)
	- Enhanced test name matching with regex support

- **Bug Fixes**
	- Corrected calculation of 'invocation-numbers' in testng-failed.xml
	- Fixed issues with data providers and success percentage
	- Resolved execution stalls with global thread pool
	- Corrected deep comparison for Sets
	- Fixed display of ignored tests in XML results

- **Documentation**
	- Added reference for GPG key trust in README

- **Improvements**
	- Updated JCommander library to version 1.83
	- Enhanced assertEquals for arrays with index information
<!-- end of auto-generated comment: release notes by coderabbit.ai -->