### PR TITLE
refactor(xml): move suite serialization out of the model and into the weaver

### DIFF
--- a/testng-core-api/src/main/java/org/testng/xml/CommentDisabledXmlWeaver.java
+++ b/testng-core-api/src/main/java/org/testng/xml/CommentDisabledXmlWeaver.java
@@ -3,9 +3,11 @@ package org.testng.xml;
 /**
  * This class provides String representation of both {@link XmlSuite} and {@link XmlTest} without
  * adding an XML comment as the test name and suite name at the end of the corresponding tags.
+ *
+ * <p>Select it with {@code -Dtestng.xml.weaver=org.testng.xml.CommentDisabledXmlWeaver}.
  */
-final class CommentDisabledXmlWeaver extends DefaultXmlWeaver {
-  CommentDisabledXmlWeaver() {
+public final class CommentDisabledXmlWeaver extends DefaultXmlWeaver {
+  public CommentDisabledXmlWeaver() {
     super("");
   }
 }

--- a/testng-core-api/src/main/java/org/testng/xml/DefaultXmlWeaver.java
+++ b/testng-core-api/src/main/java/org/testng/xml/DefaultXmlWeaver.java
@@ -443,27 +443,22 @@ public class DefaultXmlWeaver implements IWeaveXml {
   }
 
   protected void asXml(XMLStringBuffer xsb, XmlPackage xmlPackage) {
-    Properties p = new Properties();
-    p.setProperty("name", xmlPackage.getName());
+    List<String> includes = xmlPackage.getInclude();
+    List<String> excludes = xmlPackage.getExclude();
 
-    if (xmlPackage.getInclude().isEmpty() && xmlPackage.getExclude().isEmpty()) {
-      xsb.addEmptyElement("package", p);
-    } else {
-      xsb.push("package", p);
-
-      for (String m : xmlPackage.getInclude()) {
-        Properties includeProp = new Properties();
-        includeProp.setProperty("name", m);
-        xsb.addEmptyElement("include", includeProp);
-      }
-      for (String m : xmlPackage.getExclude()) {
-        Properties excludeProp = new Properties();
-        excludeProp.setProperty("name", m);
-        xsb.addEmptyElement("exclude", excludeProp);
-      }
-
-      xsb.pop("package");
+    if (includes.isEmpty() && excludes.isEmpty()) {
+      xsb.addEmptyElement("package", "name", xmlPackage.getName());
+      return;
     }
+
+    xsb.push("package", "name", xmlPackage.getName());
+    for (String m : includes) {
+      xsb.addEmptyElement("include", "name", m);
+    }
+    for (String m : excludes) {
+      xsb.addEmptyElement("exclude", "name", m);
+    }
+    xsb.pop("package");
   }
 
   protected void asXml(XMLStringBuffer xsb, XmlMethodSelectors xmlMethodSelectors) {
@@ -479,7 +474,6 @@ public class DefaultXmlWeaver implements IWeaveXml {
   }
 
   protected void asXml(XMLStringBuffer xsb, XmlMethodSelector xmlMethodSelector) {
-
     xsb.push("method-selector");
 
     XmlScript script = xmlMethodSelector.getScript();
@@ -494,9 +488,7 @@ public class DefaultXmlWeaver implements IWeaveXml {
       }
       xsb.addEmptyElement("selector-class", clsProp);
     } else if (script != null && script.getLanguage() != null) {
-      Properties scriptProp = new Properties();
-      scriptProp.setProperty("language", script.getLanguage());
-      xsb.push("script", scriptProp);
+      xsb.push("script", "language", script.getLanguage());
       xsb.addCDATA(script.getExpression());
       xsb.pop("script");
     } else {
@@ -507,39 +499,31 @@ public class DefaultXmlWeaver implements IWeaveXml {
   }
 
   protected void asXml(XMLStringBuffer xsb, XmlClass xmlClass) {
-    Properties prop = new Properties();
-    prop.setProperty("name", xmlClass.getName());
-
     List<XmlInclude> includedMethods = xmlClass.getIncludedMethods();
     List<String> excludedMethods = xmlClass.getExcludedMethods();
     Map<String, String> parameters = xmlClass.getLocalParameters();
 
     boolean hasMethods = !includedMethods.isEmpty() || !excludedMethods.isEmpty();
-    boolean hasParameters = !parameters.isEmpty();
-    if (hasParameters || hasMethods) {
-      xsb.push("class", prop);
-      dumpParameters(xsb, parameters);
-
-      if (hasMethods) {
-        xsb.push("methods");
-
-        for (XmlInclude m : includedMethods) {
-          asXml(xsb, m);
-        }
-
-        for (String m : excludedMethods) {
-          Properties p = new Properties();
-          p.setProperty("name", m);
-          xsb.addEmptyElement("exclude", p);
-        }
-
-        xsb.pop("methods");
-      }
-
-      xsb.pop("class");
-    } else {
-      xsb.addEmptyElement("class", prop);
+    if (parameters.isEmpty() && !hasMethods) {
+      xsb.addEmptyElement("class", "name", xmlClass.getName());
+      return;
     }
+
+    xsb.push("class", "name", xmlClass.getName());
+    dumpParameters(xsb, parameters);
+
+    if (hasMethods) {
+      xsb.push("methods");
+      for (XmlInclude m : includedMethods) {
+        asXml(xsb, m);
+      }
+      for (String m : excludedMethods) {
+        xsb.addEmptyElement("exclude", "name", m);
+      }
+      xsb.pop("methods");
+    }
+
+    xsb.pop("class");
   }
 
   protected void asXml(XMLStringBuffer xsb, XmlInclude xmlInclude) {
@@ -571,25 +555,18 @@ public class DefaultXmlWeaver implements IWeaveXml {
    * @param parameters the parameters of the element being written
    */
   protected static void dumpParameters(XMLStringBuffer xsb, Map<String, String> parameters) {
-    // parameters
-    if (parameters.isEmpty()) {
-      return;
-    }
     for (Map.Entry<String, String> para : parameters.entrySet()) {
-      Properties paramProps = new Properties();
       if (para.getKey() == null) {
         Utils.log("Skipping a null parameter.");
         continue;
       }
       if (para.getValue() == null) {
-        String msg =
-            String.format("Skipping parameter [%s] since it has a null value", para.getKey());
-        Utils.log(msg);
+        Utils.log(
+            String.format("Skipping parameter [%s] since it has a null value", para.getKey()));
         continue;
       }
-      paramProps.setProperty("name", para.getKey());
-      paramProps.setProperty("value", para.getValue());
-      xsb.addEmptyElement("parameter", paramProps); // BUGFIX: TESTNG-27
+      // BUGFIX: TESTNG-27
+      xsb.addEmptyElement("parameter", "name", para.getKey(), "value", para.getValue());
     }
   }
 

--- a/testng-core-api/src/main/java/org/testng/xml/DefaultXmlWeaver.java
+++ b/testng-core-api/src/main/java/org/testng/xml/DefaultXmlWeaver.java
@@ -23,24 +23,27 @@ import org.testng.reporters.XMLStringBuffer;
  * <pre>{@code
  * public class MyWeaver extends DefaultXmlWeaver {
  *   @Override
- *   protected String asXml(XmlClass xmlClass, String indent) {
- *     return indent + "<class name=\"" + xmlClass.getName() + "\"/>" + XMLStringBuffer.EOL;
+ *   protected void asXml(XMLStringBuffer xsb, XmlClass xmlClass) {
+ *     xsb.addEmptyElement("class", "name", xmlClass.getName());
  *   }
  * }
  * }</pre>
+ *
+ * <p>Each hook writes into the buffer it is handed, so indentation follows the buffer's own
+ * push/pop depth and a subclass never has to compute it.
  *
  * <p>Select it at runtime with {@code -Dtestng.xml.weaver=fully.qualified.MyWeaver}. The class
  * needs a public no-argument constructor, which is how {@code XmlWeaver} instantiates it.
  *
  * <p><b>One gap to be aware of:</b> the {@code <groups>} block of a {@code <test>} is still written
- * inline by {@link #asXml(XmlTest, String)}, so overriding {@link #asXml(XmlGroups, String)},
- * {@link #asXml(XmlDefine, String)}, {@link #asXml(XmlRun, String)} or {@link
- * #asXml(XmlDependencies, String)} affects a suite-level {@code <groups>} but not a test-level one.
- * Routing it through those hooks is not a pure refactoring: group dependencies parsed from a suite
- * file are stored on {@link XmlTest} itself, not on its {@link XmlGroups} -- {@code
- * XmlGroups.setXmlDependencies} is never called by the reader -- so delegating would read them from
- * the empty side and drop them. Unifying the two is model surgery, tracked by #3317 rather than
- * done here.
+ * inline by {@link #asXml(XmlTest, String)}, so overriding {@link #asXml(XMLStringBuffer,
+ * XmlGroups)}, {@link #asXml(XMLStringBuffer, XmlDefine)}, {@link #asXml(XMLStringBuffer, XmlRun)}
+ * or {@link #asXml(XMLStringBuffer, XmlDependencies)} affects a suite-level {@code <groups>} but
+ * not a test-level one. Routing it through those hooks is not a pure refactoring: group
+ * dependencies parsed from a suite file are stored on {@link XmlTest} itself, not on its {@link
+ * XmlGroups} -- {@code XmlGroups.setXmlDependencies} is never called by the reader -- so delegating
+ * would read them from the empty side and drop them. Unifying the two is model surgery, tracked by
+ * #3317 rather than done here.
  *
  * @see IWeaveXml
  */
@@ -145,7 +148,7 @@ public class DefaultXmlWeaver implements IWeaveXml {
     xsb.push("suite", p);
 
     if (xmlSuite.getGroups() != null) {
-      xsb.getStringBuffer().append(asXml(xmlSuite.getGroups(), "  "));
+      asXml(xsb, xmlSuite.getGroups());
     } else {
       // Only synthesize a <groups> block when the suite has no XmlGroups of its own to write.
       // getIncludedGroups()/getExcludedGroups() read through to that same XmlGroups, so emitting
@@ -184,21 +187,19 @@ public class DefaultXmlWeaver implements IWeaveXml {
       xsb.push("packages");
 
       for (XmlPackage pack : xmlSuite.getXmlPackages()) {
-        xsb.getStringBuffer().append(asXml(pack, "    "));
+        asXml(xsb, pack);
       }
 
       xsb.pop("packages");
     }
 
     if (xmlSuite.getXmlMethodSelectors() != null) {
-      xsb.getStringBuffer().append(asXml(xmlSuite.getXmlMethodSelectors(), "  "));
+      asXml(xsb, xmlSuite.getXmlMethodSelectors());
     } else {
       if (hasElements(xmlSuite.getMethodSelectors())) {
         xsb.push("method-selectors");
         for (XmlMethodSelector selector : xmlSuite.getMethodSelectors()) {
-          // Same child indentation as the structured path above, which reaches the selectors
-          // through asXml(XmlMethodSelectors, "  ") and so indents them by a further two.
-          xsb.getStringBuffer().append(asXml(selector, "    "));
+          asXml(xsb, selector);
         }
 
         xsb.pop("method-selectors");
@@ -217,6 +218,10 @@ public class DefaultXmlWeaver implements IWeaveXml {
     }
 
     for (XmlTest test : xmlSuite.getTests()) {
+      // The last fragment still spliced in rather than woven straight into the buffer:
+      // asXml(XmlTest,
+      // String) is an IWeaveXml method and has to return a String, so its indent stays explicit.
+      //
       // Not test.toXml("  "): that re-resolves the weaver from testng.xml.weaver, so a subclass
       // serializing a suite through its own instance would have every override below <test>
       // silently bypassed -- including the one CommentDisabledXmlWeaver relies on.
@@ -263,7 +268,7 @@ public class DefaultXmlWeaver implements IWeaveXml {
     if (null != xmlTest.getMethodSelectors() && !xmlTest.getMethodSelectors().isEmpty()) {
       xsb.push("method-selectors");
       for (XmlMethodSelector selector : xmlTest.getMethodSelectors()) {
-        xsb.getStringBuffer().append(asXml(selector, indent + "    "));
+        asXml(xsb, selector);
       }
 
       xsb.pop("method-selectors");
@@ -340,7 +345,7 @@ public class DefaultXmlWeaver implements IWeaveXml {
       xsb.push("packages");
 
       for (XmlPackage pack : xmlTest.getXmlPackages()) {
-        xsb.getStringBuffer().append(asXml(pack, "      "));
+        asXml(xsb, pack);
       }
 
       xsb.pop("packages");
@@ -350,7 +355,7 @@ public class DefaultXmlWeaver implements IWeaveXml {
     if (null != xmlTest.getXmlClasses() && !xmlTest.getXmlClasses().isEmpty()) {
       xsb.push("classes");
       for (XmlClass cls : xmlTest.getXmlClasses()) {
-        xsb.getStringBuffer().append(asXml(cls, indent + "    "));
+        asXml(xsb, cls);
       }
       xsb.pop("classes");
     }
@@ -360,11 +365,7 @@ public class DefaultXmlWeaver implements IWeaveXml {
     return xsb.toXML();
   }
 
-  protected String asXml(XmlGroups xmlGroups, String indent) {
-    XMLStringBuffer xsb = new XMLStringBuffer(indent);
-    xsb.setDefaultComment(defaultComment);
-    String indent2 = indent + "  ";
-
+  protected void asXml(XMLStringBuffer xsb, XmlGroups xmlGroups) {
     List<XmlDefine> defines = xmlGroups.getDefines();
     XmlRun run = xmlGroups.getRun();
     List<XmlDependencies> dependencies = xmlGroups.getDependencies();
@@ -375,28 +376,24 @@ public class DefaultXmlWeaver implements IWeaveXml {
     }
 
     for (XmlDefine d : defines) {
-      xsb.getStringBuffer().append(asXml(d, indent2));
+      asXml(xsb, d);
     }
 
     if (null != run) {
       // XmlRun is optional and is not always available, so check before serializing it.
-      xsb.getStringBuffer().append(asXml(run, indent2));
+      asXml(xsb, run);
     }
 
     for (XmlDependencies d : dependencies) {
-      xsb.getStringBuffer().append(asXml(d, indent2));
+      asXml(xsb, d);
     }
 
     if (hasGroups) {
       xsb.pop("groups");
     }
-
-    return xsb.toXML();
   }
 
-  protected String asXml(XmlDefine xmlDefine, String indent) {
-    XMLStringBuffer xsb = new XMLStringBuffer(indent);
-    xsb.setDefaultComment(defaultComment);
+  protected void asXml(XMLStringBuffer xsb, XmlDefine xmlDefine) {
     List<String> includes = xmlDefine.getIncludes();
     boolean hasElements = hasElements(includes);
     if (hasElements) {
@@ -408,13 +405,9 @@ public class DefaultXmlWeaver implements IWeaveXml {
     if (hasElements) {
       xsb.pop("define");
     }
-
-    return xsb.toXML();
   }
 
-  protected String asXml(XmlRun xmlRun, String indent) {
-    XMLStringBuffer xsb = new XMLStringBuffer(indent);
-    xsb.setDefaultComment(defaultComment);
+  protected void asXml(XMLStringBuffer xsb, XmlRun xmlRun) {
     List<String> includes = xmlRun.getIncludes();
     List<String> excludes = xmlRun.getExcludes();
     boolean hasElements = hasElements(excludes) || hasElements(includes);
@@ -430,13 +423,9 @@ public class DefaultXmlWeaver implements IWeaveXml {
     if (hasElements) {
       xsb.pop("run");
     }
-
-    return xsb.toXML();
   }
 
-  protected String asXml(XmlDependencies xmlDependencies, String indent) {
-    XMLStringBuffer xsb = new XMLStringBuffer(indent);
-    xsb.setDefaultComment(defaultComment);
+  protected void asXml(XMLStringBuffer xsb, XmlDependencies xmlDependencies) {
     Map<String, String> groups = xmlDependencies.getDependencies();
     boolean hasElements = hasElements(groups);
     if (hasElements) {
@@ -451,13 +440,9 @@ public class DefaultXmlWeaver implements IWeaveXml {
     if (hasElements) {
       xsb.pop("dependencies");
     }
-
-    return xsb.toXML();
   }
 
-  protected String asXml(XmlPackage xmlPackage, String indent) {
-    XMLStringBuffer xsb = new XMLStringBuffer(indent);
-    xsb.setDefaultComment(defaultComment);
+  protected void asXml(XMLStringBuffer xsb, XmlPackage xmlPackage) {
     Properties p = new Properties();
     p.setProperty("name", xmlPackage.getName());
 
@@ -479,28 +464,21 @@ public class DefaultXmlWeaver implements IWeaveXml {
 
       xsb.pop("package");
     }
-
-    return xsb.toXML();
   }
 
-  protected String asXml(XmlMethodSelectors xmlMethodSelectors, String indent) {
-    XMLStringBuffer xsb = new XMLStringBuffer(indent);
-    xsb.setDefaultComment(defaultComment);
+  protected void asXml(XMLStringBuffer xsb, XmlMethodSelectors xmlMethodSelectors) {
     List<XmlMethodSelector> selectors = xmlMethodSelectors.getMethodSelectors();
     if (hasElements(selectors)) {
       xsb.push("method-selectors");
       for (XmlMethodSelector selector : selectors) {
-        xsb.getStringBuffer().append(asXml(selector, indent + "  "));
+        asXml(xsb, selector);
       }
 
       xsb.pop("method-selectors");
     }
-    return xsb.toXML();
   }
 
-  protected String asXml(XmlMethodSelector xmlMethodSelector, String indent) {
-    XMLStringBuffer xsb = new XMLStringBuffer(indent);
-    xsb.setDefaultComment(defaultComment);
+  protected void asXml(XMLStringBuffer xsb, XmlMethodSelector xmlMethodSelector) {
 
     xsb.push("method-selector");
 
@@ -526,13 +504,9 @@ public class DefaultXmlWeaver implements IWeaveXml {
     }
 
     xsb.pop("method-selector");
-
-    return xsb.toXML();
   }
 
-  protected String asXml(XmlClass xmlClass, String indent) {
-    XMLStringBuffer xsb = new XMLStringBuffer(indent);
-    xsb.setDefaultComment(defaultComment);
+  protected void asXml(XMLStringBuffer xsb, XmlClass xmlClass) {
     Properties prop = new Properties();
     prop.setProperty("name", xmlClass.getName());
 
@@ -550,7 +524,7 @@ public class DefaultXmlWeaver implements IWeaveXml {
         xsb.push("methods");
 
         for (XmlInclude m : includedMethods) {
-          xsb.getStringBuffer().append(asXml(m, indent + "    "));
+          asXml(xsb, m);
         }
 
         for (String m : excludedMethods) {
@@ -566,13 +540,9 @@ public class DefaultXmlWeaver implements IWeaveXml {
     } else {
       xsb.addEmptyElement("class", prop);
     }
-
-    return xsb.toXML();
   }
 
-  protected String asXml(XmlInclude xmlInclude, String indent) {
-    XMLStringBuffer xsb = new XMLStringBuffer(indent);
-    xsb.setDefaultComment(defaultComment);
+  protected void asXml(XMLStringBuffer xsb, XmlInclude xmlInclude) {
     Properties p = new Properties();
     p.setProperty("name", xmlInclude.getName());
     if (xmlInclude.getDescription() != null) {
@@ -591,8 +561,6 @@ public class DefaultXmlWeaver implements IWeaveXml {
     } else {
       xsb.addEmptyElement("include", p);
     }
-
-    return xsb.toXML();
   }
 
   /**
@@ -625,6 +593,12 @@ public class DefaultXmlWeaver implements IWeaveXml {
     }
   }
 
+  private static XMLStringBuffer newFragmentBuffer(String indent) {
+    XMLStringBuffer xsb = new XMLStringBuffer(indent);
+    xsb.setDefaultComment(LEGACY_FRAGMENT_WEAVER.defaultComment);
+    return xsb;
+  }
+
   /**
    * The serializer behind the deprecated {@code toXml(String)} methods that the model classes still
    * expose. Those methods never consulted {@code -Dtestng.xml.weaver}: they built their XML inline,
@@ -632,38 +606,56 @@ public class DefaultXmlWeaver implements IWeaveXml {
    * gets back. They keep using the default serializer.
    */
   static String asXmlFragment(XmlGroups groups, String indent) {
-    return LEGACY_FRAGMENT_WEAVER.asXml(groups, indent);
+    XMLStringBuffer xsb = newFragmentBuffer(indent);
+    LEGACY_FRAGMENT_WEAVER.asXml(xsb, groups);
+    return xsb.toXML();
   }
 
   static String asXmlFragment(XmlDefine define, String indent) {
-    return LEGACY_FRAGMENT_WEAVER.asXml(define, indent);
+    XMLStringBuffer xsb = newFragmentBuffer(indent);
+    LEGACY_FRAGMENT_WEAVER.asXml(xsb, define);
+    return xsb.toXML();
   }
 
   static String asXmlFragment(XmlRun run, String indent) {
-    return LEGACY_FRAGMENT_WEAVER.asXml(run, indent);
+    XMLStringBuffer xsb = newFragmentBuffer(indent);
+    LEGACY_FRAGMENT_WEAVER.asXml(xsb, run);
+    return xsb.toXML();
   }
 
   static String asXmlFragment(XmlDependencies dependencies, String indent) {
-    return LEGACY_FRAGMENT_WEAVER.asXml(dependencies, indent);
+    XMLStringBuffer xsb = newFragmentBuffer(indent);
+    LEGACY_FRAGMENT_WEAVER.asXml(xsb, dependencies);
+    return xsb.toXML();
   }
 
   static String asXmlFragment(XmlPackage xmlPackage, String indent) {
-    return LEGACY_FRAGMENT_WEAVER.asXml(xmlPackage, indent);
+    XMLStringBuffer xsb = newFragmentBuffer(indent);
+    LEGACY_FRAGMENT_WEAVER.asXml(xsb, xmlPackage);
+    return xsb.toXML();
   }
 
   static String asXmlFragment(XmlMethodSelectors selectors, String indent) {
-    return LEGACY_FRAGMENT_WEAVER.asXml(selectors, indent);
+    XMLStringBuffer xsb = newFragmentBuffer(indent);
+    LEGACY_FRAGMENT_WEAVER.asXml(xsb, selectors);
+    return xsb.toXML();
   }
 
   static String asXmlFragment(XmlMethodSelector selector, String indent) {
-    return LEGACY_FRAGMENT_WEAVER.asXml(selector, indent);
+    XMLStringBuffer xsb = newFragmentBuffer(indent);
+    LEGACY_FRAGMENT_WEAVER.asXml(xsb, selector);
+    return xsb.toXML();
   }
 
   static String asXmlFragment(XmlClass xmlClass, String indent) {
-    return LEGACY_FRAGMENT_WEAVER.asXml(xmlClass, indent);
+    XMLStringBuffer xsb = newFragmentBuffer(indent);
+    LEGACY_FRAGMENT_WEAVER.asXml(xsb, xmlClass);
+    return xsb.toXML();
   }
 
   static String asXmlFragment(XmlInclude include, String indent) {
-    return LEGACY_FRAGMENT_WEAVER.asXml(include, indent);
+    XMLStringBuffer xsb = newFragmentBuffer(indent);
+    LEGACY_FRAGMENT_WEAVER.asXml(xsb, include);
+    return xsb.toXML();
   }
 }

--- a/testng-core-api/src/main/java/org/testng/xml/DefaultXmlWeaver.java
+++ b/testng-core-api/src/main/java/org/testng/xml/DefaultXmlWeaver.java
@@ -14,8 +14,27 @@ import org.testng.reporters.XMLStringBuffer;
 /**
  * This class provides String representation of both {@link XmlSuite} and {@link XmlTest} but adds
  * an XML comment as the test name and suite name at the end of the corresponding tags.
+ *
+ * <p>It is also the base class to extend when you want to change how a suite is written without
+ * rewriting the whole serializer. There is one {@code asXml} method per element of {@code
+ * testng.xml}, each {@code protected}, so a subclass overrides only the element it cares about and
+ * inherits the rest:
+ *
+ * <pre>{@code
+ * public class MyWeaver extends DefaultXmlWeaver {
+ *   @Override
+ *   protected String asXml(XmlClass xmlClass, String indent) {
+ *     return indent + "<class name=\"" + xmlClass.getName() + "\"/>" + XMLStringBuffer.EOL;
+ *   }
+ * }
+ * }</pre>
+ *
+ * <p>Select it at runtime with {@code -Dtestng.xml.weaver=fully.qualified.MyWeaver}. The class
+ * needs a public no-argument constructor, which is how {@code XmlWeaver} instantiates it.
+ *
+ * @see IWeaveXml
  */
-class DefaultXmlWeaver implements IWeaveXml {
+public class DefaultXmlWeaver implements IWeaveXml {
   // TODO: move constants to XmlSuite?
   /**
    * The name of the TestNG DTD. Must stay in sync with {@code Parser.TESTNG_DTD}, which is the
@@ -35,11 +54,17 @@ class DefaultXmlWeaver implements IWeaveXml {
 
   private final String defaultComment;
 
-  DefaultXmlWeaver() {
+  /** Writes the name of each named tag as a trailing XML comment, as TestNG always has. */
+  public DefaultXmlWeaver() {
     this(null);
   }
 
-  DefaultXmlWeaver(String defaultComment) {
+  /**
+   * @param defaultComment the comment to close every tag with, or {@code null} to fall back to the
+   *     tag's own {@code name} attribute. Pass the empty string to write no comment at all, which
+   *     is what {@link CommentDisabledXmlWeaver} does.
+   */
+  protected DefaultXmlWeaver(String defaultComment) {
     this.defaultComment = defaultComment;
   }
 
@@ -183,7 +208,10 @@ class DefaultXmlWeaver implements IWeaveXml {
     }
 
     for (XmlTest test : xmlSuite.getTests()) {
-      xsb.getStringBuffer().append(test.toXml("  "));
+      // Not test.toXml("  "): that re-resolves the weaver from testng.xml.weaver, so a subclass
+      // serializing a suite through its own instance would have every override below <test>
+      // silently bypassed -- including the one CommentDisabledXmlWeaver relies on.
+      xsb.getStringBuffer().append(asXml(test, "  "));
     }
 
     xsb.pop("suite");
@@ -546,7 +574,14 @@ class DefaultXmlWeaver implements IWeaveXml {
     return xsb.toXML();
   }
 
-  static void dumpParameters(XMLStringBuffer xsb, Map<String, String> parameters) {
+  /**
+   * Writes a {@code <parameter>} element per entry, skipping the ones with a null key or value.
+   * Exposed to subclasses because every element that carries parameters needs it.
+   *
+   * @param xsb the buffer to write into
+   * @param parameters the parameters of the element being written
+   */
+  protected static void dumpParameters(XMLStringBuffer xsb, Map<String, String> parameters) {
     // parameters
     if (parameters.isEmpty()) {
       return;

--- a/testng-core-api/src/main/java/org/testng/xml/DefaultXmlWeaver.java
+++ b/testng-core-api/src/main/java/org/testng/xml/DefaultXmlWeaver.java
@@ -32,6 +32,16 @@ import org.testng.reporters.XMLStringBuffer;
  * <p>Select it at runtime with {@code -Dtestng.xml.weaver=fully.qualified.MyWeaver}. The class
  * needs a public no-argument constructor, which is how {@code XmlWeaver} instantiates it.
  *
+ * <p><b>One gap to be aware of:</b> the {@code <groups>} block of a {@code <test>} is still written
+ * inline by {@link #asXml(XmlTest, String)}, so overriding {@link #asXml(XmlGroups, String)},
+ * {@link #asXml(XmlDefine, String)}, {@link #asXml(XmlRun, String)} or {@link
+ * #asXml(XmlDependencies, String)} affects a suite-level {@code <groups>} but not a test-level one.
+ * Routing it through those hooks is not a pure refactoring: group dependencies parsed from a suite
+ * file are stored on {@link XmlTest} itself, not on its {@link XmlGroups} -- {@code
+ * XmlGroups.setXmlDependencies} is never called by the reader -- so delegating would read them from
+ * the empty side and drop them. Unifying the two is model surgery, tracked by #3317 rather than
+ * done here.
+ *
  * @see IWeaveXml
  */
 public class DefaultXmlWeaver implements IWeaveXml {
@@ -189,7 +199,9 @@ public class DefaultXmlWeaver implements IWeaveXml {
       if (hasElements(xmlSuite.getMethodSelectors())) {
         xsb.push("method-selectors");
         for (XmlMethodSelector selector : xmlSuite.getMethodSelectors()) {
-          xsb.getStringBuffer().append(asXml(selector, "  "));
+          // Same child indentation as the structured path above, which reaches the selectors
+          // through asXml(XmlMethodSelectors, "  ") and so indents them by a further two.
+          xsb.getStringBuffer().append(asXml(selector, "    "));
         }
 
         xsb.pop("method-selectors");
@@ -430,7 +442,10 @@ public class DefaultXmlWeaver implements IWeaveXml {
       xsb.push("dependencies");
     }
     for (Map.Entry<String, String> entry : groups.entrySet()) {
-      xsb.addEmptyElement("include", "name", entry.getKey(), "depends-on", entry.getValue());
+      // <!ELEMENT dependencies (group*)>: an <include> here is rejected by the DTD, and the
+      // reader only maps <group> (TestNGContentHandler#xmlGroup), so writing one lost the
+      // dependency on the way back in.
+      xsb.addEmptyElement("group", "name", entry.getKey(), "depends-on", entry.getValue());
     }
     if (hasElements) {
       xsb.pop("dependencies");

--- a/testng-core-api/src/main/java/org/testng/xml/DefaultXmlWeaver.java
+++ b/testng-core-api/src/main/java/org/testng/xml/DefaultXmlWeaver.java
@@ -7,6 +7,8 @@ import static org.testng.xml.XmlSuite.*;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import org.testng.TestNGException;
+import org.testng.internal.Utils;
 import org.testng.reporters.XMLStringBuffer;
 
 /**
@@ -24,6 +26,12 @@ class DefaultXmlWeaver implements IWeaveXml {
   private static final String TESTNG_DTD = "testng-1.1.dtd";
 
   private static final String HTTPS_TESTNG_DTD_URL = "https://testng.org/" + TESTNG_DTD;
+
+  /**
+   * Stateless as far as the leaf elements are concerned -- none of them reads {@link
+   * #defaultComment} -- so a single instance can serve every {@code asXmlFragment} call.
+   */
+  private static final DefaultXmlWeaver LEGACY_FRAGMENT_WEAVER = new DefaultXmlWeaver();
 
   private final String defaultComment;
 
@@ -105,7 +113,7 @@ class DefaultXmlWeaver implements IWeaveXml {
     xsb.push("suite", p);
 
     if (xmlSuite.getGroups() != null) {
-      xsb.getStringBuffer().append(xmlSuite.getGroups().toXml("  "));
+      xsb.getStringBuffer().append(asXml(xmlSuite.getGroups(), "  "));
     } else {
       // Only synthesize a <groups> block when the suite has no XmlGroups of its own to write.
       // getIncludedGroups()/getExcludedGroups() read through to that same XmlGroups, so emitting
@@ -128,7 +136,7 @@ class DefaultXmlWeaver implements IWeaveXml {
       }
     }
 
-    XmlUtils.dumpParameters(xsb, xmlSuite.getParameters());
+    dumpParameters(xsb, xmlSuite.getParameters());
 
     if (hasElements(xmlSuite.getListeners())) {
       xsb.push("listeners");
@@ -144,19 +152,19 @@ class DefaultXmlWeaver implements IWeaveXml {
       xsb.push("packages");
 
       for (XmlPackage pack : xmlSuite.getXmlPackages()) {
-        xsb.getStringBuffer().append(pack.toXml("    "));
+        xsb.getStringBuffer().append(asXml(pack, "    "));
       }
 
       xsb.pop("packages");
     }
 
     if (xmlSuite.getXmlMethodSelectors() != null) {
-      xsb.getStringBuffer().append(xmlSuite.getXmlMethodSelectors().toXml("  "));
+      xsb.getStringBuffer().append(asXml(xmlSuite.getXmlMethodSelectors(), "  "));
     } else {
       if (hasElements(xmlSuite.getMethodSelectors())) {
         xsb.push("method-selectors");
         for (XmlMethodSelector selector : xmlSuite.getMethodSelectors()) {
-          xsb.getStringBuffer().append(selector.toXml("  "));
+          xsb.getStringBuffer().append(asXml(selector, "  "));
         }
 
         xsb.pop("method-selectors");
@@ -218,13 +226,13 @@ class DefaultXmlWeaver implements IWeaveXml {
     if (null != xmlTest.getMethodSelectors() && !xmlTest.getMethodSelectors().isEmpty()) {
       xsb.push("method-selectors");
       for (XmlMethodSelector selector : xmlTest.getMethodSelectors()) {
-        xsb.getStringBuffer().append(selector.toXml(indent + "    "));
+        xsb.getStringBuffer().append(asXml(selector, indent + "    "));
       }
 
       xsb.pop("method-selectors");
     }
 
-    XmlUtils.dumpParameters(xsb, xmlTest.getLocalParameters());
+    dumpParameters(xsb, xmlTest.getLocalParameters());
 
     // groups
 
@@ -295,7 +303,7 @@ class DefaultXmlWeaver implements IWeaveXml {
       xsb.push("packages");
 
       for (XmlPackage pack : xmlTest.getXmlPackages()) {
-        xsb.getStringBuffer().append(pack.toXml("      "));
+        xsb.getStringBuffer().append(asXml(pack, "      "));
       }
 
       xsb.pop("packages");
@@ -305,7 +313,7 @@ class DefaultXmlWeaver implements IWeaveXml {
     if (null != xmlTest.getXmlClasses() && !xmlTest.getXmlClasses().isEmpty()) {
       xsb.push("classes");
       for (XmlClass cls : xmlTest.getXmlClasses()) {
-        xsb.getStringBuffer().append(cls.toXml(indent + "    "));
+        xsb.getStringBuffer().append(asXml(cls, indent + "    "));
       }
       xsb.pop("classes");
     }
@@ -313,5 +321,293 @@ class DefaultXmlWeaver implements IWeaveXml {
     xsb.pop("test");
 
     return xsb.toXML();
+  }
+
+  protected String asXml(XmlGroups xmlGroups, String indent) {
+    XMLStringBuffer xsb = new XMLStringBuffer(indent);
+    String indent2 = indent + "  ";
+
+    List<XmlDefine> defines = xmlGroups.getDefines();
+    XmlRun run = xmlGroups.getRun();
+    List<XmlDependencies> dependencies = xmlGroups.getDependencies();
+    boolean hasGroups = hasElements(defines) || run != null || hasElements(dependencies);
+
+    if (hasGroups) {
+      xsb.push("groups");
+    }
+
+    for (XmlDefine d : defines) {
+      xsb.getStringBuffer().append(asXml(d, indent2));
+    }
+
+    if (null != run) {
+      // XmlRun is optional and is not always available, so check before serializing it.
+      xsb.getStringBuffer().append(asXml(run, indent2));
+    }
+
+    for (XmlDependencies d : dependencies) {
+      xsb.getStringBuffer().append(asXml(d, indent2));
+    }
+
+    if (hasGroups) {
+      xsb.pop("groups");
+    }
+
+    return xsb.toXML();
+  }
+
+  protected String asXml(XmlDefine xmlDefine, String indent) {
+    XMLStringBuffer xsb = new XMLStringBuffer(indent);
+    List<String> includes = xmlDefine.getIncludes();
+    boolean hasElements = hasElements(includes);
+    if (hasElements) {
+      xsb.push("define", "name", xmlDefine.getName());
+    }
+    for (String s : includes) {
+      xsb.addEmptyElement("include", "name", s);
+    }
+    if (hasElements) {
+      xsb.pop("define");
+    }
+
+    return xsb.toXML();
+  }
+
+  protected String asXml(XmlRun xmlRun, String indent) {
+    XMLStringBuffer xsb = new XMLStringBuffer(indent);
+    List<String> includes = xmlRun.getIncludes();
+    List<String> excludes = xmlRun.getExcludes();
+    boolean hasElements = hasElements(excludes) || hasElements(includes);
+    if (hasElements) {
+      xsb.push("run");
+    }
+    for (String s : includes) {
+      xsb.addEmptyElement("include", "name", s);
+    }
+    for (String s : excludes) {
+      xsb.addEmptyElement("exclude", "name", s);
+    }
+    if (hasElements) {
+      xsb.pop("run");
+    }
+
+    return xsb.toXML();
+  }
+
+  protected String asXml(XmlDependencies xmlDependencies, String indent) {
+    XMLStringBuffer xsb = new XMLStringBuffer(indent);
+    Map<String, String> groups = xmlDependencies.getDependencies();
+    boolean hasElements = hasElements(groups);
+    if (hasElements) {
+      xsb.push("dependencies");
+    }
+    for (Map.Entry<String, String> entry : groups.entrySet()) {
+      xsb.addEmptyElement("include", "name", entry.getKey(), "depends-on", entry.getValue());
+    }
+    if (hasElements) {
+      xsb.pop("dependencies");
+    }
+
+    return xsb.toXML();
+  }
+
+  protected String asXml(XmlPackage xmlPackage, String indent) {
+    XMLStringBuffer xsb = new XMLStringBuffer(indent);
+    Properties p = new Properties();
+    p.setProperty("name", xmlPackage.getName());
+
+    if (xmlPackage.getInclude().isEmpty() && xmlPackage.getExclude().isEmpty()) {
+      xsb.addEmptyElement("package", p);
+    } else {
+      xsb.push("package", p);
+
+      for (String m : xmlPackage.getInclude()) {
+        Properties includeProp = new Properties();
+        includeProp.setProperty("name", m);
+        xsb.addEmptyElement("include", includeProp);
+      }
+      for (String m : xmlPackage.getExclude()) {
+        Properties excludeProp = new Properties();
+        excludeProp.setProperty("name", m);
+        xsb.addEmptyElement("exclude", excludeProp);
+      }
+
+      xsb.pop("package");
+    }
+
+    return xsb.toXML();
+  }
+
+  protected String asXml(XmlMethodSelectors xmlMethodSelectors, String indent) {
+    XMLStringBuffer xsb = new XMLStringBuffer(indent);
+    List<XmlMethodSelector> selectors = xmlMethodSelectors.getMethodSelectors();
+    if (hasElements(selectors)) {
+      xsb.push("method-selectors");
+      for (XmlMethodSelector selector : selectors) {
+        xsb.getStringBuffer().append(asXml(selector, indent + "  "));
+      }
+
+      xsb.pop("method-selectors");
+    }
+    return xsb.toXML();
+  }
+
+  protected String asXml(XmlMethodSelector xmlMethodSelector, String indent) {
+    XMLStringBuffer xsb = new XMLStringBuffer(indent);
+
+    xsb.push("method-selector");
+
+    XmlScript script = xmlMethodSelector.getScript();
+    if (null != xmlMethodSelector.getClassName()) {
+      Properties clsProp = new Properties();
+      clsProp.setProperty("name", xmlMethodSelector.getClassName());
+      // Omit the value the parser falls back to when the attribute is absent, so that a
+      // round trip is lossless. A negative priority is meaningful (see RunInfo#includeMethod)
+      // and must therefore be written out.
+      if (xmlMethodSelector.getPriority() != XmlMethodSelector.DEFAULT_PRIORITY) {
+        clsProp.setProperty("priority", String.valueOf(xmlMethodSelector.getPriority()));
+      }
+      xsb.addEmptyElement("selector-class", clsProp);
+    } else if (script != null && script.getLanguage() != null) {
+      Properties scriptProp = new Properties();
+      scriptProp.setProperty("language", script.getLanguage());
+      xsb.push("script", scriptProp);
+      xsb.addCDATA(script.getExpression());
+      xsb.pop("script");
+    } else {
+      throw new TestNGException("Invalid Method Selector:  found neither class name nor language");
+    }
+
+    xsb.pop("method-selector");
+
+    return xsb.toXML();
+  }
+
+  protected String asXml(XmlClass xmlClass, String indent) {
+    XMLStringBuffer xsb = new XMLStringBuffer(indent);
+    Properties prop = new Properties();
+    prop.setProperty("name", xmlClass.getName());
+
+    List<XmlInclude> includedMethods = xmlClass.getIncludedMethods();
+    List<String> excludedMethods = xmlClass.getExcludedMethods();
+    Map<String, String> parameters = xmlClass.getLocalParameters();
+
+    boolean hasMethods = !includedMethods.isEmpty() || !excludedMethods.isEmpty();
+    boolean hasParameters = !parameters.isEmpty();
+    if (hasParameters || hasMethods) {
+      xsb.push("class", prop);
+      dumpParameters(xsb, parameters);
+
+      if (hasMethods) {
+        xsb.push("methods");
+
+        for (XmlInclude m : includedMethods) {
+          xsb.getStringBuffer().append(asXml(m, indent + "    "));
+        }
+
+        for (String m : excludedMethods) {
+          Properties p = new Properties();
+          p.setProperty("name", m);
+          xsb.addEmptyElement("exclude", p);
+        }
+
+        xsb.pop("methods");
+      }
+
+      xsb.pop("class");
+    } else {
+      xsb.addEmptyElement("class", prop);
+    }
+
+    return xsb.toXML();
+  }
+
+  protected String asXml(XmlInclude xmlInclude, String indent) {
+    XMLStringBuffer xsb = new XMLStringBuffer(indent);
+    Properties p = new Properties();
+    p.setProperty("name", xmlInclude.getName());
+    if (xmlInclude.getDescription() != null) {
+      p.setProperty("description", xmlInclude.getDescription());
+    }
+    List<Integer> invocationNumbers = xmlInclude.getInvocationNumbers();
+    if (invocationNumbers != null && !invocationNumbers.isEmpty()) {
+      p.setProperty("invocation-numbers", XmlClass.listToString(invocationNumbers));
+    }
+
+    Map<String, String> parameters = xmlInclude.getLocalParameters();
+    if (!parameters.isEmpty()) {
+      xsb.push("include", p);
+      dumpParameters(xsb, parameters);
+      xsb.pop("include");
+    } else {
+      xsb.addEmptyElement("include", p);
+    }
+
+    return xsb.toXML();
+  }
+
+  static void dumpParameters(XMLStringBuffer xsb, Map<String, String> parameters) {
+    // parameters
+    if (parameters.isEmpty()) {
+      return;
+    }
+    for (Map.Entry<String, String> para : parameters.entrySet()) {
+      Properties paramProps = new Properties();
+      if (para.getKey() == null) {
+        Utils.log("Skipping a null parameter.");
+        continue;
+      }
+      if (para.getValue() == null) {
+        String msg =
+            String.format("Skipping parameter [%s] since it has a null value", para.getKey());
+        Utils.log(msg);
+        continue;
+      }
+      paramProps.setProperty("name", para.getKey());
+      paramProps.setProperty("value", para.getValue());
+      xsb.addEmptyElement("parameter", paramProps); // BUGFIX: TESTNG-27
+    }
+  }
+
+  /**
+   * The serializer behind the deprecated {@code toXml(String)} methods that the model classes still
+   * expose. Those methods never consulted {@code -Dtestng.xml.weaver}: they built their XML inline,
+   * so routing them through {@link XmlWeaver} now would change what a user with a custom weaver
+   * gets back. They keep using the default serializer.
+   */
+  static String asXmlFragment(XmlGroups groups, String indent) {
+    return LEGACY_FRAGMENT_WEAVER.asXml(groups, indent);
+  }
+
+  static String asXmlFragment(XmlDefine define, String indent) {
+    return LEGACY_FRAGMENT_WEAVER.asXml(define, indent);
+  }
+
+  static String asXmlFragment(XmlRun run, String indent) {
+    return LEGACY_FRAGMENT_WEAVER.asXml(run, indent);
+  }
+
+  static String asXmlFragment(XmlDependencies dependencies, String indent) {
+    return LEGACY_FRAGMENT_WEAVER.asXml(dependencies, indent);
+  }
+
+  static String asXmlFragment(XmlPackage xmlPackage, String indent) {
+    return LEGACY_FRAGMENT_WEAVER.asXml(xmlPackage, indent);
+  }
+
+  static String asXmlFragment(XmlMethodSelectors selectors, String indent) {
+    return LEGACY_FRAGMENT_WEAVER.asXml(selectors, indent);
+  }
+
+  static String asXmlFragment(XmlMethodSelector selector, String indent) {
+    return LEGACY_FRAGMENT_WEAVER.asXml(selector, indent);
+  }
+
+  static String asXmlFragment(XmlClass xmlClass, String indent) {
+    return LEGACY_FRAGMENT_WEAVER.asXml(xmlClass, indent);
+  }
+
+  static String asXmlFragment(XmlInclude include, String indent) {
+    return LEGACY_FRAGMENT_WEAVER.asXml(include, indent);
   }
 }

--- a/testng-core-api/src/main/java/org/testng/xml/DefaultXmlWeaver.java
+++ b/testng-core-api/src/main/java/org/testng/xml/DefaultXmlWeaver.java
@@ -56,10 +56,7 @@ public class DefaultXmlWeaver implements IWeaveXml {
 
   private static final String HTTPS_TESTNG_DTD_URL = "https://testng.org/" + TESTNG_DTD;
 
-  /**
-   * Stateless as far as the leaf elements are concerned -- none of them reads {@link
-   * #defaultComment} -- so a single instance can serve every {@code asXmlFragment} call.
-   */
+  /** Immutable, so a single instance can serve every {@code asXmlFragment} call. */
   private static final DefaultXmlWeaver LEGACY_FRAGMENT_WEAVER = new DefaultXmlWeaver();
 
   private final String defaultComment;
@@ -365,6 +362,7 @@ public class DefaultXmlWeaver implements IWeaveXml {
 
   protected String asXml(XmlGroups xmlGroups, String indent) {
     XMLStringBuffer xsb = new XMLStringBuffer(indent);
+    xsb.setDefaultComment(defaultComment);
     String indent2 = indent + "  ";
 
     List<XmlDefine> defines = xmlGroups.getDefines();
@@ -398,6 +396,7 @@ public class DefaultXmlWeaver implements IWeaveXml {
 
   protected String asXml(XmlDefine xmlDefine, String indent) {
     XMLStringBuffer xsb = new XMLStringBuffer(indent);
+    xsb.setDefaultComment(defaultComment);
     List<String> includes = xmlDefine.getIncludes();
     boolean hasElements = hasElements(includes);
     if (hasElements) {
@@ -415,6 +414,7 @@ public class DefaultXmlWeaver implements IWeaveXml {
 
   protected String asXml(XmlRun xmlRun, String indent) {
     XMLStringBuffer xsb = new XMLStringBuffer(indent);
+    xsb.setDefaultComment(defaultComment);
     List<String> includes = xmlRun.getIncludes();
     List<String> excludes = xmlRun.getExcludes();
     boolean hasElements = hasElements(excludes) || hasElements(includes);
@@ -436,6 +436,7 @@ public class DefaultXmlWeaver implements IWeaveXml {
 
   protected String asXml(XmlDependencies xmlDependencies, String indent) {
     XMLStringBuffer xsb = new XMLStringBuffer(indent);
+    xsb.setDefaultComment(defaultComment);
     Map<String, String> groups = xmlDependencies.getDependencies();
     boolean hasElements = hasElements(groups);
     if (hasElements) {
@@ -456,6 +457,7 @@ public class DefaultXmlWeaver implements IWeaveXml {
 
   protected String asXml(XmlPackage xmlPackage, String indent) {
     XMLStringBuffer xsb = new XMLStringBuffer(indent);
+    xsb.setDefaultComment(defaultComment);
     Properties p = new Properties();
     p.setProperty("name", xmlPackage.getName());
 
@@ -483,6 +485,7 @@ public class DefaultXmlWeaver implements IWeaveXml {
 
   protected String asXml(XmlMethodSelectors xmlMethodSelectors, String indent) {
     XMLStringBuffer xsb = new XMLStringBuffer(indent);
+    xsb.setDefaultComment(defaultComment);
     List<XmlMethodSelector> selectors = xmlMethodSelectors.getMethodSelectors();
     if (hasElements(selectors)) {
       xsb.push("method-selectors");
@@ -497,6 +500,7 @@ public class DefaultXmlWeaver implements IWeaveXml {
 
   protected String asXml(XmlMethodSelector xmlMethodSelector, String indent) {
     XMLStringBuffer xsb = new XMLStringBuffer(indent);
+    xsb.setDefaultComment(defaultComment);
 
     xsb.push("method-selector");
 
@@ -528,6 +532,7 @@ public class DefaultXmlWeaver implements IWeaveXml {
 
   protected String asXml(XmlClass xmlClass, String indent) {
     XMLStringBuffer xsb = new XMLStringBuffer(indent);
+    xsb.setDefaultComment(defaultComment);
     Properties prop = new Properties();
     prop.setProperty("name", xmlClass.getName());
 
@@ -567,6 +572,7 @@ public class DefaultXmlWeaver implements IWeaveXml {
 
   protected String asXml(XmlInclude xmlInclude, String indent) {
     XMLStringBuffer xsb = new XMLStringBuffer(indent);
+    xsb.setDefaultComment(defaultComment);
     Properties p = new Properties();
     p.setProperty("name", xmlInclude.getName());
     if (xmlInclude.getDescription() != null) {

--- a/testng-core-api/src/main/java/org/testng/xml/IWeaveXml.java
+++ b/testng-core-api/src/main/java/org/testng/xml/IWeaveXml.java
@@ -1,6 +1,19 @@
 package org.testng.xml;
 
-/** Represents the capabilities of a XML serializer (As string) */
+/**
+ * Represents the capabilities of a XML serializer (As string).
+ *
+ * <p>TestNG picks the implementation from the {@code testng.xml.weaver} system property, which
+ * defaults to {@link DefaultXmlWeaver}; {@link CommentDisabledXmlWeaver} is the other one shipped.
+ * A custom implementation is selected by fully qualified name and needs a public no-argument
+ * constructor:
+ *
+ * <pre>{@code -Dtestng.xml.weaver=fully.qualified.MyWeaver}</pre>
+ *
+ * <p>Implementing this interface directly means writing every element of {@code testng.xml} by
+ * hand. Unless that is the point, extend {@link DefaultXmlWeaver} instead and override only the
+ * elements you want to change.
+ */
 public interface IWeaveXml {
   /**
    * Helps represent the contents of {@link XmlSuite} as a String.

--- a/testng-core-api/src/main/java/org/testng/xml/XmlClass.java
+++ b/testng-core-api/src/main/java/org/testng/xml/XmlClass.java
@@ -2,13 +2,11 @@ package org.testng.xml;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import org.testng.TestNGException;
 import org.testng.collections.Lists;
 import org.testng.collections.Maps;
 import org.testng.collections.Objects;
 import org.testng.internal.ClassHelper;
-import org.testng.reporters.XMLStringBuffer;
 
 /** This class describes the tag <code>&lt;class&gt;</code> in testng.xml. */
 public class XmlClass implements Cloneable {
@@ -128,39 +126,13 @@ public class XmlClass implements Cloneable {
     return Objects.toStringHelper(getClass()).add("class", m_name).toString();
   }
 
+  /**
+   * @deprecated Serialization has moved to {@code DefaultXmlWeaver}. This method always uses the
+   *     default serializer; it never honoured {@code -Dtestng.xml.weaver} and still does not.
+   */
+  @Deprecated
   public String toXml(String indent) {
-    XMLStringBuffer xsb = new XMLStringBuffer(indent);
-    Properties prop = new Properties();
-    prop.setProperty("name", getName());
-
-    boolean hasMethods = !m_includedMethods.isEmpty() || !m_excludedMethods.isEmpty();
-    boolean hasParameters = !m_parameters.isEmpty();
-    if (hasParameters || hasMethods) {
-      xsb.push("class", prop);
-      XmlUtils.dumpParameters(xsb, m_parameters);
-
-      if (hasMethods) {
-        xsb.push("methods");
-
-        for (XmlInclude m : getIncludedMethods()) {
-          xsb.getStringBuffer().append(m.toXml(indent + "    "));
-        }
-
-        for (String m : getExcludedMethods()) {
-          Properties p = new Properties();
-          p.setProperty("name", m);
-          xsb.addEmptyElement("exclude", p);
-        }
-
-        xsb.pop("methods");
-      }
-
-      xsb.pop("class");
-    } else {
-      xsb.addEmptyElement("class", prop);
-    }
-
-    return xsb.toXML();
+    return DefaultXmlWeaver.asXmlFragment(this, indent);
   }
 
   public static String listToString(List<Integer> invocationNumbers) {

--- a/testng-core-api/src/main/java/org/testng/xml/XmlDefine.java
+++ b/testng-core-api/src/main/java/org/testng/xml/XmlDefine.java
@@ -1,10 +1,7 @@
 package org.testng.xml;
 
-import static org.testng.collections.CollectionUtils.hasElements;
-
 import java.util.List;
 import org.testng.collections.Lists;
-import org.testng.reporters.XMLStringBuffer;
 
 public class XmlDefine {
 
@@ -18,20 +15,13 @@ public class XmlDefine {
     return m_name;
   }
 
+  /**
+   * @deprecated Serialization has moved to {@code DefaultXmlWeaver}. This method always uses the
+   *     default serializer; it never honoured {@code -Dtestng.xml.weaver} and still does not.
+   */
+  @Deprecated
   public String toXml(String indent) {
-    XMLStringBuffer xsb = new XMLStringBuffer(indent);
-    boolean hasElements = hasElements(m_includes);
-    if (hasElements) {
-      xsb.push("define", "name", m_name);
-    }
-    for (String s : m_includes) {
-      xsb.addEmptyElement("include", "name", s);
-    }
-    if (hasElements) {
-      xsb.pop("define");
-    }
-
-    return xsb.toXML();
+    return DefaultXmlWeaver.asXmlFragment(this, indent);
   }
 
   private List<String> m_includes = Lists.newArrayList();

--- a/testng-core-api/src/main/java/org/testng/xml/XmlDependencies.java
+++ b/testng-core-api/src/main/java/org/testng/xml/XmlDependencies.java
@@ -1,10 +1,7 @@
 package org.testng.xml;
 
-import static org.testng.collections.CollectionUtils.hasElements;
-
 import java.util.Map;
 import org.testng.collections.Maps;
-import org.testng.reporters.XMLStringBuffer;
 
 public class XmlDependencies {
 
@@ -18,19 +15,12 @@ public class XmlDependencies {
     return m_xmlDependencyGroups;
   }
 
+  /**
+   * @deprecated Serialization has moved to {@code DefaultXmlWeaver}. This method always uses the
+   *     default serializer; it never honoured {@code -Dtestng.xml.weaver} and still does not.
+   */
+  @Deprecated
   public String toXml(String indent) {
-    XMLStringBuffer xsb = new XMLStringBuffer(indent);
-    boolean hasElements = hasElements(m_xmlDependencyGroups);
-    if (hasElements) {
-      xsb.push("dependencies");
-    }
-    for (Map.Entry<String, String> entry : m_xmlDependencyGroups.entrySet()) {
-      xsb.addEmptyElement("include", "name", entry.getKey(), "depends-on", entry.getValue());
-    }
-    if (hasElements) {
-      xsb.pop("dependencies");
-    }
-
-    return xsb.toXML();
+    return DefaultXmlWeaver.asXmlFragment(this, indent);
   }
 }

--- a/testng-core-api/src/main/java/org/testng/xml/XmlGroups.java
+++ b/testng-core-api/src/main/java/org/testng/xml/XmlGroups.java
@@ -1,10 +1,7 @@
 package org.testng.xml;
 
-import static org.testng.collections.CollectionUtils.hasElements;
-
 import java.util.List;
 import org.testng.collections.Lists;
-import org.testng.reporters.XMLStringBuffer;
 
 public class XmlGroups {
 
@@ -40,34 +37,12 @@ public class XmlGroups {
     m_dependencies.add(dependencies);
   }
 
+  /**
+   * @deprecated Serialization has moved to {@code DefaultXmlWeaver}. This method always uses the
+   *     default serializer; it never honoured {@code -Dtestng.xml.weaver} and still does not.
+   */
+  @Deprecated
   public String toXml(String indent) {
-    XMLStringBuffer xsb = new XMLStringBuffer(indent);
-    String indent2 = indent + "  ";
-
-    boolean hasGroups = hasElements(m_defines) || m_run != null || hasElements(m_dependencies);
-
-    if (hasGroups) {
-      xsb.push("groups");
-    }
-
-    for (XmlDefine d : m_defines) {
-      xsb.getStringBuffer().append(d.toXml(indent2));
-    }
-
-    if (null != m_run) {
-      // XmlRun is optional and is not always available. So check if its available before running
-      // toXml()
-      xsb.getStringBuffer().append(m_run.toXml(indent2));
-    }
-
-    for (XmlDependencies d : m_dependencies) {
-      xsb.getStringBuffer().append(d.toXml(indent2));
-    }
-
-    if (hasGroups) {
-      xsb.pop("groups");
-    }
-
-    return xsb.toXML();
+    return DefaultXmlWeaver.asXmlFragment(this, indent);
   }
 }

--- a/testng-core-api/src/main/java/org/testng/xml/XmlInclude.java
+++ b/testng-core-api/src/main/java/org/testng/xml/XmlInclude.java
@@ -4,11 +4,9 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
 import org.testng.collections.Lists;
 import org.testng.collections.Maps;
-import org.testng.reporters.XMLStringBuffer;
 
 public class XmlInclude {
 
@@ -71,27 +69,13 @@ public class XmlInclude {
     return m_index;
   }
 
+  /**
+   * @deprecated Serialization has moved to {@code DefaultXmlWeaver}. This method always uses the
+   *     default serializer; it never honoured {@code -Dtestng.xml.weaver} and still does not.
+   */
+  @Deprecated
   public String toXml(String indent) {
-    XMLStringBuffer xsb = new XMLStringBuffer(indent);
-    Properties p = new Properties();
-    p.setProperty("name", getName());
-    if (m_description != null) {
-      p.setProperty("description", m_description);
-    }
-    List<Integer> invocationNumbers = getInvocationNumbers();
-    if (invocationNumbers != null && !invocationNumbers.isEmpty()) {
-      p.setProperty("invocation-numbers", XmlClass.listToString(invocationNumbers));
-    }
-
-    if (!m_parameters.isEmpty()) {
-      xsb.push("include", p);
-      XmlUtils.dumpParameters(xsb, m_parameters);
-      xsb.pop("include");
-    } else {
-      xsb.addEmptyElement("include", p);
-    }
-
-    return xsb.toXML();
+    return DefaultXmlWeaver.asXmlFragment(this, indent);
   }
 
   @Override

--- a/testng-core-api/src/main/java/org/testng/xml/XmlMethodSelector.java
+++ b/testng-core-api/src/main/java/org/testng/xml/XmlMethodSelector.java
@@ -1,9 +1,5 @@
 package org.testng.xml;
 
-import java.util.Properties;
-import org.testng.TestNGException;
-import org.testng.reporters.XMLStringBuffer;
-
 /** This class describes the tag <code>&lt;method-selector&gt;</code> in testng.xml. */
 public class XmlMethodSelector {
 
@@ -52,34 +48,13 @@ public class XmlMethodSelector {
     m_priority = priority;
   }
 
+  /**
+   * @deprecated Serialization has moved to {@code DefaultXmlWeaver}. This method always uses the
+   *     default serializer; it never honoured {@code -Dtestng.xml.weaver} and still does not.
+   */
+  @Deprecated
   public String toXml(String indent) {
-    XMLStringBuffer xsb = new XMLStringBuffer(indent);
-
-    xsb.push("method-selector");
-
-    if (null != m_className) {
-      Properties clsProp = new Properties();
-      clsProp.setProperty("name", getClassName());
-      // Omit the value the parser falls back to when the attribute is absent, so that a
-      // round trip is lossless. A negative priority is meaningful (see RunInfo#includeMethod)
-      // and must therefore be written out.
-      if (getPriority() != DEFAULT_PRIORITY) {
-        clsProp.setProperty("priority", String.valueOf(getPriority()));
-      }
-      xsb.addEmptyElement("selector-class", clsProp);
-    } else if (getScript() != null && getScript().getLanguage() != null) {
-      Properties scriptProp = new Properties();
-      scriptProp.setProperty("language", getScript().getLanguage());
-      xsb.push("script", scriptProp);
-      xsb.addCDATA(getScript().getExpression());
-      xsb.pop("script");
-    } else {
-      throw new TestNGException("Invalid Method Selector:  found neither class name nor language");
-    }
-
-    xsb.pop("method-selector");
-
-    return xsb.toXML();
+    return DefaultXmlWeaver.asXmlFragment(this, indent);
   }
 
   @Override

--- a/testng-core-api/src/main/java/org/testng/xml/XmlMethodSelectors.java
+++ b/testng-core-api/src/main/java/org/testng/xml/XmlMethodSelectors.java
@@ -1,10 +1,7 @@
 package org.testng.xml;
 
-import static org.testng.collections.CollectionUtils.hasElements;
-
 import java.util.List;
 import org.testng.collections.Lists;
-import org.testng.reporters.XMLStringBuffer;
 
 public class XmlMethodSelectors {
 
@@ -20,16 +17,12 @@ public class XmlMethodSelectors {
     m_methodSelectors.add(xms);
   }
 
+  /**
+   * @deprecated Serialization has moved to {@code DefaultXmlWeaver}. This method always uses the
+   *     default serializer; it never honoured {@code -Dtestng.xml.weaver} and still does not.
+   */
+  @Deprecated
   public String toXml(String indent) {
-    XMLStringBuffer xsb = new XMLStringBuffer(indent);
-    if (hasElements(m_methodSelectors)) {
-      xsb.push("method-selectors");
-      for (XmlMethodSelector selector : m_methodSelectors) {
-        xsb.getStringBuffer().append(selector.toXml(indent + "  "));
-      }
-
-      xsb.pop("method-selectors");
-    }
-    return xsb.toXML();
+    return DefaultXmlWeaver.asXmlFragment(this, indent);
   }
 }

--- a/testng-core-api/src/main/java/org/testng/xml/XmlPackage.java
+++ b/testng-core-api/src/main/java/org/testng/xml/XmlPackage.java
@@ -2,12 +2,10 @@ package org.testng.xml;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Properties;
 import org.testng.collections.Lists;
 import org.testng.internal.PackageUtils;
 import org.testng.internal.Utils;
 import org.testng.internal.protocols.UnhandledIOException;
-import org.testng.reporters.XMLStringBuffer;
 
 /** This class describes the tag <code>&lt;package&gt;</code> in testng.xml. */
 public class XmlPackage {
@@ -78,31 +76,13 @@ public class XmlPackage {
     return result;
   }
 
+  /**
+   * @deprecated Serialization has moved to {@code DefaultXmlWeaver}. This method always uses the
+   *     default serializer; it never honoured {@code -Dtestng.xml.weaver} and still does not.
+   */
+  @Deprecated
   public String toXml(String indent) {
-    XMLStringBuffer xsb = new XMLStringBuffer(indent);
-    Properties p = new Properties();
-    p.setProperty("name", getName());
-
-    if (getInclude().isEmpty() && getExclude().isEmpty()) {
-      xsb.addEmptyElement("package", p);
-    } else {
-      xsb.push("package", p);
-
-      for (String m : getInclude()) {
-        Properties includeProp = new Properties();
-        includeProp.setProperty("name", m);
-        xsb.addEmptyElement("include", includeProp);
-      }
-      for (String m : getExclude()) {
-        Properties excludeProp = new Properties();
-        excludeProp.setProperty("name", m);
-        xsb.addEmptyElement("exclude", excludeProp);
-      }
-
-      xsb.pop("package");
-    }
-
-    return xsb.toXML();
+    return DefaultXmlWeaver.asXmlFragment(this, indent);
   }
 
   @Override

--- a/testng-core-api/src/main/java/org/testng/xml/XmlRun.java
+++ b/testng-core-api/src/main/java/org/testng/xml/XmlRun.java
@@ -1,30 +1,17 @@
 package org.testng.xml;
 
-import static org.testng.collections.CollectionUtils.hasElements;
-
 import java.util.List;
 import org.testng.collections.Lists;
-import org.testng.reporters.XMLStringBuffer;
 
 public class XmlRun {
 
+  /**
+   * @deprecated Serialization has moved to {@code DefaultXmlWeaver}. This method always uses the
+   *     default serializer; it never honoured {@code -Dtestng.xml.weaver} and still does not.
+   */
+  @Deprecated
   public String toXml(String indent) {
-    XMLStringBuffer xsb = new XMLStringBuffer(indent);
-    boolean hasElements = hasElements(m_excludes) || hasElements(m_includes);
-    if (hasElements) {
-      xsb.push("run");
-    }
-    for (String s : m_includes) {
-      xsb.addEmptyElement("include", "name", s);
-    }
-    for (String s : m_excludes) {
-      xsb.addEmptyElement("exclude", "name", s);
-    }
-    if (hasElements) {
-      xsb.pop("run");
-    }
-
-    return xsb.toXML();
+    return DefaultXmlWeaver.asXmlFragment(this, indent);
   }
 
   private List<String> m_excludes = Lists.newArrayList();

--- a/testng-core-api/src/main/java/org/testng/xml/XmlUtils.java
+++ b/testng-core-api/src/main/java/org/testng/xml/XmlUtils.java
@@ -2,7 +2,6 @@ package org.testng.xml;
 
 import java.util.Map;
 import java.util.Properties;
-import org.testng.internal.Utils;
 import org.testng.reporters.XMLStringBuffer;
 
 public class XmlUtils {
@@ -21,26 +20,14 @@ public class XmlUtils {
     }
   }
 
+  /**
+   * @deprecated Moved to {@code DefaultXmlWeaver}. This class is the one place in {@code
+   *     org.testng.xml} that still mentions {@link XMLStringBuffer}, because the buffer is the
+   *     parameter type: dropping the method would be a hard break of a public signature, and this
+   *     module has no binary compatibility check in CI to measure the fallout.
+   */
+  @Deprecated
   public static void dumpParameters(XMLStringBuffer xsb, Map<String, String> parameters) {
-    // parameters
-    if (parameters.isEmpty()) {
-      return;
-    }
-    for (Map.Entry<String, String> para : parameters.entrySet()) {
-      Properties paramProps = new Properties();
-      if (para.getKey() == null) {
-        Utils.log("Skipping a null parameter.");
-        continue;
-      }
-      if (para.getValue() == null) {
-        String msg =
-            String.format("Skipping parameter [%s] since it has a null value", para.getKey());
-        Utils.log(msg);
-        continue;
-      }
-      paramProps.setProperty("name", para.getKey());
-      paramProps.setProperty("value", para.getValue());
-      xsb.addEmptyElement("parameter", paramProps); // BUGFIX: TESTNG-27
-    }
+    DefaultXmlWeaver.dumpParameters(xsb, parameters);
   }
 }

--- a/testng-core/src/test/java/org/testng/xml/DeprecatedToXmlShimTest.java
+++ b/testng-core/src/test/java/org/testng/xml/DeprecatedToXmlShimTest.java
@@ -1,0 +1,271 @@
+package org.testng.xml;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.reporters.XMLStringBuffer.EOL;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.testng.annotations.Test;
+
+/**
+ * Pins the {@code toXml(String)} methods the model classes still expose after the serialization
+ * moved into {@code DefaultXmlWeaver}.
+ *
+ * <p>These need their own test: no caller left in the repository exercises them. Everything goes
+ * through {@link XmlSuite#toXml()} or {@link XmlTest#toXml(String)}, so {@link XmlRoundTripTest}
+ * covers the weaver but would stay green if every shim below returned the empty string. They are
+ * kept only for third-party binary compatibility, and this module has no binary compatibility check
+ * in CI, so the expectations are spelled out literally rather than compared against another call
+ * into the same code.
+ *
+ * <p>Two quirks below are {@code XMLStringBuffer}'s, not typos: closing a tag that was pushed with
+ * a {@code name} attribute echoes that name as a trailing XML comment, and attributes come out in
+ * {@link java.util.Properties} iteration order rather than the order they were set, which is why
+ * {@code depends-on} precedes {@code name}.
+ */
+public class DeprecatedToXmlShimTest {
+
+  @Test
+  public void xmlClassSerializesItsMethodsAndParameters() {
+    XmlClass xmlClass = new XmlClass("com.example.SampleTest", 0, false);
+    xmlClass.setParameters(Collections.singletonMap("browser", "firefox"));
+    XmlInclude include = new XmlInclude("shouldRun");
+    include.setDescription("a described method");
+    xmlClass.setIncludedMethods(Collections.singletonList(include));
+    xmlClass.setExcludedMethods(Collections.singletonList("shouldNotRun"));
+
+    assertThat(xmlClass.toXml("  "))
+        .isEqualTo(
+            "  <class name=\"com.example.SampleTest\">" //
+                + EOL
+                + "    <parameter name=\"browser\" value=\"firefox\"/>"
+                + EOL
+                + "    <methods>"
+                + EOL
+                + "      <include name=\"shouldRun\" description=\"a described method\"/>"
+                + EOL
+                + "      <exclude name=\"shouldNotRun\"/>"
+                + EOL
+                + "    </methods>"
+                + EOL
+                + "  </class> <!-- com.example.SampleTest -->"
+                + EOL);
+  }
+
+  @Test
+  public void xmlClassWithoutMethodsOrParametersIsAnEmptyElement() {
+    XmlClass xmlClass = new XmlClass("com.example.SampleTest", 0, false);
+
+    assertThat(xmlClass.toXml("  ")).isEqualTo("  <class name=\"com.example.SampleTest\"/>" + EOL);
+  }
+
+  @Test
+  public void xmlIncludeSerializesItsInvocationNumbers() {
+    XmlInclude include = new XmlInclude("shouldRun", Arrays.asList(1, 3), 0);
+
+    assertThat(include.toXml("  "))
+        .isEqualTo("  <include name=\"shouldRun\" invocation-numbers=\"1 3\"/>" + EOL);
+  }
+
+  @Test
+  public void xmlIncludeSerializesItsParameters() {
+    XmlInclude include = new XmlInclude("shouldRun");
+    include.setParameters(Collections.singletonMap("browser", "firefox"));
+
+    assertThat(include.toXml("  "))
+        .isEqualTo(
+            "  <include name=\"shouldRun\">" //
+                + EOL
+                + "    <parameter name=\"browser\" value=\"firefox\"/>"
+                + EOL
+                + "  </include> <!-- shouldRun -->"
+                + EOL);
+  }
+
+  @Test
+  public void xmlPackageSerializesItsIncludesAndExcludes() {
+    XmlPackage xmlPackage = new XmlPackage("com.example");
+    xmlPackage.setInclude(Collections.singletonList("Included"));
+    xmlPackage.setExclude(Collections.singletonList("Excluded"));
+
+    assertThat(xmlPackage.toXml("  "))
+        .isEqualTo(
+            "  <package name=\"com.example\">" //
+                + EOL
+                + "    <include name=\"Included\"/>"
+                + EOL
+                + "    <exclude name=\"Excluded\"/>"
+                + EOL
+                + "  </package> <!-- com.example -->"
+                + EOL);
+  }
+
+  @Test
+  public void xmlPackageWithoutFiltersIsAnEmptyElement() {
+    assertThat(new XmlPackage("com.example").toXml("  "))
+        .isEqualTo("  <package name=\"com.example\"/>" + EOL);
+  }
+
+  @Test
+  public void xmlGroupsSerializesDefinesRunAndDependencies() {
+    XmlGroups groups = new XmlGroups();
+    XmlDefine define = new XmlDefine();
+    define.setName("all");
+    define.onElement("fast");
+    groups.addDefine(define);
+    XmlRun run = new XmlRun();
+    run.onInclude("fast");
+    run.onExclude("slow");
+    groups.setRun(run);
+    XmlDependencies dependencies = new XmlDependencies();
+    dependencies.onGroup("fast", "slow");
+    groups.setXmlDependencies(dependencies);
+
+    assertThat(groups.toXml("  "))
+        .isEqualTo(
+            "  <groups>" //
+                + EOL
+                + "    <define name=\"all\">"
+                + EOL
+                + "      <include name=\"fast\"/>"
+                + EOL
+                + "    </define> <!-- all -->"
+                + EOL
+                + "    <run>"
+                + EOL
+                + "      <include name=\"fast\"/>"
+                + EOL
+                + "      <exclude name=\"slow\"/>"
+                + EOL
+                + "    </run>"
+                + EOL
+                + "    <dependencies>"
+                + EOL
+                + "      <include depends-on=\"slow\" name=\"fast\"/>"
+                + EOL
+                + "    </dependencies>"
+                + EOL
+                + "  </groups>"
+                + EOL);
+  }
+
+  @Test
+  public void emptyXmlGroupsSerializesToNothing() {
+    assertThat(new XmlGroups().toXml("  ")).isEmpty();
+  }
+
+  @Test
+  public void xmlMethodSelectorOmitsTheDefaultPriority() {
+    XmlMethodSelector selector = new XmlMethodSelector();
+    selector.setName("com.example.Selector");
+    selector.setPriority(XmlMethodSelector.DEFAULT_PRIORITY);
+
+    assertThat(selector.toXml("  "))
+        .isEqualTo(
+            "  <method-selector>" //
+                + EOL
+                + "    <selector-class name=\"com.example.Selector\"/>"
+                + EOL
+                + "  </method-selector>"
+                + EOL);
+  }
+
+  /**
+   * A negative priority short-circuits {@code RunInfo#includeMethod}, so dropping it changes what
+   * the suite does. It was dropped until #3315; the shim must not bring that back.
+   */
+  @Test
+  public void xmlMethodSelectorWritesANegativePriority() {
+    XmlMethodSelector selector = new XmlMethodSelector();
+    selector.setName("com.example.Selector");
+    selector.setPriority(-1);
+
+    assertThat(selector.toXml("  "))
+        .contains("<selector-class name=\"com.example.Selector\" priority=\"-1\"/>");
+  }
+
+  @Test
+  public void xmlMethodSelectorsWrapsItsSelectors() {
+    XmlMethodSelectors selectors = new XmlMethodSelectors();
+    XmlMethodSelector selector = new XmlMethodSelector();
+    selector.setName("com.example.Selector");
+    selectors.setMethodSelector(selector);
+
+    assertThat(selectors.toXml("  "))
+        .isEqualTo(
+            "  <method-selectors>" //
+                + EOL
+                + "    <method-selector>"
+                + EOL
+                + "      <selector-class name=\"com.example.Selector\"/>"
+                + EOL
+                + "    </method-selector>"
+                + EOL
+                + "  </method-selectors>"
+                + EOL);
+  }
+
+  @Test
+  public void xmlDependenciesSerializesItsGroups() {
+    XmlDependencies dependencies = new XmlDependencies();
+    dependencies.onGroup("fast", "slow");
+
+    assertThat(dependencies.toXml("  "))
+        .isEqualTo(
+            "  <dependencies>" //
+                + EOL
+                + "    <include depends-on=\"slow\" name=\"fast\"/>"
+                + EOL
+                + "  </dependencies>"
+                + EOL);
+  }
+
+  @Test
+  public void emptyXmlDependenciesSerializesToNothing() {
+    assertThat(new XmlDependencies().toXml("  ")).isEmpty();
+  }
+
+  @Test
+  public void xmlDefineSerializesItsIncludes() {
+    XmlDefine define = new XmlDefine();
+    define.setName("all");
+    define.onElement("fast");
+
+    assertThat(define.toXml("  "))
+        .isEqualTo(
+            "  <define name=\"all\">" //
+                + EOL
+                + "    <include name=\"fast\"/>"
+                + EOL
+                + "  </define> <!-- all -->"
+                + EOL);
+  }
+
+  @Test
+  public void xmlRunSerializesItsIncludesAndExcludes() {
+    XmlRun run = new XmlRun();
+    run.onInclude("fast");
+    run.onExclude("slow");
+
+    assertThat(run.toXml("  "))
+        .isEqualTo(
+            "  <run>" //
+                + EOL
+                + "    <include name=\"fast\"/>"
+                + EOL
+                + "    <exclude name=\"slow\"/>"
+                + EOL
+                + "  </run>"
+                + EOL);
+  }
+
+  /** The deprecated {@code XmlUtils} entry point must keep writing what it used to. */
+  @Test
+  public void xmlUtilsDumpParametersStillWrites() {
+    org.testng.reporters.XMLStringBuffer xsb = new org.testng.reporters.XMLStringBuffer("  ");
+
+    XmlUtils.dumpParameters(xsb, Collections.singletonMap("k", "v"));
+
+    assertThat(xsb.toXML()).isEqualTo("  <parameter name=\"k\" value=\"v\"/>" + EOL);
+  }
+}

--- a/testng-core/src/test/java/org/testng/xml/DeprecatedToXmlShimTest.java
+++ b/testng-core/src/test/java/org/testng/xml/DeprecatedToXmlShimTest.java
@@ -141,7 +141,7 @@ public class DeprecatedToXmlShimTest {
                 + EOL
                 + "    <dependencies>"
                 + EOL
-                + "      <include depends-on=\"slow\" name=\"fast\"/>"
+                + "      <group depends-on=\"slow\" name=\"fast\"/>"
                 + EOL
                 + "    </dependencies>"
                 + EOL
@@ -214,7 +214,7 @@ public class DeprecatedToXmlShimTest {
         .isEqualTo(
             "  <dependencies>" //
                 + EOL
-                + "    <include depends-on=\"slow\" name=\"fast\"/>"
+                + "    <group depends-on=\"slow\" name=\"fast\"/>"
                 + EOL
                 + "  </dependencies>"
                 + EOL);

--- a/testng-core/src/test/java/test/xml/XmlWeaverExtensionTest.java
+++ b/testng-core/src/test/java/test/xml/XmlWeaverExtensionTest.java
@@ -33,20 +33,19 @@ public class XmlWeaverExtensionTest {
   /** Overrides one element and inherits every other. */
   private static final class ClassOnlyWeaver extends DefaultXmlWeaver {
     @Override
-    protected String asXml(XmlClass xmlClass, String indent) {
-      return indent + "<class name=\"" + xmlClass.getName() + "\"/> " + MARKER + EOL;
+    protected void asXml(XMLStringBuffer xsb, XmlClass xmlClass) {
+      xsb.addString(xsb.getCurrentIndent() + "<class name=\"" + xmlClass.getName() + "\"/> ");
+      xsb.addString(MARKER + EOL);
     }
   }
 
   /** Uses the helper the base class exposes to subclasses. */
   private static final class IncludeParametersWeaver extends DefaultXmlWeaver {
     @Override
-    protected String asXml(XmlInclude xmlInclude, String indent) {
-      XMLStringBuffer xsb = new XMLStringBuffer(indent);
+    protected void asXml(XMLStringBuffer xsb, XmlInclude xmlInclude) {
       xsb.push("include", "name", xmlInclude.getName());
       dumpParameters(xsb, xmlInclude.getLocalParameters());
       xsb.pop("include");
-      return xsb.toXML();
     }
   }
 

--- a/testng-core/src/test/java/test/xml/XmlWeaverExtensionTest.java
+++ b/testng-core/src/test/java/test/xml/XmlWeaverExtensionTest.java
@@ -90,6 +90,26 @@ public class XmlWeaverExtensionTest {
     assertThat(withoutComments).doesNotContain("<!-- command_line_test -->");
   }
 
+  /**
+   * The comment was only suppressed on {@code </suite>} and {@code </test>}, because those are the
+   * two buffers the weaver configured. Every leaf element built its own, so {@code </class>} still
+   * carried the class name.
+   */
+  @Test
+  public void theCommentDisabledWeaverAlsoSilencesLeafElements() {
+    XmlSuite suite = createSuite();
+    XmlClass xmlClass = suite.getTests().get(0).getXmlClasses().get(0);
+    xmlClass.setIncludedMethods(Collections.singletonList(new XmlInclude("shouldRun")));
+
+    String withComments = new DefaultXmlWeaver().asXml(suite);
+    String withoutComments = new CommentDisabledXmlWeaver().asXml(suite);
+
+    String classComment = "<!-- " + XmlWeaverExtensionTest.class.getName() + " -->";
+    assertThat(withComments).contains(classComment);
+    assertThat(withoutComments).doesNotContain(classComment);
+    assertThat(withoutComments).doesNotContain("<!--");
+  }
+
   private static XmlSuite createSuite() {
     XmlSuite suite = new XmlSuite();
     XmlTest test = new XmlTest(suite);

--- a/testng-core/src/test/java/test/xml/XmlWeaverExtensionTest.java
+++ b/testng-core/src/test/java/test/xml/XmlWeaverExtensionTest.java
@@ -1,0 +1,100 @@
+package test.xml;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.reporters.XMLStringBuffer.EOL;
+
+import java.util.Collections;
+import org.testng.annotations.Test;
+import org.testng.reporters.XMLStringBuffer;
+import org.testng.xml.CommentDisabledXmlWeaver;
+import org.testng.xml.DefaultXmlWeaver;
+import org.testng.xml.XmlClass;
+import org.testng.xml.XmlInclude;
+import org.testng.xml.XmlSuite;
+import org.testng.xml.XmlTest;
+
+/**
+ * Proves that {@code -Dtestng.xml.weaver} is an extension point a third party can actually reach.
+ *
+ * <p>Before this, {@code IWeaveXml} was advertised as pluggable while every implementation of it
+ * was package-private, so the only way to change how one element is written was to reimplement the
+ * whole serializer. The weavers below live outside {@code org.testng.xml} on purpose: if the class,
+ * its constructor or the per-element hooks were not visible from another package, this file would
+ * not compile.
+ *
+ * <p>The system property itself is exercised by {@link XmlVerifyTest}. It is deliberately not
+ * exercised here: {@code XmlWeaver} resolves a non-shipped weaver to {@code null} when {@code
+ * testng.testmode} is on, and that flag is set process-wide by another test in this suite.
+ */
+public class XmlWeaverExtensionTest {
+
+  private static final String MARKER = "<!-- woven by the test -->";
+
+  /** Overrides one element and inherits every other. */
+  private static final class ClassOnlyWeaver extends DefaultXmlWeaver {
+    @Override
+    protected String asXml(XmlClass xmlClass, String indent) {
+      return indent + "<class name=\"" + xmlClass.getName() + "\"/> " + MARKER + EOL;
+    }
+  }
+
+  /** Uses the helper the base class exposes to subclasses. */
+  private static final class IncludeParametersWeaver extends DefaultXmlWeaver {
+    @Override
+    protected String asXml(XmlInclude xmlInclude, String indent) {
+      XMLStringBuffer xsb = new XMLStringBuffer(indent);
+      xsb.push("include", "name", xmlInclude.getName());
+      dumpParameters(xsb, xmlInclude.getLocalParameters());
+      xsb.pop("include");
+      return xsb.toXML();
+    }
+  }
+
+  @Test
+  public void aSubclassCanReplaceASingleElement() {
+    String xml = new ClassOnlyWeaver().asXml(createSuite());
+
+    assertThat(xml).contains("<class name=\"" + XmlWeaverExtensionTest.class.getName() + "\"/> ");
+    assertThat(xml).contains(MARKER);
+  }
+
+  @Test
+  public void theRestOfTheSuiteStillComesFromTheBaseClass() {
+    String xml = new ClassOnlyWeaver().asXml(createSuite());
+
+    assertThat(xml).contains("<!DOCTYPE suite SYSTEM");
+    assertThat(xml).contains("<suite name=\"Default Suite\"");
+    assertThat(xml).contains("name=\"command_line_test\"");
+    assertThat(xml).contains("</suite>");
+  }
+
+  @Test
+  public void aSubclassCanReuseDumpParameters() {
+    XmlSuite suite = createSuite();
+    XmlClass xmlClass = suite.getTests().get(0).getXmlClasses().get(0);
+    XmlInclude include = new XmlInclude("shouldRun");
+    include.setParameters(Collections.singletonMap("browser", "firefox"));
+    xmlClass.setIncludedMethods(Collections.singletonList(include));
+
+    String xml = new IncludeParametersWeaver().asXml(suite);
+
+    assertThat(xml).contains("<parameter name=\"browser\" value=\"firefox\"/>");
+  }
+
+  @Test
+  public void theCommentDisabledWeaverIsDirectlyConstructible() {
+    String withComments = new DefaultXmlWeaver().asXml(createSuite());
+    String withoutComments = new CommentDisabledXmlWeaver().asXml(createSuite());
+
+    assertThat(withComments).contains("<!-- command_line_test -->");
+    assertThat(withoutComments).doesNotContain("<!-- command_line_test -->");
+  }
+
+  private static XmlSuite createSuite() {
+    XmlSuite suite = new XmlSuite();
+    XmlTest test = new XmlTest(suite);
+    test.setName("command_line_test");
+    test.getXmlClasses().add(new XmlClass(XmlWeaverExtensionTest.class));
+    return suite;
+  }
+}

--- a/testng-core/src/test/resources/testng.xml
+++ b/testng-core/src/test/resources/testng.xml
@@ -816,6 +816,7 @@
       <class name="org.testng.xml.XmlTestTest"/>
       <class name="org.testng.xml.ParserTest"/>
       <class name="org.testng.xml.XmlRoundTripTest"/>
+      <class name="org.testng.xml.DeprecatedToXmlShimTest"/>
       <class name="org.testng.xml.XMLParserTest"/>
       <class name="org.testng.xml.XmlValidationTest"/>
       <class name="org.testng.xml.XsdValidationTest"/>

--- a/testng-core/src/test/resources/testng.xml
+++ b/testng-core/src/test/resources/testng.xml
@@ -121,6 +121,7 @@
       <class name="test.jar.JarTest" />
  -->
       <class name="test.xml.XmlVerifyTest" />
+      <class name="test.xml.XmlWeaverExtensionTest"/>
       <class name="test.xml.issue2231.IssueTest"/>
       <class name="test.xml.XMLStringBufferTest"/>
       <class name="test.invokedmethodlistener.InvokedMethodListenerTest" />


### PR DESCRIPTION
Part of #3317, and its fourth step. Depends on nothing that is not already in `master`.

## The half-applied abstraction

`IWeaveXml` was applied to `XmlSuite` and `XmlTest` only. `DefaultXmlWeaver` then called straight
back into the `toXml()` of the nine leaf classes:

```java
xsb.getStringBuffer().append(cls.toXml(indent + "    "));
```

So 10 of the 17 files in `org.testng.xml` imported `XMLStringBuffer` and built XML themselves, and
the advertised extension point was not one: `XmlWeaver`, `DefaultXmlWeaver` and
`CommentDisabledXmlWeaver` were all package-private, so a third party could only implement
`IWeaveXml` from scratch — every element of `testng.xml` by hand — to change how one of them is
written.

## The six commits

**1. `refactor(xml): move leaf element serialization into DefaultXmlWeaver`**

The nine leaf `toXml(indent)` bodies move into `DefaultXmlWeaver`, which already called them.
`XmlUtils.dumpParameters` moves with them. The public `toXml(String)` methods stay as
`@Deprecated` delegating shims: `XmlSuite` is reachable through `IAlterSuiteListener`,
`org.testng.xml` is exported by the OSGi manifest, and there is no binary compatibility check in CI,
so nothing is removed.

The shims delegate to the default serializer rather than to `XmlWeaver.getInstance()`. The leaf
`toXml()` methods never consulted `-Dtestng.xml.weaver` — they built their XML inline — so routing
them through it now would change what a user with a custom weaver gets back. It also keeps
`IWeaveXml` at two methods instead of eleven.

**2. `refactor(xml): make the testng.xml.weaver extension point extensible`**

`DefaultXmlWeaver` becomes public with a public no-argument constructor and `protected` per-element
hooks, so a subclass overrides the one element it cares about and inherits the rest.
`CommentDisabledXmlWeaver` becomes public too, since users are told to select it by name.
`IWeaveXml` documents `-Dtestng.xml.weaver`.

Publishing the class was not enough — subclassing did not work at all. `asXml(XmlSuite)` reached the
tests through `test.toXml("  ")`, and `XmlTest.toXml` re-resolves the weaver from
`testng.xml.weaver` instead of using the current instance, so every override below `<test>` was
silently bypassed. This was already wrong before subclassing existed: constructing
`CommentDisabledXmlWeaver` directly still emitted the comment on `</test>`. Calling
`asXml(test, "  ")` dispatches on `this`.

**3. `fix(xml): write <group> inside <dependencies>, and align selector indent`**

Two defects inherited from the code that moved, both found in review.

`asXml(XmlDependencies, …)` wrote `<include name= depends-on=>`, but the DTD says
`<!ELEMENT dependencies (group*)>` and the reader only maps `<group>`
(`TestNGContentHandler#xmlGroup`). The element was rejected by strict validation and the dependency
was dropped on the way back in. It went unnoticed because nothing reaches it from a parsed suite —
`XmlGroups.setXmlDependencies` has no caller outside tests, and the reader stores group
dependencies on `XmlTest` instead — but it is reachable from a programmatically built suite and
from YAML.

The fallback branch for suite-level method selectors indented each selector by two rather than
four, putting `<method-selector>` at the same level as the `<method-selectors>` containing it.
Cosmetic only.

**4. `fix(xml): let CommentDisabledXmlWeaver silence every element`**

The weaver applied its default comment to the two buffers it created itself. Every leaf element
built its own and never propagated it, so selecting
`-Dtestng.xml.weaver=org.testng.xml.CommentDisabledXmlWeaver` still wrote the name of each class,
define, include and package:

```xml
<class name="com.example.Sample">
  ...
</class> <!-- com.example.Sample -->
```

On the default weaver the propagation is a no-op, since `XMLStringBuffer` already starts with a
null default comment and falls back to the tag's own `name` attribute.

**5. `refactor(xml): weave elements into the buffer instead of splicing strings`**

The nine hooks become `void asXml(XMLStringBuffer, X)` and write into the buffer they are handed.
Indentation now follows the buffer's own push/pop depth instead of travelling as the string literals
`"  "` / `"    "` / `"      "` computed by hand at each call site — one of which was wrong for a
`<test>` serialized at a non-default indent. Eight of the nine `getStringBuffer()` splices go away;
the last one stays because `asXml(XmlTest, String)` is an `IWeaveXml` method and must return a
`String`.

**6. `refactor(xml): use the varargs attribute overloads of XMLStringBuffer`**

`push(String, String...)` and `addEmptyElement(String, String...)` already build the `Properties`
internally. The weaver used them for some elements and hand-rolled a `Properties` for others,
including in the class javadoc's own example. Settled on the varargs form wherever every attribute
is unconditional; both overloads funnel into the same `createProperties`, so attributes and their
order are unchanged.

## Two decisions worth reviewing

- **`XmlUtils` still names `XMLStringBuffer`**, so the "no file but the weaver imports it" criterion
  of #3320 is not met to the letter. The buffer *is* the parameter type of the deprecated
  `dumpParameters`, so dropping the method would break a public signature outright, with no tooling
  in CI to measure the fallout. Happy to delete it instead if you would rather take the break.
- **The `<groups>` block of a `<test>` is still written inline**, so overriding the group hooks
  affects a suite-level `<groups>` but not a test-level one. Routing it through them is not a
  refactoring: group dependencies parsed from a suite file are stored on `XmlTest`, not on its
  `XmlGroups`, so delegating would read the empty side and drop them. Documented in the class
  javadoc; unifying the two belongs to a later step of #3317.

## Tests

- `DeprecatedToXmlShimTest` — 16 tests covering the shims directly. They need their own test: no
  caller left in the repository uses the leaf `toXml(String)` methods, so `XmlRoundTripTest` would
  stay green even if every shim returned an empty string.
- `XmlWeaverExtensionTest` — 5 tests, deliberately outside `org.testng.xml`: if the class, its
  constructor or the hooks were not visible from another package, the file would not compile. It
  does not go through the system property, because `XmlWeaver` resolves a non-shipped weaver to
  `null` when `testng.testmode` is on and that flag is set process-wide by `XmlVerifyTest`; the
  property path stays covered by `XmlVerifyTest`.

`XmlRoundTripTest` is **unchanged** and green after every commit — that is the point of it: the
serialized form is still a fixed point byte for byte, and the parsed model still compares equal
through `SuiteDigest`.

`./gradlew build` is green, and green under `-Dtestng.xml.validation=strict`.

Fix #3320
