### PR TITLE
chore: setup-java Oracle action supports Java 21+ only

### DIFF
--- a/.github/workflows/matrix.js
+++ b/.github/workflows/matrix.js
@@ -20,7 +20,7 @@ matrix.addAxis({
   ]
 });
 
-const eaJava = '22';
+const eaJava = '24';
 matrix.addAxis({
   name: 'java_version',
   // Strings allow versions like 18-ea
@@ -70,8 +70,8 @@ matrix.addAxis({
 matrix.setNamePattern(['java_version', 'java_distribution', 'hash', 'os', 'tz', 'locale']);
 
 matrix.imply({java_version: eaJava}, {java_distribution: {value: 'oracle'}})
-// Oracle JDK is only supported for JDK 17 and later
-matrix.exclude({java_distribution: {value: 'oracle'}, java_version: ['11']});
+// Oracle JDK is only supported for JDK 21 and later
+matrix.imply({java_distribution: {value: 'oracle'}}, {java_version: v => v === eaJava || v >= 21});
 // Semeru uses OpenJ9 jit which has no option for making hash codes the same
 // See https://github.com/eclipse-openj9/openj9/issues/17309
 matrix.exclude({java_distribution: {value: 'semeru'}, hash: {value: 'same'}});

--- a/testng-test-osgi/src/test/java/org/testng/test/osgi/DefaultTestngOsgiOptions.java
+++ b/testng-test-osgi/src/test/java/org/testng/test/osgi/DefaultTestngOsgiOptions.java
@@ -40,8 +40,7 @@ public class DefaultTestngOsgiOptions {
             .versionAsInProject(),
         systemProperty("logback.configurationFile")
             .value(System.getProperty("logback.configurationFile")),
-        mavenBundle("org.slf4j", "slf4j-api").versionAsInProject(),
-        mavenBundle("ch.qos.logback", "logback-core").versionAsInProject(),
-        mavenBundle("ch.qos.logback", "logback-classic").versionAsInProject());
+        mavenBundle("org.ops4j.pax.logging", "pax-logging-api").versionAsInProject(),
+        mavenBundle("org.ops4j.pax.logging", "pax-logging-logback").versionAsInProject());
   }
 }

--- a/testng-test-osgi/testng-test-osgi-build.gradle.kts
+++ b/testng-test-osgi/testng-test-osgi-build.gradle.kts
@@ -38,14 +38,18 @@ dependencies {
     testImplementation("org.ops4j.pax.exam:pax-exam-link-mvn:4.14.0")
     testImplementation("org.ops4j.pax.url:pax-url-aether:2.6.12")
     testImplementation("org.apache.felix:org.apache.felix.framework:7.0.5")
-    testImplementation("ch.qos.logback:logback-core:1.4.11")
-    testImplementation("ch.qos.logback:logback-classic:1.4.11")
     testRuntimeOnly("org.assertj:assertj-core:3.23.1")
     testRuntimeOnly("org.apache.servicemix.bundles:org.apache.servicemix.bundles.aopalliance:1.0_6") {
         because("Guice requires org.aopalliance.intercept package in osgi, however, aopalliance:aopalliance has no osgi headers")
     }
     testRuntimeOnly("com.google.errorprone:error_prone_annotations:2.36.0") {
         because("It is needed for Guava, only recent version of error_prone_annotations have osgi headers")
+    }
+    testRuntimeOnly("org.ops4j.pax.logging:pax-logging-api:2.2.8") {
+        because("It will actually be used in osgi for logging")
+    }
+    testRuntimeOnly("org.ops4j.pax.logging:pax-logging-logback:2.2.8") {
+        because("It will actually be used in osgi for logging, basic slf4j+logback is hard to launch in osgi, see https://stackoverflow.com/a/77867804")
     }
     testRuntimeOnly("org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:1.3.7") {
         because("slf4j-api 2.0 requires osgi.serviceloader.processor, see https://stackoverflow.com/a/77867804")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated Java compatibility settings to support a broader range of Oracle JDK versions.
  - Enhanced version handling logic by removing previous limitations, ensuring more flexible Java version support.
  - Transitioned logging framework from Logback to Pax Logging for improved compatibility in the OSGi test environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->