### PR TITLE
docs: add AGENTS.md and CLAUDE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ outputDir/
 **/bin/
 node_modules
 .kotlin
+
+# Agent tooling state
+.serena/
+.context/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,110 @@
+# Working on TestNG
+
+Notes for coding agents, limited to what is easy to get wrong here. General contributor
+documentation lives in [`.github/CONTRIBUTING.md`](.github/CONTRIBUTING.md) and [`docs/`](docs/) —
+read those for the build model, the Java versions and the release process rather than assuming.
+
+Where this file contradicts the build, the build wins: fix the file.
+
+## Verification
+
+**`./gradlew build -x test` does not compile test sources.** It is a smoke check, never the gate.
+Checks that only fail once tests are compiled, or after a `clean`, slip straight through it — Error
+Prone rules that fire on test fixtures, formatter tasks that were up to date, dependency upgrades
+that break test code but not main.
+
+The gate is a full build, which is also what CI runs on every push and pull request:
+
+```bash
+./gradlew clean build     # several minutes, must be 0 failures
+```
+
+`verifyPublishedPomDependencies` (in `testng/testng-build.gradle.kts`, wired into `check`) pins the
+exact dependency set of the published pom, versions ignored. When it fails, either the change is
+wrong or the expected list needs updating — decide which, do not just update the list.
+
+## Layout
+
+Modules are listed in `settings.gradle.kts`; only `:testng` is published, as a shaded jar merging
+the others. `docs/BUILD_SYSTEM.md` describes the structure.
+
+Two things that are not documented elsewhere and cost tool calls to discover:
+
+- Per-project build files are named `<module>/<module>-build.gradle.kts`, not `build.gradle.kts`.
+- Build logic lives in two included builds: `build-logic-commons/` builds the plugins that
+  `build-logic/` uses. Conventions are precompiled script plugins,
+  `build-logic/*/src/main/kotlin/testng.*.gradle.kts` — prefer changing a convention over repeating
+  configuration per module.
+
+The `guice` and `yaml` optional features are hand-rolled rather than declared with
+`registerFeature`; the reasoning is in the KDoc of
+`build-logic/jvm/src/main/kotlin/buildlogic/OptionalFeatureVariants.kt`. If you touch them, check
+the published pom and Gradle Module Metadata are unchanged.
+
+## Changing the build JDK
+
+`docs/JAVA_VERSIONS_QUICK_REFERENCE.md` explains the three Java versions. Read the current values
+rather than assuming them:
+
+```bash
+grep -E '^jdkBuildVersion|^targetJavaVersion' gradle.properties
+```
+
+The root `gradle.properties` drives local builds, but it is **not** the only place the build JDK
+appears. Moving it means updating all of:
+
+- `gradle.properties`
+- the fallback defaults in `build-logic/build-parameters/build.gradle.kts`
+- the fallbacks in `build-logic-commons/gradle-plugin/build.gradle.kts` and its
+  `build-logic.kotlin-dsl-gradle-plugin.gradle.kts` (that build is configured before the root
+  properties are available, so it reads them from disk)
+- `.github/workflows/` — `test.yml` passes `jdkBuildVersion` as a Gradle property, which
+  **overrides** `gradle.properties`, and the publish workflows pin the JDK they install
+
+Bytecode is produced with `--release targetJavaVersion`, so the launching JDK does not leak into the
+artifacts. Gradle itself needs JDK 17+; the build then resolves a `jdkBuildVersion` toolchain,
+auto-detected or auto-provisioned. Where no matching JDK is available and auto-provisioning is off
+(as in CI), the failure is `Cannot find a Java installation on your machine ... matching:
+{languageVersion=N, ...}`.
+
+## Dependencies
+
+- Everything reachable from `:testng-core` ends up in the shaded jar, and any third-party dependency
+  it pulls lands in the published pom. Treat major bumps as API decisions and check the pom diff.
+- `targetJavaVersion` blocks some upgrades outright — Gradle says so plainly, e.g. *"only compatible
+  with JVM runtime version 17 or newer"*. Those are tracked for the next major release.
+- Dependabot covers `github-actions` and `gradle`. Actions are pinned to a commit SHA with the
+  version as a trailing comment; keep that shape, and check the SHA really is the tag it claims.
+- A version that must not be taken belongs in `ignore` in `.github/dependabot.yml`, with the reason
+  written there. Closing the pull request alone makes it come back.
+
+## Git
+
+The canonical repository is `testng-team/testng`. When working from a fork, its `master` is often
+behind, so diff, branch and rebase against the canonical remote — reasoning from a stale `master`
+produces confident, wrong analysis. Check before starting:
+
+```bash
+git remote -v                                  # which remote is canonical?
+git fetch <canonical> master
+git rev-list --count HEAD..<canonical>/master  # 0 means you are current
+```
+
+From a fork, pull requests are cross-fork:
+
+```bash
+gh pr create --repo testng-team/testng --base master --head <fork-owner>:<branch>
+```
+
+Conventional Commits. Record user-visible changes in `CHANGES.txt`, newest first, under the current
+version heading.
+
+## Working style
+
+- **Verify claims before acting on them.** A statement inherited from a pull request description, an
+  issue or a comment is not evidence. Checking a release date or a changelog costs a minute; acting
+  on a wrong premise costs hours. This has already caused one full migration to be written and
+  reverted.
+- Report what you actually observed. If a run was flaky, say so and show both runs.
+- When an upgrade is refused, record the error that refused it, so the next person does not retry it
+  blind.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,57 @@
+# CLAUDE.md
+
+Read [AGENTS.md](AGENTS.md) first — it holds everything about this repository. This file only adds
+what is specific to Claude Code.
+
+## Selecting the build JDK
+
+The ambient `java` is whatever the version manager resolved for the session, not necessarily what
+the build wants. With `mise`, derive it from the property so it stays correct across bumps:
+
+```bash
+export JAVA_HOME="$(mise where java@$(sed -n 's/^jdkBuildVersion=//p' gradle.properties))"
+```
+
+This needs the `java@<N>` alias to point at an installed version; `mise where` fails otherwise.
+
+## Long-running commands
+
+`./gradlew clean build` takes several minutes — well over the default `Bash` timeout. Pass an
+explicit one:
+
+```text
+timeout: 900000
+```
+
+Filter the output rather than reading it whole; a full build log runs to thousands of lines, and the
+test logger prints a line per test class, so match on the summary only. Set `pipefail` first —
+without it the pipeline reports grep's status, so a failed build still exits 0:
+
+```bash
+set -o pipefail
+./gradlew --console=plain clean build 2>&1 | grep -E "^BUILD (SUCCESSFUL|FAILED)|[1-9][0-9]* failed"
+```
+
+For a failure, extract the useful part instead of scrolling:
+
+```bash
+set -o pipefail
+./gradlew --console=plain clean build 2>&1 | grep -A15 "What went wrong"
+```
+
+Gradle names the HTML report on failure, but locating the failing test is quicker from the result
+files:
+
+```bash
+grep -l '<failure\|<error' testng-core/build/test-results/test/*.xml
+grep -o 'message="[^"]*"' testng-core/build/test-results/test/TEST-<the-class>.xml | head
+```
+
+## Environment
+
+- The workspace may be reset to an older commit between sessions. Run the staleness check from
+  `AGENTS.md` before anything else, and fast-forward if needed.
+- The SSH agent is not always loaded. If `git push` fails with `Permission denied (publickey)`, push
+  over HTTPS using the `gh` credentials:
+  `git push https://github.com/<owner>/testng.git <branch>`. With no remote-tracking ref,
+  `--force-with-lease` needs the expected SHA spelled out: `--force-with-lease=<branch>:<sha>`.

--- a/build-logic/code-quality/build.gradle.kts
+++ b/build-logic/code-quality/build.gradle.kts
@@ -6,6 +6,8 @@ dependencies {
     api(projects.buildParameters)
     api(projects.basics)
     api("org.sonarqube:org.sonarqube.gradle.plugin:7.3.1.8318")
+    // Pinned: 4.0.1 fails on JDK 25. See the ignore entry in .github/dependabot.yml and
+    // https://github.com/testng-team/testng/issues/3292
     api("com.github.autostyle:autostyle-plugin-gradle:4.0")
     api("net.ltgt.gradle:gradle-errorprone-plugin:5.1.0")
 }

--- a/docs/BUILD_SYSTEM.md
+++ b/docs/BUILD_SYSTEM.md
@@ -350,7 +350,8 @@ Automatically publishes snapshots on every push to master:
 # Build everything
 ./gradlew build
 
-# Build without tests
+# Build without tests. Note this also skips compiling them, so it is a smoke
+# check, not a substitute for `./gradlew build`.
 ./gradlew build -x test
 
 # Build with specific Java version for tests

--- a/docs/README.md
+++ b/docs/README.md
@@ -82,7 +82,8 @@ cd testng
 # Build everything
 ./gradlew build
 
-# Build without tests
+# Build without tests. Note this also skips compiling them, so it is a smoke
+# check, not a substitute for `./gradlew build`.
 ./gradlew build -x test
 
 # Run tests with specific Java version


### PR DESCRIPTION
## What

Adds `AGENTS.md` and `CLAUDE.md` at the repository root.

Neither existed, and the last two build PRs (#3291, #3300) burned real time rediscovering the same
few facts — or, in one case, acting on a claim that turned out to be false. These files write those
down.

## AGENTS.md — tool-agnostic

The parts that actually caused mistakes, not a tour of the codebase:

- **The build JDK is a property, not the target.** `jdkBuildVersion=25` builds bytecode for
  `targetJavaVersion=11`. Both live in the root `gradle.properties`; the included builds read it
  from disk rather than inheriting it. Building on an older JDK fails with a cryptic
  `What went wrong: 25.0.2`.
- **`./gradlew build -x test` does not compile test sources**, so it cannot be the gate. This one bit
  repeatedly: Error Prone rules that only fire on fixtures, formatter tasks that were up to date,
  and a dependency upgrade that broke test code but not main all passed it. The gate is
  `./gradlew clean build`.
- **`origin` is a fork and lags behind `upstream`.** Diffing against `origin/master` once produced a
  completely wrong analysis of an incoming PR.
- The published pom is pinned by `verifyPublishedPomDependencies`, and when a manual check gets
  repeated more than twice it should become a task instead.
- Layout, optional-feature machinery, dependency and formatting constraints, git and PR conventions.

It closes on a working-style note that is the most expensive lesson of the two PRs: **verify claims
before acting on them.** A statement inherited from a PR description is not evidence — one such
claim ("Autostyle unmaintained since 2021", actually released in 2025) led to a full formatter
migration being written, measured and reverted.

## CLAUDE.md — Claude Code specifics only

Points at `AGENTS.md` and adds just what is tool-specific: selecting the JDK through `mise`, the
explicit timeout a six-minute build needs, filtering build output instead of reading it whole,
locating failing tests from the result files, the fork-push fallback when the SSH agent is not
loaded, and how the HTML report was validated in a browser.

## Verification

Written against `master` as merged, not from memory — this branch was 69 commits behind and was
fast-forwarded first, which is exactly the trap the git section warns about.

Every documented command was executed:

| Claim | Checked |
|---|---|
| `jdkBuildVersion=25`, `targetJavaVersion=11` | read from `gradle.properties` |
| bytecode is Java 11 | `javap` → `major version: 55` |
| `clean build` is green | 12 624 tests, 0 failures |
| `verifyPublishedPomDependencies` passes | exit 0 |
| `git rev-list --count HEAD..upstream/master` | 0 |
| `./gradlew parameters` lists the parameters | 14 listed |

Module list, convention plugin names and build parameters were enumerated from the build rather
than written from recollection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that running `./gradlew build -x test` also skips compiling tests, making it a smoke check rather than a full build.
  * Added contributor workflow guidance for build/test gates, dependency verification expectations, JDK selection, troubleshooting, and repository practices.
  * Added Claude Code–specific repository instructions for running builds and diagnosing failures.

* **Chores**
  * Updated ignore rules for local agent tooling state.

* **Chores**
  * Documented a pinned code-quality plugin version required for JDK compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->