### PR TITLE
Fix throwable for skipped configuration methods

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current (7.13.0)
+Fixed: GITHUB-3166: Skipped configuration methods not receiving the causal throwable before configuration listeners are invoked
 Fixed: GITHUB-3263: dataProviderClass cache mutation causes subclasses to use wrong data provider when run together (Aleksei Dobrynin)
 Fixed: GITHUB-3120: ITestNGListenerFactory is broken and never invoked (Krishnan Mahadevan)
 

--- a/testng-core/src/main/java/org/testng/internal/invokers/ConfigInvoker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/ConfigInvoker.java
@@ -289,6 +289,7 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
           // Set test result as 'SKIP' in 'beforeConfiguration' & 'beforeInvocation' if
           // config method is skip.
           testResult.setStatus(ITestResult.SKIP);
+          testResult.setThrowable(ExceptionUtils.getExceptionDetails(m_testContext, inst));
           runConfigurationListeners(testResult, arguments.getTestMethod(), true /* before */);
           runInvokedMethodListeners(BEFORE_INVOCATION, invokedMethod, testResult);
           testResult.setEndMillis(testResult.getStartMillis());

--- a/testng-core/src/test/java/test/listeners/ConfigurationListenerTest.java
+++ b/testng-core/src/test/java/test/listeners/ConfigurationListenerTest.java
@@ -3,15 +3,32 @@ package test.listeners;
 import org.testng.Assert;
 import org.testng.IConfigurationListener;
 import org.testng.ITestResult;
+import org.testng.SkipException;
 import org.testng.TestNG;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import test.SimpleBaseTest;
 
 public class ConfigurationListenerTest extends SimpleBaseTest {
 
+  public static class Issue3166Sample {
+
+    @BeforeClass
+    public void firstBeforeClass() {
+      throw new SkipException("Skip");
+    }
+
+    @BeforeClass(dependsOnMethods = "firstBeforeClass")
+    public void secondBeforeClass() {}
+
+    @Test
+    public void test() {}
+  }
+
   public static class CL implements IConfigurationListener {
 
     private static int m_status = 0;
+    private Throwable throwable;
 
     @Override
     public void beforeConfiguration(ITestResult tr) {
@@ -31,6 +48,9 @@ public class ConfigurationListenerTest extends SimpleBaseTest {
     @Override
     public void onConfigurationSkip(ITestResult itr) {
       m_status += 7;
+      if (itr.getMethod().getMethodName().equals("secondBeforeClass")) {
+        throwable = itr.getThrowable();
+      }
     }
   }
 
@@ -57,5 +77,17 @@ public class ConfigurationListenerTest extends SimpleBaseTest {
   @Test
   public void shouldSkip() {
     runTest(ConfigurationListenerSkipSampleTest.class, 1 + 1 + 5 + 7); // fail + skip
+  }
+
+  @Test(description = "github 3166")
+  public void skippedConfigurationShouldHaveThrowable() {
+    TestNG tng = create(Issue3166Sample.class);
+    CL listener = new CL();
+    tng.addListener(listener);
+    tng.run();
+
+    Assert.assertNotNull(listener.throwable);
+    Assert.assertTrue(listener.throwable instanceof SkipException);
+    Assert.assertEquals(listener.throwable.getMessage(), "Skip");
   }
 }


### PR DESCRIPTION
Fixes #3166.

This sets the causal throwable on skipped configuration results before configuration listeners are invoked.

Validation:
- `ConfigurationListenerTest`: PASS
- `org.testng.internal.invokers.*`: PASS
- `git show --check`: PASS
- Full `:testng-core:test`: 6 unrelated timing/parallel/timeout failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Skipped configuration methods now carry the original throwable into test results and listener callbacks, improving visibility into the root cause of configuration skips (GITHUB-3166).
* **Tests**
  * Added a test verifying skipped configuration events include the causal throwable.
* **Documentation**
  * Updated release notes to document the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->