### PR TITLE
ci: switch CodeQL java-kotlin analysis to manual build mode

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,7 +56,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     permissions:
       # required for all workflows
       security-events: write
@@ -40,15 +40,17 @@ jobs:
         # Use `javascript-typescript` to analyze code written in JavaScript, TypeScript or both
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      with:
+        persist-credentials: false
 
-    # The autobuild action was unable to build this repository's Gradle/Kotlin
-    # project (see the failed CI run), so java-kotlin now uses "manual" build
-    # mode. We build the project ourselves using the same JDK and Gradle task
-    # that the repository's own Test workflow (test.yml) relies on.
+          # The autobuild action was unable to build this repository's Gradle/Kotlin
+          # project (see the failed CI run), so java-kotlin now uses "manual" build
+      # mode. We build the project ourselves using the same JDK and Gradle task
+      # that the repository's own Test workflow (test.yml) relies on.
     - name: Set up JDK 25 (Temurin)
       if: matrix.build-mode == 'manual'
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
       with:
         java-version: 25
         distribution: temurin
@@ -69,6 +71,6 @@ jobs:
         ./gradlew --no-daemon -PjdkBuildVersion=25 -Dorg.gradle.java.installations.auto-download=false testClasses
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,74 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+name: "CodeQL Advanced"
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  schedule:
+    - cron: '45 8 * * 5'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    permissions:
+      # required for all workflows
+      security-events: write
+      # required to fetch internal or private CodeQL packs
+      packages: read
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - language: java-kotlin
+          build-mode: manual
+        - language: javascript-typescript
+          build-mode: none
+        # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp',
+        # 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
+        # Use `java-kotlin` to analyze code written in Java, Kotlin or both
+        # Use `javascript-typescript` to analyze code written in JavaScript, TypeScript or both
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    # The autobuild action was unable to build this repository's Gradle/Kotlin
+    # project (see the failed CI run), so java-kotlin now uses "manual" build
+    # mode. We build the project ourselves using the same JDK and Gradle task
+    # that the repository's own Test workflow (test.yml) relies on.
+    - name: Set up JDK 25 (Temurin)
+      if: matrix.build-mode == 'manual'
+      uses: actions/setup-java@v5
+      with:
+        java-version: 25
+        distribution: temurin
+        architecture: x64
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v4
+      with:
+        languages: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
+        # queries: security-extended,security-and-quality
+
+    - name: Run manual build steps
+      if: matrix.build-mode == 'manual'
+      shell: bash
+      run: |
+        ./gradlew --no-daemon -PjdkBuildVersion=25 -Dorg.gradle.java.installations.auto-download=false testClasses
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v4
+      with:
+        category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## Problem

The `Analyze (java-kotlin)` CodeQL job was failing on `master` with:

```
Error: We were unable to automatically build your code. Please replace the call to the autobuild
action with your custom build steps... A fatal error occurred: Exit status 1 from command:
[.../codeql/java/tools/autobuild.sh]
```

CodeQL's `autobuild` mode tried to run `./gradlew ... testClasses` under its build tracer, and the
Kotlin compiler crashed partway through (see the failed run: `Push on master #148`). Autobuild's
heuristics aren't a great fit for this multi-module Gradle/Kotlin build.

## Fix

This adds an advanced CodeQL workflow (`.github/workflows/codeql.yml`) that switches the
`java-kotlin` language from `build-mode: autobuild` to `build-mode: manual`, and builds the
project ourselves:

- Installs Temurin JDK 25 via `actions/setup-java`, matching the JDK used to run Gradle in
  `test.yml` (`jdkBuildVersion=25`).
- Runs `./gradlew --no-daemon -PjdkBuildVersion=25 -Dorg.gradle.java.installations.auto-download=false testClasses`
  directly as the manual build step, so CodeQL traces our own build instead of autobuild's
  heuristics.
- Leaves `javascript-typescript` on `build-mode: none` (no build required), unchanged.

## Verification

Pushed this change to my fork and confirmed the workflow now completes successfully end to end:
JDK setup, the full Gradle build (all modules compile with only javadoc/lint warnings, no errors),
and the CodeQL analyze step, which finalizes the database and runs all Java queries. Both matrix
jobs (`java-kotlin` and `javascript-typescript`) finished with status **Success** in ~8.5 minutes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated security analysis to help identify potential vulnerabilities in the application.
  * Security checks run automatically on code updates, pull requests, and a weekly schedule.
  * Analysis covers Java, Kotlin, JavaScript, and TypeScript code.
  * Java and Kotlin checks include a build validation step to improve scan accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->