### PR TITLE
Remove orphaned Ant taskdef resource

### DIFF
--- a/testng-core/src/main/resources/testngtasks
+++ b/testng-core/src/main/resources/testngtasks
@@ -1,1 +1,0 @@
-testng=org.testng.TestNGAntTask


### PR DESCRIPTION
Removes the leftover `testng-core/src/main/resources/testngtasks` file.

This resource maps the `<testng>` Ant task name to `org.testng.TestNGAntTask`, a class that was removed when Ant support was moved to [testng-team/testng-ant](https://github.com/testng-team/testng-ant) in #3033 (commit 998e17bf). The removal commit missed this resource file, leaving a dangling reference to a class that no longer exists in this repository.

The resource belongs in testng-ant, where it is currently missing — tracked in testng-team/testng-ant#13.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an outdated task mapping from the TestNG configuration resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->