### PR TITLE
Improve/test workflow jdk25

### DIFF
--- a/.github/workflows/matrix.js
+++ b/.github/workflows/matrix.js
@@ -20,7 +20,7 @@ matrix.addAxis({
   ]
 });
 
-const eaJava = '25';
+const eaJava = '26';
 matrix.addAxis({
   name: 'java_version',
   // Strings allow versions like 18-ea
@@ -28,6 +28,7 @@ matrix.addAxis({
     '11',
     '17',
     '21',
+    '25',
     eaJava,
   ]
 });
@@ -86,6 +87,8 @@ matrix.generateRow({java_version: "11"});
 matrix.generateRow({java_version: "17"});
 // Ensure there will be at least one job with Java 21
 matrix.generateRow({java_version: "21"});
+// Ensure there will be at least one job with Java 25
+matrix.generateRow({java_version: "25"});
 // Ensure there will be at least one job with Java EA
 matrix.generateRow({java_version: eaJava});
 const include = matrix.generateRows(process.env.MATRIX_JOBS || 5);

--- a/.github/workflows/matrix.js
+++ b/.github/workflows/matrix.js
@@ -20,7 +20,7 @@ matrix.addAxis({
   ]
 });
 
-const eaJava = '24';
+const eaJava = '25';
 matrix.addAxis({
   name: 'java_version',
   // Strings allow versions like 18-ea

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current (7.12.0)
+Update: Updated GitHub Actions test matrix to include JDK 25 (Bartek Florczak)
 Fixed: GITHUB-3227: assertEqualsNoOrder false positive when collection has same size and actual Collection is subset of expected collection (Krishnan Mahadevan)
 Fixed: GITHUB-3177: Method org.testng.xml.XmlSuite#toXml do not save new properties like "share-thread-pool-for-data-providers" (Krishnan Mahadevan)
 Fixed: GITHUB-3179: ClassCastException when use shouldUseGlobalThreadPool(true) property (Krishnan Mahadevan)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,5 @@
 Current (7.12.0)
-Update: Updated GitHub Actions test matrix to include JDK 25 (Bartek Florczak)
+Update: Updated GitHub Actions test matrix to include JDK 25 and JDK 26 EA (Bartek Florczak)
 Fixed: GITHUB-3236: DataProvider parameters are not refreshed on retry when cacheDataForTestRetries=false (Bartek Florczak)
 Fixed: GITHUB-3227: assertEqualsNoOrder false positive when collection has same size and actual Collection is subset of expected collection (Krishnan Mahadevan)
 Fixed: GITHUB-3177: Method org.testng.xml.XmlSuite#toXml do not save new properties like "share-thread-pool-for-data-providers" (Krishnan Mahadevan)


### PR DESCRIPTION
Fixes #.

### Did you remember to?

- [ ] Add test case(s)
- [x] Update `CHANGES.txt`
- [x] Auto applied styling via `./gradlew autostyleApply`

### Description

This pull request improves the CI workflow by updating the early access JDK version in the test matrix.

**Changes:**
- Replaced JDK 24 with JDK 25 in `.github/workflows/matrix.js`.
- Updated `CHANGES.txt` to reflect the workflow improvement.
- Verified the updated matrix generation by running `node .github/workflows/matrix.js` locally.
- Applied automatic styling via `./gradlew autostyleApply`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI test matrix to include Java 25 (JDK 25) and Java 26 early-access.

* **Bug Fixes**
  * Fixed data provider parameter refresh on retries when test-retry caching is disabled.
  * Resolved false-positive order assertion when actual collection is a subset with equal size.
  * Ensured suite XML serialization preserves newly added properties (e.g., thread pool sharing).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->