### PR TITLE
Fix flaky test:Move method invocation counter increment to call() method

### DIFF
--- a/testng-core/src/main/java/org/testng/internal/invokers/InvokeMethodRunnable.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/InvokeMethodRunnable.java
@@ -38,44 +38,45 @@ public class InvokeMethodRunnable implements Callable<Boolean> {
 
   private boolean runOne() {
     boolean invoked;
+    RuntimeException t = null;
     try {
-      RuntimeException t = null;
-      try {
-        ConstructorOrMethod m = m_method.getConstructorOrMethod();
-        if (m_hookable == null) {
-          invoked = true;
-          MethodInvocationHelper.invokeMethod(m.getMethod(), m_instance, m_parameters);
-        } else {
-          invoked =
-              MethodInvocationHelper.invokeHookable(
-                  m_instance, m_parameters, m_hookable, m.getMethod(), m_testResult);
-        }
-      } catch (Throwable e) {
+      ConstructorOrMethod m = m_method.getConstructorOrMethod();
+      if (m_hookable == null) {
         invoked = true;
-        Throwable cause = Optional.ofNullable(e.getCause()).orElse(e);
-        t = new TestNGRuntimeException(cause);
+        MethodInvocationHelper.invokeMethod(m.getMethod(), m_instance, m_parameters);
+      } else {
+        invoked =
+            MethodInvocationHelper.invokeHookable(
+                m_instance, m_parameters, m_hookable, m.getMethod(), m_testResult);
       }
-      if (null != t) {
-        Thread.currentThread().interrupt();
-        throw t;
-      }
-      return invoked;
-    } finally {
-      m_method.incrementCurrentInvocationCount();
+    } catch (Throwable e) {
+      invoked = true;
+      Throwable cause = Optional.ofNullable(e.getCause()).orElse(e);
+      t = new TestNGRuntimeException(cause);
     }
+    if (null != t) {
+      Thread.currentThread().interrupt();
+      throw t;
+    }
+    return invoked;
   }
 
   @Override
   public Boolean call() throws Exception {
     boolean flag = true;
-    if (m_method.getInvocationTimeOut() > 0) {
-      for (int i = 0; i < m_method.getInvocationCount(); i++) {
-        flag = flag && runOne();
+    try {
+      if (m_method.getInvocationTimeOut() > 0) {
+        for (int i = 0; i < m_method.getInvocationCount(); i++) {
+          flag = flag && runOne();
+        }
+      } else {
+        flag = runOne();
       }
-    } else {
-      flag = runOne();
+      return flag;
+    } finally {
+      // Ensure method increment happens always, even if there's an exception
+      m_method.incrementCurrentInvocationCount();
     }
-    return flag;
   }
 
   public static class TestNGRuntimeException extends RuntimeException {


### PR DESCRIPTION
Closes #2586

This commit fixes the flaky test in test.hook.HookableTest where tests with  timeouts (related to issue #599) would inconsistently report pass counts.

Changes:
- Move incrementCurrentInvocationCount() from runOne() to call() method's  finally block to ensure it's called exactly once per method execution
- Add try/finally block in call() to guarantee counter increment even when  exceptions occur
- Improve exception handling in runOne() to properly propagate errors
- Remove multiple invocation counting when tests are run with timeouts

The root cause was that the invocation counter could be incremented multiple  times or inconsistently during test execution with timeouts, leading to flaky behavior where verifyTests() would fail with "expected [1] but found [0]".

This change ensures reliable test counting regardless of timeout settings or  execution conditions, fixing issue #2586.

Fixes #2586  .

### Did you remember to?

- [ ] Add test case(s)
- [ ] Update `CHANGES.txt`
- [X] Auto applied styling via `./gradlew autostyleApply`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.

**Note:** For more information on contribution guidelines  please make sure you refer our [Contributing](.github/CONTRIBUTING.md) section for detailed set of steps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exception handling so failures during test method execution are consistently wrapped and reported.
  * Ensured the invocation counter is reliably incremented on all exit paths, preserving accurate counts across repeated runs, timeouts, and error scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/testng-team/testng/pull/3274)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->