### PR TITLE
Fix flaky time-out tests: measure time-out from method execution start

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 Current (7.13.0)
 Fixed: GITHUB-426: firstTimeOnly @BeforeMethod / lastTimeOnly @AfterMethod were not run as a barrier around a parallel invocationCount thread pool (firstTimeOnly could run concurrently with test invocations, lastTimeOnly ran once per invocation instead of once)
+Fixed: Time-out now measures a method's own execution time instead of the wall-clock time since dispatch, so thread-pool start-up and scheduling overhead under load no longer cause spurious time-outs; a method that never starts now reports an actionable infrastructure-starvation message
 Fixed: GITHUB-3166: Skipped configuration methods not receiving the causal throwable before configuration listeners are invoked
 Fixed: GITHUB-3263: dataProviderClass cache mutation causes subclasses to use wrong data provider when run together (Aleksei Dobrynin)
 Fixed: GITHUB-3120: ITestNGListenerFactory is broken and never invoked (Krishnan Mahadevan)

--- a/testng-core/src/main/java/org/testng/internal/invokers/InvokeMethodRunnable.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/InvokeMethodRunnable.java
@@ -15,6 +15,13 @@ public class InvokeMethodRunnable implements Callable<Boolean> {
   private final IHookable m_hookable;
   private final ITestResult m_testResult;
 
+  /**
+   * The wall-clock time at which the worker thread actually started executing the method body, or
+   * {@code -1} if it has not started yet. Used to tell apart a genuinely slow test method from a
+   * time-out exhausted by thread scheduling / pool start-up overhead.
+   */
+  private volatile long m_executionStartMillis = -1;
+
   public InvokeMethodRunnable(
       ITestNGMethod thisMethod,
       Object instance,
@@ -61,8 +68,17 @@ public class InvokeMethodRunnable implements Callable<Boolean> {
     return invoked;
   }
 
+  /**
+   * @return the wall-clock time (in milliseconds) at which the worker thread started executing the
+   *     method body, or {@code -1} if it never started.
+   */
+  public long getExecutionStartMillis() {
+    return m_executionStartMillis;
+  }
+
   @Override
   public Boolean call() throws Exception {
+    m_executionStartMillis = System.currentTimeMillis();
     boolean flag = true;
     try {
       if (m_method.getInvocationTimeOut() > 0) {

--- a/testng-core/src/main/java/org/testng/internal/invokers/MethodInvocationHelper.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/MethodInvocationHelper.java
@@ -51,9 +51,9 @@ public class MethodInvocationHelper {
   /**
    * How long, in milliseconds, we are willing to wait for the worker thread to even <em>start</em>
    * executing a timed-out method before declaring an infrastructure failure. This is intentionally
-   * generous: thread-pool start-up and OS scheduling normally take well under a millisecond, so this
-   * grace period is only ever consumed under pathological load or thread-pool starvation. It is
-   * deliberately not counted against the user's time-out budget.
+   * generous: thread-pool start-up and OS scheduling normally take well under a millisecond, so
+   * this grace period is only ever consumed under pathological load or thread-pool starvation. It
+   * is deliberately not counted against the user's time-out budget.
    */
   private static final long TIMEOUT_STARTUP_GRACE_MILLIS = 10_000;
 
@@ -412,10 +412,18 @@ public class MethodInvocationHelper {
     long realTimeOut = MethodHelper.calculateTimeOut(tm);
 
     // The time-out must measure the method's own execution time, not the wall-clock time since we
-    // started waiting: thread-pool start-up and OS scheduling can otherwise consume the whole budget
+    // started waiting: thread-pool start-up and OS scheduling can otherwise consume the whole
+    // budget
     // under load and produce spurious time-outs. We therefore start the clock from the moment the
-    // worker thread actually begins running the method, while still bounding how long we wait for it
+    // worker thread actually begins running the method, while still bounding how long we wait for
+    // it
     // to start so a thread that can never be scheduled cannot hang us forever.
+    //
+    // The start-up grace scales with the execution time-out (rather than being a flat cap) so that
+    // we never wait less for the worker to start than the old implementation would have waited in
+    // total: a caller who tolerates a long execution time-out implicitly tolerates at least that
+    // long for the method to get going. In practice scheduling takes well under a millisecond, so
+    // this bound is only ever reached under pathological thread-pool starvation.
     long startupGraceMillis = Math.max(realTimeOut, TIMEOUT_STARTUP_GRACE_MILLIS);
     long startupDeadline = System.currentTimeMillis() + startupGraceMillis;
     boolean finished = false;

--- a/testng-core/src/main/java/org/testng/internal/invokers/MethodInvocationHelper.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/MethodInvocationHelper.java
@@ -48,6 +48,22 @@ import org.testng.xml.XmlSuite;
 /** Collections of helper methods to help deal with invocation of TestNG methods */
 public class MethodInvocationHelper {
 
+  /**
+   * How long, in milliseconds, we are willing to wait for the worker thread to even <em>start</em>
+   * executing a timed-out method before declaring an infrastructure failure. This is intentionally
+   * generous: thread-pool start-up and OS scheduling normally take well under a millisecond, so this
+   * grace period is only ever consumed under pathological load or thread-pool starvation. It is
+   * deliberately not counted against the user's time-out budget.
+   */
+  private static final long TIMEOUT_STARTUP_GRACE_MILLIS = 10_000;
+
+  /**
+   * Polling interval, in milliseconds, used while waiting for the worker thread to start. Short
+   * enough to react promptly once the method begins, so a method that hangs immediately still times
+   * out close to its configured time-out rather than after the whole start-up grace period.
+   */
+  private static final long TIMEOUT_STARTUP_POLL_MILLIS = 10;
+
   protected static Object invokeMethodNoCheckedException(
       Method thisMethod, Object instance, List<Object> parameters) {
     try {
@@ -394,10 +410,44 @@ public class MethodInvocationHelper {
     Future<Boolean> future = exec.submit(imr);
     exec.shutdown();
     long realTimeOut = MethodHelper.calculateTimeOut(tm);
-    boolean finished = exec.awaitTermination(realTimeOut, TimeUnit.MILLISECONDS);
+
+    // The time-out must measure the method's own execution time, not the wall-clock time since we
+    // started waiting: thread-pool start-up and OS scheduling can otherwise consume the whole budget
+    // under load and produce spurious time-outs. We therefore start the clock from the moment the
+    // worker thread actually begins running the method, while still bounding how long we wait for it
+    // to start so a thread that can never be scheduled cannot hang us forever.
+    long startupGraceMillis = Math.max(realTimeOut, TIMEOUT_STARTUP_GRACE_MILLIS);
+    long startupDeadline = System.currentTimeMillis() + startupGraceMillis;
+    boolean finished = false;
+    while (!finished) {
+      long executionStartMillis = imr.getExecutionStartMillis();
+      long waitMillis;
+      if (executionStartMillis < 0) {
+        // The worker thread has not started executing the method yet. Poll in short intervals so we
+        // react promptly once it does, but give up if it never starts within the start-up grace.
+        long remainingStartup = startupDeadline - System.currentTimeMillis();
+        if (remainingStartup <= 0) {
+          break;
+        }
+        waitMillis = Math.min(remainingStartup, TIMEOUT_STARTUP_POLL_MILLIS);
+      } else {
+        // The method is running: it has until its execution start plus the configured time-out.
+        waitMillis = executionStartMillis + realTimeOut - System.currentTimeMillis();
+        if (waitMillis <= 0) {
+          break;
+        }
+      }
+      finished = exec.awaitTermination(waitMillis, TimeUnit.MILLISECONDS);
+    }
 
     if (!finished) {
-      ThreadTimeoutException exception = new ThreadTimeoutException(tm, realTimeOut);
+      // A genuinely slow method (one that started but ran too long) keeps the canonical message so
+      // existing tooling and assertions still recognise it. Only a method that never started gets
+      // the infrastructure diagnostic, since that is not the user's method being slow.
+      ThreadTimeoutException exception =
+          imr.getExecutionStartMillis() < 0
+              ? new ThreadTimeoutException(buildNeverStartedMessage(tm, startupGraceMillis))
+              : new ThreadTimeoutException(tm, realTimeOut);
       StackTraceElement[] realStackTrace = getRunningMethodStackTrace(exec);
       if (realStackTrace != null) {
         exception.setStackTrace(realStackTrace);
@@ -420,6 +470,23 @@ public class MethodInvocationHelper {
     } catch (ExecutionException e) {
       throw new ThreadExecutionException(e.getCause());
     }
+  }
+
+  /**
+   * Builds the message for a {@link ThreadTimeoutException} raised because the worker thread never
+   * even started executing the method within the start-up grace period. This is an infrastructure
+   * problem (system load or thread-pool starvation), not a slow test method, so the message says so
+   * explicitly and points at actionable remedies rather than blaming the user's method.
+   */
+  private static String buildNeverStartedMessage(ITestNGMethod tm, long startupGraceMillis) {
+    return "Method "
+        + tm.getQualifiedName()
+        + "() never started executing within "
+        + startupGraceMillis
+        + "ms: the worker thread could not be scheduled in time. This is most likely caused by "
+        + "system load or thread-pool starvation (e.g. too many parallel tests) rather than a slow "
+        + "test method. Consider reducing the level of parallelism or increasing the thread-pool "
+        + "size.";
   }
 
   private static StackTraceElement[] getRunningMethodStackTrace(ExecutorService exec) {

--- a/testng-core/src/test/java/test/priority/parallel/EfficientPriorityParallelizationTest2.java
+++ b/testng-core/src/test/java/test/priority/parallel/EfficientPriorityParallelizationTest2.java
@@ -1,7 +1,7 @@
 package test.priority.parallel;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 import static test.thread.parallelization.TestNgRunStateTracker.*;
 
 import java.util.HashMap;
@@ -282,15 +282,12 @@ public class EfficientPriorityParallelizationTest2 extends BaseParallelizationTe
     // LISTENER_TEST_METHOD_PASS. This is robust because the slow method sleeps far longer than the
     // low-priority ones.
     for (EventLog lowPriEvent : lowPriEvents) {
-      assertTrue(
-          lowPriEvent.getTimeOfEvent() <= highPriEnd.getTimeOfEvent(),
-          "All the low-priority method events should occur before the slow, high-priority method "
-              + "ends.\nFinal event: "
-              + highPriEnd
-              + ".\nOffending event: "
-              + lowPriEvent
-              + ".\nAll low-priority events: "
-              + lowPriEvents);
+      assertThat(lowPriEvent.getTimeOfEvent())
+          .as(
+              "All the low-priority method events should occur before the slow, high-priority "
+                  + "method ends.\nFinal event: %s\nOffending event: %s\nAll low-priority events: %s",
+              highPriEnd, lowPriEvent, lowPriEvents)
+          .isLessThanOrEqualTo(highPriEnd.getTimeOfEvent());
     }
 
     // The slow, high-priority method must run in parallel with the low-priority ones: it starts
@@ -304,14 +301,20 @@ public class EfficientPriorityParallelizationTest2 extends BaseParallelizationTe
         lowPriEvents.stream()
             .filter(e -> e.getEvent() == TestNgRunEvent.LISTENER_TEST_METHOD_PASS)
             .collect(Collectors.toList());
+    assertThat(lowPriEndEvents)
+        .as(
+            "Expected low-priority method completion events to validate parallelism against, but "
+                + "found none. Low-priority events: %s",
+            lowPriEvents)
+        .isNotEmpty();
     for (EventLog lowPriEnd : lowPriEndEvents) {
-      assertTrue(
-          highPriStart.getTimeOfEvent() <= lowPriEnd.getTimeOfEvent(),
-          "The slow, high-priority method should start before any low-priority method finishes, "
-              + "proving they run in parallel.\nStart Event: "
-              + highPriStart
-              + ".\nLow-priority completion event: "
-              + lowPriEnd);
+      assertThat(highPriStart.getTimeOfEvent())
+          .as(
+              "The slow, high-priority method should start before any low-priority method "
+                  + "finishes, proving they run in parallel.\nStart Event: %s\nLow-priority "
+                  + "completion event: %s",
+              highPriStart, lowPriEnd)
+          .isLessThanOrEqualTo(lowPriEnd.getTimeOfEvent());
     }
   }
 }

--- a/testng-core/src/test/java/test/priority/parallel/EfficientPriorityParallelizationTest2.java
+++ b/testng-core/src/test/java/test/priority/parallel/EfficientPriorityParallelizationTest2.java
@@ -1,6 +1,7 @@
 package test.priority.parallel;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 import static test.thread.parallelization.TestNgRunStateTracker.*;
 
 import java.util.HashMap;
@@ -276,15 +277,41 @@ public class EfficientPriorityParallelizationTest2 extends BaseParallelizationTe
                   return rightClass;
                 })
             .collect(Collectors.toList());
-    verifyEventsOccurBetween(
-        highPriStart,
-        lowPriEvents,
-        highPriEnd,
-        "All the test two methods should run between when test one starts and ends.\nStart Event: "
-            + highPriStart
-            + ".\nIn between events: "
-            + lowPriEvents
-            + ".\nFinal event: "
-            + highPriEnd);
+
+    // The slow, high-priority method must end last: every low-priority event happens before its
+    // LISTENER_TEST_METHOD_PASS. This is robust because the slow method sleeps far longer than the
+    // low-priority ones.
+    for (EventLog lowPriEvent : lowPriEvents) {
+      assertTrue(
+          lowPriEvent.getTimeOfEvent() <= highPriEnd.getTimeOfEvent(),
+          "All the low-priority method events should occur before the slow, high-priority method "
+              + "ends.\nFinal event: "
+              + highPriEnd
+              + ".\nOffending event: "
+              + lowPriEvent
+              + ".\nAll low-priority events: "
+              + lowPriEvents);
+    }
+
+    // The slow, high-priority method must run in parallel with the low-priority ones: it starts
+    // before any of them finishes (their LISTENER_TEST_METHOD_PASS). We deliberately do NOT assert
+    // that it starts strictly first: with parallel=METHODS and a 2-thread pool, the high- and
+    // low-priority methods are dispatched onto the two threads simultaneously, so their START
+    // timestamps can race within a few milliseconds. Comparing against the low-priority methods'
+    // completion (they sleep, so completion is well after their start) keeps the intent ("the slow
+    // method wraps the fast ones") without the timing flakiness.
+    List<EventLog> lowPriEndEvents =
+        lowPriEvents.stream()
+            .filter(e -> e.getEvent() == TestNgRunEvent.LISTENER_TEST_METHOD_PASS)
+            .collect(Collectors.toList());
+    for (EventLog lowPriEnd : lowPriEndEvents) {
+      assertTrue(
+          highPriStart.getTimeOfEvent() <= lowPriEnd.getTimeOfEvent(),
+          "The slow, high-priority method should start before any low-priority method finishes, "
+              + "proving they run in parallel.\nStart Event: "
+              + highPriStart
+              + ".\nLow-priority completion event: "
+              + lowPriEnd);
+    }
   }
 }


### PR DESCRIPTION
## Problem

Three tests were intermittently failing across CI runs:

- `HookableTest.hookSuccess[1]` / `[2]` (the `GITHUB-599` timeout scenarios)
- `EfficientPriorityParallelizationTest2.verifyThatSlowMethodStartedFirstAndEndedLast`

They had two distinct root causes.

### 1. Time-out budget included dispatch overhead (product bug)

A method with `@Test(timeOut = N)` was run through a single-thread executor and
awaited with `awaitTermination(N)`. That clock started the moment we began
waiting, so **thread-pool start-up and OS thread scheduling were charged against
the user's time-out**. Under load (e.g. several parallel Gradle test workers
competing for CPU), the worker thread could be scheduled too late, and a method
that did essentially no work would still fail with *"didn't finish within the
time-out"* — with no way for the user to tell their method apart from
infrastructure overhead.

The `HookSuccessTimeout*` samples use `timeOut = 100` with a near-empty body,
so they tripped this whenever the machine was busy.

### 2. Over-specified ordering assertion (flaky test)

`verifyThatSlowMethodStartedFirstAndEndedLast` required the high-priority
method's START event to be timestamped before every low-priority START event.
With `parallel=METHODS` and a 2-thread pool, both methods are dispatched onto
the two threads simultaneously, so their START timestamps can race within ~1ms
and invert.

## Fix

**Time-out measurement (main + behavior change):**
- `InvokeMethodRunnable` records when the worker thread actually starts executing
  the method body.
- `MethodInvocationHelper` measures the time-out from that point, not from the
  start of the wait, while bounding how long it waits for the worker to *start*
  (so a thread that can never be scheduled still fails instead of hanging).
- A genuinely slow method keeps the canonical *"didn't finish within the
  time-out"* message (existing assertions/tooling unaffected); a method that
  never started now reports an actionable infrastructure-starvation message.

**Test:**
- `verifyThatSlowMethodStartedFirstAndEndedLast` now asserts the real intent:
  the slow method ends last and starts before any low-priority method *finishes*
  (proving parallel overlap). Both bounds rely on the slow method's much longer
  sleep, so they hold regardless of scheduling jitter.

## Verification

- All `test.timeout.*`, `HookableTest`, `ParameterTest`, and both
  `EfficientPriorityParallelization*` tests pass (276 tests).
- The previously flaky tests pass across repeated forced reruns.
- Exact-message timeout assertions (`TimeOutTest`, `ParameterTest`) remain green,
  confirming the genuine-timeout path is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated worker-thread method timeout behavior to measure from when the method actually starts executing, reducing false timeouts caused by scheduling/startup delays.
  * Enhanced timeout messaging: when the method never begins, the error includes an actionable “infrastructure-starvation” style diagnostic; otherwise canonical timeout details remain.

* **Tests**
  * Improved parallel priority test verification with timestamp-based assertions for more reliable start/end ordering checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->