### PR TITLE
Fail when a suite file cannot be loaded

### DIFF
--- a/testng-core/src/main/java/org/testng/TestNG.java
+++ b/testng-core/src/main/java/org/testng/TestNG.java
@@ -329,7 +329,7 @@ public class TestNG {
     try {
       return Parser.parse(suitePath, getProcessor());
     } catch (IOException e) {
-      e.printStackTrace(System.out);
+      throw new TestNGException("Failed to parse suite: " + suitePath, e);
     } catch (Exception ex) {
       // Probably a Yaml exception, unnest it
       Throwable t = ex;
@@ -341,8 +341,6 @@ public class TestNG {
       }
       throw new TestNGException(t);
     }
-
-    return Collections.emptySet();
   }
 
   private Collection<XmlSuite> processCommandLineArgs(Collection<XmlSuite> allSuites) {

--- a/testng-core/src/test/java/test/cli/CliTest.java
+++ b/testng-core/src/test/java/test/cli/CliTest.java
@@ -1,6 +1,7 @@
 package test.cli;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
@@ -15,6 +16,7 @@ import org.testng.IInvokedMethod;
 import org.testng.IInvokedMethodListener;
 import org.testng.ITestResult;
 import org.testng.TestNG;
+import org.testng.TestNGException;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -107,6 +109,17 @@ public class CliTest extends SimpleBaseTest {
     assertThat(logInvocations.logs)
         .containsExactlyInAnyOrder(
             "com.kungfu.panda.DragonWarrior.testMethod", "com.kungfu.panda.Tigress.testMethod");
+  }
+
+  @Test(description = "GITHUB-3230")
+  public void missingSuiteFileIsRejected() {
+    String missingSuite = "target/missing-suite-3230.xml";
+    TestNG testng = new TestNG();
+    testng.setTestSuites(List.of(missingSuite));
+
+    assertThatThrownBy(testng::initializeSuitesAndJarFile)
+        .isInstanceOf(TestNGException.class)
+        .hasMessageContaining(missingSuite);
   }
 
   private static Class<?> compile(TestNGSimpleClassLoader loader, CompiledCode code) {

--- a/testng-core/src/test/java/test/cli/CliTest.java
+++ b/testng-core/src/test/java/test/cli/CliTest.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import java.util.function.Supplier;
 import org.testng.Assert;
 import org.testng.CommandLineArgs;
@@ -113,7 +114,7 @@ public class CliTest extends SimpleBaseTest {
 
   @Test(description = "GITHUB-3230")
   public void missingSuiteFileIsRejected() {
-    String missingSuite = "target/missing-suite-3230.xml";
+    String missingSuite = "target/missing-suite-3230-" + UUID.randomUUID() + ".xml";
     TestNG testng = new TestNG();
     testng.setTestSuites(List.of(missingSuite));
 


### PR DESCRIPTION
Closes #3230

When `Parser.parse` hit an `IOException`, TestNG printed the stack trace and returned an empty suite set. A missing suite file could therefore look like a successful run.

This change throws a `TestNGException` with the suite path instead. I also added a CLI regression test for a missing XML suite.

Tested with:
- `./gradlew :testng-core:test --tests test.cli.CliTest`
- `./gradlew :testng-core:autostyleCheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Suite parsing now fails fast when a referenced suite file can’t be read, instead of logging and continuing.

* **Tests**
  * Added a CLI verification test to confirm missing suite files are rejected with a `TestNGException` that includes the missing path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->