### PR TITLE
Streamline working of shared thread pools

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 Current (7.12.0)
-Fixed: GITHUB-2765: Test timeouts using existing Executor now propagate the stack trace to the ThreadTimeoutException
+Fixed: GITHUB-3179: ClassCastException when use shouldUseGlobalThreadPool(true) property (Krishnan Mahadevan)
+Fixed: GITHUB-2765: Test timeouts using existing Executor now propagate the stack trace to the ThreadTimeoutException (Charlie Hayes)
 
 7.11.0
 Fixed: GITHUB-3180: TestNG testng-failed.xml 'invocation-numbers' values are not calculated correctly with retry and dataproviders (Krishnan Mahadevan)

--- a/testng-core/src/test/java/test/thread/SharedThreadPoolTest.java
+++ b/testng-core/src/test/java/test/thread/SharedThreadPoolTest.java
@@ -17,6 +17,8 @@ import test.thread.issue2019.TestClassSample;
 import test.thread.issue3028.AnotherDataDrivenTestSample;
 import test.thread.issue3028.DataDrivenTestSample;
 import test.thread.issue3028.FactoryPoweredDataDrivenTestSample;
+import test.thread.issue3179.DummyMethodInterceptor;
+import test.thread.issue3179.SampleSuiteAlteringListener;
 
 public class SharedThreadPoolTest extends SimpleBaseTest {
 
@@ -81,6 +83,15 @@ public class SharedThreadPoolTest extends SimpleBaseTest {
     testng.setParallel(mode);
     testng.setThreadCount(2);
     testng.run();
+  }
+
+  @Test(description = "GITHUB-3179")
+  public void ensurePriorityAgnosticInterceptorsDontCauseExceptions() {
+    TestNG testng = create(test.thread.issue3179.TestClassSample.class);
+    testng.addListener(new SampleSuiteAlteringListener());
+    testng.addListener(new DummyMethodInterceptor());
+    testng.run();
+    assertThat(testng.getStatus()).isZero();
   }
 
   @DataProvider(name = "modes")

--- a/testng-core/src/test/java/test/thread/issue3179/DummyMethodInterceptor.java
+++ b/testng-core/src/test/java/test/thread/issue3179/DummyMethodInterceptor.java
@@ -1,0 +1,13 @@
+package test.thread.issue3179;
+
+import java.util.List;
+import org.testng.IMethodInstance;
+import org.testng.IMethodInterceptor;
+import org.testng.ITestContext;
+
+public class DummyMethodInterceptor implements IMethodInterceptor {
+  @Override
+  public List<IMethodInstance> intercept(List<IMethodInstance> methods, ITestContext context) {
+    return methods;
+  }
+}

--- a/testng-core/src/test/java/test/thread/issue3179/SampleSuiteAlteringListener.java
+++ b/testng-core/src/test/java/test/thread/issue3179/SampleSuiteAlteringListener.java
@@ -1,0 +1,14 @@
+package test.thread.issue3179;
+
+import java.util.List;
+import org.testng.IAlterSuiteListener;
+import org.testng.xml.XmlSuite;
+
+public class SampleSuiteAlteringListener implements IAlterSuiteListener {
+  @Override
+  public void alter(List<XmlSuite> suites) {
+    suites.get(0).shouldUseGlobalThreadPool(true);
+    suites.get(0).setThreadCount(3);
+    suites.get(0).setParallel(XmlSuite.ParallelMode.METHODS);
+  }
+}

--- a/testng-core/src/test/java/test/thread/issue3179/TestClassSample.java
+++ b/testng-core/src/test/java/test/thread/issue3179/TestClassSample.java
@@ -1,0 +1,23 @@
+package test.thread.issue3179;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class TestClassSample {
+  @DataProvider(parallel = true)
+  public Object[] dp() {
+    return new Object[] {1};
+  }
+
+  @Test(dataProvider = "dp")
+  public void test1(int dp) {}
+
+  @Test(dataProvider = "dp")
+  public void test3(int dp) {}
+
+  @Test
+  public void test2() {}
+
+  @Test
+  public void test4() {}
+}


### PR DESCRIPTION
If a user is not using priority driven tests then
TestNG should not consider any method interceptors that a user may be using.

Closes #3179

Fixes #3179 .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`
- [X] Auto applied styling via `./gradlew autostyleApply`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.

**Note:** For more information on contribution guidelines  please make sure you refer our [Contributing](.github/CONTRIBUTING.md) section for detailed set of steps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed a `ClassCastException` when using the `shouldUseGlobalThreadPool(true)` property.
  - Improved error reporting for test timeouts by ensuring stack traces are propagated correctly.

- **Refactor**
  - Enhanced the internal test execution ordering mechanism to better handle prioritization.

- **Tests**
  - Added new tests to verify that priority-agnostic interceptors do not cause exceptions.
  - Introduced a sample test suite demonstrating parallel, data-driven test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->