### PR TITLE
docs: clarify @Ignore behavior for nested classes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current (7.13.0)
+Fixed: GITHUB-3138: Clarified that class-level @Ignore applies to subclasses, not nested classes (ShinyHero666)
 New: Added OpenRewrite to the build with a hand-picked recipe list (see rewrite.yml), and applied it to the main sources (Julien Herr)
 Fixed: Remove leftover dead JUnit code: the deprecated unused ConversionUtils and orphaned JUnit test samples, following the removal of JUnit execution support in 7.10.0 (Julien Herr)
 New: Extract the command line front end out of testng-core into the new testng-cli and testng-jcommander modules, so that testng-core no longer depends on JCommander (Julien Herr)

--- a/testng-core-api/src/main/java/org/testng/annotations/Ignore.java
+++ b/testng-core-api/src/main/java/org/testng/annotations/Ignore.java
@@ -12,7 +12,8 @@ import java.lang.annotation.Target;
  *
  * <p>Notice that @Ignore on a class will disable all test methods of the class.
  *
- * <p>Ignoring a class will ignore tests from child classes too.
+ * <p>Ignoring a class will ignore tests from subclasses too. An {@code @Ignore} annotation on an
+ * enclosing class does not apply to its nested classes.
  *
  * <p>Ignoring a package will ignore all tests in the package and its sub-packages
  *

--- a/testng-core/src/test/java/test/ignore/IgnoreClassWithNestedSample.java
+++ b/testng-core/src/test/java/test/ignore/IgnoreClassWithNestedSample.java
@@ -1,0 +1,17 @@
+package test.ignore;
+
+import org.testng.annotations.Ignore;
+import org.testng.annotations.Test;
+
+@Ignore
+public class IgnoreClassWithNestedSample {
+
+  @Test
+  public void outerTest() {}
+
+  public static class Nested {
+
+    @Test
+    public void nestedTest() {}
+  }
+}

--- a/testng-core/src/test/java/test/ignore/IgnoreTest.java
+++ b/testng-core/src/test/java/test/ignore/IgnoreTest.java
@@ -28,6 +28,13 @@ public class IgnoreTest extends SimpleBaseTest {
     assertThat(listener.getInvokedMethods()).isEmpty();
   }
 
+  @Test(description = "GITHUB-3138")
+  public void ignore_class_should_not_ignore_nested_class() {
+    InvokedMethodListener listener =
+        runTest(IgnoreClassWithNestedSample.class, IgnoreClassWithNestedSample.Nested.class);
+    assertThat(listener.getInvokedMethods()).containsExactly("nestedTest");
+  }
+
   @Test
   public void ignore_test_should_not_run_test() {
     InvokedMethodListener listener = runTest(IgnoreTestSample.class);


### PR DESCRIPTION
Fixes #3138.

### Summary

- Clarify that class-level `@Ignore` applies to subclasses, not nested classes.
- Add coverage showing that an ignored outer class does not suppress an explicitly included nested test class.
- Record the documentation clarification in `CHANGES.txt`.

### Verification

- `./gradlew :testng-core:test --tests test.ignore.IgnoreTest`
- `./gradlew build` (16,544 tests, 0 failed, 16 skipped)
- `./gradlew autostyleCheck`
- `./gradlew autostyleApply`
- `./gradlew rewriteDryRun -PfailOnRewriteDryRun=true`

### Did you remember to?

- [x] Add test case(s)
- [x] Update `CHANGES.txt`
- [x] Auto applied styling via `./gradlew autostyleApply`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified `@Ignore` behavior: ignoring a class applies to its subclasses, but not to tests in nested classes.

* **Bug Fixes**
  * Fixed handling of nested test classes so their tests continue to run when the enclosing class is ignored.

* **Changelog**
  * Added release notes for version 7.13.0, covering behavioral updates, CLI improvements, integrations, and reliability fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->