### PR TITLE
[ci] Fix version number of gradle-update/update-gradle-wrapper-action

### DIFF
--- a/.github/workflows/publish-maven-central.yml
+++ b/.github/workflows/publish-maven-central.yml
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Gradle wrapper validation
-      uses: gradle/actions/wrapper-validation@v3
+      uses: gradle/actions/wrapper-validation@v6
 
     # JDK 21 is used for:
     # 1. Building TestNG (jdkBuildVersion=21 in build-parameters)

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Gradle wrapper validation
-      uses: gradle/actions/wrapper-validation@v3
+      uses: gradle/actions/wrapper-validation@v6
 
     # JDK 21 is used for:
     # 1. Building TestNG (jdkBuildVersion=21 in build-parameters)

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -12,4 +12,4 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Update Gradle Wrapper
-        uses: gradle-update/update-gradle-wrapper-action@v6
+        uses: gradle-update/update-gradle-wrapper-action@v2


### PR DESCRIPTION
Also adjust gradle/actions/wrapper-validation to v6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Gradle wrapper validation configurations across build and publishing workflows to use newer tooling versions, enhancing the robustness of the continuous integration pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->