### PR TITLE
[Flaky test fix] - Issue 2579

### DIFF
--- a/testng-core/src/test/java/test/thread/issue188/Issue188TestSample.java
+++ b/testng-core/src/test/java/test/thread/issue188/Issue188TestSample.java
@@ -1,44 +1,54 @@
 package test.thread.issue188;
 
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-import org.testng.ITestResult;
-import org.testng.Reporter;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-import test.support.SafeRandoms;
 
 public class Issue188TestSample {
-  public static final Map<Long, Set<String>> timestamps = new ConcurrentHashMap<>();
+  public static final int EXPECTED_METHOD_INVOCATIONS = 6;
+  private static final AtomicInteger startedTestMethods = new AtomicInteger();
+  private static final AtomicInteger activeTestMethods = new AtomicInteger();
+  private static final AtomicInteger maxActiveTestMethods = new AtomicInteger();
+
+  public static void reset() {
+    startedTestMethods.set(0);
+    activeTestMethods.set(0);
+    maxActiveTestMethods.set(0);
+  }
+
+  public static int getStartedTestMethods() {
+    return startedTestMethods.get();
+  }
+
+  public static int getMaxActiveTestMethods() {
+    return maxActiveTestMethods.get();
+  }
 
   @BeforeMethod
-  public void logTime(ITestResult itr) {
-    String txt =
-        Reporter.getCurrentTestResult().getTestContext().getName()
-            + "_"
-            + itr.getMethod().getQualifiedName();
-    timestamps
-        .computeIfAbsent(System.currentTimeMillis(), k -> ConcurrentHashMap.newKeySet())
-        .add(txt);
+  public void logStart() {
+    startedTestMethods.incrementAndGet();
   }
 
   @Test
   public void sampleTest() {
-    sleepSilently();
+    trackParallelExecution();
   }
 
   @Test
   public void anotherSampleTest() {
-    sleepSilently();
+    trackParallelExecution();
   }
 
-  private void sleepSilently() {
+  private static void trackParallelExecution() {
+    int activeMethods = activeTestMethods.incrementAndGet();
+    maxActiveTestMethods.accumulateAndGet(activeMethods, Math::max);
     try {
-      TimeUnit.MILLISECONDS.sleep(500L * SafeRandoms.nextInt(1, 10));
+      TimeUnit.SECONDS.sleep(1);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
+    } finally {
+      activeTestMethods.decrementAndGet();
     }
   }
 }

--- a/testng-core/src/test/java/test/thread/issue188/IssueTest.java
+++ b/testng-core/src/test/java/test/thread/issue188/IssueTest.java
@@ -1,7 +1,8 @@
 package test.thread.issue188;
 
-import java.util.Collections;
 import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
 import org.testng.TestNG;
 import org.testng.annotations.Test;
 import org.testng.internal.RuntimeBehavior;

--- a/testng-core/src/test/java/test/thread/issue188/IssueTest.java
+++ b/testng-core/src/test/java/test/thread/issue188/IssueTest.java
@@ -1,10 +1,6 @@
 package test.thread.issue188;
 
 import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
 import org.assertj.core.api.Assertions;
 import org.testng.TestNG;
 import org.testng.annotations.Test;
@@ -18,6 +14,7 @@ public class IssueTest extends SimpleBaseTest {
   public void testSuiteLevelParallelMode() {
     System.setProperty(RuntimeBehavior.STRICTLY_HONOUR_PARALLEL_MODE, "true");
     try {
+      Issue188TestSample.reset();
       TestNG testng = new TestNG();
       XmlSuite xmlSuite = new XmlSuite();
       xmlSuite.setParallel(XmlSuite.ParallelMode.METHODS);
@@ -28,35 +25,12 @@ public class IssueTest extends SimpleBaseTest {
       createXmlTest(xmlSuite, "Test3", Issue188TestSample.class);
       testng.setXmlSuites(Collections.singletonList(xmlSuite));
       testng.run();
-      Set<Long> timestamps = Issue188TestSample.timestamps.keySet();
-      if (timestamps.size() == 1) {
-        Assertions.assertThat(Issue188TestSample.timestamps.values().iterator().next())
-            .withFailMessage(
-                "Since all tests were started simultaneously,test method count should have been 6")
-            .hasSize(6);
-      } else {
-        List<Long> keyset =
-            Issue188TestSample.timestamps.keySet().stream().sorted().collect(Collectors.toList());
-        String allTimeStamps =
-            keyset.stream().map(Objects::toString).collect(Collectors.joining(","));
-        long prev = keyset.get(0);
-        int permissibleLag = 40;
-        for (int i = 1; i < keyset.size(); i++) {
-          long current = keyset.get(i);
-          long diff = current - prev;
-          Assertions.assertThat(diff)
-              .withFailMessage(
-                  "Test methods should have started within a lag of max "
-                      + permissibleLag
-                      + " ms but it was "
-                      + diff
-                      + " ms ["
-                      + allTimeStamps
-                      + "]")
-              .isLessThanOrEqualTo(permissibleLag);
-          prev = current;
-        }
-      }
+      Assertions.assertThat(Issue188TestSample.getStartedTestMethods())
+          .withFailMessage("All test methods should have started")
+          .isEqualTo(Issue188TestSample.EXPECTED_METHOD_INVOCATIONS);
+      Assertions.assertThat(Issue188TestSample.getMaxActiveTestMethods())
+          .withFailMessage("All test methods should have run in parallel")
+          .isEqualTo(Issue188TestSample.EXPECTED_METHOD_INVOCATIONS);
     } finally {
       System.setProperty(RuntimeBehavior.STRICTLY_HONOUR_PARALLEL_MODE, "false");
     }

--- a/testng-core/src/test/java/test/thread/issue188/IssueTest.java
+++ b/testng-core/src/test/java/test/thread/issue188/IssueTest.java
@@ -1,7 +1,7 @@
 package test.thread.issue188;
 
 import java.util.Collections;
-import org.assertj.core.api.Assertions;
+import static org.assertj.core.api.Assertions.assertThat;
 import org.testng.TestNG;
 import org.testng.annotations.Test;
 import org.testng.internal.RuntimeBehavior;
@@ -25,10 +25,10 @@ public class IssueTest extends SimpleBaseTest {
       createXmlTest(xmlSuite, "Test3", Issue188TestSample.class);
       testng.setXmlSuites(Collections.singletonList(xmlSuite));
       testng.run();
-      Assertions.assertThat(Issue188TestSample.getStartedTestMethods())
+      assertThat(Issue188TestSample.getStartedTestMethods())
           .withFailMessage("All test methods should have started")
           .isEqualTo(Issue188TestSample.EXPECTED_METHOD_INVOCATIONS);
-      Assertions.assertThat(Issue188TestSample.getMaxActiveTestMethods())
+      assertThat(Issue188TestSample.getMaxActiveTestMethods())
           .withFailMessage("All test methods should have run in parallel")
           .isEqualTo(Issue188TestSample.EXPECTED_METHOD_INVOCATIONS);
     } finally {


### PR DESCRIPTION
Closes #2579

What the new test measures

Instead of checking an arbitrary timestamp gap, each test method records when it is actively executing.

```
time ---->

active count
6 |                 ***************
5 |              ***               ***
4 |           ***                     ***
3 |        ***                           ***
2 |     ***                               ***
1 |  ***                                   ***
0 +------------------------------------------------
  m1  m2  m3  m4  m5  m6 start running
```

New assertion:
startedTestMethods == 6
maxActiveTestMethods == 6

Meaning:
all 6 methods started, and at one point all 6 were observed executing concurrently.

Behavioral difference

Old:
"Did every method start within 40 ms of the previous one?"

New:
"Did all six methods actually run at the same time?"

The new check matches the feature under test: suite-level parallel="methods" should execute methods concurrently. It removes the host-specific 40 ms timing assumption while still failing if execution becomes sequential.

Fixes # .

### Did you remember to?

- [ ] Add test case(s)
- [ ] Update `CHANGES.txt`
- [ ] Auto applied styling via `./gradlew autostyleApply`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.

**Note:** For more information on contribution guidelines  please make sure you refer our [Contributing](.github/CONTRIBUTING.md) section for detailed set of steps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Replaced fragile timestamp-based tracking with reliable concurrency counters to measure parallel test execution.
  * Improved test setup/reset and made metrics collection deterministic for parallel runs.
  * Simplified assertions to directly validate expected counts of started and concurrently active test methods, strengthening parallel-execution verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->