### PR TITLE
ci: never pair Microsoft OpenJDK with non-LTS Java versions

### DIFF
--- a/.github/workflows/matrix.mjs
+++ b/.github/workflows/matrix.mjs
@@ -12,7 +12,9 @@ matrix.addAxis({
   values: [
     {value: 'corretto', vendor: 'amazon', weight: 1},
     {value: 'liberica', vendor: 'bellsoft', weight: 1},
-    {value: 'microsoft', vendor: 'microsoft', weight: 1},
+    // Microsoft Build of OpenJDK publishes LTS releases only
+    // See https://learn.microsoft.com/java/openjdk/download
+    {value: 'microsoft', vendor: 'microsoft', ltsOnly: true, weight: 1},
     {value: 'oracle', vendor: 'oracle', weight: 1},
     // There are issues running Semeru JDK with Gradle 8.5
     // See https://github.com/gradle/gradle/issues/27273
@@ -22,17 +24,18 @@ matrix.addAxis({
   ]
 });
 
+// LTS releases: the only versions an ltsOnly distribution publishes
+const ltsJava = ['11', '17', '21', '25'];
+// GA feature releases that are not LTS
+const nonLtsJava = ['26'];
 // Early-access JDKs (not yet released). Verify they are downloadable before adding.
 const eaJava = ['27', '28'];
 matrix.addAxis({
   name: 'java_version',
   // Strings allow versions like 18-ea
   values: [
-    '11',
-    '17',
-    '21',
-    '25',
-    '26',
+    ...ltsJava,
+    ...nonLtsJava,
     ...eaJava,
   ]
 });
@@ -78,6 +81,8 @@ matrix.setNamePattern(['java_version', 'java_distribution', 'hash', 'os', 'tz', 
 eaJava.forEach(ea => matrix.imply({java_version: ea}, {java_distribution: {value: 'oracle'}}));
 // Oracle JDK is only supported for JDK 21 and later
 matrix.imply({java_distribution: {value: 'oracle'}}, {java_version: v => eaJava.includes(v) || v >= 21});
+// Some vendors publish LTS releases only, so they must never be paired with a non-LTS version
+matrix.imply({java_distribution: {ltsOnly: true}}, {java_version: ltsJava});
 // Semeru uses OpenJ9 jit which has no option for making hash codes the same
 // See https://github.com/eclipse-openj9/openj9/issues/17309
 matrix.exclude({java_distribution: {value: 'semeru'}, hash: {value: 'same'}});

--- a/.github/workflows/matrix.mjs
+++ b/.github/workflows/matrix.mjs
@@ -78,7 +78,7 @@ matrix.addAxis({
 matrix.setNamePattern(['java_version', 'java_distribution', 'hash', 'os', 'tz', 'locale']);
 
 // EA JDKs are only published on jdk.java.net (the "oracle" distribution here)
-eaJava.forEach(ea => matrix.imply({java_version: ea}, {java_distribution: {value: 'oracle'}}));
+matrix.imply({java_version: eaJava}, {java_distribution: {value: 'oracle'}});
 // Oracle JDK is only supported for JDK 21 and later
 matrix.imply({java_distribution: {value: 'oracle'}}, {java_version: v => eaJava.includes(v) || v >= 21});
 // Some vendors publish LTS releases only, so they must never be paired with a non-LTS version


### PR DESCRIPTION
## Problem

The CI matrix draws a JDK distribution and a Java version independently, and the version axis now contains **26**, a GA feature release that is not LTS.

Microsoft Build of OpenJDK ships **LTS releases only** — 11, 17, 21, 25 ([download page](https://learn.microsoft.com/java/openjdk/download); for Java 8 it even points at Temurin). Nothing in the matrix said so, so the draw could produce `microsoft × 26`: a variant that does not exist, failing in `Set up Java` at random and for reasons unrelated to the pull request under test.

It was the last impossible pair left. Corretto does publish 26 (the AWS docs list 8/11/17/21/25/26), Temurin, Zulu and Liberica publish every feature release, and early-access builds are already restricted to `oracle`/jdk.java.net by an existing rule.

## Change

The version axis is now the concatenation of three lists that evolve independently, mirroring the existing `eaJava`:

```js
const ltsJava = ['11', '17', '21', '25'];
const nonLtsJava = ['26'];
const eaJava = ['27', '28'];
```

Distributions that only publish LTS builds carry a marker, and a single implication rules the impossible combinations out:

```js
{value: 'microsoft', vendor: 'microsoft', ltsOnly: true, weight: 1},

matrix.imply({java_distribution: {ltsOnly: true}}, {java_version: ltsJava});
```

`Axis.matches` does a partial match on the axis value, so distributions without the property never match the antecedent and stay unconstrained. Marking another distribution is now enough — no rule has to be touched. When JDK 29 ships, moving it from `eaJava` to `ltsJava` makes the axis, both implications and `non_ea_java_version` follow.

The second commit collapses `eaJava.forEach(ea => matrix.imply(...))` into a single implication: an array filter is already an OR, which is the same idiom the new rule uses.

The version axis keeps the exact same 7 values, so `MATRIX_JOBS: 8` and its comment in `test.yml` stay accurate and no workflow change is needed.

## Verification

Pairwise coverage before/after: the feasible pair count goes from **239 to 238**. Exactly one pair leaves the set — `microsoft × 26`; `microsoft × 27/28` were already excluded by the EA rule. That total is also unchanged by the second commit, confirming it is a pure refactor.

Over 400 generated rows:

|           | 11 | 17 | 21 | 25 | 26 | 27 | 28 |
|-----------|----|----|----|----|----|----|----|
| corretto  | X  | X  | X  | X  | X  | ·  | ·  |
| liberica  | X  | X  | X  | X  | X  | ·  | ·  |
| microsoft | X  | X  | X  | X  | ·  | ·  | ·  |
| oracle    | ·  | ·  | X  | X  | X  | X  | X  |
| temurin   | X  | X  | X  | X  | X  | ·  | ·  |
| zulu      | X  | X  | X  | X  | X  | ·  | ·  |

`microsoft × non-LTS: 0`, `oracle × 11/17: 0`, `EA × non-oracle: 0`.

A nominal `MATRIX_JOBS=8` run still covers all 7 versions in 8 jobs, emits no `Unable to generate row` warning, and leaves `non_ea_java_version` empty only on the EA rows.

## Noted, not addressed here

`test.yml` still references a `jdk` axis that no longer exists: `job-id: jdk${{ matrix.jdk.version }}` and `build-reports-${{ matrix.jdk.group }}-${{ matrix.jdk.version }}`. Both resolve to an empty string, so the Gradle cache shares one `job-id` across every JDK and the artifacts are all named `build-reports---<timestamp>`. Real, but independent — happy to send it as a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Java test matrix generation to correctly align distributions with LTS, non-LTS, and early-access Java versions.
  * Restricted Microsoft OpenJDK coverage to supported LTS versions.
  * Refined Oracle distribution coverage for early-access and newer Java releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->