### PR TITLE
Ensure assertions is contents aware

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current (7.12.0)
+Fixed: GITHUB-3227: assertEqualsNoOrder false positive when collection has same size and actual Collection is subset of expected collection (Krishnan Mahadevan)
 Fixed: GITHUB-3177: Method org.testng.xml.XmlSuite#toXml do not save new properties like "share-thread-pool-for-data-providers" (Krishnan Mahadevan)
 Fixed: GITHUB-3179: ClassCastException when use shouldUseGlobalThreadPool(true) property (Krishnan Mahadevan)
 Fixed: GITHUB-2765: Test timeouts using existing Executor now propagate the stack trace to the ThreadTimeoutException (Charlie Hayes)

--- a/testng-asserts/src/main/java/org/testng/Assert.java
+++ b/testng-asserts/src/main/java/org/testng/Assert.java
@@ -1856,18 +1856,7 @@ public class Assert {
    */
   public static void assertEqualsNoOrder(
       Collection<?> actual, Collection<?> expected, String message) {
-    if (actual.size() != expected.size()) {
-      failAssertNoEqual(
-          "Collections do not have the same size: " + actual.size() + " != " + expected.size(),
-          message);
-    }
-
-    List<?> actualCollection = Lists.newArrayList(actual);
-    actualCollection.removeAll(expected);
-    if (!actualCollection.isEmpty()) {
-      failAssertNoEqual(
-          "Collections not equal: expected: " + expected + " and actual: " + actual, message);
-    }
+    validateEqualityNoOrder(actual, expected, "Collections", message);
   }
 
   /**
@@ -1879,26 +1868,25 @@ public class Assert {
    * @param message the assertion error message
    */
   public static void assertEqualsNoOrder(Iterator<?> actual, Iterator<?> expected, String message) {
-    List<?> actualCollection = Lists.newArrayList(actual);
-    List<?> expectedCollection = Lists.newArrayList(expected);
+    validateEqualityNoOrder(
+        Lists.newArrayList(actual), Lists.newArrayList(expected), "Iterators", message);
+  }
 
-    if (actualCollection.size() != expectedCollection.size()) {
+  private static void validateEqualityNoOrder(
+      Collection<?> actual, Collection<?> expected, String prefix, String message) {
+    if (actual.size() != expected.size()) {
       failAssertNoEqual(
-          "Iterators do not have the same size: "
-              + actualCollection.size()
-              + " != "
-              + expectedCollection.size(),
+          prefix + " do not have the same size: " + actual.size() + " != " + expected.size(),
           message);
     }
+    List<?> actualCollection = Lists.newArrayList(actual);
+    for (Object o : expected) {
+      actualCollection.remove(o);
+    }
 
-    actualCollection.removeAll(expectedCollection);
     if (!actualCollection.isEmpty()) {
       failAssertNoEqual(
-          "Iterators not equal: expected: "
-              + toString(expected)
-              + " and actual: "
-              + toString(actual),
-          message);
+          prefix + " not equal: expected: " + expected + " and actual: " + actual, message);
     }
   }
 

--- a/testng-asserts/src/test/java/org/testng/AssertTest.java
+++ b/testng-asserts/src/test/java/org/testng/AssertTest.java
@@ -2,6 +2,7 @@ package org.testng;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.*;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.testng.collections.Lists;
 import org.testng.collections.Maps;
@@ -600,6 +601,46 @@ public class AssertTest {
     actualSet.add(new Contrived(1));
     actualSet.add(new Contrived[] {new Contrived(2)});
     Assert.assertEqualsDeep(actualSet, expectedSet);
+  }
+
+  @Test(
+      description = "GITHUB-3227",
+      dataProvider = "3227-dp",
+      expectedExceptions = AssertionError.class,
+      expectedExceptionsMessageRegExp = "list should not be equal")
+  public void testAssertEqualsNoOrderList(List<String> actual, List<String> expected) {
+    Assert.assertEqualsNoOrder(actual, expected, "list should not be equal");
+  }
+
+  @DataProvider(name = "3227-dp")
+  public Object[][] dataProvider() {
+    return new Object[][] {
+      {List.of("a", "b", "b"), List.of("a", "b", "c")},
+      {List.of("a", "b", "b"), List.of("a", "a", "b")},
+      {List.of("a", "a", "a", "a", "a", "a", "b"), List.of("a", "b", "b", "b", "b", "b", "b")}
+    };
+  }
+
+  @Test(
+      description = "GITHUB-3227",
+      dataProvider = "3227-dp",
+      expectedExceptions = AssertionError.class,
+      expectedExceptionsMessageRegExp = "queue should not be equal")
+  public void testAssertEqualsNoOrderQueue(List<String> actualIn, List<String> expectedIn) {
+    var actual = new ArrayDeque<>(actualIn);
+    var expected = new ArrayDeque<>(expectedIn);
+    Assert.assertEqualsNoOrder(actual, expected, "queue should not be equal");
+  }
+
+  @Test(
+      description = "GITHUB-3227",
+      dataProvider = "3227-dp",
+      expectedExceptions = AssertionError.class,
+      expectedExceptionsMessageRegExp = "iterator should not be equal")
+  public void testAssertEqualsNoOrderIterator(List<String> actualIn, List<String> expectedIn) {
+    var actual = actualIn.iterator();
+    var expected = expectedIn.iterator();
+    Assert.assertEqualsNoOrder(actual, expected, "iterator should not be equal");
   }
 
   static class Contrived {


### PR DESCRIPTION
Closes #3227

Fixes #3227  .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`
- [X] Auto applied styling via `./gradlew autostyleApply`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.

**Note:** For more information on contribution guidelines  please make sure you refer our [Contributing](.github/CONTRIBUTING.md) section for detailed set of steps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where collection equality assertions could incorrectly fail when the actual collection was a subset of the expected collection with the same size.

- **Tests**
  - Added tests to ensure collection equality assertions accurately detect differences, including cases with duplicates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->