### PR TITLE
Add CacheTest for dataprovider issue 3236

### DIFF
--- a/testng-core/src/test/java/test/dataprovider/issue3236/CacheTest.java
+++ b/testng-core/src/test/java/test/dataprovider/issue3236/CacheTest.java
@@ -1,0 +1,41 @@
+package test.dataprovider.issue3236;
+
+import static org.testng.Assert.assertEquals;
+
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.testng.IRetryAnalyzer;
+import org.testng.ITestResult;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class CacheTest {
+
+  public static final AtomicInteger invocationCount = new AtomicInteger(0);
+  private String currentUuid;
+
+  @Test(dataProvider = "dp", retryAnalyzer = MyRetry.class)
+  public void testMethod(String uuid) {
+    assertEquals(currentUuid, uuid);
+    if (invocationCount.get() != 2) {
+      throw new RuntimeException("Failed for " + uuid);
+    }
+  }
+
+  @DataProvider(name = "dp", cacheDataForTestRetries = false)
+  public Object[][] getData() {
+    invocationCount.incrementAndGet();
+    currentUuid = UUID.randomUUID().toString();
+    return new Object[][]{{currentUuid}};
+  }
+
+  public static class MyRetry implements IRetryAnalyzer {
+
+    private final AtomicInteger counter = new AtomicInteger(1);
+
+    @Override
+    public boolean retry(ITestResult result) {
+      return counter.getAndIncrement() != 2;
+    }
+  }
+}


### PR DESCRIPTION
Introduces a new test class to verify dataprovider behavior with retries and caching disabled. The test ensures unique data per retry and validates invocation count.

Fixes # .

### Did you remember to?

- [ ] Add test case(s)
- [ ] Update `CHANGES.txt`
- [ ] Auto applied styling via `./gradlew autostyleApply`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.

**Note:** For more information on contribution guidelines  please make sure you refer our [Contributing](.github/CONTRIBUTING.md) section for detailed set of steps.
