### PR TITLE
ci: build the test matrix in a single generateRows call

### DIFF
--- a/.github/workflows/matrix.mjs
+++ b/.github/workflows/matrix.mjs
@@ -1,5 +1,6 @@
 // The script generates a random subset of valid jdk, os, timezone, and other axes.
 // You can preview the results by running "node matrix.mjs"
+// Run "node matrix.mjs --coverage" to print pairwise coverage instead of the matrix.
 // See https://github.com/vlsi/github-actions-random-matrix
 import { appendFileSync } from 'fs';
 import { EOL } from 'os';
@@ -77,22 +78,23 @@ matrix.imply({java_distribution: {value: 'oracle'}}, {java_version: v => v === e
 // Semeru uses OpenJ9 jit which has no option for making hash codes the same
 // See https://github.com/eclipse-openj9/openj9/issues/17309
 matrix.exclude({java_distribution: {value: 'semeru'}, hash: {value: 'same'}});
-// Ensure at least one job with "same" hashcode exists
-matrix.generateRow({hash: {value: 'same'}});
-// Ensure at least one windows and at least one linux job is present (macos is almost the same as linux)
-matrix.generateRow({os: 'windows-latest'});
-matrix.generateRow({os: 'ubuntu-latest'});
-// Ensure there will be at least one job with Java 11
-matrix.generateRow({java_version: "11"});
-// Ensure there will be at least one job with Java 17
-matrix.generateRow({java_version: "17"});
-// Ensure there will be at least one job with Java 21
-matrix.generateRow({java_version: "21"});
-// Ensure there will be at least one job with Java 25
-matrix.generateRow({java_version: "25"});
-// Ensure there will be at least one job with Java EA
-matrix.generateRow({java_version: eaJava});
-const include = matrix.generateRows(process.env.MATRIX_JOBS || 5);
+
+// Drive the whole matrix from one batch of requirements. generateRows guarantees a row for
+// each entry, packs them into as few jobs as it can, and spends the rest of the MATRIX_JOBS
+// budget on pairwise coverage. Unlike a sequence of generateRow() calls, the job count is
+// exactly MATRIX_JOBS and the result no longer depends on the order of the list.
+const include = matrix.generateRows(Number(process.env.MATRIX_JOBS || 5), {
+  require: [
+    // Ensure at least one job with "same" hashcode exists
+    {hash: {value: 'same'}},
+    // Ensure at least one windows and at least one linux job is present
+    // (macos is almost the same as linux, so it is left to the random fill)
+    {os: 'windows-latest'},
+    {os: 'ubuntu-latest'},
+    // Ensure every Java version under test gets at least one job
+    ...matrix.allAxisValues('java_version'),
+  ],
+});
 if (include.length === 0) {
   throw new Error('Matrix list is empty');
 }
@@ -147,10 +149,15 @@ include.forEach(v => {
   delete v.hash;
 });
 
-console.log(include);
-let filePath = process.env['GITHUB_OUTPUT'] || '';
-if (filePath) {
-  appendFileSync(filePath, `matrix<<MATRIX_BODY${EOL}${JSON.stringify({include})}${EOL}MATRIX_BODY${EOL}`, {
-    encoding: 'utf8'
-  });
+if (process.argv.includes('--coverage')) {
+  const coverage = matrix.pairCoverageReport();
+  console.log(`Pair coverage: ${coverage.covered}/${coverage.total} (${coverage.percentage}%), weight coverage ${coverage.weightPercentage}%`);
+} else {
+  console.log(include);
+  let filePath = process.env['GITHUB_OUTPUT'] || '';
+  if (filePath) {
+    appendFileSync(filePath, `matrix<<MATRIX_BODY${EOL}${JSON.stringify({include})}${EOL}MATRIX_BODY${EOL}`, {
+      encoding: 'utf8'
+    });
+  }
 }

--- a/.github/workflows/package-lock.json
+++ b/.github/workflows/package-lock.json
@@ -5,13 +5,13 @@
   "packages": {
     "": {
       "dependencies": {
-        "@vlsi/github-actions-random-matrix": "2.0.0"
+        "@vlsi/github-actions-random-matrix": "2.1.0"
       }
     },
     "node_modules/@vlsi/github-actions-random-matrix": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@vlsi/github-actions-random-matrix/-/github-actions-random-matrix-2.0.0.tgz",
-      "integrity": "sha512-8lEb4eadMBKs+Hnj9dCmcHtgHoWelT4RMXAQ/VcQ1r3vjR8P2hSMVGhkRXaXibCBf0lMttS934CGo2mlBMopPA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@vlsi/github-actions-random-matrix/-/github-actions-random-matrix-2.1.0.tgz",
+      "integrity": "sha512-+KDQS/+AwEUBRrQR3WbBGva2Z2X5NAXDzWvaPAijSB0zNtUEAepw0YJWdsXDnSESeFpQ/rtna+SfEdKkTcIW8A==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16"

--- a/.github/workflows/package.json
+++ b/.github/workflows/package.json
@@ -2,6 +2,6 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@vlsi/github-actions-random-matrix": "2.0.0"
+    "@vlsi/github-actions-random-matrix": "2.1.0"
   }
 }


### PR DESCRIPTION
Why
----

The CI matrix script drove the build matrix imperatively: a sequence of `matrix.generateRow(...)` calls followed by a final `matrix.generateRows(n)`. With that style the job count is an emergent function of how many `generateRow()` calls happen to produce a fresh row, and coverage depends on the order of the calls, because a row generated for an early filter may satisfy a later one by chance.

What
----

- Upgrade `@vlsi/github-actions-random-matrix` from `2.0.0` to `2.1.0` (`package.json`, `package-lock.json`). The single-batch `generateRows(n, {require})` API lands in 2.1.0; 2.0.0 only has the legacy `generateRows(maxRows, filter)` signature.
- Generate the whole matrix in one `generateRows(Number(process.env.MATRIX_JOBS || 5), {require: [...]})` call. The batch API guarantees a row for each requirement, packs them into as few jobs as it can, and spends the rest of the `MATRIX_JOBS` budget on pairwise coverage. The job count is now exactly `MATRIX_JOBS` and no longer depends on the order of the requirement list.
- Collapse the five per-version `generateRow({java_version: ...})` calls into `...matrix.allAxisValues('java_version')`. `windows-latest` and `ubuntu-latest` stay explicit so macOS is left to the random fill, matching the previous intent.
- Add a `node matrix.mjs --coverage` mode that prints pairwise coverage instead of the matrix, mirroring the pgjdbc script.

The `imply` / `exclude` constraints and the post-processing of each row are unchanged. `test.yml` needs no change: it already runs `npm ci --prefix .github/workflows` and `node .github/workflows/matrix.mjs`.

How to verify
-------------

- `npm ci --prefix .github/workflows` succeeds and leaves `package-lock.json` unchanged.
- `MATRIX_JOBS=7 node .github/workflows/matrix.mjs` produces exactly 7 jobs, with every Java version (11, 17, 21, 25, 26), both `ubuntu-latest` and `windows-latest`, and one `same hashcode` row.
- `node .github/workflows/matrix.mjs --coverage` prints a pair-coverage summary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a coverage-report mode for workflow matrix generation, making it easier to review job coverage.
* **Improvements**
  * Made generated workflow jobs more deterministic and consistent, with guaranteed coverage across key operating systems and Java versions.
  * Simplified matrix generation to better control the total number of jobs.
* **Chores**
  * Updated a workflow-related dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->