### PR TITLE
Flaky Test Fix - 2587

### DIFF
--- a/testng-core/src/test/java/test/factory/issue326/IssueTest.java
+++ b/testng-core/src/test/java/test/factory/issue326/IssueTest.java
@@ -2,8 +2,10 @@ package test.factory.issue326;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.testng.TestNG;
 import org.testng.annotations.Test;
 import org.testng.xml.XmlSuite.ParallelMode;
@@ -23,32 +25,52 @@ public class IssueTest extends SimpleBaseTest {
     testng.addListener(listener);
     testng.run();
 
-    // Ensure that the difference in start times for the methods in both instances is <= 1000 ms.
-    long diff = computeDiffInStartTimeFor(listener.getResults(), SampleTestClass.FREDDY);
-    assertThat(diff).isLessThanOrEqualTo(1000);
-    diff = computeDiffInStartTimeFor(listener.getResults(), SampleTestClass.BARNEY);
-    assertThat(diff).isLessThanOrEqualTo(1000);
+    Map<String, List<Statistics>> results = listener.getResults();
 
-    // Ensure that the thread ids for both the instances are different.
+    assertThat(results).containsOnlyKeys(SampleTestClass.FREDDY, SampleTestClass.BARNEY);
+    assertThat(results.get(SampleTestClass.FREDDY)).hasSize(2);
+    assertThat(results.get(SampleTestClass.BARNEY)).hasSize(2);
+
+    assertThat(threadIdsFor(results, SampleTestClass.FREDDY)).hasSize(1);
+    assertThat(threadIdsFor(results, SampleTestClass.BARNEY)).hasSize(1);
+
     long threadIdFreddyInstance = listener.getThreadIds().get(SampleTestClass.FREDDY);
     long threadIdBarneyInstance = listener.getThreadIds().get(SampleTestClass.BARNEY);
-
     assertThat(threadIdFreddyInstance).isNotEqualTo(threadIdBarneyInstance);
+
+    assertThat(executionWindowsOverlap(results, SampleTestClass.FREDDY, SampleTestClass.BARNEY))
+        .isTrue();
   }
 
-  private static long computeDiffInStartTimeFor(
+  private static Collection<Long> threadIdsFor(
       Map<String, List<Statistics>> allStats, String instanceName) {
-    long test1OnFreddyInstance = getStartTimeFrom(allStats, instanceName, "test1");
-    long test2OnFreddyInstance = getStartTimeFrom(allStats, instanceName, "test2");
-    return Math.abs(test2OnFreddyInstance - test1OnFreddyInstance);
+    return allStats.get(instanceName).stream()
+        .map(statistics -> statistics.threadId)
+        .distinct()
+        .collect(Collectors.toList());
+  }
+
+  private static boolean executionWindowsOverlap(
+      Map<String, List<Statistics>> allStats, String firstInstanceName, String secondInstanceName) {
+    long firstStartTime = getStartTimeFrom(allStats, firstInstanceName);
+    long firstEndTime = getEndTimeFrom(allStats, firstInstanceName);
+    long secondStartTime = getStartTimeFrom(allStats, secondInstanceName);
+    long secondEndTime = getEndTimeFrom(allStats, secondInstanceName);
+    return firstStartTime < secondEndTime && secondStartTime < firstEndTime;
   }
 
   private static long getStartTimeFrom(
-      Map<String, List<Statistics>> allStats, String instanceName, String methodName) {
+      Map<String, List<Statistics>> allStats, String instanceName) {
     return allStats.get(instanceName).stream()
-        .filter(statistics -> statistics.methodName.equals(methodName))
-        .findFirst()
-        .map(statistics -> statistics.startTimeInMs)
+        .mapToLong(statistics -> statistics.startTimeInMs)
+        .min()
+        .orElseThrow(IllegalStateException::new);
+  }
+
+  private static long getEndTimeFrom(Map<String, List<Statistics>> allStats, String instanceName) {
+    return allStats.get(instanceName).stream()
+        .mapToLong(statistics -> statistics.endTimeInMs)
+        .max()
         .orElseThrow(IllegalStateException::new);
   }
 }

--- a/testng-core/src/test/java/test/factory/issue326/IssueTest.java
+++ b/testng-core/src/test/java/test/factory/issue326/IssueTest.java
@@ -27,17 +27,38 @@ public class IssueTest extends SimpleBaseTest {
 
     Map<String, List<Statistics>> results = listener.getResults();
 
+    // 1. We should be having only 2 instances (factory gets only 2 iterations via dataprovider)
     assertThat(results).containsOnlyKeys(SampleTestClass.FREDDY, SampleTestClass.BARNEY);
+    // 2. Every instance has 2 method invocations
     assertThat(results.get(SampleTestClass.FREDDY)).hasSize(2);
     assertThat(results.get(SampleTestClass.BARNEY)).hasSize(2);
 
+    // 3. The thread id for the methods that belong to each instance is the same.
     assertThat(threadIdsFor(results, SampleTestClass.FREDDY)).hasSize(1);
     assertThat(threadIdsFor(results, SampleTestClass.BARNEY)).hasSize(1);
 
+    // 4. Check to ensure that the thread id on which methods belonging to first instance ran
+    // is not the same as that of the methods that belong to second instance.
     long threadIdFreddyInstance = listener.getThreadIds().get(SampleTestClass.FREDDY);
     long threadIdBarneyInstance = listener.getThreadIds().get(SampleTestClass.BARNEY);
     assertThat(threadIdFreddyInstance).isNotEqualTo(threadIdBarneyInstance);
 
+    //    Illustration:
+    //
+    //    Time --->
+    //    Freddy:  |-------------|
+    //        100ms       900ms
+    //
+    //    Barney:       |-------------|
+    //        300ms       1100ms
+    //
+    //    Check:
+    //
+    //    Freddy starts before Barney ends: 100 < 1100  true
+    //    Barney starts before Freddy ends: 300 < 900   true
+    //
+    // So the windows overlap,
+    // meaning TestNG did not run Freddy completely first and Barney completely second.
     assertThat(executionWindowsOverlap(results, SampleTestClass.FREDDY, SampleTestClass.BARNEY))
         .isTrue();
   }

--- a/testng-core/src/test/java/test/factory/issue326/LocalTrackingListener.java
+++ b/testng-core/src/test/java/test/factory/issue326/LocalTrackingListener.java
@@ -18,7 +18,7 @@ public class LocalTrackingListener implements IInvokedMethodListener {
   public void afterInvocation(IInvokedMethod method, ITestResult testResult) {
     String key = testResult.getInstance().toString();
     results.computeIfAbsent(key, k -> new CopyOnWriteArrayList<>()).add(new Statistics(testResult));
-    Long threadId = Long.parseLong(testResult.getAttribute(SampleTestClass.THREAD_ID).toString());
+    Long threadId = asLong(testResult);
     threadIds.putIfAbsent(key, threadId);
   }
 
@@ -41,7 +41,7 @@ public class LocalTrackingListener implements IInvokedMethodListener {
           testResult.getMethod().getMethodName(),
           testResult.getStartMillis(),
           testResult.getEndMillis(),
-          Long.parseLong(testResult.getAttribute(SampleTestClass.THREAD_ID).toString()));
+          asLong(testResult));
     }
 
     public Statistics(String methodName, long startTimeInMs, long endTimeInMs, long threadId) {
@@ -50,5 +50,9 @@ public class LocalTrackingListener implements IInvokedMethodListener {
       this.endTimeInMs = endTimeInMs;
       this.threadId = threadId;
     }
+  }
+
+  private static long asLong(ITestResult itr) {
+    return ((Number) itr.getAttribute(SampleTestClass.THREAD_ID)).longValue();
   }
 }

--- a/testng-core/src/test/java/test/factory/issue326/LocalTrackingListener.java
+++ b/testng-core/src/test/java/test/factory/issue326/LocalTrackingListener.java
@@ -2,25 +2,24 @@ package test.factory.issue326;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import org.testng.IInvokedMethod;
 import org.testng.IInvokedMethodListener;
 import org.testng.ITestResult;
-import org.testng.collections.Lists;
-import org.testng.collections.Maps;
 
 public class LocalTrackingListener implements IInvokedMethodListener {
 
-  private final Map<String, List<Statistics>> results = Maps.newConcurrentMap();
-  private final Map<String, Long> threadIds = Maps.newConcurrentMap();
+  private final ConcurrentMap<String, List<Statistics>> results = new ConcurrentHashMap<>();
+  private final ConcurrentMap<String, Long> threadIds = new ConcurrentHashMap<>();
 
   @Override
   public void afterInvocation(IInvokedMethod method, ITestResult testResult) {
     String key = testResult.getInstance().toString();
-    results.computeIfAbsent(key, k -> Lists.newArrayList()).add(new Statistics(testResult));
-    if (!threadIds.containsKey(key)) {
-      Long threadId = Long.parseLong(testResult.getAttribute(SampleTestClass.THREAD_ID).toString());
-      threadIds.put(key, threadId);
-    }
+    results.computeIfAbsent(key, k -> new CopyOnWriteArrayList<>()).add(new Statistics(testResult));
+    Long threadId = Long.parseLong(testResult.getAttribute(SampleTestClass.THREAD_ID).toString());
+    threadIds.putIfAbsent(key, threadId);
   }
 
   public Map<String, List<Statistics>> getResults() {
@@ -31,17 +30,25 @@ public class LocalTrackingListener implements IInvokedMethodListener {
     return threadIds;
   }
 
-  static class Statistics {
+  public static class Statistics {
     String methodName;
     long startTimeInMs;
+    long endTimeInMs;
+    long threadId;
 
     public Statistics(ITestResult testResult) {
-      this(testResult.getMethod().getMethodName(), testResult.getStartMillis());
+      this(
+          testResult.getMethod().getMethodName(),
+          testResult.getStartMillis(),
+          testResult.getEndMillis(),
+          Long.parseLong(testResult.getAttribute(SampleTestClass.THREAD_ID).toString()));
     }
 
-    public Statistics(String methodName, long startTimeInMs) {
+    public Statistics(String methodName, long startTimeInMs, long endTimeInMs, long threadId) {
       this.methodName = methodName;
       this.startTimeInMs = startTimeInMs;
+      this.endTimeInMs = endTimeInMs;
+      this.threadId = threadId;
     }
   }
 }


### PR DESCRIPTION
Closes #2587

Illustration:

```
Time --->
Freddy:  |-------------|
       100ms       900ms

Barney:       |-------------|
            300ms       1100ms
```

Check:

Freddy starts before Barney ends: 100 < 1100  true
Barney starts before Freddy ends: 300 < 900   true

So the windows overlap, meaning TestNG did not run Freddy completely first and Barney completely second.

Non-overlapping sequential execution would look like this:

```
Time --->

Freddy:  |-------------|
       100ms       900ms

Barney:                  |-------------|
                       950ms       1600ms
```

Check:

Freddy starts before Barney ends: 100 < 1600  true
Barney starts before Freddy ends: 950 < 900   false

So the assertion would fail.

Fixes # .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`
- [X] Auto applied styling via `./gradlew autostyleApply`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.

**Note:** For more information on contribution guidelines  please make sure you refer our [Contributing](.github/CONTRIBUTING.md) section for detailed set of steps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened parallelism validation: verifies overlapping execution windows, exact per-instance invocation counts, and that each instance ran on a single, distinct thread.
  * Reworked timing checks to use interval overlap assertions rather than per-method start-time deltas for more robust concurrency verification.
* **Refactor**
  * Standardized concurrency utilities and listener internals for thread-safe recording.
  * Enhanced listener tracking to record end times and thread identifiers for more reliable timing and thread assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->