### PR TITLE
fix(xml): stop advising a DOCTYPE that the suite already declares

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,6 +10,7 @@ Fixed: XmlSuite.toXml() emitted two sibling <groups> elements for a suite that h
 Fixed: DTD violations were discarded for suite files pointing at their own copy or a mirror of the DTD rather than at testng.org, so those suites were never validated (Julien Herr)
 New: GITHUB-3319: testng.xml now has an XSD, testng-1.1.xsd, shipped next to testng-1.1.dtd and mirroring it declaration for declaration, for the tools that cannot consume a DTD. The DTD stays authoritative for files carrying a doctype; a test validates the whole suite corpus under both schemas and fails when the two stop agreeing (Julien Herr)
 Fixed: Suite files pointing at their own copy or a mirror of the DTD were told to add a <!DOCTYPE> they already declared (Julien Herr)
+Fixed: A suite whose doctype had only an internal subset was treated as having none: advised to add a <!DOCTYPE> it already declared, and its DTD violations discarded even under strict validation (Julien Herr)
 New: Added round trip characterization tests covering every suite file of the test corpus, so that XML serialization can be refactored safely (Julien Herr)
 Fixed: GITHUB-3138: Clarified that class-level @Ignore applies to subclasses, not nested classes (ShinyHero666)
 New: Added OpenRewrite to the build with a hand-picked recipe list (see rewrite.yml), and applied it to the main sources (Julien Herr)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,7 @@ Fixed: The doctype written by XmlSuite.toXml() advertised testng-1.0.dtd althoug
 Fixed: XmlSuite.toXml() emitted two sibling <groups> elements for a suite that has suite-level groups, which the DTD allows only once, so TestNG's own output did not validate (Julien Herr)
 Fixed: DTD violations were discarded for suite files pointing at their own copy or a mirror of the DTD rather than at testng.org, so those suites were never validated (Julien Herr)
 New: GITHUB-3319: testng.xml now has an XSD, testng-1.1.xsd, shipped next to testng-1.1.dtd and mirroring it declaration for declaration, for the tools that cannot consume a DTD. The DTD stays authoritative for files carrying a doctype; a test validates the whole suite corpus under both schemas and fails when the two stop agreeing (Julien Herr)
+Fixed: Suite files pointing at their own copy or a mirror of the DTD were told to add a <!DOCTYPE> they already declared (Julien Herr)
 New: Added round trip characterization tests covering every suite file of the test corpus, so that XML serialization can be refactored safely (Julien Herr)
 Fixed: GITHUB-3138: Clarified that class-level @Ignore applies to subclasses, not nested classes (ShinyHero666)
 New: Added OpenRewrite to the build with a hand-picked recipe list (see rewrite.yml), and applied it to the main sources (Julien Herr)

--- a/testng-core/src/main/java/org/testng/xml/TestNGContentHandler.java
+++ b/testng-core/src/main/java/org/testng/xml/TestNGContentHandler.java
@@ -33,6 +33,7 @@ import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
+import org.xml.sax.ext.LexicalHandler;
 import org.xml.sax.helpers.DefaultHandler;
 
 /**
@@ -42,7 +43,7 @@ import org.xml.sax.helpers.DefaultHandler;
  * @author <a href='mailto:the_mindstorm@evolva.ro'>Alexandru Popescu</a>
  */
 // TODO move to internal
-public class TestNGContentHandler extends DefaultHandler {
+public class TestNGContentHandler extends DefaultHandler implements LexicalHandler {
   private static final int DTD_CONNECTION_TIMEOUT_MILLIS = 10_000;
 
   private XmlSuite m_currentSuite = null;
@@ -153,15 +154,43 @@ public class TestNGContentHandler extends DefaultHandler {
     m_loadClasses = loadClasses;
   }
 
+  /**
+   * Records that the document declares a doctype, whoever ends up providing the grammar.
+   *
+   * <p>Tracked here rather than in {@link #resolveEntity}, which only fires for an
+   * <em>external</em> subset: a suite declaring {@code <!DOCTYPE suite [ <!ENTITY ...> ]>} never
+   * reaches it, so it used to be treated as having no doctype at all -- advised to add the one it
+   * had just written, and with its validity errors discarded. {@code startDTD} fires for an
+   * internal subset as well, and always before any content, so it is the exact signal. A document
+   * with no doctype does not trigger it, which is what keeps "no grammar found" errors suppressed
+   * for those files.
+   */
+  @Override
+  public void startDTD(String name, String publicId, String systemId) {
+    m_doctypeDeclared = true;
+  }
+
+  @Override
+  public void endDTD() {}
+
+  @Override
+  public void startEntity(String name) {}
+
+  @Override
+  public void endEntity(String name) {}
+
+  @Override
+  public void startCDATA() {}
+
+  @Override
+  public void endCDATA() {}
+
+  @Override
+  public void comment(char[] ch, int start, int length) {}
+
   @Override
   public InputSource resolveEntity(String publicId, String systemId)
       throws SAXException, IOException {
-
-    // The document declares a doctype, whoever ends up providing it. Tracked separately from
-    // m_validate, which means "TestNG substituted its own copy of the DTD": gating error reporting
-    // on m_validate silently discarded every violation for suites pointing at their own DTD copy
-    // or at a corporate mirror.
-    m_doctypeDeclared = true;
 
     if (skipConsideringSystemId(systemId)) {
       m_validate = true;

--- a/testng-core/src/main/java/org/testng/xml/TestNGContentHandler.java
+++ b/testng-core/src/main/java/org/testng/xml/TestNGContentHandler.java
@@ -157,13 +157,16 @@ public class TestNGContentHandler extends DefaultHandler implements LexicalHandl
   /**
    * Records that the document declares a doctype, whoever ends up providing the grammar.
    *
-   * <p>Tracked here rather than in {@link #resolveEntity}, which only fires for an
-   * <em>external</em> subset: a suite declaring {@code <!DOCTYPE suite [ <!ENTITY ...> ]>} never
-   * reaches it, so it used to be treated as having no doctype at all -- advised to add the one it
-   * had just written, and with its validity errors discarded. {@code startDTD} fires for an
-   * internal subset as well, and always before any content, so it is the exact signal. A document
-   * with no doctype does not trigger it, which is what keeps "no grammar found" errors suppressed
-   * for those files.
+   * <p>{@link #resolveEntity} cannot be the only signal: it fires solely for an <em>external</em>
+   * subset, so a suite declaring {@code <!DOCTYPE suite [ <!ENTITY ...> ]>} never reaches it and
+   * used to be treated as having no doctype at all -- advised to add the one it had just written,
+   * and with its validity errors discarded. {@code startDTD} covers both kinds, and always fires
+   * before any content, so it is the exact signal. A document with no doctype does not trigger it,
+   * which is what keeps "no grammar found" errors suppressed for those files.
+   *
+   * <p>The two overlap deliberately. The lexical handler is optional in SAX, so on a parser that
+   * refuses it {@code resolveEntity} still catches the external case rather than losing detection
+   * altogether.
    */
   @Override
   public void startDTD(String name, String publicId, String systemId) {
@@ -191,6 +194,11 @@ public class TestNGContentHandler extends DefaultHandler implements LexicalHandl
   @Override
   public InputSource resolveEntity(String publicId, String systemId)
       throws SAXException, IOException {
+
+    // Being asked to resolve the external subset is itself proof that a doctype was declared.
+    // Redundant with startDTD when the lexical handler could be registered, and the only signal
+    // left when it could not -- see XMLParser#registerLexicalHandler.
+    m_doctypeDeclared = true;
 
     if (skipConsideringSystemId(systemId)) {
       m_validate = true;

--- a/testng-core/src/main/java/org/testng/xml/TestNGContentHandler.java
+++ b/testng-core/src/main/java/org/testng/xml/TestNGContentHandler.java
@@ -598,7 +598,7 @@ public class TestNGContentHandler extends DefaultHandler {
    */
   @Override
   public void startElement(String uri, String localName, String qName, Attributes attributes) {
-    if (!m_validate && !m_hasWarn) {
+    if (!m_doctypeDeclared && !m_hasWarn) {
       String msg =
           String.format(
               "It is strongly recommended to add "

--- a/testng-core/src/main/java/org/testng/xml/XMLParser.java
+++ b/testng-core/src/main/java/org/testng/xml/XMLParser.java
@@ -9,6 +9,9 @@ import javax.xml.parsers.SAXParserFactory;
 import org.testng.TestNGException;
 import org.testng.log4testng.Logger;
 import org.xml.sax.SAXException;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
+import org.xml.sax.ext.LexicalHandler;
 import org.xml.sax.helpers.DefaultHandler;
 
 public abstract class XMLParser<T> implements IFileParser<T> {
@@ -47,7 +50,29 @@ public abstract class XMLParser<T> implements IFileParser<T> {
       Logger.getLogger(XMLParser.class).error(e.getMessage(), e);
       throw new TestNGException("No SAXParser could be configured to read suite files.", e);
     }
+    registerLexicalHandler(parser, dh);
     parser.parse(is, dh);
+  }
+
+  /**
+   * Lets the handler observe the doctype declaration itself.
+   *
+   * <p>{@code SAXParser.parse(InputStream, DefaultHandler)} wires the content, error, DTD and
+   * entity handlers, but not the lexical one, which has to be set as a property. Without it {@code
+   * startDTD} is never delivered and an internal-subset doctype goes unnoticed.
+   */
+  private static void registerLexicalHandler(SAXParser parser, DefaultHandler dh) {
+    if (!(dh instanceof LexicalHandler)) {
+      return;
+    }
+    try {
+      parser.setProperty("http://xml.org/sax/properties/lexical-handler", dh);
+    } catch (SAXNotRecognizedException | SAXNotSupportedException e) {
+      // Optional in SAX. Losing it only means falling back to the previous behaviour for a
+      // doctype with no external subset, so it is not worth failing the parse over.
+      Logger.getLogger(XMLParser.class)
+          .warn("The XML parser in use does not report doctype declarations: " + e);
+    }
   }
 
   /**

--- a/testng-core/src/main/java/org/testng/xml/XMLParser.java
+++ b/testng-core/src/main/java/org/testng/xml/XMLParser.java
@@ -68,8 +68,9 @@ public abstract class XMLParser<T> implements IFileParser<T> {
     try {
       parser.setProperty("http://xml.org/sax/properties/lexical-handler", dh);
     } catch (SAXNotRecognizedException | SAXNotSupportedException e) {
-      // Optional in SAX. Losing it only means falling back to the previous behaviour for a
-      // doctype with no external subset, so it is not worth failing the parse over.
+      // Optional in SAX. Losing it costs detection of a doctype that has no external subset;
+      // TestNGContentHandler.resolveEntity still catches the external case, so this degrades
+      // rather than breaks and is not worth failing the parse over.
       Logger.getLogger(XMLParser.class)
           .warn("The XML parser in use does not report doctype declarations: " + e);
     }

--- a/testng-core/src/main/java/org/testng/xml/XMLParser.java
+++ b/testng-core/src/main/java/org/testng/xml/XMLParser.java
@@ -90,6 +90,14 @@ public abstract class XMLParser<T> implements IFileParser<T> {
    */
   private static boolean supportsValidation(SAXParserFactory spf) {
     try {
+      // The value is deliberately discarded: this feature reports whether validation is currently
+      // ON, not whether it is available. The JDK's Xerces answers false here and only turns true
+      // after setValidating(true) -- and this runs before that call, so the answer is always the
+      // default. Returning it would leave validation permanently off on a parser that supports it
+      // perfectly well.
+      //
+      // Availability is signalled by the exception instead: SAXNotRecognizedException when the
+      // feature name is unknown, SAXNotSupportedException when it is known but unavailable here.
       spf.getFeature("http://xml.org/sax/features/validation");
       return true;
     } catch (Exception ex) {

--- a/testng-core/src/test/java/org/testng/xml/XmlValidationTest.java
+++ b/testng-core/src/test/java/org/testng/xml/XmlValidationTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static test.SimpleBaseTest.getPathToResource;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -218,6 +219,40 @@ public class XmlValidationTest {
 
     assertThatThrownBy(() -> parseValidating("xml/validation/internal-subset-only.xml"))
         .isInstanceOf(SAXParseException.class);
+  }
+
+  /**
+   * A suite with no doctype at all must keep parsing, even under strict.
+   *
+   * <p>A validating parser reports "no grammar found" for such a document. Those errors are
+   * suppressed because neither {@code startDTD} nor {@code resolveEntity} fires, so {@code
+   * m_doctypeDeclared} stays false -- and that suppression is what keeps strict mode usable for the
+   * many suites that never declared a doctype. Tightening the gate would silently start rejecting
+   * all of them, which is the regression this pins.
+   *
+   * <p>Written inline because the fixtures named {@code xml/*WithoutDoctype.xml} all declare one:
+   * they are byte-identical to their {@code WithDoctype} counterparts apart from the root element's
+   * case.
+   *
+   * <p>The hint asking for a doctype is not asserted. It goes through {@code Logger}, and the test
+   * runtime classpath carries slf4j-api with no provider, so the NOP logger swallows it.
+   */
+  @Test
+  public void strictModeStillAcceptsASuiteWithNoDoctype() {
+    System.setProperty(RuntimeBehavior.XML_VALIDATION_MODE, "strict");
+    String xml =
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+            + "<suite name=\"NoDoctype\">\n"
+            + "  <test name=\"t\"><classes><class name=\"test.sample.C\"/></classes></test>\n"
+            + "</suite>\n";
+
+    assertThatCode(
+            () -> {
+              InputStream stream = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
+              assertThat(new SuiteXmlParser().parse("no-doctype.xml", stream, false).getName())
+                  .isEqualTo("NoDoctype");
+            })
+        .doesNotThrowAnyException();
   }
 
   @Test

--- a/testng-core/src/test/java/org/testng/xml/XmlValidationTest.java
+++ b/testng-core/src/test/java/org/testng/xml/XmlValidationTest.java
@@ -13,6 +13,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Locale;
 import java.util.Objects;
+import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 import org.testng.SkipException;
 import org.testng.TestNGException;
@@ -202,6 +203,23 @@ public class XmlValidationTest {
     }
   }
 
+  /**
+   * A doctype with only an internal subset counts as a declared doctype.
+   *
+   * <p>{@code resolveEntity} never fires for one, so tracking the declaration there treated such a
+   * suite as having none: it was advised to add the doctype it had just written, and its violations
+   * were dropped even under strict. The internal subset is a grammar that does not declare {@code
+   * <suite>}, so a validating parser rightly rejects the document -- and that rejection now reaches
+   * the user.
+   */
+  @Test
+  public void strictModeRejectsASuiteWhoseDoctypeHasOnlyAnInternalSubset() {
+    System.setProperty(RuntimeBehavior.XML_VALIDATION_MODE, "strict");
+
+    assertThatThrownBy(() -> parseValidating("xml/validation/internal-subset-only.xml"))
+        .isInstanceOf(SAXParseException.class);
+  }
+
   @Test
   public void anUnknownModeFallsBackToWarn() {
     System.setProperty(RuntimeBehavior.XML_VALIDATION_MODE, "not-a-mode");
@@ -247,10 +265,9 @@ public class XmlValidationTest {
   }
 
   /**
-   * Parses with a validating parser created here rather than with {@link SuiteXmlParser}, whose
-   * parser is a JVM-wide singleton configured once at class-initialisation time. Only the reporting
-   * path is under test; {@link #theSharedParserValidatesSuiteFilesByDefault()} covers the
-   * singleton.
+   * Parses with a validating parser created here rather than with {@link SuiteXmlParser}, so that
+   * only the reporting path is under test. It must mirror how {@code XMLParser} configures its own
+   * parser, or the two would drift apart and these tests would stop describing production.
    */
   private static XmlSuite parseValidating(String suiteFile) throws Exception {
     return parseValidating(Paths.get(getPathToResource(suiteFile)));
@@ -260,13 +277,18 @@ public class XmlValidationTest {
     SAXParserFactory factory = SAXParserFactory.newInstance();
     factory.setValidating(true);
     TestNGContentHandler handler = new TestNGContentHandler(path.toString(), false);
+    SAXParser parser = factory.newSAXParser();
+    // Same wiring as XMLParser.parse. Without it startDTD is never delivered, the handler believes
+    // no doctype was declared, and every violation is discarded -- so the parser built here has to
+    // be configured like the real one or these tests would prove nothing.
+    parser.setProperty("http://xml.org/sax/properties/lexical-handler", handler);
     try (InputStream stream = Files.newInputStream(path)) {
       InputSource source = new InputSource(stream);
       // The system id matters: without it a relative doctype cannot be resolved, so TestNG falls
       // back to substituting its own DTD and the "suite points at its own DTD" case would silently
       // exercise the substituted path instead.
       source.setSystemId(path.toUri().toString());
-      factory.newSAXParser().parse(source, handler);
+      parser.parse(source, handler);
     }
     return handler.getSuite();
   }

--- a/testng-core/src/test/java/org/testng/xml/XmlValidationTest.java
+++ b/testng-core/src/test/java/org/testng/xml/XmlValidationTest.java
@@ -45,6 +45,7 @@ public class XmlValidationTest {
 
   private static final String INVALID_SUITE = "xml/validation/wrong-element-order.xml";
   private static final String VALID_SUITE = "xml/goodWithDoctype.xml";
+  private static final String INTERNAL_SUBSET_SUITE = "xml/validation/internal-subset-only.xml";
 
   private String previousMode;
 
@@ -212,13 +213,27 @@ public class XmlValidationTest {
    * were dropped even under strict. The internal subset is a grammar that does not declare {@code
    * <suite>}, so a validating parser rightly rejects the document -- and that rejection now reaches
    * the user.
+   *
+   * <p>Asserted through both parsers, because they fail differently. The one built here registers
+   * the lexical handler itself, so it only proves that {@code startDTD} is honoured once delivered.
+   * {@link SuiteXmlParser} is the only path that goes through {@link XMLParser#parse}, which is
+   * where the handler is registered -- and this is the one case where that registration matters,
+   * since {@code resolveEntity} cannot stand in for it. Breaking the registration used to leave
+   * every XML test green.
    */
   @Test
-  public void strictModeRejectsASuiteWhoseDoctypeHasOnlyAnInternalSubset() {
+  public void strictModeRejectsASuiteWhoseDoctypeHasOnlyAnInternalSubset() throws Exception {
     System.setProperty(RuntimeBehavior.XML_VALIDATION_MODE, "strict");
 
-    assertThatThrownBy(() -> parseValidating("xml/validation/internal-subset-only.xml"))
+    assertThatThrownBy(() -> parseValidating(INTERNAL_SUBSET_SUITE))
         .isInstanceOf(SAXParseException.class);
+
+    try (InputStream stream =
+        Files.newInputStream(Paths.get(getPathToResource(INTERNAL_SUBSET_SUITE)))) {
+      assertThatThrownBy(() -> new SuiteXmlParser().parse(INTERNAL_SUBSET_SUITE, stream, false))
+          .isInstanceOf(TestNGException.class)
+          .hasRootCauseInstanceOf(SAXParseException.class);
+    }
   }
 
   /**

--- a/testng-core/src/test/java/org/testng/xml/XmlValidationTest.java
+++ b/testng-core/src/test/java/org/testng/xml/XmlValidationTest.java
@@ -15,6 +15,7 @@ import java.util.Locale;
 import java.util.Objects;
 import javax.xml.parsers.SAXParserFactory;
 import org.testng.SkipException;
+import org.testng.TestNGException;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -31,11 +32,12 @@ import org.xml.sax.SAXParseException;
  * reached. A test asserting only that valid files parse would have passed throughout, so the check
  * that matters is that an <em>invalid</em> file is rejected.
  *
- * <p>The two halves of the wiring are asserted separately on purpose. Whether {@code XMLParser}
+ * <p>The halves of the wiring are asserted separately on purpose. Whether {@code XMLParser}
  * validates is read back directly rather than inferred from a parse: inferring it made this test
  * fail intermittently across the CI matrix, because "no error was reported" and "validation is not
- * enabled" look identical from the outside. How a violation is <em>reported</em> is exercised
- * through a parser built here, so it cannot depend on the state of the shared one.
+ * enabled" look identical from the outside. How a violation is <em>reported</em> is then exercised
+ * through a parser this test configures, which isolates the reporting from the configuration. Since
+ * neither of those goes through {@link SuiteXmlParser}, one test walks the whole path users take.
  */
 public class XmlValidationTest {
 
@@ -96,6 +98,27 @@ public class XmlValidationTest {
     System.setProperty(RuntimeBehavior.XML_VALIDATION_MODE, "strict");
 
     assertThatThrownBy(() -> parseValidating(INVALID_SUITE)).isInstanceOf(SAXParseException.class);
+  }
+
+  /**
+   * The same rejection, but through {@link SuiteXmlParser} rather than through a parser this test
+   * configures.
+   *
+   * <p>{@link #strictModeRejectsASuiteThatViolatesTheDtd()} calls {@code setValidating(true)}
+   * itself, so it proves that a violation is reported but says nothing about whether the mode ever
+   * reaches a parser. Only {@link XMLParser#parse} reads {@link XmlValidationMode} and configures
+   * the factory from it, and that is the path users take. Without this test, breaking that wiring
+   * would leave the whole class green.
+   */
+  @Test
+  public void theSuiteParserReportsAViolationInStrictMode() throws Exception {
+    System.setProperty(RuntimeBehavior.XML_VALIDATION_MODE, "strict");
+
+    try (InputStream stream = Files.newInputStream(Paths.get(getPathToResource(INVALID_SUITE)))) {
+      assertThatThrownBy(() -> new SuiteXmlParser().parse(INVALID_SUITE, stream, false))
+          .isInstanceOf(TestNGException.class)
+          .hasRootCauseInstanceOf(SAXParseException.class);
+    }
   }
 
   @Test

--- a/testng-core/src/test/java/org/testng/xml/XmlValidationTest.java
+++ b/testng-core/src/test/java/org/testng/xml/XmlValidationTest.java
@@ -185,8 +185,10 @@ public class XmlValidationTest {
    * Deletes every path, so that one failure does not leave the rest behind. The suite runs in one
    * fork per two cores, so leaking a directory holding a copy of the DTD on every build adds up.
    *
-   * <p>Deletion can genuinely fail on Windows: the entity resolver hands the DTD stream to {@code
-   * InputSource} without closing it, and a lingering handle blocks the delete.
+   * <p>Deletion is not assumed to succeed. It used to fail on Windows, where the entity resolver
+   * handed the DTD stream to {@code InputSource} without closing it and the lingering handle
+   * blocked the delete; #3334 now buffers and closes it, but a cleanup that hides the assertion it
+   * was cleaning up after is worth avoiding whatever the cause.
    */
   private static void deleteAll(Path... paths) throws IOException {
     IOException failures = null;

--- a/testng-core/src/test/resources/xml/validation/internal-subset-only.xml
+++ b/testng-core/src/test/resources/xml/validation/internal-subset-only.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Declares a doctype with an internal subset and no external one, which is a way to
+  define entities without pulling the TestNG DTD. The internal subset is a grammar, and
+  it does not declare <suite>, so a validating parser rejects the document.
+
+  resolveEntity() never fires for such a file, so before startDTD was observed it was
+  treated as having no doctype at all: advised to add the one it had just written, and
+  with its validity errors discarded even under strict.
+-->
+<!DOCTYPE suite [
+  <!ENTITY suiteName "InternalSubsetOnly">
+]>
+<suite name="&suiteName;">
+  <test name="t">
+    <classes>
+      <class name="test.sample.C"/>
+    </classes>
+  </test>
+</suite>


### PR DESCRIPTION
Follow-up to #3315, which is merged; this branch is cut from `master` and depends on nothing else.

## The false warning

`TestNGContentHandler.startElement` gates the "it is strongly recommended to add `<!DOCTYPE ...>`" hint on `m_validate`, which does not mean what the hint needs:

```java
-    if (!m_validate && !m_hasWarn) {
+    if (!m_doctypeDeclared && !m_hasWarn) {
```

- `m_validate` means **"TestNG substituted its own copy of the DTD"**. It is set only in the `skipConsideringSystemId` branch of `resolveEntity` — a `testng.org` / `beust.com` system id, or a `file:` path that does not exist.
- `m_doctypeDeclared` means **"a doctype is declared"**, whoever ends up providing the file.

So a suite starting with `<!DOCTYPE suite SYSTEM "https://dtd.internal.example/testng-1.1.dtd">`, or pointing at a local copy, resolves through the *other* branch and is told on every parse to add a doctype it just used.

This is the same conflation that #3315 fixed one method below, in `error()` — where it was worse, since DTD violations were being discarded outright for those same users. `startElement` was left behind. The line itself is old: `git log -L 576,576:...` reaches `f55c66645` "Warn user when doctype is missing".

**Not covered by a test, deliberately.** The hint goes through `Logger`, and the test runtime classpath carries `slf4j-api` with no provider, so the NOP logger swallows it. Asserting it would mean adding an slf4j binding to the test classpath — a build change unrelated to this fix.

## The coverage gap it revealed

`XmlValidationTest` checks `isValidating()` directly, and checks reporting through a parser the test configures itself. Nothing walked the whole path through `SuiteXmlParser`, which is the one users take — and it is the only path that reads `XmlValidationMode` and configures the factory from it. The existing strict tests call `setValidating(true)` themselves, so they prove a violation gets reported but say nothing about whether the configured mode ever reaches a parser.

`theSuiteParserReportsAViolationInStrictMode` closes that.

The gap was verified rather than assumed: reverting the SAX feature name to its `https` spelling turns the new test red with *"Expecting code to raise a throwable"*, **alongside** `theParserValidatesSuiteFilesByDefault`. Had only the latter failed, the new test would be guarding nothing.

## Also, answering the review on #3315

[This review comment](https://github.com/testng-team/testng/pull/3315#discussion_r3746407842) asked whether `supportsValidation` should return what `getFeature` answered instead of ignoring it. It should not, and the reason was nowhere in the code, so it is now written down.

That feature reports whether validation is currently **on**, not whether it is **available**. Measured on the JDK's Xerces, which supports DTD validation perfectly well:

```
default        getFeature=false  isValidating=false
setValidating  getFeature=true   isValidating=true
```

The probe runs *before* `setValidating`, so the answer is always the default. Honouring it would compute `validating = mode.isValidating() && false` and leave validation permanently off — the very failure this setting exists to prevent. Availability is signalled by the exception instead: `SAXNotRecognizedException` when the name is unknown, `SAXNotSupportedException` when it is known but unavailable.

## Verification

`./gradlew build` — BUILD SUCCESSFUL, 14316 tests, 0 failed.

### Did you remember to?

- [x] Add test case(s)
- [x] Update `CHANGES.txt`
- [x] Auto applied styling via `./gradlew autostyleApply`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed duplicate `DOCTYPE` warnings for suites referencing local or mirrored DTDs.
  - Improved recognition and validation of suites with only an internal DTD subset.
  - Strict validation now correctly rejects invalid suites and reports XML violations.
  - Suites without a `DOCTYPE` remain accepted when strict validation does not require one.

- **Documentation**
  - Updated the 7.13.0 changelog with XML validation fixes and behavior clarifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->