### PR TITLE
test(xml): cover a parser that rejects the lexical handler property

### DIFF
--- a/testng-core/src/test/java/org/testng/xml/XmlValidationTest.java
+++ b/testng-core/src/test/java/org/testng/xml/XmlValidationTest.java
@@ -272,6 +272,44 @@ public class XmlValidationTest {
         .doesNotThrowAnyException();
   }
 
+  /**
+   * The lexical handler property is optional in SAX, so a parser may reject it and {@code
+   * XMLParser.registerLexicalHandler} carries on without it. What the two tests below pin is what
+   * that costs and what it does not.
+   *
+   * <p>An external doctype is still detected, because {@code resolveEntity} sets the flag too. That
+   * redundancy is the whole point of the fallback, and until now nothing held it in place: removing
+   * it left all 3456 XML tests green.
+   */
+  @Test
+  public void anExternalDoctypeIsStillDetectedWithoutLexicalEvents() {
+    System.setProperty(RuntimeBehavior.XML_VALIDATION_MODE, "strict");
+
+    assertThatThrownBy(() -> parseValidating(pathOf(INVALID_SUITE), false))
+        .isInstanceOf(SAXParseException.class);
+  }
+
+  /**
+   * The documented cost of the same situation: a doctype with only an internal subset goes
+   * unnoticed, since {@code resolveEntity} is never called for one. Asserted so the trade-off is
+   * recorded rather than merely described in a comment -- and so that a future parser change which
+   * happens to fix it does not do so silently.
+   */
+  @Test
+  public void anInternalSubsetIsMissedWithoutLexicalEvents() {
+    System.setProperty(RuntimeBehavior.XML_VALIDATION_MODE, "strict");
+
+    assertThatCode(
+            () ->
+                assertThat(parseValidating(pathOf(INTERNAL_SUBSET_SUITE), false).getName())
+                    .isEqualTo("InternalSubsetOnly"))
+        .doesNotThrowAnyException();
+  }
+
+  private static Path pathOf(String suiteFile) {
+    return Paths.get(getPathToResource(suiteFile));
+  }
+
   @Test
   public void anUnknownModeFallsBackToWarn() {
     System.setProperty(RuntimeBehavior.XML_VALIDATION_MODE, "not-a-mode");
@@ -326,14 +364,26 @@ public class XmlValidationTest {
   }
 
   private static XmlSuite parseValidating(Path path) throws Exception {
+    return parseValidating(path, true);
+  }
+
+  /**
+   * @param withLexicalHandler whether to register the lexical handler, as {@code XMLParser.parse}
+   *     does. Passing {@code false} reproduces a parser that rejects the property: the handler then
+   *     never receives {@code startDTD}, which is the situation the {@code resolveEntity} fallback
+   *     exists for.
+   */
+  private static XmlSuite parseValidating(Path path, boolean withLexicalHandler) throws Exception {
     SAXParserFactory factory = SAXParserFactory.newInstance();
     factory.setValidating(true);
     TestNGContentHandler handler = new TestNGContentHandler(path.toString(), false);
     SAXParser parser = factory.newSAXParser();
-    // Same wiring as XMLParser.parse. Without it startDTD is never delivered, the handler believes
-    // no doctype was declared, and every violation is discarded -- so the parser built here has to
-    // be configured like the real one or these tests would prove nothing.
-    parser.setProperty("http://xml.org/sax/properties/lexical-handler", handler);
+    if (withLexicalHandler) {
+      // Same wiring as XMLParser.parse. Without it startDTD is never delivered, the handler
+      // believes no doctype was declared, and every violation is discarded -- so the parser built
+      // here has to be configured like the real one or these tests would prove nothing.
+      parser.setProperty("http://xml.org/sax/properties/lexical-handler", handler);
+    }
     try (InputStream stream = Files.newInputStream(path)) {
       InputSource source = new InputSource(stream);
       // The system id matters: without it a relative doctype cannot be resolved, so TestNG falls


### PR DESCRIPTION
Answers [this review comment](https://github.com/testng-team/testng/pull/3336#discussion_r3748779405) on #3336, which asked whether we should test a SAX parser that rejects `http://xml.org/sax/properties/lexical-handler`.

We should. The property is optional in SAX, `XMLParser.registerLexicalHandler` deliberately carries on when a parser refuses it, and the `resolveEntity` fallback exists for exactly that case -- but none of it was held in place by a test.

## The gap was measurable

Removing the fallback, on current `master`:

```
3456 tests completed, 0 failed
```

So the redundancy between `startDTD` and `resolveEntity` could have been deleted as dead code at any point, and CI would have agreed.

## What the two tests pin

Rather than one test, two, because losing the property has an effect on one side and none on the other -- and only saying so in a comment leaves both unverified.

- `anExternalDoctypeIsStillDetectedWithoutLexicalEvents` -- an external doctype is **still** detected, because `resolveEntity` sets the flag too. This is what the fallback buys.
- `anInternalSubsetIsMissedWithoutLexicalEvents` -- a doctype with only an internal subset is **missed**, because `resolveEntity` is never called for one. This is the documented cost, asserted so that a future change which happens to fix it cannot do so silently.

On "real or simulated": the rejection is reproduced by simply not registering the property. From the handler's side the two situations are identical -- no `startDTD` is delivered either way -- and it avoids wrapping a parser purely to make it throw.

## Verification

- `./gradlew build`: BUILD SUCCESSFUL, 16728 tests, 0 failed.
- Control: removing the `resolveEntity` fallback fails exactly `anExternalDoctypeIsStillDetectedWithoutLexicalEvents`, and leaves the other thirteen green.

No issue to close: this is coverage for behaviour introduced in #3336, not a reported defect.

### Did you remember to?

- [x] Add test case(s)
- [ ] Update `CHANGES.txt` -- test-only change, no user visible behaviour
- [x] Auto applied styling via `./gradlew autostyleApply`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for XML validation when SAX lexical-handler events are unavailable.
  * Verified that external doctypes continue to trigger strict validation through entity resolution.
  * Documented behavior for internal-subset-only doctypes, which are not detected without lexical events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->