### PR TITLE
GITHUB-426: run firstTimeOnly/lastTimeOnly configs as a barrier around the invocation pool

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current (7.13.0)
+Fixed: GITHUB-426: firstTimeOnly @BeforeMethod / lastTimeOnly @AfterMethod were not run as a barrier around a parallel invocationCount thread pool (firstTimeOnly could run concurrently with test invocations, lastTimeOnly ran once per invocation instead of once)
 Fixed: GITHUB-3166: Skipped configuration methods not receiving the causal throwable before configuration listeners are invoked
 Fixed: GITHUB-3263: dataProviderClass cache mutation causes subclasses to use wrong data provider when run together (Aleksei Dobrynin)
 Fixed: GITHUB-3120: ITestNGListenerFactory is broken and never invoked (Krishnan Mahadevan)

--- a/testng-core/src/main/java/org/testng/internal/BaseTestMethod.java
+++ b/testng-core/src/main/java/org/testng/internal/BaseTestMethod.java
@@ -65,6 +65,11 @@ public abstract class BaseTestMethod
   private String m_description = null;
   protected AtomicInteger m_currentInvocationCount = new AtomicInteger(0);
   private int m_parameterInvocationCount = 1;
+  // Set on the per-invocation clones created for a parallel (threadPoolSize > 1)
+  // invocationCount. For those clones the firstTimeOnly @BeforeMethod and the
+  // lastTimeOnly @AfterMethod are run once - as a barrier - around the whole pool
+  // instead of inside each parallel invocation, so the clones must not run them.
+  private boolean m_skipFirstAndLastTimeOnlyConfigs;
   private Callable<Boolean> m_moreInvocationChecker;
   private IRetryAnalyzer m_retryAnalyzer = null;
   private Class<? extends IRetryAnalyzer> m_retryAnalyzerClass = null;
@@ -653,6 +658,19 @@ public abstract class BaseTestMethod
   @Override
   public int getCurrentInvocationCount() {
     return m_currentInvocationCount.get();
+  }
+
+  /**
+   * @return {@code true} when this (cloned) method represents a single invocation of a parallel
+   *     {@code invocationCount}, for which the firstTimeOnly/lastTimeOnly configuration methods are
+   *     run around the thread pool rather than inside the invocation.
+   */
+  public boolean skipFirstAndLastTimeOnlyConfigs() {
+    return m_skipFirstAndLastTimeOnlyConfigs;
+  }
+
+  public void setSkipFirstAndLastTimeOnlyConfigs(boolean skip) {
+    m_skipFirstAndLastTimeOnlyConfigs = skip;
   }
 
   @Override

--- a/testng-core/src/main/java/org/testng/internal/invokers/TestInvoker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/TestInvoker.java
@@ -500,14 +500,67 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
       ITestNGMethod clonedMethod = testMethod.clone();
       clonedMethod.setInvocationCount(1);
       clonedMethod.setThreadPoolSize(1);
+      // The invocations run in parallel, so the firstTimeOnly @BeforeMethod and
+      // lastTimeOnly @AfterMethod cannot be run inside an invocation (none of them is
+      // guaranteed to be the "first"/"last"). They are run once around the pool below,
+      // hence the clones must not run them.
+      if (clonedMethod instanceof BaseTestMethod) {
+        ((BaseTestMethod) clonedMethod).setSkipFirstAndLastTimeOnlyConfigs(true);
+      }
 
       MethodInstance mi = new MethodInstance(clonedMethod);
       workers.add(
           new SingleTestMethodWorker(this, invoker, mi, parameters, testContext, m_classListeners));
     }
 
-    return runWorkers(
-        testMethod, workers, testMethod.getThreadPoolSize(), groupMethods, parameters);
+    // Run the firstTimeOnly @BeforeMethod once, before the pool starts, so it acts as a
+    // barrier for every parallel invocation (GITHUB-426).
+    invokeTimeOnlyConfigurations(testMethod, parameters, true);
+    try {
+      return runWorkers(
+          testMethod, workers, testMethod.getThreadPoolSize(), groupMethods, parameters);
+    } finally {
+      // Run the lastTimeOnly @AfterMethod once, after every invocation has completed.
+      invokeTimeOnlyConfigurations(testMethod, parameters, false);
+    }
+  }
+
+  /**
+   * Runs the firstTimeOnly @BeforeMethod (when {@code before} is {@code true}) or the
+   * lastTimeOnly @AfterMethod (when {@code before} is {@code false}) exactly once for a parallel
+   * {@code invocationCount}. Running them outside the thread pool turns them into a barrier, which
+   * the per-invocation filtering inside the pool cannot provide.
+   */
+  private void invokeTimeOnlyConfigurations(
+      ITestNGMethod testMethod, Map<String, String> parameters, boolean before) {
+    ITestClass testClass = testMethod.getTestClass();
+    XmlSuite suite = m_testContext.getSuite().getXmlSuite();
+    for (IObject.IdentifiableObject identifiable : IObject.objects(testClass, true)) {
+      Object instance = identifiable.getInstance();
+      ITestNGMethod[] configMethods =
+          before
+              ? TestNgMethodUtils.filterFirstTimeOnlySetupMethods(
+                  testMethod,
+                  TestNgMethodUtils.filterBeforeTestMethods(
+                      instance, testClass, CAN_RUN_FROM_CLASS))
+              : TestNgMethodUtils.filterLastTimeOnlyTeardownMethods(
+                  testMethod,
+                  TestNgMethodUtils.filterAfterTestMethods(
+                      instance, testClass, CAN_RUN_FROM_CLASS));
+      if (configMethods.length == 0) {
+        continue;
+      }
+      ConfigMethodArguments cfgArgs =
+          new ConfigMethodArguments.Builder()
+              .forTestClass(testClass)
+              .forTestMethod(testMethod)
+              .usingConfigMethodsAs(configMethods)
+              .forSuite(suite)
+              .usingParameters(parameters)
+              .usingInstance(instance)
+              .build();
+      invoker.invokeConfigurations(cfgArgs);
+    }
   }
 
   private void collectResults(ITestNGMethod testMethod, ITestResult result) {

--- a/testng-core/src/main/java/org/testng/internal/invokers/TestNgMethodUtils.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/TestNgMethodUtils.java
@@ -4,11 +4,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BiPredicate;
+import java.util.function.Predicate;
 import org.testng.IClass;
 import org.testng.ITestClass;
 import org.testng.ITestNGMethod;
 import org.testng.collections.Lists;
 import org.testng.collections.Sets;
+import org.testng.internal.BaseTestMethod;
 import org.testng.internal.ConfigurationMethod;
 import org.testng.internal.Utils;
 
@@ -156,12 +158,58 @@ class TestNgMethodUtils {
 
   private static boolean doesSetupMethodPassFirstTimeFilter(
       ConfigurationMethod cm, ITestNGMethod tm) {
-    return !cm.isFirstTimeOnly() || (cm.isFirstTimeOnly() && tm.getCurrentInvocationCount() == 0);
+    if (cm.isFirstTimeOnly() && skipsTimeScopedConfigs(tm)) {
+      // This is one invocation of a parallel invocationCount; the firstTimeOnly
+      // @BeforeMethod is run once around the thread pool, not inside the invocation.
+      return false;
+    }
+    return !cm.isFirstTimeOnly() || tm.getCurrentInvocationCount() == 0;
   }
 
   private static boolean doesTeardownMethodPassLastTimeFilter(
       ConfigurationMethod cm, ITestNGMethod tm) {
-    return !cm.isLastTimeOnly() || (cm.isLastTimeOnly() && !tm.hasMoreInvocation());
+    if (cm.isLastTimeOnly() && skipsTimeScopedConfigs(tm)) {
+      // This is one invocation of a parallel invocationCount; the lastTimeOnly
+      // @AfterMethod is run once around the thread pool, not inside the invocation.
+      return false;
+    }
+    return !cm.isLastTimeOnly() || !tm.hasMoreInvocation();
+  }
+
+  private static boolean skipsTimeScopedConfigs(ITestNGMethod tm) {
+    return tm instanceof BaseTestMethod && ((BaseTestMethod) tm).skipFirstAndLastTimeOnlyConfigs();
+  }
+
+  /**
+   * @return the subset of {@code methods} that are firstTimeOnly @BeforeMethod configuration
+   *     methods applicable to {@code tm}. Used to run them once, as a barrier, before a parallel
+   *     invocationCount thread pool starts.
+   */
+  static ITestNGMethod[] filterFirstTimeOnlySetupMethods(
+      ITestNGMethod tm, ITestNGMethod[] methods) {
+    return filterTimeOnlyConfigMethods(tm, methods, ConfigurationMethod::isFirstTimeOnly);
+  }
+
+  /**
+   * @return the subset of {@code methods} that are lastTimeOnly @AfterMethod configuration methods
+   *     applicable to {@code tm}. Used to run them once, as a barrier, after a parallel
+   *     invocationCount thread pool completes.
+   */
+  static ITestNGMethod[] filterLastTimeOnlyTeardownMethods(
+      ITestNGMethod tm, ITestNGMethod[] methods) {
+    return filterTimeOnlyConfigMethods(tm, methods, ConfigurationMethod::isLastTimeOnly);
+  }
+
+  private static ITestNGMethod[] filterTimeOnlyConfigMethods(
+      ITestNGMethod tm, ITestNGMethod[] methods, Predicate<ConfigurationMethod> timeScope) {
+    List<ITestNGMethod> result = Lists.newArrayList();
+    for (ITestNGMethod m : methods) {
+      ConfigurationMethod cm = (ConfigurationMethod) m;
+      if (timeScope.test(cm) && doesConfigMethodPassGroupFilters(cm, tm)) {
+        result.add(m);
+      }
+    }
+    return result.toArray(new ITestNGMethod[0]);
   }
 
   private static boolean doesConfigMethodPassGroupFilters(

--- a/testng-core/src/test/java/test/invocationcount/FirstAndLastTimeTest.java
+++ b/testng-core/src/test/java/test/invocationcount/FirstAndLastTimeTest.java
@@ -9,6 +9,8 @@ import org.testng.annotations.Test;
 import test.InvokedMethodNameListener;
 import test.SimpleBaseTest;
 import test.invocationcount.issue426.SampleTestClassWithNoThreadPoolSizeDefined;
+import test.invocationcount.issue426.SampleTestClassWithThreadPoolAndFailingFirstTimeConfig;
+import test.invocationcount.issue426.SampleTestClassWithThreadPoolAndFirstLastTimeConfigs;
 import test.invocationcount.issue426.SampleTestClassWithThreadPoolSizeDefined;
 
 /**
@@ -151,6 +153,11 @@ public class FirstAndLastTimeTest extends SimpleBaseTest {
   public void verifyFirstTimeOnly(Class<?> clazz) {
     List<String> invokedMethodNames = run(clazz);
     String[] expected = new String[] {"beforeMethod", "testMethod", "testMethod"};
+    // The order is asserted on purpose, including for the sample class that runs its
+    // invocations through a thread pool: a firstTimeOnly @BeforeMethod must complete
+    // *before the first test invocation*, even when the invocations run in parallel.
+    // The engine enforces this by running the firstTimeOnly configuration once, as a
+    // barrier, before the pool starts (see TestInvoker#invokePooledTestMethods).
     assertThat(invokedMethodNames).containsExactly(expected);
   }
 
@@ -162,13 +169,40 @@ public class FirstAndLastTimeTest extends SimpleBaseTest {
     };
   }
 
+  @Test(description = "GITHUB-426")
+  public void verifyFirstAndLastTimeOnlyWithThreadPool() {
+    List<String> invokedMethodNames =
+        run(SampleTestClassWithThreadPoolAndFirstLastTimeConfigs.class);
+    // Even though the two invocations run in parallel through a thread pool, the
+    // firstTimeOnly @BeforeMethod must run once before any invocation and the
+    // lastTimeOnly @AfterMethod once after every invocation has completed.
+    assertThat(invokedMethodNames)
+        .containsExactly("beforeMethod", "testMethod", "testMethod", "afterMethod");
+  }
+
+  @Test(description = "GITHUB-426")
+  public void verifyFailingFirstTimeOnlySkipsAllParallelInvocations() {
+    InvokedMethodNameListener listener =
+        runWithListener(SampleTestClassWithThreadPoolAndFailingFirstTimeConfig.class);
+    // The firstTimeOnly @BeforeMethod is shared by every parallel invocation and is run
+    // once, as a barrier, before the pool starts. When it fails, every invocation must be
+    // skipped and none must be executed - the failure must not be swallowed by the pool.
+    assertThat(listener.getFailedMethodNames()).containsExactly("beforeMethod");
+    assertThat(listener.getSkippedMethodNames()).containsExactly("testMethod", "testMethod");
+    assertThat(listener.getSucceedMethodNames()).isEmpty();
+  }
+
   private static List<String> run(Class<?> cls) {
+    return runWithListener(cls).getInvokedMethodNames();
+  }
+
+  private static InvokedMethodNameListener runWithListener(Class<?> cls) {
     TestNG tng = create(cls);
     InvokedMethodNameListener listener = new InvokedMethodNameListener();
     tng.addListener(listener);
 
     tng.run();
 
-    return listener.getInvokedMethodNames();
+    return listener;
   }
 }

--- a/testng-core/src/test/java/test/invocationcount/issue426/SampleTestClassWithNoThreadPoolSizeDefined.java
+++ b/testng-core/src/test/java/test/invocationcount/issue426/SampleTestClassWithNoThreadPoolSizeDefined.java
@@ -7,6 +7,6 @@ public class SampleTestClassWithNoThreadPoolSizeDefined {
   @BeforeMethod(firstTimeOnly = true)
   public void beforeMethod() {}
 
-  @Test(invocationCount = 2, threadPoolSize = 5)
+  @Test(invocationCount = 2)
   public void testMethod() {}
 }

--- a/testng-core/src/test/java/test/invocationcount/issue426/SampleTestClassWithThreadPoolAndFailingFirstTimeConfig.java
+++ b/testng-core/src/test/java/test/invocationcount/issue426/SampleTestClassWithThreadPoolAndFailingFirstTimeConfig.java
@@ -3,9 +3,11 @@ package test.invocationcount.issue426;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-public class SampleTestClassWithThreadPoolSizeDefined {
+public class SampleTestClassWithThreadPoolAndFailingFirstTimeConfig {
   @BeforeMethod(firstTimeOnly = true)
-  public void beforeMethod() {}
+  public void beforeMethod() {
+    throw new RuntimeException("firstTimeOnly setup failed");
+  }
 
   @Test(invocationCount = 2, threadPoolSize = 5)
   public void testMethod() {}

--- a/testng-core/src/test/java/test/invocationcount/issue426/SampleTestClassWithThreadPoolAndFirstLastTimeConfigs.java
+++ b/testng-core/src/test/java/test/invocationcount/issue426/SampleTestClassWithThreadPoolAndFirstLastTimeConfigs.java
@@ -1,12 +1,16 @@
 package test.invocationcount.issue426;
 
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-public class SampleTestClassWithThreadPoolSizeDefined {
+public class SampleTestClassWithThreadPoolAndFirstLastTimeConfigs {
   @BeforeMethod(firstTimeOnly = true)
   public void beforeMethod() {}
 
   @Test(invocationCount = 2, threadPoolSize = 5)
   public void testMethod() {}
+
+  @AfterMethod(lastTimeOnly = true)
+  public void afterMethod() {}
 }


### PR DESCRIPTION
## Problem

`FirstAndLastTimeTest.verifyFirstTimeOnly` was flaky, occasionally failing with:

```
expected: ["beforeMethod", "testMethod", "testMethod"]
but was:  ["testMethod", "beforeMethod", "testMethod"]
```

Investigation showed this is **not** a test-only issue — it surfaces a real contract violation in the engine.

## Root cause

When a `@Test` has `invocationCount > 1` **and** `threadPoolSize > 1`, each invocation runs in its own pool thread (`TestInvoker#invokePooledTestMethods`). The `firstTimeOnly @BeforeMethod` / `lastTimeOnly @AfterMethod` were invoked *inside* those parallel workers:

- **`firstTimeOnly`** ran exactly once (deduped via `ConfigInvoker#m_executedConfigMethods`) but **with no barrier** — a losing worker proceeded straight to its test, so a test body could run *before* the `@BeforeMethod` completed. The Javadoc says it runs *"before the first test invocation"*, so this is a contract violation, not just a listener-ordering artifact.
- **`lastTimeOnly`** had no dedup at all: it ran **once per invocation** (e.g. 4× for `invocationCount=4`) instead of once, and could run while invocations were still in flight.

Measured on real execution (method bodies, not listeners), `invocationCount=4, threadPoolSize=4`:

| Config | Times run | Barrier honored? |
|---|---|---|
| `firstTimeOnly @BeforeMethod` | 1 ✅ | **No** ❌ — a test ran before it finished: 30/30 |
| `lastTimeOnly @AfterMethod` | 4 ❌ | **No** ❌ — ran while tests pending: 30/30 |

After the fix, both run exactly once and as a barrier (0/30 violations).

## Fix

Hoist both configs out of the pool, mirroring the existing `@BeforeGroups`/`@AfterGroups` barrier already present in `runWorkers`:

- `invokePooledTestMethods` runs the `firstTimeOnly` setup **once before** the workers start, and the `lastTimeOnly` teardown **once after** every worker completes.
- The per-invocation clones are flagged (`BaseTestMethod#skipFirstAndLastTimeOnlyConfigs`) so the in-pool config filtering (`TestNgMethodUtils`) skips those two configs.

A failing `firstTimeOnly` in the pooled path still skips all invocations (verified).

## Also

- Fix the two `issue426` sample class names, which were **swapped** relative to their content (`...WithNoThreadPoolSizeDefined` actually had `threadPoolSize=5`, and vice versa).
- Add coverage for the previously-untested `lastTimeOnly` + thread pool case, and a regression test asserting that a **failing** shared `firstTimeOnly` config skips every parallel invocation (none executed).
- `CHANGES.txt` entry.

## Validation

- Full `:testng-core:test` suite: **12480 passed, 0 failed**.
- `FirstAndLastTimeTest` deterministic across repeated `--rerun-tasks` runs.
- `autostyleCheck` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `@BeforeMethod(firstTimeOnly=true)` and `@AfterMethod(lastTimeOnly=true)` to execute correctly as a single barrier around parallel test invocations when using `threadPoolSize`, ensuring proper synchronization and preventing concurrency issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->