### PR TITLE
docs: make the gate ./gradlew build, not clean build

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,11 +13,18 @@ Checks that only fail once tests are compiled, or after a `clean`, slip straight
 Prone rules that fire on test fixtures, formatter tasks that were up to date, dependency upgrades
 that break test code but not main.
 
-The gate is a full build, which is also what CI runs on every push and pull request:
+The gate is `./gradlew build`, the same task CI runs. Let Gradle decide how much of it to re-run:
+a change that reaches nothing finishes in seconds, so there is no need to judge by hand what a diff
+can affect. Add `clean` only to rule out stale output.
 
 ```bash
-./gradlew clean build     # several minutes, must be 0 failures
+./gradlew build     # minutes when it has work to do, seconds when it does not; 0 failures
 ```
+
+A green local build is not a green CI. Pull requests against `master` also run an OpenRewrite check
+that `.github/CONTRIBUTING.md` documents, and a wrapper validation. Pushes are weaker than they
+look: the `branches: ['*']` filter in `test.yml` does not match `/`, so pushing a branch named
+`docs/foo` triggers no build until a pull request exists.
 
 `verifyPublishedPomDependencies` (in `testng/testng-build.gradle.kts`, wired into `check`) pins the
 exact dependency set of the published pom, versions ignored. When it fails, either the change is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,8 +16,8 @@ This needs the `java@<N>` alias to point at an installed version; `mise where` f
 
 ## Long-running commands
 
-`./gradlew clean build` takes several minutes — well over the default `Bash` timeout. Pass an
-explicit one:
+`./gradlew build` takes several minutes whenever it has real work to do — well over the default
+`Bash` timeout. Pass an explicit one:
 
 ```text
 timeout: 900000
@@ -29,14 +29,14 @@ without it the pipeline reports grep's status, so a failed build still exits 0:
 
 ```bash
 set -o pipefail
-./gradlew --console=plain clean build 2>&1 | grep -E "^BUILD (SUCCESSFUL|FAILED)|[1-9][0-9]* failed"
+./gradlew --console=plain build 2>&1 | grep -E "^BUILD (SUCCESSFUL|FAILED)|[1-9][0-9]* failed"
 ```
 
 For a failure, extract the useful part instead of scrolling:
 
 ```bash
 set -o pipefail
-./gradlew --console=plain clean build 2>&1 | grep -A15 "What went wrong"
+./gradlew --console=plain build 2>&1 | grep -A15 "What went wrong"
 ```
 
 Gradle names the HTML report on failure, but locating the failing test is quicker from the result


### PR DESCRIPTION
Follow-up to #3302 and #3309.

## What this started as, and what it became

The first version of this PR added a paragraph telling agents to judge by hand whether a diff could affect the build, so they could skip the six-minute `clean build` on documentation changes. A review pass took it apart.

**The paragraph was working around a cost I had created myself.** CI runs `build`, not `clean build`. Without `clean`, Gradle's up-to-date check already answers the question the paragraph asked a human to answer — and answers it from the real task inputs, which cannot drift. Measured here:

| | |
|---|---|
| `build` with real work to do | 6m 44s |
| `build` after a documentation-only change | **1–3s** |

So the gate becomes `./gradlew build`, and the paragraph is deleted rather than fixed. `clean` stays documented for ruling out stale output.

## The list it carried was wrong in both directions

- **`.github/workflows/` cannot fail a Gradle build.** It was listed as something that "does break the build", one sentence after the build was defined as `clean build`. An agent editing a workflow, running the gate and seeing green would have verified nothing — the exact failure the paragraph existed to prevent.
- **`LICENSE.txt` does.** It reads as documentation and is copied into `META-INF` of every jar by `testng.java-library.gradle.kts`.
- **Comments were listed as safe.** They are not: `autostyleCheck` runs google-java-format, which reflows javadoc, and `.java` files ship in the published sources jar. Both were reproduced as failing builds during review.

## Also corrected

`"CI runs it on every push and pull request"` was false. The `branches: ['*']` filter in `test.yml` does not match `/`, and every branch here has one — so pushing `docs/foo` triggers **no** Test run until a pull request exists. Verified against the run history: every push-triggered run is on `master`. Pull requests also get an OpenRewrite check and wrapper validation on top of the matrix, so a green local build is not a green CI.

`CLAUDE.md` is aligned with the new gate.

## Verification

Applied the new rule to itself: documentation-only diff, so `./gradlew build` — 1s, exit 0, and `verifyPublishedPomDependencies` still green. Staleness checked before committing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated build verification guidance to recommend running `./gradlew build` as the CI gate.
  * Clarified when `clean` is appropriate and why local results may not match CI outcomes.
  * Added CI pull request check context and explained how workflow triggers behave for push branches.
  * Refreshed long-running build and log-monitoring examples to match the `build` workflow and improve pipeline failure visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->