### PR TITLE
Support Streams in Data provider

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 Current (7.13.0)
 Fixed: GITHUB-3242: use-global-thread-pool no longer refuses to start a suite when the number of data-driven tests reaches thread-count (Krishnan Mahadevan)
+New: GITHUB-3290: Support data providers that return Stream<Object[]> or Stream<Object>; the stream is consumed lazily and closed once its rows have been consumed (Krishnan Mahadevan)
 Fixed: GITHUB-426: firstTimeOnly @BeforeMethod / lastTimeOnly @AfterMethod were not run as a barrier around a parallel invocationCount thread pool (firstTimeOnly could run concurrently with test invocations, lastTimeOnly ran once per invocation instead of once)
 Fixed: Time-out now measures a method's own execution time instead of the wall-clock time since dispatch, so thread-pool start-up and scheduling overhead under load no longer cause spurious time-outs; a method that never starts now reports an actionable infrastructure-starvation message
 Fixed: GITHUB-3166: Skipped configuration methods not receiving the causal throwable before configuration listeners are invoked (Anmol Jain)

--- a/testng-core-api/src/main/java/org/testng/annotations/DataProvider.java
+++ b/testng-core-api/src/main/java/org/testng/annotations/DataProvider.java
@@ -15,11 +15,21 @@ import org.testng.IRetryDataProvider;
  * <p>The annotated method must return any of the following:
  *
  * <ul>
- *   <li>{@code Object[][]} or {@code Iterator<Object[]>}, where each {@code Object[]} is assigned
- *       to the parameter list of the test method.
- *   <li>{@code Object[]} or {@code Iterator<Object>}, where each {@code Object} is assigned to the
- *       single parameter of the test method.
+ *   <li>{@code Object[][]}, {@code Iterator<Object[]>} or {@code Stream<Object[]>}, where each
+ *       {@code Object[]} is assigned to the parameter list of the test method.
+ *   <li>{@code Object[]}, {@code Iterator<Object>} or {@code Stream<Object>}, where each {@code
+ *       Object} is assigned to the single parameter of the test method.
  * </ul>
+ *
+ * <p>{@code Iterator} and {@code Stream} return types are consumed lazily.
+ *
+ * <p><b>Note on parallel streams:</b> a returned {@code Stream} is always consumed sequentially,
+ * one row at a time, via its {@link java.util.stream.Stream#iterator() iterator}. Returning a
+ * parallel stream (for example one created with {@link java.util.stream.Stream#parallel()}) is
+ * accepted and works correctly, but the stream's parallelism has no effect - {@code iterator()}
+ * collapses any stream to a sequential traversal, so no data is produced in parallel. To run the
+ * test method's invocations in parallel, use {@link #parallel()} (optionally together with the
+ * {@code dataproviderthreadcount} setting) instead of {@code Stream.parallel()}.
  *
  * <p>The {@link Test @Test} method that wants to receive data from this {@link DataProvider} needs
  * to use a {@link Test#dataProvider()} name equal to the name of this annotation.

--- a/testng-core/src/main/java/org/testng/internal/FactoryMethod.java
+++ b/testng-core/src/main/java/org/testng/internal/FactoryMethod.java
@@ -23,6 +23,7 @@ import org.testng.annotations.IListenersAnnotation;
 import org.testng.collections.Lists;
 import org.testng.collections.Maps;
 import org.testng.internal.annotations.IAnnotationFinder;
+import org.testng.internal.invokers.ParameterHolder;
 import org.testng.xml.XmlTest;
 
 /** This class represents a method annotated with @Factory */
@@ -157,19 +158,19 @@ public class FactoryMethod extends BaseTestMethod {
             m_testContext,
             null /* testResult */);
 
-    Iterator<Object[]> parameterIterator =
+    ParameterHolder parameterHolder =
         Parameters.handleParameters(
-                m_objectFactory,
-                this,
-                allParameterNames,
-                m_instance,
-                methodParameters,
-                m_testContext.getCurrentXmlTest().getSuite(),
-                m_annotationFinder,
-                null /* fedInstance */,
-                this.holder,
-                "@Factory")
-            .parameters;
+            m_objectFactory,
+            this,
+            allParameterNames,
+            m_instance,
+            methodParameters,
+            m_testContext.getCurrentXmlTest().getSuite(),
+            m_annotationFinder,
+            null /* fedInstance */,
+            this.holder,
+            "@Factory");
+    Iterator<Object[]> parameterIterator = parameterHolder.parameters;
 
     try {
       List<Integer> indices = factoryAnnotation.getIndices();
@@ -224,6 +225,10 @@ public class FactoryMethod extends BaseTestMethod {
               + com.getName()
               + "() threw an exception",
           t);
+    } finally {
+      // Release any resource backing a lazily-loaded data provider (for example a Stream) once the
+      // factory has consumed the rows it needs.
+      parameterHolder.close();
     }
 
     return result.toArray(new IParameterInfo[0]);

--- a/testng-core/src/main/java/org/testng/internal/Parameters.java
+++ b/testng-core/src/main/java/org/testng/internal/Parameters.java
@@ -24,6 +24,7 @@ import org.testng.internal.annotations.AnnotationHelper;
 import org.testng.internal.annotations.IAnnotationFinder;
 import org.testng.internal.annotations.IDataProvidable;
 import org.testng.internal.collections.ArrayIterator;
+import org.testng.internal.collections.CloseableIterator;
 import org.testng.internal.invokers.MethodInvocationHelper;
 import org.testng.internal.invokers.ParameterHolder;
 import org.testng.internal.invokers.ParameterHolder.ParameterOrigin;
@@ -801,7 +802,7 @@ public class Parameters {
         retry = (IRetryDataProvider) dispenser.dispense(attributes);
       }
 
-      Iterator<Object[]> initParams = null;
+      CloseableIterator<Object[]> initParams = null;
       RuntimeException thrownException;
       do {
 
@@ -858,6 +859,9 @@ public class Parameters {
 
       Iterator<Object[]> filteredParameters =
           new FilteredParameters(initParams, testMethod, dataProviderMethod.getName(), allIndices);
+      // Preserve a handle on the original closeable source before it is wrapped by
+      // FilteredParameters and any interceptors, so the resource can be released later.
+      CloseableIterator<Object[]> closeableSource = initParams;
 
       testMethod.setMoreInvocationChecker(filteredParameters::hasNext);
       for (IDataProviderInterceptor interceptor : holder.getInterceptors()) {
@@ -875,7 +879,10 @@ public class Parameters {
       }
 
       return new ParameterHolder(
-          filteredParameters, ParameterOrigin.ORIGIN_DATA_PROVIDER, dataProviderMethod);
+          filteredParameters,
+          ParameterOrigin.ORIGIN_DATA_PROVIDER,
+          dataProviderMethod,
+          closeableSource);
     } else if (methodParams.xmlParameters.isEmpty()) {
       origin = ParameterOrigin.NATIVE;
     } else {

--- a/testng-core/src/main/java/org/testng/internal/Parameters.java
+++ b/testng-core/src/main/java/org/testng/internal/Parameters.java
@@ -847,42 +847,52 @@ public class Parameters {
         throw thrownException;
       }
 
-      for (IDataProviderListener dataProviderListener : holder.getListeners()) {
-        dataProviderListener.afterDataProviderExecution(
-            dataProviderMethod, testMethod, methodParams.context);
-      }
-
-      // If the data provider is restricting the indices to return, filter them out
-      final List<Integer> allIndices = new ArrayList<>();
-      allIndices.addAll(testMethod.getInvocationNumbers());
-      allIndices.addAll(dataProviderMethod.getIndices());
-
-      Iterator<Object[]> filteredParameters =
-          new FilteredParameters(initParams, testMethod, dataProviderMethod.getName(), allIndices);
       // Preserve a handle on the original closeable source before it is wrapped by
-      // FilteredParameters and any interceptors, so the resource can be released later.
+      // FilteredParameters and any interceptors, so the resource can be released later - including
+      // if the setup below (listeners / filtering / interceptors) throws before a ParameterHolder
+      // takes ownership of it.
       CloseableIterator<Object[]> closeableSource = initParams;
-
-      testMethod.setMoreInvocationChecker(filteredParameters::hasNext);
-      for (IDataProviderInterceptor interceptor : holder.getInterceptors()) {
-        filteredParameters =
-            interceptor.intercept(
-                filteredParameters, dataProviderMethod, testMethod, methodParams.context);
-      }
-
-      if (dataProviderMethod instanceof DataProviderMethodRemovable) {
-        ((DataProviderMethodRemovable) dataProviderMethod).setMethod(null);
-        ((DataProviderMethodRemovable) dataProviderMethod).setInstance(null);
-        if (testMethod instanceof TestNGMethod) {
-          ((TestNGMethod) testMethod).setDataProviderMethod(null);
+      try {
+        for (IDataProviderListener dataProviderListener : holder.getListeners()) {
+          dataProviderListener.afterDataProviderExecution(
+              dataProviderMethod, testMethod, methodParams.context);
         }
-      }
 
-      return new ParameterHolder(
-          filteredParameters,
-          ParameterOrigin.ORIGIN_DATA_PROVIDER,
-          dataProviderMethod,
-          closeableSource);
+        // If the data provider is restricting the indices to return, filter them out
+        final List<Integer> allIndices = new ArrayList<>();
+        allIndices.addAll(testMethod.getInvocationNumbers());
+        allIndices.addAll(dataProviderMethod.getIndices());
+
+        Iterator<Object[]> filteredParameters =
+            new FilteredParameters(
+                initParams, testMethod, dataProviderMethod.getName(), allIndices);
+
+        testMethod.setMoreInvocationChecker(filteredParameters::hasNext);
+        for (IDataProviderInterceptor interceptor : holder.getInterceptors()) {
+          filteredParameters =
+              interceptor.intercept(
+                  filteredParameters, dataProviderMethod, testMethod, methodParams.context);
+        }
+
+        if (dataProviderMethod instanceof DataProviderMethodRemovable) {
+          ((DataProviderMethodRemovable) dataProviderMethod).setMethod(null);
+          ((DataProviderMethodRemovable) dataProviderMethod).setInstance(null);
+          if (testMethod instanceof TestNGMethod) {
+            ((TestNGMethod) testMethod).setDataProviderMethod(null);
+          }
+        }
+
+        return new ParameterHolder(
+            filteredParameters,
+            ParameterOrigin.ORIGIN_DATA_PROVIDER,
+            dataProviderMethod,
+            closeableSource);
+      } catch (RuntimeException | Error e) {
+        // Setup failed before the ParameterHolder could take ownership of the source, so no one
+        // else will close it; release it here so a Stream-backed data provider does not leak.
+        closeableSource.close();
+        throw e;
+      }
     } else if (methodParams.xmlParameters.isEmpty()) {
       origin = ParameterOrigin.NATIVE;
     } else {

--- a/testng-core/src/main/java/org/testng/internal/collections/CloseableIterator.java
+++ b/testng-core/src/main/java/org/testng/internal/collections/CloseableIterator.java
@@ -1,0 +1,18 @@
+package org.testng.internal.collections;
+
+import java.util.Iterator;
+
+/**
+ * An {@link Iterator} that may own a resource (such as a {@link java.util.stream.Stream}) which
+ * must be released once iteration is finished. Callers that drive the iterator are responsible for
+ * invoking {@link #close()} when they are done consuming it - whether the iterator was fully
+ * drained or not.
+ *
+ * <p>{@link #close()} never throws a checked exception, is idempotent and is a no-op for iterators
+ * that own no resource.
+ */
+public interface CloseableIterator<T> extends Iterator<T>, AutoCloseable {
+
+  @Override
+  void close();
+}

--- a/testng-core/src/main/java/org/testng/internal/collections/ResourceAwareIterator.java
+++ b/testng-core/src/main/java/org/testng/internal/collections/ResourceAwareIterator.java
@@ -1,5 +1,8 @@
 package org.testng.internal.collections;
 
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.Iterator;
 import org.testng.internal.Utils;
 
@@ -26,6 +29,51 @@ public class ResourceAwareIterator<T> implements CloseableIterator<T> {
   public ResourceAwareIterator(Iterator<T> delegate, AutoCloseable resource) {
     this.delegate = delegate;
     this.resource = resource;
+  }
+
+  /**
+   * Builds a {@link CloseableIterator} of {@code Object[]} rows from the iterator produced by a
+   * lazily-loaded data provider (either an {@code Iterator} or a {@code Stream}). The declared
+   * generic return type is inspected to decide whether each element is already an {@code Object[]}
+   * row or a single value that needs to be wrapped into one.
+   *
+   * @param iterator the iterator produced by the data provider.
+   * @param returnType the declared generic return type of the data provider method.
+   * @param resource the resource to release on {@link #close()} (typically the {@code Stream} the
+   *     iterator was derived from), or {@code null} if there is nothing to release.
+   */
+  public static CloseableIterator<Object[]> forDataProvider(
+      Iterator<Object> iterator, Type returnType, AutoCloseable resource) {
+    return new ResourceAwareIterator<>(toObjectArrayIterator(iterator, returnType), resource);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Iterator<Object[]> toObjectArrayIterator(
+      Iterator<Object> iterator, Type returnType) {
+    if (!(returnType instanceof ParameterizedType)) {
+      // Raw Iterator/Stream, we expect the user to provide rows of the expected shape.
+      return (Iterator<Object[]>) (Iterator<?>) iterator;
+    }
+
+    // Inspect only the direct element type of the Iterator/Stream. Each element is treated as an
+    // already-formed Object[] row only when that element type is itself a reference (non-primitive)
+    // array; otherwise every element is wrapped into a single-element row. This keeps, for example,
+    // Stream<List<Object[]>> being delivered as one List<Object[]> parameter rather than being
+    // mistaken for a row of Object[].
+    Type elementType = ((ParameterizedType) returnType).getActualTypeArguments()[0];
+    if (isObjectArrayRow(elementType)) {
+      return (Iterator<Object[]>) (Iterator<?>) iterator;
+    }
+    return new OneToTwoDimIterator(iterator);
+  }
+
+  private static boolean isObjectArrayRow(Type elementType) {
+    if (elementType instanceof Class) {
+      Class<?> clazz = (Class<?>) elementType;
+      return clazz.isArray() && !clazz.getComponentType().isPrimitive();
+    }
+    // A generic array type such as T[] is also a reference-array row.
+    return elementType instanceof GenericArrayType;
   }
 
   @Override

--- a/testng-core/src/main/java/org/testng/internal/collections/ResourceAwareIterator.java
+++ b/testng-core/src/main/java/org/testng/internal/collections/ResourceAwareIterator.java
@@ -1,0 +1,60 @@
+package org.testng.internal.collections;
+
+import java.util.Iterator;
+import org.testng.internal.Utils;
+
+/**
+ * A {@link CloseableIterator} that delegates iteration to another {@link Iterator} and, on {@link
+ * #close()}, releases an optional resource (for example the {@link java.util.stream.Stream} the
+ * delegate was derived from). When no resource is supplied, {@link #close()} is a no-op.
+ *
+ * <p>The iterator is consumed lazily; the backing resource is only released when {@link #close()}
+ * is called, so a data provider that returns a resource-backed {@code Stream} keeps that resource
+ * open for exactly as long as the rows are being pulled.
+ */
+public class ResourceAwareIterator<T> implements CloseableIterator<T> {
+
+  private final Iterator<T> delegate;
+  private final AutoCloseable resource;
+  private boolean closed;
+
+  /**
+   * @param delegate the iterator that actually produces the elements.
+   * @param resource the resource to release on {@link #close()}, or {@code null} if there is
+   *     nothing to release.
+   */
+  public ResourceAwareIterator(Iterator<T> delegate, AutoCloseable resource) {
+    this.delegate = delegate;
+    this.resource = resource;
+  }
+
+  @Override
+  public boolean hasNext() {
+    return delegate.hasNext();
+  }
+
+  @Override
+  public T next() {
+    return delegate.next();
+  }
+
+  @Override
+  public void remove() {
+    delegate.remove();
+  }
+
+  @Override
+  public void close() {
+    if (closed || resource == null) {
+      return;
+    }
+    closed = true;
+    try {
+      resource.close();
+    } catch (Exception e) {
+      // Closing happens during clean-up, after the data has already been consumed, so a failure
+      // here must never mask the outcome of the test(s) that used this data provider.
+      Utils.warn("Failed to close the resource backing a data provider: " + e);
+    }
+  }
+}

--- a/testng-core/src/main/java/org/testng/internal/invokers/MethodInvocationHelper.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/MethodInvocationHelper.java
@@ -4,8 +4,6 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -38,7 +36,6 @@ import org.testng.internal.annotations.IAnnotationFinder;
 import org.testng.internal.collections.ArrayIterator;
 import org.testng.internal.collections.CloseableIterator;
 import org.testng.internal.collections.OneToTwoDimArrayIterator;
-import org.testng.internal.collections.OneToTwoDimIterator;
 import org.testng.internal.collections.Pair;
 import org.testng.internal.collections.ResourceAwareIterator;
 import org.testng.internal.invokers.InvokeMethodRunnable.TestNGRuntimeException;
@@ -185,17 +182,15 @@ public class MethodInvocationHelper {
     } else if (result instanceof Object[]) {
       return new ResourceAwareIterator<>(new OneToTwoDimArrayIterator((Object[]) result), null);
     } else if (result instanceof Iterator) {
-      Iterator<Object[]> iterator =
-          toObjectArrayIterator((Iterator<Object>) result, dataProvider.getGenericReturnType());
-      return new ResourceAwareIterator<>(iterator, null);
+      return ResourceAwareIterator.forDataProvider(
+          (Iterator<Object>) result, dataProvider.getGenericReturnType(), null);
     } else if (result instanceof Stream) {
       // A Stream is AutoCloseable and must be released once the rows have been consumed, so keep a
       // handle on it and hand it to the iterator as the resource to close. Iteration stays lazy: we
       // drive the Stream through its own iterator() rather than collecting it eagerly.
       Stream<Object> stream = (Stream<Object>) result;
-      Iterator<Object[]> iterator =
-          toObjectArrayIterator(stream.iterator(), dataProvider.getGenericReturnType());
-      return new ResourceAwareIterator<>(iterator, stream);
+      return ResourceAwareIterator.forDataProvider(
+          stream.iterator(), dataProvider.getGenericReturnType(), stream);
     }
     throw new TestNGException(
         "Data Provider "
@@ -204,34 +199,6 @@ public class MethodInvocationHelper {
             + " either Object[][] or Object[] or Iterator<Object[]> or Iterator<Object>"
             + " or Stream<Object[]> or Stream<Object>, not "
             + dataProvider.getReturnType());
-  }
-
-  /**
-   * Converts the iterator produced by a lazily-loaded data provider (either an {@code Iterator} or
-   * a {@code Stream}) into an {@code Iterator<Object[]>} that the invoker consumes, inspecting the
-   * declared generic return type to decide whether each element is already an {@code Object[]} row
-   * or a single value that needs to be wrapped into one.
-   */
-  @SuppressWarnings("unchecked")
-  private static Iterator<Object[]> toObjectArrayIterator(
-      Iterator<Object> iterator, Type returnType) {
-    if (!(returnType instanceof ParameterizedType)) {
-      // Raw Iterator/Stream, we expect user provides the expected type
-      return (Iterator<Object[]>) (Iterator<?>) iterator;
-    }
-
-    ParameterizedType contentType = (ParameterizedType) returnType;
-    Type actualType = contentType.getActualTypeArguments()[0];
-    Class<?> type;
-    if (actualType instanceof ParameterizedType) {
-      type = (Class<?>) ((ParameterizedType) actualType).getActualTypeArguments()[0];
-    } else {
-      type = (Class<?>) actualType;
-    }
-    if (type.isArray()) {
-      return (Iterator<Object[]>) (Iterator<?>) iterator;
-    }
-    return new OneToTwoDimIterator(iterator);
   }
 
   private static List<Object> getParameters(

--- a/testng-core/src/main/java/org/testng/internal/invokers/MethodInvocationHelper.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/MethodInvocationHelper.java
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import org.testng.IConfigurable;
 import org.testng.IConfigureCallBack;
 import org.testng.IHookCallBack;
@@ -35,9 +36,11 @@ import org.testng.internal.MethodHelper;
 import org.testng.internal.Utils;
 import org.testng.internal.annotations.IAnnotationFinder;
 import org.testng.internal.collections.ArrayIterator;
+import org.testng.internal.collections.CloseableIterator;
 import org.testng.internal.collections.OneToTwoDimArrayIterator;
 import org.testng.internal.collections.OneToTwoDimIterator;
 import org.testng.internal.collections.Pair;
+import org.testng.internal.collections.ResourceAwareIterator;
 import org.testng.internal.invokers.InvokeMethodRunnable.TestNGRuntimeException;
 import org.testng.internal.thread.TestNGThreadFactory;
 import org.testng.internal.thread.ThreadExecutionException;
@@ -163,7 +166,7 @@ public class MethodInvocationHelper {
   }
 
   @SuppressWarnings("unchecked")
-  public static Iterator<Object[]> invokeDataProvider(
+  public static CloseableIterator<Object[]> invokeDataProvider(
       Object instance,
       Method dataProvider,
       ITestNGMethod method,
@@ -178,36 +181,57 @@ public class MethodInvocationHelper {
     }
     // If it returns an Object[][] or Object[], convert it to an Iterator<Object[]>
     if (result instanceof Object[][]) {
-      return new ArrayIterator((Object[][]) result);
+      return new ResourceAwareIterator<>(new ArrayIterator((Object[][]) result), null);
     } else if (result instanceof Object[]) {
-      return new OneToTwoDimArrayIterator((Object[]) result);
+      return new ResourceAwareIterator<>(new OneToTwoDimArrayIterator((Object[]) result), null);
     } else if (result instanceof Iterator) {
-      Type returnType = dataProvider.getGenericReturnType();
-      if (returnType instanceof ParameterizedType) {
-        ParameterizedType contentType = (ParameterizedType) returnType;
-        Type actualType = contentType.getActualTypeArguments()[0];
-        Class<?> type;
-        if (actualType instanceof ParameterizedType) {
-          type = (Class<?>) ((ParameterizedType) actualType).getActualTypeArguments()[0];
-        } else {
-          type = (Class<?>) actualType;
-        }
-        if (type.isArray()) {
-          return (Iterator<Object[]>) result;
-        } else {
-          return new OneToTwoDimIterator((Iterator<Object>) result);
-        }
-      } else {
-        // Raw Iterator, we expect user provides the expected type
-        return (Iterator<Object[]>) result;
-      }
+      Iterator<Object[]> iterator =
+          toObjectArrayIterator((Iterator<Object>) result, dataProvider.getGenericReturnType());
+      return new ResourceAwareIterator<>(iterator, null);
+    } else if (result instanceof Stream) {
+      // A Stream is AutoCloseable and must be released once the rows have been consumed, so keep a
+      // handle on it and hand it to the iterator as the resource to close. Iteration stays lazy: we
+      // drive the Stream through its own iterator() rather than collecting it eagerly.
+      Stream<Object> stream = (Stream<Object>) result;
+      Iterator<Object[]> iterator =
+          toObjectArrayIterator(stream.iterator(), dataProvider.getGenericReturnType());
+      return new ResourceAwareIterator<>(iterator, stream);
     }
     throw new TestNGException(
         "Data Provider "
             + dataProvider
             + " must return"
-            + " either Object[][] or Object[] or Iterator<Object[]> or Iterator<Object>, not "
+            + " either Object[][] or Object[] or Iterator<Object[]> or Iterator<Object>"
+            + " or Stream<Object[]> or Stream<Object>, not "
             + dataProvider.getReturnType());
+  }
+
+  /**
+   * Converts the iterator produced by a lazily-loaded data provider (either an {@code Iterator} or
+   * a {@code Stream}) into an {@code Iterator<Object[]>} that the invoker consumes, inspecting the
+   * declared generic return type to decide whether each element is already an {@code Object[]} row
+   * or a single value that needs to be wrapped into one.
+   */
+  @SuppressWarnings("unchecked")
+  private static Iterator<Object[]> toObjectArrayIterator(
+      Iterator<Object> iterator, Type returnType) {
+    if (!(returnType instanceof ParameterizedType)) {
+      // Raw Iterator/Stream, we expect user provides the expected type
+      return (Iterator<Object[]>) (Iterator<?>) iterator;
+    }
+
+    ParameterizedType contentType = (ParameterizedType) returnType;
+    Type actualType = contentType.getActualTypeArguments()[0];
+    Class<?> type;
+    if (actualType instanceof ParameterizedType) {
+      type = (Class<?>) ((ParameterizedType) actualType).getActualTypeArguments()[0];
+    } else {
+      type = (Class<?>) actualType;
+    }
+    if (type.isArray()) {
+      return (Iterator<Object[]>) (Iterator<?>) iterator;
+    }
+    return new OneToTwoDimIterator(iterator);
   }
 
   private static List<Object> getParameters(

--- a/testng-core/src/main/java/org/testng/internal/invokers/ParameterHolder.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/ParameterHolder.java
@@ -2,12 +2,13 @@ package org.testng.internal.invokers;
 
 import java.util.Iterator;
 import org.testng.IDataProviderMethod;
+import org.testng.internal.collections.CloseableIterator;
 
 /**
  * A simple holder for parameters that contains the parameters and where these came from (data
  * provider or testng.xml)
  */
-public class ParameterHolder {
+public class ParameterHolder implements AutoCloseable {
   /** Origin of the parameters. */
   public enum ParameterOrigin {
     ORIGIN_DATA_PROVIDER, // A data provider
@@ -19,11 +20,40 @@ public class ParameterHolder {
   public final Iterator<Object[]> parameters;
   final ParameterOrigin origin;
 
+  /**
+   * The (optional) closeable data provider source that {@link #parameters} was derived from. It is
+   * kept separately from {@link #parameters} - which may have been wrapped by {@code
+   * FilteredParameters} and by user supplied {@code IDataProviderInterceptor}s - so that the
+   * original resource is released regardless of how the exposed iterator was wrapped or how much of
+   * it was consumed.
+   */
+  private final CloseableIterator<Object[]> closeableSource;
+
   public ParameterHolder(
       Iterator<Object[]> parameters, ParameterOrigin origin, IDataProviderMethod dph) {
+    this(parameters, origin, dph, null);
+  }
+
+  public ParameterHolder(
+      Iterator<Object[]> parameters,
+      ParameterOrigin origin,
+      IDataProviderMethod dph,
+      CloseableIterator<Object[]> closeableSource) {
     super();
     this.parameters = parameters;
     this.origin = origin;
     this.dataProviderHolder = dph;
+    this.closeableSource = closeableSource;
+  }
+
+  /**
+   * Releases the resource backing a lazily-loaded data provider (for example a {@code Stream}), if
+   * any. Safe to call more than once and a no-op when there is nothing to release. Never throws.
+   */
+  @Override
+  public void close() {
+    if (closeableSource != null) {
+      closeableSource.close();
+    }
   }
 }

--- a/testng-core/src/main/java/org/testng/internal/invokers/TestInvoker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/TestInvoker.java
@@ -138,20 +138,25 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
         ParameterBag bag =
             handler.createParameters(
                 testMethod, Maps.newHashMap(), Maps.newHashMap(), context, instance);
-        Iterator<Object[]> allParamValues = Objects.requireNonNull(bag.parameterHolder).parameters;
-        Iterable<Object[]> allParameterValues = CollectionUtils.asIterable(allParamValues);
-        for (Object[] next : allParameterValues) {
-          if (next == null) {
-            continue;
+        ParameterHolder parameterHolder = Objects.requireNonNull(bag.parameterHolder);
+        try {
+          Iterator<Object[]> allParamValues = parameterHolder.parameters;
+          Iterable<Object[]> allParameterValues = CollectionUtils.asIterable(allParamValues);
+          for (Object[] next : allParameterValues) {
+            if (next == null) {
+              continue;
+            }
+            Method m = testMethod.getConstructorOrMethod().getMethod();
+            Object[] parameterValues = Parameters.injectParameters(next, m, context);
+            ITestResult result =
+                registerSkippedTestResult(
+                    testMethod, System.currentTimeMillis(), new Throwable(okToProceed));
+            result.setParameters(parameterValues);
+            resultProcessor.accept(result);
+            results.add(result);
           }
-          Method m = testMethod.getConstructorOrMethod().getMethod();
-          Object[] parameterValues = Parameters.injectParameters(next, m, context);
-          ITestResult result =
-              registerSkippedTestResult(
-                  testMethod, System.currentTimeMillis(), new Throwable(okToProceed));
-          result.setParameters(parameterValues);
-          resultProcessor.accept(result);
-          results.add(result);
+        } finally {
+          parameterHolder.close();
         }
       } else {
         ITestResult result =
@@ -259,14 +264,18 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
           continue;
         }
         if (bag.parameterHolder != null) {
-          Iterator<Object[]> it = bag.parameterHolder.parameters;
-          int targetIndex = arguments.getParametersIndex();
-          for (int i = 0; it.hasNext(); i++) {
-            Object[] current = it.next();
-            if (i == targetIndex) {
-              parameterValues = current;
-              break;
+          try {
+            Iterator<Object[]> it = bag.parameterHolder.parameters;
+            int targetIndex = arguments.getParametersIndex();
+            for (int i = 0; it.hasNext(); i++) {
+              Object[] current = it.next();
+              if (i == targetIndex) {
+                parameterValues = current;
+                break;
+              }
             }
+          } finally {
+            bag.parameterHolder.close();
           }
         }
       }
@@ -1036,8 +1045,8 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
         return invocationCount.get();
       }
 
-      Iterator<Object[]> allParameterValues =
-          Objects.requireNonNull(bag.parameterHolder).parameters;
+      ParameterHolder parameterHolder = Objects.requireNonNull(bag.parameterHolder);
+      Iterator<Object[]> allParameterValues = parameterHolder.parameters;
 
       try {
 
@@ -1075,7 +1084,12 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
         result.add(r);
         runTestResultListener(r);
         m_notifier.addFailedTest(arguments.getTestMethod(), r);
-      } // catch
+      } finally {
+        // The runners above consume the iterator synchronously (runInParallel blocks until every
+        // invocation has completed), so by this point the data provider has been fully drained or
+        // abandoned and it is safe to release any resource backing it.
+        parameterHolder.close();
+      }
       return invocationCount.get();
     }
   }

--- a/testng-core/src/test/java/test/dataprovider/DataProviderTest.java
+++ b/testng-core/src/test/java/test/dataprovider/DataProviderTest.java
@@ -81,7 +81,9 @@ import test.dataprovider.issue3290.StreamDataProviderSample;
 import test.dataprovider.issue3290.StreamFactoryDataProviderSample;
 import test.dataprovider.issue3290.StreamIndicesSample;
 import test.dataprovider.issue3290.StreamLazyLoadingDataProviderSample;
+import test.dataprovider.issue3290.StreamOfListRowsDataProviderSample;
 import test.dataprovider.issue3290.StreamRetryDataProviderSample;
+import test.dataprovider.issue3290.ThrowingAfterExecutionListener;
 import test.dataprovider.issue3290.UnsupportedReturnTypeDataProviderSample;
 
 public class DataProviderTest extends SimpleBaseTest {
@@ -259,12 +261,28 @@ public class DataProviderTest extends SimpleBaseTest {
   @Test(description = "GITHUB-3290")
   public void streamDataProviderShouldBeClosedWhenUsedByFactory() {
     StreamFactoryDataProviderSample.CLOSE_COUNT.set(0);
+    StreamFactoryDataProviderSample.RECEIVED.clear();
 
     InvokedMethodNameListener listener = run(StreamFactoryDataProviderSample.class);
 
     // The factory produces one instance per stream row; each instance runs testMethod once.
     assertThat(listener.getSucceedMethodNames()).containsExactly("testMethod", "testMethod");
+    // Both rows created an instance, and each row's argument was forwarded to its instance.
+    assertThat(StreamFactoryDataProviderSample.RECEIVED).containsExactlyInAnyOrder(1, 2);
     assertThat(StreamFactoryDataProviderSample.CLOSE_COUNT).hasValue(1);
+  }
+
+  @Test(description = "GITHUB-3290")
+  public void streamShouldBeClosedWhenParameterSetupFailsAfterDataProviderExecution() {
+    StreamClosingDataProviderSample.CLOSE_COUNT.set(0);
+
+    TestNG tng = create(StreamClosingDataProviderSample.class);
+    tng.addListener(new ThrowingAfterExecutionListener());
+    run(false, tng);
+
+    // The listener throws after the data provider was invoked but before a ParameterHolder takes
+    // ownership of the source; the stream must still be closed rather than leaked.
+    assertThat(StreamClosingDataProviderSample.CLOSE_COUNT).hasValue(1);
   }
 
   @Test(description = "GITHUB-3290")
@@ -315,6 +333,16 @@ public class DataProviderTest extends SimpleBaseTest {
   }
 
   @Test(description = "GITHUB-3290")
+  public void streamOfListRowsShouldDeliverEachListAsASingleParameter() {
+    InvokedMethodNameListener listener = run(StreamOfListRowsDataProviderSample.class);
+
+    // Stream<List<Object[]>>: each List is one parameter, so there are exactly two invocations and
+    // neither List is flattened into an Object[] row.
+    assertThat(listener.getFailedMethodNames()).isEmpty();
+    assertThat(listener.getSucceedMethodNames()).hasSize(2);
+  }
+
+  @Test(description = "GITHUB-3290")
   public void rawStreamDataProviderShouldWork() {
     InvokedMethodNameListener listener = run(RawStreamDataProviderSample.class);
 
@@ -327,10 +355,16 @@ public class DataProviderTest extends SimpleBaseTest {
   @Test(description = "GITHUB-3290")
   public void parallelStreamDataProviderShouldWorkAndBeClosed() {
     ParallelStreamDataProviderSample.CLOSE_COUNT.set(0);
+    List<String> expected = new ArrayList<>();
+    for (int i = 1; i <= ParallelStreamDataProviderSample.ROWS; i++) {
+      expected.add("checkParallel(" + i + ")");
+    }
 
     InvokedMethodNameListener listener = run(ParallelStreamDataProviderSample.class);
 
-    assertThat(listener.getSucceedMethodNames()).hasSize(50);
+    // Every row must be delivered exactly once (no loss, no duplicates) and the stream closed once.
+    assertThat(listener.getFailedMethodNames()).isEmpty();
+    assertThat(listener.getSucceedMethodNames()).containsExactlyInAnyOrderElementsOf(expected);
     assertThat(ParallelStreamDataProviderSample.CLOSE_COUNT).hasValue(1);
   }
 

--- a/testng-core/src/test/java/test/dataprovider/DataProviderTest.java
+++ b/testng-core/src/test/java/test/dataprovider/DataProviderTest.java
@@ -69,6 +69,20 @@ import test.dataprovider.issue3242.SharedPoolSecondTestSample;
 import test.dataprovider.issue3242.SkippedDataDrivenSample;
 import test.dataprovider.issue3263.FirstSubclassTestSample;
 import test.dataprovider.issue3263.SecondSubclassTestSample;
+import test.dataprovider.issue3290.DrainingDataProviderInterceptor;
+import test.dataprovider.issue3290.EmptyStreamDataProviderSample;
+import test.dataprovider.issue3290.FileBackedStreamDataProviderSample;
+import test.dataprovider.issue3290.ParallelConsumerOfParallelStreamSample;
+import test.dataprovider.issue3290.ParallelStreamDataProviderSample;
+import test.dataprovider.issue3290.RawStreamDataProviderSample;
+import test.dataprovider.issue3290.SequentialConsumerOfParallelStreamSample;
+import test.dataprovider.issue3290.StreamClosingDataProviderSample;
+import test.dataprovider.issue3290.StreamDataProviderSample;
+import test.dataprovider.issue3290.StreamFactoryDataProviderSample;
+import test.dataprovider.issue3290.StreamIndicesSample;
+import test.dataprovider.issue3290.StreamLazyLoadingDataProviderSample;
+import test.dataprovider.issue3290.StreamRetryDataProviderSample;
+import test.dataprovider.issue3290.UnsupportedReturnTypeDataProviderSample;
 
 public class DataProviderTest extends SimpleBaseTest {
 
@@ -192,6 +206,177 @@ public class DataProviderTest extends SimpleBaseTest {
             "testIterator(foo)", "testIterator(bar)",
             "testStaticArray(foo)", "testStaticArray(bar)",
             "testStaticIterator(foo)", "testStaticIterator(bar)");
+  }
+
+  @Test(description = "GITHUB-3290")
+  public void streamDataProviderShouldWork() {
+    InvokedMethodNameListener listener = run(StreamDataProviderSample.class);
+
+    assertThat(listener.getSucceedMethodNames())
+        .containsExactly(
+            "testOneDimStream(foo)", "testOneDimStream(bar)",
+            "testStaticOneDimStream(foo)", "testStaticOneDimStream(bar)",
+            "testStaticStream(Jack,5)", "testStaticStream(Joe,10)",
+            "testStream(Jack,5)", "testStream(Joe,10)");
+  }
+
+  @Test(description = "GITHUB-3290")
+  public void streamDataProviderShouldBeClosedAfterConsumption() {
+    StreamClosingDataProviderSample.CLOSE_COUNT.set(0);
+
+    InvokedMethodNameListener listener = run(StreamClosingDataProviderSample.class);
+
+    assertThat(listener.getSucceedMethodNames())
+        .containsExactly("testMethod(Jack,5)", "testMethod(Joe,10)");
+    assertThat(StreamClosingDataProviderSample.CLOSE_COUNT).hasValue(1);
+  }
+
+  @Test(description = "GITHUB-3290")
+  public void resourceBackedStreamDataProviderShouldWorkAndBeClosed() {
+    FileBackedStreamDataProviderSample.CLOSE_COUNT.set(0);
+
+    InvokedMethodNameListener listener = run(FileBackedStreamDataProviderSample.class);
+
+    assertThat(listener.getSucceedMethodNames())
+        .containsExactly("testMethod(Jack,5)", "testMethod(Joe,10)");
+    assertThat(FileBackedStreamDataProviderSample.CLOSE_COUNT).hasValue(1);
+  }
+
+  @Test(description = "GITHUB-3290")
+  public void streamDataProviderShouldBeClosedEvenWhenInterceptorReplacesIterator() {
+    StreamClosingDataProviderSample.CLOSE_COUNT.set(0);
+
+    TestNG tng = create(StreamClosingDataProviderSample.class);
+    tng.addListener(new DrainingDataProviderInterceptor());
+    InvokedMethodNameListener listener = run(false, tng);
+
+    // The interceptor drains the stream-backed iterator, drops the first row and hands back a
+    // brand-new iterator; the stream must still be closed exactly once.
+    assertThat(listener.getSucceedMethodNames()).containsExactly("testMethod(Joe,10)");
+    assertThat(StreamClosingDataProviderSample.CLOSE_COUNT).hasValue(1);
+  }
+
+  @Test(description = "GITHUB-3290")
+  public void streamDataProviderShouldBeClosedWhenUsedByFactory() {
+    StreamFactoryDataProviderSample.CLOSE_COUNT.set(0);
+
+    InvokedMethodNameListener listener = run(StreamFactoryDataProviderSample.class);
+
+    // The factory produces one instance per stream row; each instance runs testMethod once.
+    assertThat(listener.getSucceedMethodNames()).containsExactly("testMethod", "testMethod");
+    assertThat(StreamFactoryDataProviderSample.CLOSE_COUNT).hasValue(1);
+  }
+
+  @Test(description = "GITHUB-3290")
+  public void streamDataProviderShouldBeClosedOnEveryRetryReInvocation() {
+    StreamRetryDataProviderSample.OPEN_COUNT.set(0);
+    StreamRetryDataProviderSample.CLOSE_COUNT.set(0);
+
+    run(StreamRetryDataProviderSample.class);
+
+    // cacheDataForTestRetries=false re-invokes the data provider on retry, and that path only
+    // consumes the stream up to the failing index before breaking. Every stream handed out - the
+    // initial one and each re-invocation - must still be closed.
+    assertThat(StreamRetryDataProviderSample.OPEN_COUNT.get()).isGreaterThan(1);
+    assertThat(StreamRetryDataProviderSample.CLOSE_COUNT)
+        .hasValue(StreamRetryDataProviderSample.OPEN_COUNT.get());
+  }
+
+  @Test(description = "GITHUB-3290")
+  public void streamDataProviderShouldBeConsumedLazily() {
+    StreamLazyLoadingDataProviderSample.EVENTS.clear();
+
+    run(StreamLazyLoadingDataProviderSample.class);
+
+    // If the stream were drained up front the events would be all "produced:" then all "consumed:".
+    // Lazy consumption interleaves them, one row produced right before it is consumed.
+    assertThat(StreamLazyLoadingDataProviderSample.EVENTS)
+        .containsExactly(
+            "produced:a", "consumed:a",
+            "produced:b", "consumed:b",
+            "produced:c", "consumed:c");
+  }
+
+  @Test(description = "GITHUB-3290")
+  public void streamDataProviderShouldHonourIndices() {
+    InvokedMethodNameListener listener = run(StreamIndicesSample.class);
+
+    assertThat(listener.getSucceedMethodNames()).containsExactly("indicesShouldWork(3)");
+    assertThat(listener.getFailedMethodNames()).isEmpty();
+  }
+
+  @Test(description = "GITHUB-3290")
+  public void emptyStreamDataProviderShouldResultInNoInvocations() {
+    InvokedMethodNameListener listener = run(EmptyStreamDataProviderSample.class);
+
+    assertThat(listener.getFailedMethodNames()).isEmpty();
+    assertThat(listener.getSkippedMethodNames()).isEmpty();
+    assertThat(listener.getSucceedMethodNames()).isEmpty();
+  }
+
+  @Test(description = "GITHUB-3290")
+  public void rawStreamDataProviderShouldWork() {
+    InvokedMethodNameListener listener = run(RawStreamDataProviderSample.class);
+
+    assertThat(listener.getSucceedMethodNames())
+        .containsExactly(
+            "testStaticStream(foo)", "testStaticStream(bar)",
+            "testStream(foo)", "testStream(bar)");
+  }
+
+  @Test(description = "GITHUB-3290")
+  public void parallelStreamDataProviderShouldWorkAndBeClosed() {
+    ParallelStreamDataProviderSample.CLOSE_COUNT.set(0);
+
+    InvokedMethodNameListener listener = run(ParallelStreamDataProviderSample.class);
+
+    assertThat(listener.getSucceedMethodNames()).hasSize(50);
+    assertThat(ParallelStreamDataProviderSample.CLOSE_COUNT).hasValue(1);
+  }
+
+  @Test(description = "GITHUB-3290")
+  public void sequentialTestShouldConsumeParallelStreamFullyAndCloseIt() {
+    SequentialConsumerOfParallelStreamSample.CLOSE_COUNT.set(0);
+    List<String> expected = new ArrayList<>();
+    for (int i = 1; i <= SequentialConsumerOfParallelStreamSample.ROWS; i++) {
+      expected.add("test(" + i + ")");
+    }
+
+    InvokedMethodNameListener listener = run(SequentialConsumerOfParallelStreamSample.class);
+
+    // A parallel stream is driven through its iterator, so every row is delivered exactly once (no
+    // loss, no duplicates) and the stream is closed once.
+    assertThat(listener.getFailedMethodNames()).isEmpty();
+    assertThat(listener.getSucceedMethodNames()).containsExactlyInAnyOrderElementsOf(expected);
+    assertThat(SequentialConsumerOfParallelStreamSample.CLOSE_COUNT).hasValue(1);
+  }
+
+  @Test(description = "GITHUB-3290")
+  public void parallelTestShouldConsumeParallelStreamFullyAndCloseIt() {
+    ParallelConsumerOfParallelStreamSample.CLOSE_COUNT.set(0);
+    List<String> expected = new ArrayList<>();
+    for (int i = 1; i <= ParallelConsumerOfParallelStreamSample.ROWS; i++) {
+      expected.add("test(" + i + ")");
+    }
+
+    InvokedMethodNameListener listener = run(ParallelConsumerOfParallelStreamSample.class);
+
+    // A parallel data provider consuming a parallel stream: rows are pulled under TestNG's own
+    // synchronization, so every row is still delivered exactly once and the stream closed once.
+    assertThat(listener.getFailedMethodNames()).isEmpty();
+    assertThat(listener.getSucceedMethodNames()).containsExactlyInAnyOrderElementsOf(expected);
+    assertThat(ParallelConsumerOfParallelStreamSample.CLOSE_COUNT).hasValue(1);
+  }
+
+  @Test(description = "GITHUB-3290")
+  public void unsupportedReturnTypeErrorMessageShouldMentionStream() {
+    InvokedMethodNameListener listener = run(UnsupportedReturnTypeDataProviderSample.class);
+
+    Throwable throwable = listener.getResult("testMethod").getThrowable();
+    assertThat(throwable).isInstanceOf(TestNGException.class);
+    assertThat(throwable)
+        .hasMessageContaining("Stream<Object[]>")
+        .hasMessageContaining("Stream<Object>");
   }
 
   @Test

--- a/testng-core/src/test/java/test/dataprovider/issue3290/DrainingDataProviderInterceptor.java
+++ b/testng-core/src/test/java/test/dataprovider/issue3290/DrainingDataProviderInterceptor.java
@@ -1,0 +1,32 @@
+package test.dataprovider.issue3290;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import org.testng.IDataProviderInterceptor;
+import org.testng.IDataProviderMethod;
+import org.testng.ITestContext;
+import org.testng.ITestNGMethod;
+
+/**
+ * An interceptor that fully drains the original data provider iterator into a list, drops the first
+ * row and returns a brand-new iterator. This mirrors the common interceptor pattern and is used to
+ * confirm that a resource-backed {@code Stream} is still closed even though the iterator the test
+ * actually runs against is not the one derived from the stream.
+ */
+public class DrainingDataProviderInterceptor implements IDataProviderInterceptor {
+
+  @Override
+  public Iterator<Object[]> intercept(
+      Iterator<Object[]> original,
+      IDataProviderMethod dataProviderMethod,
+      ITestNGMethod method,
+      ITestContext iTestContext) {
+    Iterable<Object[]> iterable = () -> original;
+    List<Object[]> list =
+        StreamSupport.stream(iterable.spliterator(), false).collect(Collectors.toList());
+    list.remove(0);
+    return list.iterator();
+  }
+}

--- a/testng-core/src/test/java/test/dataprovider/issue3290/EmptyStreamDataProviderSample.java
+++ b/testng-core/src/test/java/test/dataprovider/issue3290/EmptyStreamDataProviderSample.java
@@ -1,0 +1,21 @@
+package test.dataprovider.issue3290;
+
+import static org.assertj.core.api.Assertions.fail;
+
+import java.util.stream.Stream;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/** An empty {@link Stream} should simply result in no invocations, not a failure. */
+public class EmptyStreamDataProviderSample {
+
+  @DataProvider
+  public Stream<Object[]> dp() {
+    return Stream.empty();
+  }
+
+  @Test(dataProvider = "dp")
+  public void test() {
+    fail();
+  }
+}

--- a/testng-core/src/test/java/test/dataprovider/issue3290/FileBackedStreamDataProviderSample.java
+++ b/testng-core/src/test/java/test/dataprovider/issue3290/FileBackedStreamDataProviderSample.java
@@ -1,0 +1,46 @@
+package test.dataprovider.issue3290;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Exercises a genuinely resource-backed {@link Stream} (one produced by {@link Files#lines(Path)},
+ * which keeps a file handle open) to prove that lazily-loaded, resource-backed streams work end to
+ * end and are closed once consumed. {@link #CLOSE_COUNT} is asserted by the driving test.
+ */
+public class FileBackedStreamDataProviderSample {
+
+  public static final AtomicInteger CLOSE_COUNT = new AtomicInteger(0);
+
+  @DataProvider
+  public Stream<Object[]> data() {
+    try {
+      Path file = Files.createTempFile("dp-stream", ".csv");
+      file.toFile().deleteOnExit();
+      Files.write(file, Arrays.asList("Jack,5", "Joe,10"));
+      // Files.lines keeps the file handle open until the stream is closed; onClose lets the test
+      // confirm our pipeline releases it.
+      return Files.lines(file)
+          .map(line -> line.split(","))
+          .map(parts -> new Object[] {parts[0], Integer.parseInt(parts[1])})
+          .onClose(CLOSE_COUNT::incrementAndGet);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  @Test(dataProvider = "data")
+  public void testMethod(String name, int age) {
+    assertThat(name).isNotNull();
+    assertThat(age).isPositive();
+  }
+}

--- a/testng-core/src/test/java/test/dataprovider/issue3290/ParallelConsumerOfParallelStreamSample.java
+++ b/testng-core/src/test/java/test/dataprovider/issue3290/ParallelConsumerOfParallelStreamSample.java
@@ -1,0 +1,35 @@
+package test.dataprovider.issue3290;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * A parallel data-driven test ({@code @DataProvider(parallel = true)}) whose data provider also
+ * returns a <em>parallel</em> {@link Stream}. TestNG pulls rows from the stream's iterator under
+ * its own synchronization while dispatching invocations across threads, so every row should still
+ * be delivered exactly once and the stream closed once. {@link #CLOSE_COUNT} is asserted by the
+ * driving test.
+ */
+public class ParallelConsumerOfParallelStreamSample {
+
+  public static final int ROWS = 50;
+  public static final AtomicInteger CLOSE_COUNT = new AtomicInteger(0);
+
+  @DataProvider(parallel = true)
+  public Stream<Object[]> provide() {
+    return IntStream.rangeClosed(1, ROWS)
+        .parallel()
+        .mapToObj(i -> new Object[] {i})
+        .onClose(CLOSE_COUNT::incrementAndGet);
+  }
+
+  @Test(dataProvider = "provide")
+  public void test(Integer i) {
+    assertThat(i).isNotNull();
+  }
+}

--- a/testng-core/src/test/java/test/dataprovider/issue3290/ParallelStreamDataProviderSample.java
+++ b/testng-core/src/test/java/test/dataprovider/issue3290/ParallelStreamDataProviderSample.java
@@ -1,0 +1,31 @@
+package test.dataprovider.issue3290;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * A {@code @DataProvider(parallel = true)} that returns a {@link Stream}. Confirms every row is
+ * delivered when the data provider runs in parallel and that the stream is still closed exactly
+ * once afterwards. {@link #CLOSE_COUNT} is asserted by the driving test.
+ */
+public class ParallelStreamDataProviderSample {
+
+  public static final AtomicInteger CLOSE_COUNT = new AtomicInteger(0);
+
+  @DataProvider(parallel = true)
+  public Stream<Object[]> provide() {
+    return IntStream.range(0, 50)
+        .mapToObj(i -> new Object[] {i})
+        .onClose(CLOSE_COUNT::incrementAndGet);
+  }
+
+  @Test(dataProvider = "provide")
+  public void checkParallel(Integer i) {
+    assertThat(i).isNotNull();
+  }
+}

--- a/testng-core/src/test/java/test/dataprovider/issue3290/ParallelStreamDataProviderSample.java
+++ b/testng-core/src/test/java/test/dataprovider/issue3290/ParallelStreamDataProviderSample.java
@@ -15,11 +15,12 @@ import org.testng.annotations.Test;
  */
 public class ParallelStreamDataProviderSample {
 
+  public static final int ROWS = 50;
   public static final AtomicInteger CLOSE_COUNT = new AtomicInteger(0);
 
   @DataProvider(parallel = true)
   public Stream<Object[]> provide() {
-    return IntStream.range(0, 50)
+    return IntStream.rangeClosed(1, ROWS)
         .mapToObj(i -> new Object[] {i})
         .onClose(CLOSE_COUNT::incrementAndGet);
   }

--- a/testng-core/src/test/java/test/dataprovider/issue3290/RawStreamDataProviderSample.java
+++ b/testng-core/src/test/java/test/dataprovider/issue3290/RawStreamDataProviderSample.java
@@ -1,0 +1,34 @@
+package test.dataprovider.issue3290;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * A raw (unparameterized) {@link Stream} return type should behave like a raw {@code Iterator} does
+ * today - the user is responsible for providing rows in the shape the test method expects.
+ */
+public class RawStreamDataProviderSample {
+
+  @DataProvider
+  public static Stream staticStream() {
+    return Stream.of(new Object[] {"foo"}, new Object[] {"bar"});
+  }
+
+  @Test(dataProvider = "staticStream")
+  public void testStaticStream(String s) {
+    assertThat(s).isNotNull();
+  }
+
+  @DataProvider
+  public Stream stream() {
+    return Stream.of(new Object[] {"foo"}, new Object[] {"bar"});
+  }
+
+  @Test(dataProvider = "stream")
+  public void testStream(String s) {
+    assertThat(s).isNotNull();
+  }
+}

--- a/testng-core/src/test/java/test/dataprovider/issue3290/SequentialConsumerOfParallelStreamSample.java
+++ b/testng-core/src/test/java/test/dataprovider/issue3290/SequentialConsumerOfParallelStreamSample.java
@@ -1,0 +1,34 @@
+package test.dataprovider.issue3290;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * A sequential (non-parallel) data-driven test whose data provider returns a <em>parallel</em>
+ * {@link Stream} (one built with {@code .parallel()}). TestNG drives it through the stream's
+ * iterator regardless of the stream's parallel flag, so every row should still be delivered exactly
+ * once and the stream closed once. {@link #CLOSE_COUNT} is asserted by the driving test.
+ */
+public class SequentialConsumerOfParallelStreamSample {
+
+  public static final int ROWS = 50;
+  public static final AtomicInteger CLOSE_COUNT = new AtomicInteger(0);
+
+  @DataProvider
+  public Stream<Object[]> provide() {
+    return IntStream.rangeClosed(1, ROWS)
+        .parallel()
+        .mapToObj(i -> new Object[] {i})
+        .onClose(CLOSE_COUNT::incrementAndGet);
+  }
+
+  @Test(dataProvider = "provide")
+  public void test(Integer i) {
+    assertThat(i).isNotNull();
+  }
+}

--- a/testng-core/src/test/java/test/dataprovider/issue3290/StreamClosingDataProviderSample.java
+++ b/testng-core/src/test/java/test/dataprovider/issue3290/StreamClosingDataProviderSample.java
@@ -1,0 +1,30 @@
+package test.dataprovider.issue3290;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Verifies that a {@link Stream} returned by a data provider has its {@link Stream#close()} invoked
+ * once the rows have been consumed. The {@link #CLOSE_COUNT} is asserted by the driving test after
+ * the run completes.
+ */
+public class StreamClosingDataProviderSample {
+
+  public static final AtomicInteger CLOSE_COUNT = new AtomicInteger(0);
+
+  @DataProvider
+  public Stream<Object[]> data() {
+    return Stream.of(new Object[] {"Jack", 5}, new Object[] {"Joe", 10})
+        .onClose(CLOSE_COUNT::incrementAndGet);
+  }
+
+  @Test(dataProvider = "data")
+  public void testMethod(String name, int age) {
+    assertThat(name).isNotNull();
+    assertThat(age).isPositive();
+  }
+}

--- a/testng-core/src/test/java/test/dataprovider/issue3290/StreamDataProviderSample.java
+++ b/testng-core/src/test/java/test/dataprovider/issue3290/StreamDataProviderSample.java
@@ -1,0 +1,52 @@
+package test.dataprovider.issue3290;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class StreamDataProviderSample {
+
+  @DataProvider
+  public static Stream<Object[]> staticStream() {
+    return Stream.of(new Object[] {"Jack", 5}, new Object[] {"Joe", 10});
+  }
+
+  @Test(dataProvider = "staticStream")
+  public void testStaticStream(String name, int age) {
+    assertThat(name).isNotNull();
+    assertThat(age).isPositive();
+  }
+
+  @DataProvider
+  public Stream<Object[]> stream() {
+    return Stream.of(new Object[] {"Jack", 5}, new Object[] {"Joe", 10});
+  }
+
+  @Test(dataProvider = "stream")
+  public void testStream(String name, int age) {
+    assertThat(name).isNotNull();
+    assertThat(age).isPositive();
+  }
+
+  @DataProvider
+  public static Stream<Object> staticOneDimStream() {
+    return Stream.of("foo", "bar");
+  }
+
+  @Test(dataProvider = "staticOneDimStream")
+  public void testStaticOneDimStream(String s) {
+    assertThat(s).isNotNull();
+  }
+
+  @DataProvider
+  public Stream<Object> oneDimStream() {
+    return Stream.of("foo", "bar");
+  }
+
+  @Test(dataProvider = "oneDimStream")
+  public void testOneDimStream(String s) {
+    assertThat(s).isNotNull();
+  }
+}

--- a/testng-core/src/test/java/test/dataprovider/issue3290/StreamFactoryDataProviderSample.java
+++ b/testng-core/src/test/java/test/dataprovider/issue3290/StreamFactoryDataProviderSample.java
@@ -1,5 +1,9 @@
 package test.dataprovider.issue3290;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 import org.testng.annotations.DataProvider;
@@ -8,12 +12,16 @@ import org.testng.annotations.Test;
 
 /**
  * A {@link Factory} powered by a data provider that returns a {@link Stream}. Exercises the {@code
- * FactoryMethod} consumption path and confirms the stream is closed once the factory has produced
- * its instances. {@link #CLOSE_COUNT} is asserted by the driving test.
+ * FactoryMethod} consumption path and confirms that each stream row creates an instance with its
+ * argument forwarded, and that the stream is closed once the factory has produced its instances.
+ * {@link #RECEIVED} and {@link #CLOSE_COUNT} are asserted by the driving test.
  */
 public class StreamFactoryDataProviderSample {
 
   public static final AtomicInteger CLOSE_COUNT = new AtomicInteger(0);
+  public static final List<Integer> RECEIVED = new CopyOnWriteArrayList<>();
+
+  private final int value;
 
   @DataProvider
   public static Stream<Object[]> data() {
@@ -21,8 +29,15 @@ public class StreamFactoryDataProviderSample {
   }
 
   @Factory(dataProvider = "data")
-  public StreamFactoryDataProviderSample(int i) {}
+  public StreamFactoryDataProviderSample(int i) {
+    this.value = i;
+  }
 
   @Test
-  public void testMethod() {}
+  public void testMethod() {
+    // Record the argument forwarded to this instance so the driving test can assert that every
+    // stream row produced an instance with the correct value.
+    RECEIVED.add(value);
+    assertThat(value).isIn(1, 2);
+  }
 }

--- a/testng-core/src/test/java/test/dataprovider/issue3290/StreamFactoryDataProviderSample.java
+++ b/testng-core/src/test/java/test/dataprovider/issue3290/StreamFactoryDataProviderSample.java
@@ -1,0 +1,28 @@
+package test.dataprovider.issue3290;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+
+/**
+ * A {@link Factory} powered by a data provider that returns a {@link Stream}. Exercises the {@code
+ * FactoryMethod} consumption path and confirms the stream is closed once the factory has produced
+ * its instances. {@link #CLOSE_COUNT} is asserted by the driving test.
+ */
+public class StreamFactoryDataProviderSample {
+
+  public static final AtomicInteger CLOSE_COUNT = new AtomicInteger(0);
+
+  @DataProvider
+  public static Stream<Object[]> data() {
+    return Stream.of(new Object[] {1}, new Object[] {2}).onClose(CLOSE_COUNT::incrementAndGet);
+  }
+
+  @Factory(dataProvider = "data")
+  public StreamFactoryDataProviderSample(int i) {}
+
+  @Test
+  public void testMethod() {}
+}

--- a/testng-core/src/test/java/test/dataprovider/issue3290/StreamIndicesSample.java
+++ b/testng-core/src/test/java/test/dataprovider/issue3290/StreamIndicesSample.java
@@ -1,0 +1,25 @@
+package test.dataprovider.issue3290;
+
+import java.util.stream.Stream;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Confirms that {@code @DataProvider(indices = ...)} selects the same rows from a {@link Stream} as
+ * it does from an array or {@code Iterator}. Only the row at index {@code 2} (the value {@code 3})
+ * should reach the test method.
+ */
+public class StreamIndicesSample {
+
+  @DataProvider(indices = {2})
+  public Stream<Object[]> dp() {
+    return Stream.of(new Object[] {1}, new Object[] {2}, new Object[] {3});
+  }
+
+  @Test(dataProvider = "dp")
+  public void indicesShouldWork(int n) {
+    if (n != 3) {
+      throw new RuntimeException("Only the row at index 2 (value 3) should have been selected");
+    }
+  }
+}

--- a/testng-core/src/test/java/test/dataprovider/issue3290/StreamLazyLoadingDataProviderSample.java
+++ b/testng-core/src/test/java/test/dataprovider/issue3290/StreamLazyLoadingDataProviderSample.java
@@ -1,0 +1,30 @@
+package test.dataprovider.issue3290;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Stream;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Proves that a {@link Stream} returned by a data provider is consumed lazily (one row at a time as
+ * the test runs) rather than being drained up front. Each row records a {@code produced:} event
+ * when the stream yields it and the test records a {@code consumed:} event; if consumption is lazy
+ * the two interleave. {@link #EVENTS} is asserted by the driving test.
+ */
+public class StreamLazyLoadingDataProviderSample {
+
+  public static final List<String> EVENTS = new CopyOnWriteArrayList<>();
+
+  @DataProvider
+  public Stream<Object[]> data() {
+    return Stream.of("a", "b", "c")
+        .peek(value -> EVENTS.add("produced:" + value))
+        .map(value -> new Object[] {value});
+  }
+
+  @Test(dataProvider = "data")
+  public void testMethod(String value) {
+    EVENTS.add("consumed:" + value);
+  }
+}

--- a/testng-core/src/test/java/test/dataprovider/issue3290/StreamOfListRowsDataProviderSample.java
+++ b/testng-core/src/test/java/test/dataprovider/issue3290/StreamOfListRowsDataProviderSample.java
@@ -1,0 +1,30 @@
+package test.dataprovider.issue3290;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * A data provider returning {@code Stream<List<Object[]>>}. The element type is {@code
+ * List<Object[]>} (not an array), so each element must be delivered as a single test parameter - it
+ * must not be mistaken for a row of {@code Object[]}.
+ */
+public class StreamOfListRowsDataProviderSample {
+
+  @DataProvider
+  public Stream<List<Object[]>> data() {
+    return Stream.of(
+        Arrays.asList(new Object[] {1}, new Object[] {2}),
+        Collections.singletonList(new Object[] {3}));
+  }
+
+  @Test(dataProvider = "data")
+  public void testMethod(List<Object[]> row) {
+    assertThat(row).isNotEmpty();
+  }
+}

--- a/testng-core/src/test/java/test/dataprovider/issue3290/StreamRetryDataProviderSample.java
+++ b/testng-core/src/test/java/test/dataprovider/issue3290/StreamRetryDataProviderSample.java
@@ -1,0 +1,47 @@
+package test.dataprovider.issue3290;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+import org.testng.IRetryAnalyzer;
+import org.testng.ITestResult;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Drives the retry path that re-invokes a {@code cacheDataForTestRetries = false} data provider and
+ * consumes only up to the failing index before breaking out (the early-break consumption path in
+ * {@code TestInvoker#retryFailed}). {@link #OPEN_COUNT} counts every stream the provider hands out
+ * and {@link #CLOSE_COUNT} counts every stream that was closed; the driving test asserts they
+ * match, which proves the partially-consumed stream is still closed.
+ */
+public class StreamRetryDataProviderSample {
+
+  public static final AtomicInteger OPEN_COUNT = new AtomicInteger(0);
+  public static final AtomicInteger CLOSE_COUNT = new AtomicInteger(0);
+
+  private final AtomicInteger invocationCount = new AtomicInteger(0);
+
+  @DataProvider(name = "dp", cacheDataForTestRetries = false)
+  public Stream<Object[]> getData() {
+    OPEN_COUNT.incrementAndGet();
+    return Stream.of(new Object[] {"a"}, new Object[] {"b"}).onClose(CLOSE_COUNT::incrementAndGet);
+  }
+
+  @Test(dataProvider = "dp", retryAnalyzer = OneRetry.class)
+  public void testMethod(String value) {
+    // Fail the first invocation so the retry path (which re-invokes the data provider) is
+    // exercised.
+    if (invocationCount.getAndIncrement() < 1) {
+      throw new RuntimeException("Deliberate failure to force a retry for " + value);
+    }
+  }
+
+  public static class OneRetry implements IRetryAnalyzer {
+    private int count = 0;
+
+    @Override
+    public boolean retry(ITestResult result) {
+      return count++ < 1;
+    }
+  }
+}

--- a/testng-core/src/test/java/test/dataprovider/issue3290/ThrowingAfterExecutionListener.java
+++ b/testng-core/src/test/java/test/dataprovider/issue3290/ThrowingAfterExecutionListener.java
@@ -1,0 +1,20 @@
+package test.dataprovider.issue3290;
+
+import org.testng.IDataProviderListener;
+import org.testng.IDataProviderMethod;
+import org.testng.ITestContext;
+import org.testng.ITestNGMethod;
+
+/**
+ * A data provider listener that fails in {@link #afterDataProviderExecution}, i.e. after the data
+ * provider has been invoked but before TestNG hands the parameters over for consumption. Used to
+ * confirm that a resource-backed {@code Stream} is still closed when parameter setup aborts.
+ */
+public class ThrowingAfterExecutionListener implements IDataProviderListener {
+
+  @Override
+  public void afterDataProviderExecution(
+      IDataProviderMethod dataProviderMethod, ITestNGMethod method, ITestContext iTestContext) {
+    throw new RuntimeException("Deliberate failure from afterDataProviderExecution");
+  }
+}

--- a/testng-core/src/test/java/test/dataprovider/issue3290/UnsupportedReturnTypeDataProviderSample.java
+++ b/testng-core/src/test/java/test/dataprovider/issue3290/UnsupportedReturnTypeDataProviderSample.java
@@ -1,0 +1,19 @@
+package test.dataprovider.issue3290;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * A data provider whose return type is none of the supported ones. Used to confirm the guidance in
+ * the resulting error message now lists {@code Stream} amongst the accepted return types.
+ */
+public class UnsupportedReturnTypeDataProviderSample {
+
+  @DataProvider(name = "dp")
+  public String dp() {
+    return "this is not a supported data provider return type";
+  }
+
+  @Test(dataProvider = "dp")
+  public void testMethod(String value) {}
+}


### PR DESCRIPTION
Closes #3290

Fixes #3290  .

### Did you remember to?

- [X] Add test case(s)
- [X] Update `CHANGES.txt`
- [X] Auto applied styling via `./gradlew autostyleApply`

We encourage pull requests that:

* Add new features to TestNG (or)
* Fix bugs in TestNG

If your pull request involves fixing SonarQube issues then we would suggest that you please discuss this with the 
[TestNG-dev](https://groups.google.com/forum/#!forum/testng-dev) before you spend time working on it.

**Note:** For more information on contribution guidelines  please make sure you refer our [Contributing](.github/CONTRIBUTING.md) section for detailed set of steps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Data providers can now return `Stream<Object[]>` or `Stream<Object>`.
  * Stream-based data is consumed lazily and the stream is reliably closed after consumption (including resource-backed, factory-based, and index-based providers).
* **Bug Fixes**
  * Stream lifecycle is correctly finalized even when interceptors modify consumption, when parameter setup fails after invocation, and across retries.
  * Parallel stream providers are handled correctly with one-time delivery and proper closure.
* **Documentation**
  * Updated `@DataProvider` Javadoc with supported stream types and parallel-stream guidance.
* **Tests**
  * Added coverage for stream consumption, closure, laziness, retries, indices, and unsupported return type messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->