### PR TITLE
Fix: dataProviderClass cache mutation corrupts provider resolution for subclasses (#3263)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current (7.13.0)
+Fixed: GITHUB-3263: dataProviderClass cache mutation causes subclasses to use wrong data provider when run together (Aleksei Dobrynin)
 Fixed: GITHUB-3120: ITestNGListenerFactory is broken and never invoked (Krishnan Mahadevan)
 
 7.12.0

--- a/testng-core/src/main/java/org/testng/internal/Parameters.java
+++ b/testng-core/src/main/java/org/testng/internal/Parameters.java
@@ -575,18 +575,24 @@ public class Parameters {
       return methodLevel;
     }
 
-    if (Strings.isNullOrEmpty(methodLevel.getDataProvider())
-        && Strings.isNotNullAndNotEmpty(classLevel.getDataProvider())) {
-      methodLevel.setDataProvider(classLevel.getDataProvider());
-    }
-    if (isDataProviderClassEmpty(methodLevel) && !isDataProviderClassEmpty(classLevel)) {
-      methodLevel.setDataProviderClass(classLevel.getDataProviderClass());
-    }
-    if (isDynamicDataProviderClassEmpty(methodLevel)
-        && !isDynamicDataProviderClassEmpty(classLevel)) {
-      methodLevel.setDataProviderDynamicClass(classLevel.getDataProviderDynamicClass());
-    }
-    return methodLevel;
+    String dataProvider =
+        (Strings.isNullOrEmpty(methodLevel.getDataProvider())
+                && Strings.isNotNullAndNotEmpty(classLevel.getDataProvider()))
+            ? classLevel.getDataProvider()
+            : methodLevel.getDataProvider();
+
+    Class<?> dataProviderClass =
+        (isDataProviderClassEmpty(methodLevel) && !isDataProviderClassEmpty(classLevel))
+            ? classLevel.getDataProviderClass()
+            : methodLevel.getDataProviderClass();
+
+    String dataProviderDynamicClass =
+        (isDynamicDataProviderClassEmpty(methodLevel)
+                && !isDynamicDataProviderClassEmpty(classLevel))
+            ? classLevel.getDataProviderDynamicClass()
+            : methodLevel.getDataProviderDynamicClass();
+
+    return new ImmutableDataProvidable(dataProvider, dataProviderClass, dataProviderDynamicClass);
   }
 
   private static boolean isDataProviderClassEmpty(ITestAnnotation annotation) {
@@ -959,5 +965,43 @@ public class Parameters {
       parameterValues = pv;
       testResult = tr;
     }
+  }
+
+  private static final class ImmutableDataProvidable implements IDataProvidable {
+    private final String dataProvider;
+    private final Class<?> dataProviderClass;
+    private final String dataProviderDynamicClass;
+
+    private ImmutableDataProvidable(
+        String dataProvider, Class<?> dataProviderClass, String dataProviderDynamicClass) {
+      this.dataProvider = dataProvider;
+      this.dataProviderClass = dataProviderClass;
+      this.dataProviderDynamicClass =
+          dataProviderDynamicClass != null ? dataProviderDynamicClass : "";
+    }
+
+    @Override
+    public String getDataProvider() {
+      return dataProvider;
+    }
+
+    @Override
+    public void setDataProvider(String v) {}
+
+    @Override
+    public Class<?> getDataProviderClass() {
+      return dataProviderClass;
+    }
+
+    @Override
+    public void setDataProviderClass(Class<?> v) {}
+
+    @Override
+    public String getDataProviderDynamicClass() {
+      return dataProviderDynamicClass;
+    }
+
+    @Override
+    public void setDataProviderDynamicClass(String v) {}
   }
 }

--- a/testng-core/src/test/java/test/dataprovider/DataProviderTest.java
+++ b/testng-core/src/test/java/test/dataprovider/DataProviderTest.java
@@ -61,6 +61,8 @@ import test.dataprovider.issue3045.DataProviderTestClassSample;
 import test.dataprovider.issue3045.DataProviderWithoutListenerTestClassSample;
 import test.dataprovider.issue3081.NoOpMethodInterceptor;
 import test.dataprovider.issue3081.TestClassWithPrioritiesSample;
+import test.dataprovider.issue3263.FirstSubclassTestSample;
+import test.dataprovider.issue3263.SecondSubclassTestSample;
 
 public class DataProviderTest extends SimpleBaseTest {
 
@@ -162,6 +164,16 @@ public class DataProviderTest extends SimpleBaseTest {
       {ChildClassHasFullDefinitionOfDataProviderAtClassLevel.class},
       {ChildClassWithNoDataProviderInformationInTestMethod.class},
     };
+  }
+
+  @Test(description = "GITHUB-3263")
+  public void testDifferentDataProviderClassesForMultipleSubclassesRunTogether() {
+    InvokedMethodNameListener listener =
+        run(FirstSubclassTestSample.class, SecondSubclassTestSample.class);
+    assertThat(listener.getSucceedMethodNames())
+        .containsExactlyInAnyOrder(
+            "verifyPlace(alpha_place1,alpha_city1)", "verifyPlace(alpha_place2,alpha_city2)",
+            "verifyPlace(beta_place1,beta_city1)", "verifyPlace(beta_place2,beta_city2)");
   }
 
   @Test(description = "GITHUB-1139")

--- a/testng-core/src/test/java/test/dataprovider/issue3263/AbstractBaseTestSample.java
+++ b/testng-core/src/test/java/test/dataprovider/issue3263/AbstractBaseTestSample.java
@@ -1,0 +1,8 @@
+package test.dataprovider.issue3263;
+
+import org.testng.annotations.Test;
+
+public abstract class AbstractBaseTestSample {
+  @Test(dataProvider = "places")
+  public void verifyPlace(String place, String city) {}
+}

--- a/testng-core/src/test/java/test/dataprovider/issue3263/DataProviderAlpha.java
+++ b/testng-core/src/test/java/test/dataprovider/issue3263/DataProviderAlpha.java
@@ -1,0 +1,10 @@
+package test.dataprovider.issue3263;
+
+import org.testng.annotations.DataProvider;
+
+public class DataProviderAlpha {
+  @DataProvider(name = "places")
+  public Object[][] places() {
+    return new Object[][] {{"alpha_place1", "alpha_city1"}, {"alpha_place2", "alpha_city2"}};
+  }
+}

--- a/testng-core/src/test/java/test/dataprovider/issue3263/DataProviderBeta.java
+++ b/testng-core/src/test/java/test/dataprovider/issue3263/DataProviderBeta.java
@@ -1,0 +1,10 @@
+package test.dataprovider.issue3263;
+
+import org.testng.annotations.DataProvider;
+
+public class DataProviderBeta {
+  @DataProvider(name = "places")
+  public Object[][] places() {
+    return new Object[][] {{"beta_place1", "beta_city1"}, {"beta_place2", "beta_city2"}};
+  }
+}

--- a/testng-core/src/test/java/test/dataprovider/issue3263/FirstSubclassTestSample.java
+++ b/testng-core/src/test/java/test/dataprovider/issue3263/FirstSubclassTestSample.java
@@ -1,0 +1,6 @@
+package test.dataprovider.issue3263;
+
+import org.testng.annotations.Test;
+
+@Test(dataProviderClass = DataProviderAlpha.class)
+public class FirstSubclassTestSample extends AbstractBaseTestSample {}

--- a/testng-core/src/test/java/test/dataprovider/issue3263/SecondSubclassTestSample.java
+++ b/testng-core/src/test/java/test/dataprovider/issue3263/SecondSubclassTestSample.java
@@ -1,0 +1,6 @@
+package test.dataprovider.issue3263;
+
+import org.testng.annotations.Test;
+
+@Test(dataProviderClass = DataProviderBeta.class)
+public class SecondSubclassTestSample extends AbstractBaseTestSample {}


### PR DESCRIPTION
Fixes #3263.
Related to #1691.

### Did you remember to?

- [x] Add test case(s)
- [x] Update `CHANGES.txt`
- [x] Auto applied styling via `./gradlew autostyleApply`

We encourage pull requests that:
Fix bugs in TestNG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved incorrect sharing of data provider configuration between test subclasses so each subclass uses its configured provider when run together.

* **Tests**
  * Added tests covering multiple-subclass data provider inheritance scenarios to prevent regressions.

* **Documentation**
  * Updated changelog with the new release entry documenting the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->