### PR TITLE
Use newer build scan plugin

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,14 +5,16 @@ pluginManagement {
 rootProject.name = "testng-root"
 
 plugins {
-    `gradle-enterprise`
+    id("com.gradle.develocity") version("3.19.1")
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
 }
 
-gradleEnterprise {
+develocity {
     buildScan {
-        termsOfServiceUrl = "https://gradle.com/terms-of-service"
-        termsOfServiceAgree = "yes"
+        termsOfUseUrl = "https://gradle.com/terms-of-service"
+        termsOfUseAgree = "yes"
+        val isCI = System.getenv("CI") != null
+        publishing.onlyIf { isCI }
     }
 }
 


### PR DESCRIPTION
 - Use newer build scan plugin
 - See https://docs.gradle.com/develocity/gradle-plugin/current/

@cbeust 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated build configuration to use the latest Gradle Develocity plugin
	- Modified build scan settings to improve continuous integration compatibility
	- Updated terms of service configuration for build scans

<!-- end of auto-generated comment: release notes by coderabbit.ai -->