### PR TITLE
Make Issue188 parallelism check deterministic (no fixed sleep)

### DIFF
--- a/testng-core/src/test/java/test/thread/issue188/Issue188TestSample.java
+++ b/testng-core/src/test/java/test/thread/issue188/Issue188TestSample.java
@@ -1,5 +1,6 @@
 package test.thread.issue188;
 
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.testng.annotations.BeforeMethod;
@@ -7,14 +8,20 @@ import org.testng.annotations.Test;
 
 public class Issue188TestSample {
   public static final int EXPECTED_METHOD_INVOCATIONS = 6;
+
+  /** Guard against deadlock if the methods are (wrongly) serialized instead of running together. */
+  private static final long BARRIER_TIMEOUT_SECONDS = 10;
+
   private static final AtomicInteger startedTestMethods = new AtomicInteger();
   private static final AtomicInteger activeTestMethods = new AtomicInteger();
   private static final AtomicInteger maxActiveTestMethods = new AtomicInteger();
+  private static CountDownLatch allMethodsActive = new CountDownLatch(EXPECTED_METHOD_INVOCATIONS);
 
   public static void reset() {
     startedTestMethods.set(0);
     activeTestMethods.set(0);
     maxActiveTestMethods.set(0);
+    allMethodsActive = new CountDownLatch(EXPECTED_METHOD_INVOCATIONS);
   }
 
   public static int getStartedTestMethods() {
@@ -43,8 +50,12 @@ public class Issue188TestSample {
   private static void trackParallelExecution() {
     int activeMethods = activeTestMethods.incrementAndGet();
     maxActiveTestMethods.accumulateAndGet(activeMethods, Math::max);
+    allMethodsActive.countDown();
     try {
-      TimeUnit.SECONDS.sleep(1);
+      // Hold the active slot until every expected method has reached this barrier rather than
+      // sleeping for a fixed window: the peak active count then reaches EXPECTED_METHOD_INVOCATIONS
+      // deterministically when the methods run in parallel, instead of relying on a timing margin.
+      allMethodsActive.await(BARRIER_TIMEOUT_SECONDS, TimeUnit.SECONDS);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
     } finally {


### PR DESCRIPTION
Builds on the flaky-test fix from #3269.

## Context

#3269 fixed `IssueTest#testSuiteLevelParallelMode` by replacing the start-timestamp comparison with a count of the peak number of concurrently active test methods. To give the methods time to overlap, each one sleeps for a fixed 1-second window inside `trackParallelExecution()`.

That fixed window is a (very safe) timing margin rather than a guarantee: the peak only reaches `EXPECTED_METHOD_INVOCATIONS` if every method happens to become active within the same second, and every run pays a full second even on a fast machine.

## Change

Replace the fixed `sleep(1)` with a `CountDownLatch` barrier sized to `EXPECTED_METHOD_INVOCATIONS`:

- Each method records the current active count, then waits at the barrier until **all** expected methods have arrived before releasing its slot.
- The peak active count therefore reaches the expected value **deterministically** when the methods run in parallel — no timing margin involved.
- The test finishes as soon as all methods overlap instead of always waiting a full second.
- A generous timeout guards against deadlock if execution is (wrongly) serialized, so the assertion still fails cleanly in that case.

The assertions in `IssueTest` are unchanged; only `trackParallelExecution()` is touched (+12/-1).

## Verification

- Builds on JDK 21.0.2.
- `IssueTest` run repeatedly with `--rerun-tasks` (12×+): 0 failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved parallel-execution test coverage to make concurrency checks more reliable and deterministic.
  * Added tracking for how many test methods start and the highest number running at once, helping catch parallelism issues more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->