### PR TITLE
Streamline global thread pool usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ outputDir/
 **/Version.java
 **/bin/
 node_modules
+.kotlin

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,8 @@
 Current (7.13.0)
+Fixed: GITHUB-3242: use-global-thread-pool no longer refuses to start a suite when the number of data-driven tests reaches thread-count (krishnan Mahadevan)
 Fixed: GITHUB-426: firstTimeOnly @BeforeMethod / lastTimeOnly @AfterMethod were not run as a barrier around a parallel invocationCount thread pool (firstTimeOnly could run concurrently with test invocations, lastTimeOnly ran once per invocation instead of once)
 Fixed: Time-out now measures a method's own execution time instead of the wall-clock time since dispatch, so thread-pool start-up and scheduling overhead under load no longer cause spurious time-outs; a method that never starts now reports an actionable infrastructure-starvation message
-Fixed: GITHUB-3166: Skipped configuration methods not receiving the causal throwable before configuration listeners are invoked
+Fixed: GITHUB-3166: Skipped configuration methods not receiving the causal throwable before configuration listeners are invoked (Anmol Jain)
 Fixed: GITHUB-3263: dataProviderClass cache mutation causes subclasses to use wrong data provider when run together (Aleksei Dobrynin)
 Fixed: GITHUB-3120: ITestNGListenerFactory is broken and never invoked (Krishnan Mahadevan)
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,5 @@
 Current (7.13.0)
-Fixed: GITHUB-3242: use-global-thread-pool no longer refuses to start a suite when the number of data-driven tests reaches thread-count (krishnan Mahadevan)
+Fixed: GITHUB-3242: use-global-thread-pool no longer refuses to start a suite when the number of data-driven tests reaches thread-count (Krishnan Mahadevan)
 Fixed: GITHUB-426: firstTimeOnly @BeforeMethod / lastTimeOnly @AfterMethod were not run as a barrier around a parallel invocationCount thread pool (firstTimeOnly could run concurrently with test invocations, lastTimeOnly ran once per invocation instead of once)
 Fixed: Time-out now measures a method's own execution time instead of the wall-clock time since dispatch, so thread-pool start-up and scheduling overhead under load no longer cause spurious time-outs; a method that never starts now reports an actionable infrastructure-starvation message
 Fixed: GITHUB-3166: Skipped configuration methods not receiving the causal throwable before configuration listeners are invoked (Anmol Jain)

--- a/testng-core-api/src/main/java/org/testng/IExecutorServiceFactory.java
+++ b/testng-core-api/src/main/java/org/testng/IExecutorServiceFactory.java
@@ -2,8 +2,11 @@ package org.testng;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinWorkerThread;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Represents the capability to create a custom {@link ExecutorService} by downstream consumers. The
@@ -32,4 +35,34 @@ public interface IExecutorServiceFactory {
       TimeUnit unit,
       BlockingQueue<Runnable> workQueue,
       ThreadFactory threadFactory);
+
+  /**
+   * Creates the single, common {@link ExecutorService} that is shared between regular test methods
+   * and their (parallel) data-driven invocations when <code>use-global-thread-pool</code> is
+   * enabled. Override this to plug in a custom implementation for that shared pool.
+   *
+   * <p><strong>Important:</strong> the returned service should be a {@link ForkJoinPool} (as the
+   * default implementation is). With the shared pool, a data-driven test method waits for its
+   * data-row tasks by submitting them back into this <em>same</em> pool; only a {@link
+   * ForkJoinPool} lets that waiting worker help run those tasks (work-stealing) instead of parking
+   * a thread. Returning a pool that cannot work-steal (for example a plain {@link
+   * java.util.concurrent.ThreadPoolExecutor}) re-introduces the throttled parallelism and
+   * dead-locks that GITHUB-3242 addressed, so only do so if you size the pool accordingly.
+   *
+   * @param parallelism the desired parallelism, i.e. the configured <code>thread-count</code>
+   * @param threadNamePrefix the prefix to use when naming the pool's worker threads (each thread is
+   *     named <code>threadNamePrefix-N</code>)
+   * @return the {@link ExecutorService} to be shared for the whole suite
+   */
+  default ExecutorService createGlobalThreadPool(int parallelism, String threadNamePrefix) {
+    AtomicInteger threadNumber = new AtomicInteger(1);
+    ForkJoinPool.ForkJoinWorkerThreadFactory threadFactory =
+        pool -> {
+          ForkJoinWorkerThread thread =
+              ForkJoinPool.defaultForkJoinWorkerThreadFactory.newThread(pool);
+          thread.setName(threadNamePrefix + "-" + threadNumber.getAndIncrement());
+          return thread;
+        };
+    return new ForkJoinPool(Math.max(parallelism, 1), threadFactory, null, /* asyncMode= */ true);
+  }
 }

--- a/testng-core/src/main/java/org/testng/TestRunner.java
+++ b/testng-core/src/main/java/org/testng/TestRunner.java
@@ -46,7 +46,6 @@ import org.testng.internal.TestListenerHelper;
 import org.testng.internal.TestMethodComparator;
 import org.testng.internal.TestMethodContainer;
 import org.testng.internal.TestNGClassFinder;
-import org.testng.internal.TestNGDeadLockException;
 import org.testng.internal.TestNGMethodFinder;
 import org.testng.internal.Utils;
 import org.testng.internal.XmlMethodSelector;
@@ -63,7 +62,6 @@ import org.testng.util.Strings;
 import org.testng.util.TimeUtils;
 import org.testng.xml.XmlClass;
 import org.testng.xml.XmlPackage;
-import org.testng.xml.XmlSuite;
 import org.testng.xml.XmlTest;
 
 /** This class takes care of running one Test. */
@@ -815,30 +813,6 @@ public class TestRunner
     List<IWorker<ITestNGMethod>> result =
         AbstractParallelWorker.newWorker(m_xmlTest.getParallel(), m_xmlTest.getGroupByInstances())
             .createWorkers(args);
-    long dataDrivenTestCount =
-        result.stream()
-            .flatMap(it -> it.getTasks().stream())
-            .filter(ITestNGMethod::isDataDriven)
-            .count();
-    int threads = getCurrentXmlTest().getThreadCount();
-    XmlSuite.ParallelMode parallelMode = getCurrentXmlTest().getParallel();
-    XmlSuite suite = getSuite().getXmlSuite();
-    if (suite.useGlobalThreadPool()
-        && parallelMode.isParallel()
-        && dataDrivenTestCount >= threads) {
-      String msg =
-          "[Deadlock condition detected] "
-              + "Cannot run "
-              + dataDrivenTestCount
-              + " data driven tests on just "
-              + threads
-              + " threads when "
-              + "using common thread pool. "
-              + "Please increase the number of threads to at-least "
-              + (dataDrivenTestCount + 1)
-              + ".";
-      throw new TestNGDeadLockException(msg);
-    }
     return result;
   }
 

--- a/testng-core/src/main/java/org/testng/TestTaskExecutor.java
+++ b/testng-core/src/main/java/org/testng/TestTaskExecutor.java
@@ -25,6 +25,8 @@ class TestTaskExecutor {
   private final long timeOut;
 
   private ExecutorService service;
+  private GraphOrchestrator<ITestNGMethod> orchestrator;
+  private boolean reUse;
 
   private static final Logger LOGGER = Logger.getLogger(TestTaskExecutor.class);
 
@@ -47,8 +49,8 @@ class TestTaskExecutor {
   public void execute() {
     String name = "test-" + xmlTest.getName();
     int threadCount = Math.max(xmlTest.getThreadCount(), 1);
-    boolean reUse = xmlTest.getSuite().useGlobalThreadPool();
-    if (reUse) {
+    this.reUse = xmlTest.getSuite().useGlobalThreadPool();
+    if (this.reUse) {
       // A single, common pool is shared between regular test methods and their (parallel)
       // data-driven invocations. It is created via IExecutorServiceFactory#createGlobalThreadPool,
       // which by default returns a ForkJoinPool so that a data-driven method worker waiting for its
@@ -74,9 +76,10 @@ class TestTaskExecutor {
                   queue,
                   new TestNGThreadFactory(name));
     }
-    GraphOrchestrator<ITestNGMethod> executor =
-        new GraphOrchestrator<>(service, factory, graph, comparator);
-    executor.run();
+    // A shared global pool (reUse) must not be shut down when this test's graph finishes - other
+    // <test> graphs may still be using it. See GITHUB-3242.
+    orchestrator = new GraphOrchestrator<>(service, factory, graph, comparator, !reUse);
+    orchestrator.run();
   }
 
   public void awaitCompletion() {
@@ -85,8 +88,14 @@ class TestTaskExecutor {
             "Starting executor test %d with time out: %d milliseconds.", timeOut, timeOut);
     Utils.log("TestTaskExecutor", 2, msg);
     try {
-      boolean ignored = service.awaitTermination(timeOut, TimeUnit.MILLISECONDS);
-      service.shutdownNow();
+      if (reUse) {
+        // Shared global pool: wait for this test's graph to finish, but leave the pool running for
+        // the other <test>s. It is disposed once, at the end of the run, via ObjectBag cleanup.
+        boolean ignored = orchestrator.awaitCompletion(timeOut, TimeUnit.MILLISECONDS);
+      } else {
+        boolean ignored = service.awaitTermination(timeOut, TimeUnit.MILLISECONDS);
+        service.shutdownNow();
+      }
     } catch (InterruptedException handled) {
       LOGGER.error(handled.getMessage(), handled);
       Thread.currentThread().interrupt();

--- a/testng-core/src/main/java/org/testng/TestTaskExecutor.java
+++ b/testng-core/src/main/java/org/testng/TestTaskExecutor.java
@@ -9,6 +9,7 @@ import org.testng.internal.IConfiguration;
 import org.testng.internal.ObjectBag;
 import org.testng.internal.Utils;
 import org.testng.internal.thread.TestNGThreadFactory;
+import org.testng.internal.thread.ThreadUtil;
 import org.testng.internal.thread.graph.GraphOrchestrator;
 import org.testng.log4testng.Logger;
 import org.testng.thread.IThreadWorkerFactory;
@@ -47,22 +48,31 @@ class TestTaskExecutor {
     String name = "test-" + xmlTest.getName();
     int threadCount = Math.max(xmlTest.getThreadCount(), 1);
     boolean reUse = xmlTest.getSuite().useGlobalThreadPool();
-    Supplier<Object> supplier =
-        () ->
-            configuration
-                .getExecutorServiceFactory()
-                .create(
-                    threadCount,
-                    threadCount,
-                    0,
-                    TimeUnit.MILLISECONDS,
-                    queue,
-                    new TestNGThreadFactory(name));
     if (reUse) {
+      // A single, common pool is shared between regular test methods and their (parallel)
+      // data-driven invocations. It is created via IExecutorServiceFactory#createGlobalThreadPool,
+      // which by default returns a ForkJoinPool so that a data-driven method worker waiting for its
+      // data-row tasks (submitted back into this same pool) helps run them itself (work-stealing)
+      // instead of throttling throughput or dead-locking the suite. See GITHUB-3242.
+      String threadNamePrefix = ThreadUtil.THREAD_NAME + "-" + name;
+      Supplier<Object> supplier =
+          () ->
+              configuration
+                  .getExecutorServiceFactory()
+                  .createGlobalThreadPool(threadCount, threadNamePrefix);
       ObjectBag bag = ObjectBag.getInstance(xmlTest.getSuite());
       service = (ExecutorService) bag.createIfRequired(ExecutorService.class, supplier);
     } else {
-      service = (ExecutorService) supplier.get();
+      service =
+          configuration
+              .getExecutorServiceFactory()
+              .create(
+                  threadCount,
+                  threadCount,
+                  0,
+                  TimeUnit.MILLISECONDS,
+                  queue,
+                  new TestNGThreadFactory(name));
     }
     GraphOrchestrator<ITestNGMethod> executor =
         new GraphOrchestrator<>(service, factory, graph, comparator);

--- a/testng-core/src/main/java/org/testng/internal/invokers/BaseInvoker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/BaseInvoker.java
@@ -55,6 +55,10 @@ class BaseInvoker {
     return m_configuration.getAnnotationFinder();
   }
 
+  public IConfiguration getConfiguration() {
+    return m_configuration;
+  }
+
   protected void runInvokedMethodListeners(
       InvokedMethodListenerMethod listenerMethod,
       IInvokedMethod invokedMethod,

--- a/testng-core/src/main/java/org/testng/internal/invokers/ITestInvoker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/ITestInvoker.java
@@ -11,6 +11,7 @@ import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
 import org.testng.collections.Lists;
 import org.testng.internal.ConfigurationGroupMethods;
+import org.testng.internal.IConfiguration;
 import org.testng.internal.ITestResultNotifier;
 import org.testng.xml.XmlSuite;
 
@@ -52,6 +53,8 @@ public interface ITestInvoker {
   void invokeListenersForSkippedTestResult(ITestResult r, IInvokedMethod invokedMethod);
 
   ITestResultNotifier getNotifier();
+
+  IConfiguration getConfiguration();
 
   default IMethodRunner getRunner() {
     return new MethodRunner();

--- a/testng-core/src/main/java/org/testng/internal/invokers/MethodRunner.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/MethodRunner.java
@@ -8,22 +8,26 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinTask;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.testng.ITestContext;
 import org.testng.ITestResult;
 import org.testng.collections.CollectionUtils;
 import org.testng.collections.Lists;
+import org.testng.internal.IConfiguration;
 import org.testng.internal.ObjectBag;
 import org.testng.internal.Parameters;
 import org.testng.internal.invokers.ITestInvoker.FailureContext;
 import org.testng.internal.invokers.TestMethodArguments.Builder;
 import org.testng.internal.thread.Async;
 import org.testng.internal.thread.TestNGThreadFactory;
+import org.testng.internal.thread.ThreadUtil;
 import org.testng.xml.XmlSuite;
 
 public class MethodRunner implements IMethodRunner {
@@ -107,12 +111,13 @@ public class MethodRunner implements IMethodRunner {
       Iterator<Object[]> allParamValues,
       boolean skipFailedInvocationCounts) {
     XmlSuite suite = context.getSuite().getXmlSuite();
-    int parametersIndex = 0;
     ObjectBag objectBag = ObjectBag.getInstance(context.getSuite());
     boolean reUse = suite.isShareThreadPoolForDataProviders() || suite.useGlobalThreadPool();
 
-    ExecutorService service = getOrCreate(reUse, suite, objectBag);
-    List<CompletableFuture<List<ITestResult>>> all = new ArrayList<>();
+    ExecutorService service = getOrCreate(reUse, suite, objectBag, testInvoker.getConfiguration());
+
+    List<TestMethodWithDataProviderMethodWorker> workers = new ArrayList<>();
+    int parametersIndex = 0;
     for (Object[] next : CollectionUtils.asIterable(allParamValues)) {
       if (next == null) {
         // skipped value
@@ -123,7 +128,7 @@ public class MethodRunner implements IMethodRunner {
           Parameters.injectParameters(
               next, arguments.getTestMethod().getConstructorOrMethod().getMethod(), context);
 
-      TestMethodWithDataProviderMethodWorker w =
+      workers.add(
           new TestMethodWithDataProviderMethodWorker(
               testInvoker,
               arguments.getTestMethod(),
@@ -139,40 +144,110 @@ public class MethodRunner implements IMethodRunner {
               skipFailedInvocationCounts,
               invocationCount.get(),
               failure.count.get(),
-              testInvoker.getNotifier());
-      all.add(Async.run(w, service));
+              testInvoker.getNotifier()));
       // testng387: increment the param index in the bag.
       parametersIndex += 1;
     }
 
-    // don't block on execution of any of the completablefuture
-    CompletableFuture<Void> combined = allOf(all.toArray(new CompletableFuture[0]));
-
-    // Now start processing the results of each of the CompletableFutures as and when they
-    // become available
-    List<ITestResult> result =
-        combined
-            .thenApply(
-                ignored ->
-                    all.stream()
-                        .map(CompletableFuture::join)
-                        .flatMap(Collection::stream)
-                        .collect(Collectors.toList()))
-            .join();
-    if (!reUse) {
-      service.shutdown();
+    try {
+      if (service instanceof ForkJoinPool) {
+        return runWithWorkStealing((ForkJoinPool) service, workers);
+      }
+      return runAsync(service, workers);
+    } finally {
+      if (!reUse) {
+        service.shutdown();
+      }
     }
-    return result;
   }
 
-  private static ExecutorService getOrCreate(boolean reUse, XmlSuite suite, ObjectBag objectBag) {
-    AtomicReference<Integer> count = new AtomicReference<>();
-    count.set(suite.getDataProviderThreadCount());
-    Supplier<Object> supplier = () -> Executors.newFixedThreadPool(count.get(), threadFactory());
+  /**
+   * Runs the data-rows on the shared, global {@link ForkJoinPool}. The data-driven test method that
+   * triggers this executes on a worker of that very same pool, so joining the per-row {@link
+   * ForkJoinTask}s makes the calling worker actively help run the still-pending rows
+   * (work-stealing) instead of parking a pooled thread while it waits. That keeps the pool busy -
+   * rather than only {@code (thread-count - number-of-data-driven-tests)} threads - so the
+   * effective parallelism no longer degrades as more data-driven tests are added, and the pool can
+   * never be dead-locked by parked workers. See GITHUB-3242.
+   */
+  private static List<ITestResult> runWithWorkStealing(
+      ForkJoinPool pool, List<TestMethodWithDataProviderMethodWorker> workers) {
+    List<ForkJoinTask<List<ITestResult>>> tasks = new ArrayList<>(workers.size());
+    for (TestMethodWithDataProviderMethodWorker worker : workers) {
+      tasks.add(pool.submit(worker));
+    }
+    // First, wait for the whole batch to finish. quietlyJoin() blocks (helping via work-stealing)
+    // but never throws, so one failing row cannot stop us waiting for the rest - once this loop
+    // ends every row has completed and none is left running. This mirrors the async path's all-of
+    // semantics. See GITHUB-3242.
+    for (ForkJoinTask<List<ITestResult>> task : tasks) {
+      task.quietlyJoin();
+    }
+    // Now that every row has finished, collect the results. join() here only reports an
+    // already-computed outcome: it returns the result, or re-throws the first failure (exactly as
+    // the async path did) without leaving any sibling row still running.
+    List<ITestResult> results = Lists.newArrayList();
+    for (ForkJoinTask<List<ITestResult>> task : tasks) {
+      results.addAll(task.join());
+    }
+    return results;
+  }
+
+  /**
+   * Runs the data-rows on a regular (non {@link ForkJoinPool}) {@link ExecutorService}, i.e. a
+   * dedicated data-provider thread-pool that is distinct from the one running the test methods.
+   */
+  private static List<ITestResult> runAsync(
+      ExecutorService service, List<TestMethodWithDataProviderMethodWorker> workers) {
+    List<CompletableFuture<List<ITestResult>>> all = new ArrayList<>(workers.size());
+    for (TestMethodWithDataProviderMethodWorker worker : workers) {
+      all.add(Async.run(worker, service));
+    }
+
+    // Wait for the data-rows to finish and then collect their results, preserving submission order.
+    CompletableFuture<Void> combined = allOf(all.toArray(new CompletableFuture[0]));
+    return combined
+        .thenApply(
+            ignored ->
+                all.stream()
+                    .map(CompletableFuture::join)
+                    .flatMap(Collection::stream)
+                    .collect(Collectors.toList()))
+        .join();
+  }
+
+  private static ExecutorService getOrCreate(
+      boolean reUse, XmlSuite suite, ObjectBag objectBag, IConfiguration configuration) {
+    if (reUse && suite.useGlobalThreadPool()) {
+      // Reuse the single common pool that is shared with the regular test-method execution
+      // (normally already created by TestTaskExecutor via the same factory method). Running the
+      // data-rows on it lets the data-driven method worker help execute them via work-stealing
+      // (see runWithWorkStealing) rather than parking and starving the pool. See GITHUB-3242.
+      return (ExecutorService)
+          objectBag.createIfRequired(
+              ExecutorService.class,
+              () ->
+                  configuration
+                      .getExecutorServiceFactory()
+                      .createGlobalThreadPool(
+                          suite.getThreadCount(), ThreadUtil.THREAD_NAME + "-test"));
+    }
+    // Dedicated data-provider pool (shared across the suite when isShareThreadPoolForDataProviders
+    // is set, otherwise per data-driven method). Built through the configured factory so a custom
+    // -threadpoolfactoryclass is honoured here too, matching TestTaskExecutor and ThreadUtil.
+    int dataProviderThreadCount = suite.getDataProviderThreadCount();
+    Supplier<Object> supplier =
+        () ->
+            configuration
+                .getExecutorServiceFactory()
+                .create(
+                    dataProviderThreadCount,
+                    dataProviderThreadCount,
+                    0L,
+                    TimeUnit.MILLISECONDS,
+                    new LinkedBlockingQueue<>(),
+                    threadFactory());
     if (reUse) {
-      if (suite.useGlobalThreadPool()) {
-        count.set(suite.getThreadCount());
-      }
       return (ExecutorService) objectBag.createIfRequired(ExecutorService.class, supplier);
     }
     return (ExecutorService) supplier.get();

--- a/testng-core/src/main/java/org/testng/internal/thread/graph/GraphOrchestrator.java
+++ b/testng-core/src/main/java/org/testng/internal/thread/graph/GraphOrchestrator.java
@@ -23,6 +23,8 @@ public class GraphOrchestrator<T> {
   private final Map<T, T> upstream = Maps.newConcurrentMap();
   private final Comparator<T> comparator;
   private final IThreadWorkerFactory<T> factory;
+  private final boolean shutdownExecutorOnFinish;
+  private final CountDownLatch completed = new CountDownLatch(1);
 
   private final AutoCloseableLock internalLock = new AutoCloseableLock();
 
@@ -31,10 +33,26 @@ public class GraphOrchestrator<T> {
       IThreadWorkerFactory<T> factory,
       IDynamicGraph<T> graph,
       Comparator<T> comparator) {
+    this(service, factory, graph, comparator, true);
+  }
+
+  /**
+   * @param shutdownExecutorOnFinish whether the executor service should be shut down once the graph
+   *     has finished. This must be {@code false} when the executor is a shared pool owned elsewhere
+   *     (for example the suite-wide global thread-pool), so that finishing one graph does not tear
+   *     the pool down under other graphs still using it. See GITHUB-3242.
+   */
+  public GraphOrchestrator(
+      ExecutorService service,
+      IThreadWorkerFactory<T> factory,
+      IDynamicGraph<T> graph,
+      Comparator<T> comparator,
+      boolean shutdownExecutorOnFinish) {
     this.service = service;
     this.graph = graph;
     this.comparator = comparator;
     this.factory = factory;
+    this.shutdownExecutorOnFinish = shutdownExecutorOnFinish;
   }
 
   public void run() {
@@ -45,6 +63,11 @@ public class GraphOrchestrator<T> {
       }
       runNodes(freeNodes);
     }
+  }
+
+  /** Blocks until the graph has finished executing, or the timeout elapses. */
+  public boolean awaitCompletion(long timeout, TimeUnit unit) throws InterruptedException {
+    return completed.await(timeout, unit);
   }
 
   private void runNodes(List<T> freeNodes) {
@@ -77,7 +100,10 @@ public class GraphOrchestrator<T> {
     try (AutoCloseableLock ignore = internalLock.lock()) {
       setStatus(r, computeStatus(r));
       if (graph.getNodeCount() == graph.getNodeCountWithStatus(IDynamicGraph.Status.FINISHED)) {
-        service.shutdown();
+        if (shutdownExecutorOnFinish) {
+          service.shutdown();
+        }
+        completed.countDown();
       } else {
         List<T> freeNodes = graph.getFreeNodes();
         if (comparator != null) {

--- a/testng-core/src/test/java/test/dataprovider/DataProviderTest.java
+++ b/testng-core/src/test/java/test/dataprovider/DataProviderTest.java
@@ -64,6 +64,8 @@ import test.dataprovider.issue3242.ConcurrencyProbe;
 import test.dataprovider.issue3242.MixedThreadPoolSample;
 import test.dataprovider.issue3242.ParallelDataDrivenSample;
 import test.dataprovider.issue3242.RecordingExecutorServiceFactory;
+import test.dataprovider.issue3242.SharedPoolFirstTestSample;
+import test.dataprovider.issue3242.SharedPoolSecondTestSample;
 import test.dataprovider.issue3242.SkippedDataDrivenSample;
 import test.dataprovider.issue3263.FirstSubclassTestSample;
 import test.dataprovider.issue3263.SecondSubclassTestSample;
@@ -836,6 +838,40 @@ public class DataProviderTest extends SimpleBaseTest {
             "Every data-row of the 5 data-driven tests should have been skipped, not blocked by a "
                 + "dead-lock guard")
         .hasSize(40);
+  }
+
+  @Test(description = "GITHUB-3242")
+  public void sharedGlobalPoolIsNotShutdownByAnEarlierTest() {
+    // Two <test> blocks in one suite share the global thread-pool (ObjectBag is suite-scoped). The
+    // first <test> to finish must not shut the pool down, otherwise the second <test>'s workers are
+    // silently rejected and its methods never run. The pool is disposed once, at the end of the run
+    // (TestNG#runSuites -> ObjectBag::cleanup). See GITHUB-3242.
+    XmlSuite xmlSuite = createXmlSuite("global-pool-across-tests");
+    xmlSuite.setParallel(XmlSuite.ParallelMode.NONE);
+    xmlSuite.shouldUseGlobalThreadPool(true);
+    xmlSuite.setThreadCount(2);
+    XmlTest first = createXmlTest(xmlSuite, "first");
+    first.setParallel(XmlSuite.ParallelMode.METHODS);
+    createXmlClass(first, SharedPoolFirstTestSample.class);
+    XmlTest second = createXmlTest(xmlSuite, "second");
+    second.setParallel(XmlSuite.ParallelMode.METHODS);
+    createXmlClass(second, SharedPoolSecondTestSample.class);
+
+    TestListenerAdapter listener = new TestListenerAdapter();
+    TestNG testng = create(xmlSuite);
+    testng.addListener(listener);
+
+    testng.run();
+
+    assertThat(testng.getStatus())
+        .withFailMessage("Both <test> blocks should run to completion")
+        .isZero();
+    assertThat(listener.getPassedTests())
+        .extracting(result -> result.getMethod().getMethodName())
+        .withFailMessage(
+            "Both tests' methods must run on the shared pool; the second was dropped when the "
+                + "first shut the pool down")
+        .containsExactlyInAnyOrder("first", "second");
   }
 
   private static void assertSharedPoolIsBoundedTo(ConcurrencyProbe probe, int threadCount) {

--- a/testng-core/src/test/java/test/dataprovider/DataProviderTest.java
+++ b/testng-core/src/test/java/test/dataprovider/DataProviderTest.java
@@ -60,6 +60,11 @@ import test.dataprovider.issue3045.DataProviderTestClassSample;
 import test.dataprovider.issue3045.DataProviderWithoutListenerTestClassSample;
 import test.dataprovider.issue3081.NoOpMethodInterceptor;
 import test.dataprovider.issue3081.TestClassWithPrioritiesSample;
+import test.dataprovider.issue3242.ConcurrencyProbe;
+import test.dataprovider.issue3242.MixedThreadPoolSample;
+import test.dataprovider.issue3242.ParallelDataDrivenSample;
+import test.dataprovider.issue3242.RecordingExecutorServiceFactory;
+import test.dataprovider.issue3242.SkippedDataDrivenSample;
 import test.dataprovider.issue3263.FirstSubclassTestSample;
 import test.dataprovider.issue3263.SecondSubclassTestSample;
 
@@ -701,6 +706,145 @@ public class DataProviderTest extends SimpleBaseTest {
             "There should have been 9 threads ONLY used by the data driven test "
                 + "because one thread would be the main thread on which TestNG would be running")
         .hasSize(9);
+  }
+
+  @Test(description = "GITHUB-3242")
+  public void dataDrivenTestsDoNotDeadlockWhenCountMatchesThreadCount() {
+    // 5 data-driven test methods and thread-count == 5, run on a shared global thread-pool. This
+    // configuration used to be rejected up front with a TestNGDeadLockException ("Please increase
+    // the number of threads to at-least 6").
+    int threadCount = 5;
+    ConcurrencyProbe probe = new ConcurrencyProbe();
+    TestNG testng = create(ParallelDataDrivenSample.class);
+    testng.addListener(probe);
+    testng.setParallel(XmlSuite.ParallelMode.METHODS);
+    testng.setThreadCount(threadCount);
+    testng.shouldUseGlobalThreadPool(true);
+
+    testng.run();
+
+    assertThat(testng.getStatus())
+        .withFailMessage("The suite should run to completion without a dead-lock")
+        .isZero();
+    assertThat(probe.invocations())
+        .withFailMessage("Every data-row of every data-driven test should have been executed")
+        .isEqualTo(40);
+    assertSharedPoolIsBoundedTo(probe, threadCount);
+  }
+
+  @Test(description = "GITHUB-3242")
+  public void globalThreadPoolParallelismDoesNotDegradeWithTheNumberOfDataDrivenTests() {
+    // 5 data-driven test methods and thread-count == 6. Before the fix the data-rows ran with only
+    // (thread-count - numberOfDataDrivenTests) == 1 thread, so adding a data-driven test made the
+    // suite slower. Now the whole pool (bar the single thread ForkJoinPool keeps in reserve while
+    // its workers are joining) stays busy, independently of how many data-driven tests there are.
+    int threadCount = 6;
+    ConcurrencyProbe probe = new ConcurrencyProbe();
+    TestNG testng = create(ParallelDataDrivenSample.class);
+    testng.addListener(probe);
+    testng.setParallel(XmlSuite.ParallelMode.METHODS);
+    testng.setThreadCount(threadCount);
+    testng.shouldUseGlobalThreadPool(true);
+
+    testng.run();
+
+    assertThat(testng.getStatus())
+        .withFailMessage("The suite should run to completion without a dead-lock")
+        .isZero();
+    assertThat(probe.maxConcurrency())
+        .withFailMessage(
+            "Expected the data-rows to keep the global thread-pool busy (about %d threads), but "
+                + "only %d ran concurrently",
+            threadCount, probe.maxConcurrency())
+        .isGreaterThanOrEqualTo(threadCount - 1);
+    assertSharedPoolIsBoundedTo(probe, threadCount);
+  }
+
+  @Test(description = "GITHUB-3242")
+  public void regularAndDataDrivenTestsCompleteOnTheSharedGlobalThreadPool() {
+    // A class that mixes regular test methods with data-driven ones must run to completion on the
+    // single shared pool, still bounded by thread-count.
+    int threadCount = 4;
+    ConcurrencyProbe probe = new ConcurrencyProbe();
+    TestNG testng = create(MixedThreadPoolSample.class);
+    testng.addListener(probe);
+    testng.setParallel(XmlSuite.ParallelMode.METHODS);
+    testng.setThreadCount(threadCount);
+    testng.shouldUseGlobalThreadPool(true);
+
+    testng.run();
+
+    assertThat(testng.getStatus())
+        .withFailMessage("A mix of regular and data-driven tests should run to completion")
+        .isZero();
+    assertThat(probe.invocations())
+        .withFailMessage("Both regular tests and every data-row should have been executed")
+        .isEqualTo(2 + 2 * 4);
+    assertSharedPoolIsBoundedTo(probe, threadCount);
+  }
+
+  @Test(description = "GITHUB-3242")
+  public void customExecutorServiceFactoryIsUsedForTheGlobalThreadPool() {
+    // A user-supplied IExecutorServiceFactory (-threadpoolfactoryclass) must still get to build the
+    // shared global thread-pool, via IExecutorServiceFactory#createGlobalThreadPool.
+    int threadCount = 6;
+    ConcurrencyProbe probe = new ConcurrencyProbe();
+    RecordingExecutorServiceFactory factory = new RecordingExecutorServiceFactory();
+    TestNG testng = create(ParallelDataDrivenSample.class);
+    testng.addListener(probe);
+    testng.setParallel(XmlSuite.ParallelMode.METHODS);
+    testng.setThreadCount(threadCount);
+    testng.shouldUseGlobalThreadPool(true);
+    testng.setExecutorServiceFactory(factory);
+
+    testng.run();
+
+    assertThat(testng.getStatus())
+        .withFailMessage("The suite should run to completion without a dead-lock")
+        .isZero();
+    assertThat(factory.wasGlobalPoolCreated())
+        .withFailMessage(
+            "The custom IExecutorServiceFactory should have been asked to create the shared "
+                + "global thread-pool")
+        .isTrue();
+    assertSharedPoolIsBoundedTo(probe, threadCount);
+  }
+
+  @Test(description = "GITHUB-3242")
+  public void dataDrivenTestsSkippedFromExecutionDoNotBlockTheSuite() {
+    // The codebase declares 5 data-driven tests (== thread-count), so they are present in the run
+    // and used to trip the "[Deadlock condition detected]" guard up front - the whole suite refused
+    // to start. Even when those tests are filtered from execution at runtime (here by throwing a
+    // SkipException, as the reporter did with a listener), the shared-thread-pool suite must still
+    // start and run its remaining tests instead of being refused. See GITHUB-3242.
+    TestListenerAdapter tla = new TestListenerAdapter();
+    TestNG testng = create(SkippedDataDrivenSample.class);
+    testng.addListener(tla);
+    testng.setParallel(XmlSuite.ParallelMode.METHODS);
+    testng.setThreadCount(5);
+    testng.shouldUseGlobalThreadPool(true);
+
+    // On the old behaviour this threw TestNGDeadLockException before any method ran.
+    testng.run();
+
+    assertThat(tla.getFailedTests()).withFailMessage("No test should have failed").isEmpty();
+    assertThat(tla.getPassedTests())
+        .withFailMessage("The regular (non data-driven) test should still have run")
+        .hasSize(1);
+    assertThat(tla.getSkippedTests())
+        .withFailMessage(
+            "Every data-row of the 5 data-driven tests should have been skipped, not blocked by a "
+                + "dead-lock guard")
+        .hasSize(40);
+  }
+
+  private static void assertSharedPoolIsBoundedTo(ConcurrencyProbe probe, int threadCount) {
+    assertThat(probe.distinctThreadsUsed())
+        .withFailMessage(
+            "The shared global thread-pool must not use more than thread-count (%d) threads, but "
+                + "%d distinct threads ran the tests",
+            threadCount, probe.distinctThreadsUsed())
+        .isLessThanOrEqualTo(threadCount);
   }
 
   @DataProvider

--- a/testng-core/src/test/java/test/dataprovider/DataProviderTest.java
+++ b/testng-core/src/test/java/test/dataprovider/DataProviderTest.java
@@ -673,41 +673,49 @@ public class DataProviderTest extends SimpleBaseTest {
 
   @Test(description = "GITHUB-3081")
   public void ensureNoExceptionsWhenRunningInSharedThreadPoolsWithMethodInterceptorsNoPriorities() {
+    int threadCount = 10;
     TestNG testng = create(test.dataprovider.issue3081.TestClassSample.class);
     test.dataprovider.issue3081.TestClassSample.clear();
     testng.shouldUseGlobalThreadPool(true);
     testng.addListener(new NoOpMethodInterceptor());
-    testng.setThreadCount(10);
+    testng.setThreadCount(threadCount);
     testng.setParallel(XmlSuite.ParallelMode.METHODS);
     testng.shareThreadPoolForDataProviders(true);
     testng.setVerbose(2);
     testng.run();
     assertThat(testng.getStatus()).isEqualTo(0);
-    assertThat(test.dataprovider.issue3081.TestClassSample.getLogs())
+    assertThat(test.dataprovider.issue3081.TestClassSample.getLogs().size())
         .withFailMessage(
-            "There should have been 9 threads ONLY used by the data driven test "
-                + "because one thread would be the main thread on which TestNG would be running")
-        .hasSize(9);
+            "The data driven rows should run in parallel on the shared global thread-pool "
+                + "without ever exceeding its size. With the work-stealing pool the calling "
+                + "worker also helps run the rows, so the exact number of distinct threads that "
+                + "service them is timing dependent - it must simply stay above 1 (real "
+                + "parallelism) and at most the pool size.")
+        .isBetween(2, threadCount);
   }
 
   @Test(description = "GITHUB-3081")
   public void
       ensureNoExceptionsWhenRunningInSharedThreadPoolsWithMethodInterceptorsWithPriorities() {
+    int threadCount = 10;
     TestNG testng = create(TestClassWithPrioritiesSample.class);
     TestClassWithPrioritiesSample.clear();
     testng.shouldUseGlobalThreadPool(true);
     testng.addListener(new NoOpMethodInterceptor());
     testng.setParallel(XmlSuite.ParallelMode.METHODS);
     testng.shareThreadPoolForDataProviders(true);
-    testng.setThreadCount(10);
+    testng.setThreadCount(threadCount);
     testng.setVerbose(2);
     testng.run();
     assertThat(testng.getStatus()).isEqualTo(0);
-    assertThat(TestClassWithPrioritiesSample.getLogs())
+    assertThat(TestClassWithPrioritiesSample.getLogs().size())
         .withFailMessage(
-            "There should have been 9 threads ONLY used by the data driven test "
-                + "because one thread would be the main thread on which TestNG would be running")
-        .hasSize(9);
+            "The data driven rows should run in parallel on the shared global thread-pool "
+                + "without ever exceeding its size. With the work-stealing pool the calling "
+                + "worker also helps run the rows, so the exact number of distinct threads that "
+                + "service them is timing dependent - it must simply stay above 1 (real "
+                + "parallelism) and at most the pool size.")
+        .isBetween(2, threadCount);
   }
 
   @Test(description = "GITHUB-3242")

--- a/testng-core/src/test/java/test/dataprovider/issue3242/ConcurrencyProbe.java
+++ b/testng-core/src/test/java/test/dataprovider/issue3242/ConcurrencyProbe.java
@@ -1,0 +1,60 @@
+package test.dataprovider.issue3242;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.testng.IInvokedMethod;
+import org.testng.IInvokedMethodListener;
+import org.testng.ITestResult;
+
+/**
+ * An {@link IInvokedMethodListener} that measures how a single TestNG run exercised its
+ * thread-pool: the total number of test invocations, the highest number that ran concurrently, and
+ * the distinct threads that were used.
+ *
+ * <p>A fresh instance is created per test and attached to that test's own (nested) TestNG instance,
+ * so it holds no shared static state - it stays correct even if these unit tests are themselves run
+ * in parallel. Each invocation is bracketed by {@link #beforeInvocation}/{@link #afterInvocation}
+ * on the same thread that runs the test method, which is why the samples pause briefly: it lets the
+ * invocations overlap so the concurrency can actually be observed.
+ */
+public final class ConcurrencyProbe implements IInvokedMethodListener {
+
+  private final AtomicInteger active = new AtomicInteger();
+  private final AtomicInteger maxConcurrency = new AtomicInteger();
+  private final AtomicInteger invocations = new AtomicInteger();
+  private final Set<Long> threadIds = ConcurrentHashMap.newKeySet();
+
+  @Override
+  public void beforeInvocation(IInvokedMethod method, ITestResult testResult) {
+    if (!method.isTestMethod()) {
+      return;
+    }
+    invocations.incrementAndGet();
+    threadIds.add(Thread.currentThread().getId());
+    int current = active.incrementAndGet();
+    maxConcurrency.accumulateAndGet(current, Math::max);
+  }
+
+  @Override
+  public void afterInvocation(IInvokedMethod method, ITestResult testResult) {
+    if (method.isTestMethod()) {
+      active.decrementAndGet();
+    }
+  }
+
+  /** The total number of test invocations that were executed. */
+  public int invocations() {
+    return invocations.get();
+  }
+
+  /** The highest number of test invocations that were observed running concurrently. */
+  public int maxConcurrency() {
+    return maxConcurrency.get();
+  }
+
+  /** The number of distinct threads that ran the test invocations. */
+  public int distinctThreadsUsed() {
+    return threadIds.size();
+  }
+}

--- a/testng-core/src/test/java/test/dataprovider/issue3242/MixedThreadPoolSample.java
+++ b/testng-core/src/test/java/test/dataprovider/issue3242/MixedThreadPoolSample.java
@@ -1,0 +1,46 @@
+package test.dataprovider.issue3242;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * A sample that mixes regular (non data-driven) test methods with data-driven ones, so the tests
+ * can assert that both kinds run to completion on a single shared global thread-pool. Each
+ * invocation pauses briefly so that an attached {@link ConcurrencyProbe} can observe the
+ * concurrency.
+ */
+public class MixedThreadPoolSample {
+
+  @Test
+  public void regular1() {
+    pause();
+  }
+
+  @Test
+  public void regular2() {
+    pause();
+  }
+
+  @Test(dataProvider = "data")
+  public void dataDriven1(int ignored) {
+    pause();
+  }
+
+  @Test(dataProvider = "data")
+  public void dataDriven2(int ignored) {
+    pause();
+  }
+
+  @DataProvider(name = "data", parallel = true)
+  public Object[][] data() {
+    return new Object[][] {{1}, {2}, {3}, {4}};
+  }
+
+  private static void pause() {
+    try {
+      Thread.sleep(150);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+}

--- a/testng-core/src/test/java/test/dataprovider/issue3242/ParallelDataDrivenSample.java
+++ b/testng-core/src/test/java/test/dataprovider/issue3242/ParallelDataDrivenSample.java
@@ -1,0 +1,50 @@
+package test.dataprovider.issue3242;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * A sample that mimics the scenario reported in GITHUB-3242: a class with several data-driven test
+ * methods, each backed by a parallel data-provider. Each invocation pauses briefly so that a {@link
+ * ConcurrencyProbe} attached to the run can observe how the shared global thread-pool is used.
+ */
+public class ParallelDataDrivenSample {
+
+  @Test(dataProvider = "data")
+  public void test1(int ignored) {
+    pause();
+  }
+
+  @Test(dataProvider = "data")
+  public void test2(int ignored) {
+    pause();
+  }
+
+  @Test(dataProvider = "data")
+  public void test3(int ignored) {
+    pause();
+  }
+
+  @Test(dataProvider = "data")
+  public void test4(int ignored) {
+    pause();
+  }
+
+  @Test(dataProvider = "data")
+  public void test5(int ignored) {
+    pause();
+  }
+
+  @DataProvider(name = "data", parallel = true)
+  public Object[][] data() {
+    return new Object[][] {{1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}};
+  }
+
+  private static void pause() {
+    try {
+      Thread.sleep(150);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+}

--- a/testng-core/src/test/java/test/dataprovider/issue3242/RecordingExecutorServiceFactory.java
+++ b/testng-core/src/test/java/test/dataprovider/issue3242/RecordingExecutorServiceFactory.java
@@ -1,0 +1,44 @@
+package test.dataprovider.issue3242;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.testng.IExecutorServiceFactory;
+
+/**
+ * A custom {@link IExecutorServiceFactory} that records whether it was asked to build the shared
+ * global thread-pool. It delegates to the default (work-stealing {@link
+ * java.util.concurrent.ForkJoinPool}) implementation so the GITHUB-3242 fix still applies.
+ *
+ * <p>The recording is instance state, so a fresh factory is created per test and holds no shared
+ * static state - it stays correct even if these unit tests are themselves run in parallel.
+ */
+public class RecordingExecutorServiceFactory implements IExecutorServiceFactory {
+
+  private final AtomicBoolean globalPoolCreated = new AtomicBoolean(false);
+
+  public boolean wasGlobalPoolCreated() {
+    return globalPoolCreated.get();
+  }
+
+  @Override
+  public ExecutorService create(
+      int corePoolSize,
+      int maximumPoolSize,
+      long keepAliveTime,
+      TimeUnit unit,
+      BlockingQueue<Runnable> workQueue,
+      ThreadFactory threadFactory) {
+    return new ThreadPoolExecutor(
+        corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, threadFactory);
+  }
+
+  @Override
+  public ExecutorService createGlobalThreadPool(int parallelism, String threadNamePrefix) {
+    globalPoolCreated.set(true);
+    return IExecutorServiceFactory.super.createGlobalThreadPool(parallelism, threadNamePrefix);
+  }
+}

--- a/testng-core/src/test/java/test/dataprovider/issue3242/SharedPoolFirstTestSample.java
+++ b/testng-core/src/test/java/test/dataprovider/issue3242/SharedPoolFirstTestSample.java
@@ -1,0 +1,10 @@
+package test.dataprovider.issue3242;
+
+import org.testng.annotations.Test;
+
+/** First {@code <test>} of the GITHUB-3242 shared-pool-across-tests scenario. */
+public class SharedPoolFirstTestSample {
+
+  @Test
+  public void first() {}
+}

--- a/testng-core/src/test/java/test/dataprovider/issue3242/SharedPoolSecondTestSample.java
+++ b/testng-core/src/test/java/test/dataprovider/issue3242/SharedPoolSecondTestSample.java
@@ -1,0 +1,13 @@
+package test.dataprovider.issue3242;
+
+import org.testng.annotations.Test;
+
+/**
+ * Second {@code <test>} of the GITHUB-3242 shared-pool-across-tests scenario. Its method used to be
+ * silently dropped (its worker rejected) when the first {@code <test>} shut the shared pool down.
+ */
+public class SharedPoolSecondTestSample {
+
+  @Test
+  public void second() {}
+}

--- a/testng-core/src/test/java/test/dataprovider/issue3242/SkippedDataDrivenSample.java
+++ b/testng-core/src/test/java/test/dataprovider/issue3242/SkippedDataDrivenSample.java
@@ -1,0 +1,48 @@
+package test.dataprovider.issue3242;
+
+import org.testng.SkipException;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * A sample for the GITHUB-3242 scenario where the codebase <em>declares</em> as many data-driven
+ * tests as there are threads, but those tests are filtered from execution at runtime (each data-row
+ * throws a {@link SkipException}). The data-driven tests are still present in the run - which is
+ * what used to trip the "[Deadlock condition detected]" guard before the suite even started - so
+ * the suite must now start and run its remaining tests, skipping the data-driven ones.
+ */
+public class SkippedDataDrivenSample {
+
+  @Test
+  public void regular() {}
+
+  @Test(dataProvider = "data")
+  public void ddt1(int ignored) {
+    throw new SkipException("filtered from execution");
+  }
+
+  @Test(dataProvider = "data")
+  public void ddt2(int ignored) {
+    throw new SkipException("filtered from execution");
+  }
+
+  @Test(dataProvider = "data")
+  public void ddt3(int ignored) {
+    throw new SkipException("filtered from execution");
+  }
+
+  @Test(dataProvider = "data")
+  public void ddt4(int ignored) {
+    throw new SkipException("filtered from execution");
+  }
+
+  @Test(dataProvider = "data")
+  public void ddt5(int ignored) {
+    throw new SkipException("filtered from execution");
+  }
+
+  @DataProvider(name = "data", parallel = true)
+  public Object[][] data() {
+    return new Object[][] {{1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}};
+  }
+}

--- a/testng-core/src/test/java/test/thread/SharedThreadPoolTest.java
+++ b/testng-core/src/test/java/test/thread/SharedThreadPoolTest.java
@@ -10,7 +10,6 @@ import org.testng.TestNG;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import org.testng.internal.TestNGDeadLockException;
 import org.testng.xml.XmlSuite;
 import test.SimpleBaseTest;
 import test.thread.issue2019.TestClassSample;
@@ -75,14 +74,23 @@ public class SharedThreadPoolTest extends SimpleBaseTest {
         .hasSizeBetween(4, 10);
   }
 
-  @Test(expectedExceptions = TestNGDeadLockException.class, dataProvider = "modes")
-  public void ensureDeadLocksAreDetectedForDataDrivenTestsRunningInParallel(
+  @Test(dataProvider = "modes", description = "GITHUB-3242")
+  public void ensureDataDrivenTestsInParallelDoNotDeadlockOnSharedPool(
       XmlSuite.ParallelMode mode, Class<?>... classes) {
+    // With a shared (global) thread-pool, data-driven test methods running in parallel used to be
+    // rejected up front with a TestNGDeadLockException whenever their count reached thread-count.
+    // Those workers now help run their own data-rows (work-stealing), so the suite simply runs to
+    // completion.
     TestNG testng = create(classes);
     testng.shouldUseGlobalThreadPool(true);
     testng.setParallel(mode);
     testng.setThreadCount(2);
     testng.run();
+    assertThat(testng.getStatus())
+        .withFailMessage(
+            "A shared thread-pool suite with data-driven tests running in parallel should "
+                + "complete instead of dead-locking")
+        .isZero();
   }
 
   @Test(description = "GITHUB-3179")


### PR DESCRIPTION
Closes #3242

Fixes #3242 .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`
- [X] Auto applied styling via `./gradlew autostyleApply`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.

**Note:** For more information on contribution guidelines  please make sure you refer our [Contributing](.github/CONTRIBUTING.md) section for detailed set of steps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed deadlocks in parallel data-driven tests when using the shared/global thread pool.
  * Prevented the shared/global pool from being shut down by an earlier `<test>` block, avoiding dropped later methods.
  * Improved stability for suites mixing regular and data-driven tests, including runtime-skipped data-driven cases.
* **Performance**
  * Improved parallel data-provider execution on shared pools to keep concurrency consistent as test volume grows.
* **Tests**
  * Added concurrency/deadlock regression coverage for GITHUB-3242, including custom executor factory and shared-pool lifecycle scenarios.
* **Documentation**
  * Updated CHANGES.txt with entries for the affected issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->