### PR TITLE
docs: broaden the verify-before-acting rule in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,10 @@ wrong or the expected list needs updating — decide which, do not just update t
 Modules are listed in `settings.gradle.kts`; only `:testng` is published, as a shaded jar merging
 the others. `docs/BUILD_SYSTEM.md` describes the structure.
 
+Before writing documentation, read what is already in `docs/` and `.github/`. Most build topics are
+covered there; a second copy drifts from the first, and this file was itself written as a fifth copy
+before being cut back to links.
+
 Two things that are not documented elsewhere and cost tool calls to discover:
 
 - Per-project build files are named `<module>/<module>-build.gradle.kts`, not `build.gradle.kts`.
@@ -101,10 +105,14 @@ version heading.
 
 ## Working style
 
-- **Verify claims before acting on them.** A statement inherited from a pull request description, an
-  issue or a comment is not evidence. Checking a release date or a changelog costs a minute; acting
-  on a wrong premise costs hours. This has already caused one full migration to be written and
-  reverted.
+- **Verify claims before acting on them** — including your own. A pull request description, an issue
+  comment, a memory or a conclusion from an earlier session are all hearsay until re-checked against
+  whatever settles them: the build for anything about this repository, the registry or upstream
+  release notes for anything about a dependency. A release date costs a minute to check; acting on a
+  wrong premise costs hours. This has already caused one full migration to be written and reverted,
+  and one obsolete memory to be copied into a committed file.
+- Running a documented command proves it executes, not that it does what the text claims. If the
+  text promises an effect — filtering, failing, producing a value — measure that effect.
 - Report what you actually observed. If a run was flaky, say so and show both runs.
 - When an upgrade is refused, record the error that refused it, so the next person does not retry it
   blind.


### PR DESCRIPTION
Follow-up to #3302, from the retrospective on writing it.

## Why

`AGENTS.md` shipped with five factual errors, two of them serious — the build JDK was said to live in one place when it lives in six (and `test.yml` *overrides* `gradle.properties`), and a failure mode was described that stopped being true when Gradle 9 landed.

Both came from sources the existing rule did not name. It covered "a statement inherited from a pull request description, an issue or a comment" — but the actual sources were **a stale project memory** and **a conclusion drawn earlier in the same session**. Neither felt like hearsay at the time, which is exactly the problem.

## Changes

Three lines, at the two places that failed:

- The verify rule now says *including your own*, and names memories and earlier-session conclusions alongside PR descriptions.
- A new line: running a documented command proves it executes, not that it does what the text claims. The `CLAUDE.md` output filter ran perfectly while matching **2968 of 5293** log lines — it was verified as "executes", never as "filters".
- The Layout section now says to read `docs/` and `.github/` before writing documentation. `AGENTS.md` was itself written as a fifth copy of material already there, before being cut back to links.

## Verification

`./gradlew clean build` green on the merged master — 0 failures. Documentation-only change, so no `CHANGES.txt` entry, consistent with the other `docs:` commits in this repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidance to review existing documentation and workflow materials before writing new content.
  * Refined working-style instructions to emphasize verifying claims, distinguishing hearsay, and re-checking against the build.
  * Expanded guidance to clarify that successfully running a documented command confirms execution, not that it matches the described effect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->