### PR TITLE
ci: scope the Gradle cache and build reports per Java version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
         id: run_test_cases
         uses: burrunan/gradle-cache-action@4b67497abd37a511d6c1dc6299bdd84ff39f7bf5 # v3
         with:
-          job-id: jdk${{ matrix.jdk.version }}
+          job-id: jdk${{ matrix.java_version }}
           arguments: |
             --no-parallel --no-daemon --scan
             build
@@ -99,5 +99,5 @@ jobs:
         if: ${{ failure() && steps.run_test_cases.outcome == 'failure' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: build-reports-${{ matrix.jdk.group }}-${{ matrix.jdk.version }}-${{ steps.build_id.outputs.unique_id }}
+          name: build-reports-${{ matrix.java_distribution }}-${{ matrix.java_version }}-${{ steps.build_id.outputs.unique_id }}
           path: testng-core/build/reports/tests/test/**


### PR DESCRIPTION
## Problem

`test.yml` still references a matrix axis named `jdk`:

```yaml
job-id: jdk${{ matrix.jdk.version }}
name: build-reports-${{ matrix.jdk.group }}-${{ matrix.jdk.version }}-${{ steps.build_id.outputs.unique_id }}
```

That axis, with its `version` and `group` sub-fields, was split into `java_version` and `java_distribution` in a678d058. The old expressions were never updated, and GitHub Actions resolves an unknown context property to an empty string rather than failing, so the breakage is silent:

- **Gradle cache** — every job passes `job-id: jdk` regardless of the JDK it runs, so all matrix entries share a single cache scope instead of one per Java version.
- **Build reports** — a failed run uploads `build-reports---<timestamp>`. The distribution and version are gone from the name, and two jobs failing within the same second collide on it.

## Change

Point both expressions at the axes the matrix actually emits. Artifact names become e.g. `build-reports-temurin-21-<timestamp>`, and the cache job-id becomes `jdk21`.

## Verification

Cross-checked every `matrix.<key>` reference in `test.yml` against the keys `matrix.mjs` emits for a generated row (`java_version`, `java_distribution`, `java_vendor`, `os`, `tz`, `locale`, `name`, `extraGradleArgs`, `testExtraJvmArgs`, `testDisableCaching`, `non_ea_java_version`, `oracle_java_website`): after this change all of them resolve, and none were left stale. The workflow still parses as valid YAML.

Independent of #3304, which touches `matrix.mjs` only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow identifiers for more consistent Gradle caching and build report artifact naming.
  * Build reports continue to be uploaded from the same location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->