### PR TITLE
Fix label-commenter config to match actual label names

### DIFF
--- a/.github/label-commenter-config.yml
+++ b/.github/label-commenter-config.yml
@@ -1,6 +1,6 @@
 # Configuration for Label Commenter - https://github.com/peaceiris/actions-label-commenter
 labels:
-  - name: needs-sample
+  - name: "Need: sample"
     labeled:
       issue:
         body: |
@@ -18,7 +18,7 @@ labels:
 
           It would be better if you could share a sample project that can be directly used to reproduce the problem.
           Reply to this issue when all information is provided, thank you.
-  - name: question
+  - name: "Type: Question"
     labeled:
       issue:
         body: |
@@ -26,7 +26,7 @@ labels:
           * 📫 The [TestNG user group](https://groups.google.com/forum/#!forum/testng-users)
           * 📮 [StackOverflow](https://stackoverflow.com/questions/tagged/testng)
         action: close
-  - name: help-wanted
+  - name: "Need: help"
     labeled:
       issue:
         body: |


### PR DESCRIPTION
## Problem

The `label-commenter` automation in `.github/label-commenter-config.yml` referenced label names that **do not exist** in the repository, so the corresponding auto-comments never fired:

| Config referenced | Actual repository label |
|---|---|
| `needs-sample` | `Need: sample` |
| `question` | `Type: Question` |
| `help-wanted` | `Need: help` |

## Fix

Align the three `name:` entries with the real label names. This restores:
- the "please share a reproducible sample" comment on `Need: sample`
- the "ask on user group / StackOverflow" comment **and auto-close** on `Type: Question`
- the "looking for contributors" comment on `Need: help`

## Note

The duplicate `needs-sample` label is now unused (all issues migrated to `Need: sample`) and can be deleted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined GitHub issue and pull request labels for improved clarity and organization, making project navigation and categorization more intuitive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->