### PR TITLE
GITHUB-2765: Propagate timeout stack trace to fix testng-team#2765

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,7 @@
-Current (7.11.0)
+Current (7.12.0)
+Fixed: GITHUB-2765: Test timeouts using existing Executor now propagate the stack trace to the ThreadTimeoutException
+
+7.11.0
 Fixed: GITHUB-3180: TestNG testng-failed.xml 'invocation-numbers' values are not calculated correctly with retry and dataproviders (Krishnan Mahadevan)
 Fixed: GITHUB-3170: Specifying dataProvider and successPercentage causes test to always pass (Krishnan Mahadevan)
 Fixed: GITHUB-3028: Execution stalls when using "use-global-thread-pool" (Krishnan Mahadevan)

--- a/testng-core-api/src/main/java/org/testng/internal/thread/ThreadTimeoutException.java
+++ b/testng-core-api/src/main/java/org/testng/internal/thread/ThreadTimeoutException.java
@@ -8,7 +8,11 @@ public class ThreadTimeoutException extends Exception {
   private static final long serialVersionUID = 7009400729783393548L;
 
   public ThreadTimeoutException(String msg) {
-    super(msg);
+    this(msg, null);
+  }
+
+  public ThreadTimeoutException(String msg, Throwable cause) {
+    super(msg, cause);
   }
 
   public ThreadTimeoutException(Throwable cause) {
@@ -16,6 +20,12 @@ public class ThreadTimeoutException extends Exception {
   }
 
   public ThreadTimeoutException(ITestNGMethod tm, long timeout) {
-    this("Method " + tm.getQualifiedName() + "() didn't finish within the time-out " + timeout);
+    this(tm, timeout, null);
+  }
+
+  public ThreadTimeoutException(ITestNGMethod tm, long timeout, Throwable cause) {
+    this(
+        "Method " + tm.getQualifiedName() + "() didn't finish within the time-out " + timeout,
+        cause);
   }
 }

--- a/testng-core/src/main/java/org/testng/internal/invokers/MethodInvocationHelper.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/MethodInvocationHelper.java
@@ -365,7 +365,7 @@ public class MethodInvocationHelper {
       Throwable e = ex.getCause();
       boolean wasTimedOut = !(notTimedout && !interruptByMonitor.get());
       if (wasTimedOut) {
-        e = new ThreadTimeoutException(tm, realTimeOut);
+        e = new ThreadTimeoutException(tm, realTimeOut, e);
       } else {
         if (e instanceof TestNGRuntimeException) {
           e = e.getCause();

--- a/testng-core/src/test/java/test/timeout/github2672/TimeoutStacktraceTest.java
+++ b/testng-core/src/test/java/test/timeout/github2672/TimeoutStacktraceTest.java
@@ -2,6 +2,7 @@ package test.timeout.github2672;
 
 import static org.testng.Assert.assertTrue;
 
+import com.google.common.base.Throwables;
 import java.util.Arrays;
 import org.testng.ITestListener;
 import org.testng.ITestResult;
@@ -25,7 +26,7 @@ public class TimeoutStacktraceTest {
   }
 
   @Test
-  public void verifyTimeoutStacktrace() {
+  public void verifyTimeoutStacktraceNewExecutor() {
     TestNG testng = new TestNG();
     testng.setTestClasses(new Class[] {TimeoutStacktraceTestSample.class});
     TimeoutStacktraceTestListener listener = new TimeoutStacktraceTestListener();
@@ -37,6 +38,23 @@ public class TimeoutStacktraceTest {
     assertTrue(testError instanceof ThreadTimeoutException);
     assertTrue(
         Arrays.stream(testError.getStackTrace())
+            .anyMatch(s -> s.getMethodName().equals("testTimeoutStacktrace")));
+  }
+
+  @Test
+  public void verifyTimeoutStacktraceNoExecutor() {
+    TestNG testng = new TestNG();
+    testng.setTestClasses(new Class[] {TimeoutStacktraceTestSample.class});
+    TimeoutStacktraceTestListener listener = new TimeoutStacktraceTestListener();
+    testng.addListener(listener);
+    testng.setSuiteThreadPoolSize(2);
+    testng.run();
+
+    Throwable testError = listener.getTestError();
+    assertTrue(testError instanceof ThreadTimeoutException);
+    assertTrue(
+        Throwables.getCausalChain(testError).stream()
+            .flatMap((Throwable throwable) -> Arrays.stream(throwable.getStackTrace()))
             .anyMatch(s -> s.getMethodName().equals("testTimeoutStacktrace")));
   }
 }


### PR DESCRIPTION
Fixes #2765 .

### Did you remember to?

- [x] Add test case(s)
- [x] Update `CHANGES.txt`
- [x] Auto applied styling via `./gradlew autostyleApply`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.

**Note:** For more information on contribution guidelines  please make sure you refer our [Contributing](.github/CONTRIBUTING.md) section for detailed set of steps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for test timeouts, ensuring that detailed stack trace information is now available for easier debugging.

- **Tests**
  - Added and updated tests to confirm that timeout errors correctly capture comprehensive details in different execution contexts.

- **Chores**
  - Upgraded the framework version from 7.11.0 to 7.12.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->