### PR TITLE
docs: separate the verification gate from the edit loop in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,8 @@ minutes once, before committing:
 ```bash
 ./gradlew :testng-core:test \
   --tests "org.testng.xml.XmlRoundTripTest" \
-  --tests "test.xml.XmlVerifyTest" > /tmp/t.log 2>&1; echo "EXIT=$?"
+  --tests "test.xml.XmlVerifyTest" > /tmp/t.log 2>&1
+rc=$?; echo "EXIT=$rc"; (exit $rc)
 ```
 
 Naming that set before editing is the point: it is the question the change has to answer. A run like
@@ -44,7 +45,8 @@ typo in the filter. Register it in the same edit that creates it, next to its ne
 confirm it ran, rather than trusting the exit code:
 
 ```bash
-grep -o 'tests="[0-9]*"' testng-core/build/test-results/test/TEST-<class>.xml
+CLASS=org.testng.xml.XmlRoundTripTest
+grep -o 'tests="[1-9][0-9]*"' "testng-core/build/test-results/test/TEST-$CLASS.xml"
 ```
 
 A green local build is not a green CI. Pull requests against `master` also run an OpenRewrite check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,32 @@ can affect. Add `clean` only to rule out stale output.
 ./gradlew build     # minutes when it has work to do, seconds when it does not; 0 failures
 ```
 
+**The gate is not the edit loop.** Letting Gradle skip work only helps when the change reaches
+little; anything in `testng-core-api` reaches everything, so every run costs the full five minutes.
+While iterating, run the tests that would actually fail if the change is wrong, and spend the five
+minutes once, before committing:
+
+```bash
+./gradlew :testng-core:test \
+  --tests "org.testng.xml.XmlRoundTripTest" \
+  --tests "test.xml.XmlVerifyTest" > /tmp/t.log 2>&1; echo "EXIT=$?"
+```
+
+Naming that set before editing is the point: it is the question the change has to answer. A run like
+the one above returns in seconds rather than minutes.
+
+**A new `testng-core` test class does not run until it is listed in
+`testng-core/src/test/resources/testng.xml`.** The task is suite-driven, not classpath-scanned, so
+an unregistered class is skipped by `build` without a word — the file can be committed and never
+execute — and `--tests` rejects it with `No tests found for given includes`, which reads like a
+typo in the filter. Register it in the same edit that creates it, next to its neighbours:
+`org.testng.xml.*` goes in `<test name="XML">`, `test.xml.*` in `<test name="Regression2">`. Then
+confirm it ran, rather than trusting the exit code:
+
+```bash
+grep -o 'tests="[0-9]*"' testng-core/build/test-results/test/TEST-<class>.xml
+```
+
 A green local build is not a green CI. Pull requests against `master` also run an OpenRewrite check
 that `.github/CONTRIBUTING.md` documents, and a wrapper validation. Pushes are weaker than they
 look: the `branches: ['*']` filter in `test.yml` does not match `/`, so pushing a branch named


### PR DESCRIPTION
Two notes in `AGENTS.md § Verification`, each of which cost real time to rediscover while working on
#3341.

## The gate is not the edit loop

The file says the gate is `./gradlew build` and stops there, so it reads as the command to run after
every edit. The advice that follows — *"let Gradle decide how much of it to re-run"* — only holds
when a change reaches little. Anything in `testng-core-api` reaches everything, so the run costs the
full five minutes every time.

Added the missing half: name the tests that would actually fail if the change is wrong, loop on
those, and spend the five minutes once, before committing. The targeted form is spelled out, and it
is not a guess — the example returns in **6.8 seconds for 614 tests**, against 5m10s for the same
verification through `build`.

## A test class not listed in `testng.xml` never runs

`:testng-core:test` is suite-driven, not classpath-scanned. The visible symptom is `--tests` failing
with `No tests found for given includes`, which reads like a typo in the filter rather than a missing
registration. The invisible one matters more: **a new test file can be committed and never execute**,
with `build` staying green while covering nothing.

The note names the two `<test>` blocks new suite-parsing tests belong in (`org.testng.xml.*` in
`<test name="XML">`, `test.xml.*` in `<test name="Regression2">`) and shows how to confirm a class
actually ran instead of trusting the exit code.

## Verification

Documentation only; no production or test code changes. `autostyleCheck` and `./gradlew build` are
green, and the command the new note documents was executed rather than assumed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for choosing between the full Gradle build and the faster test edit loop.
  * Documented targeted XML test execution and required registration steps for new tests.
  * Added instructions for verifying executed test counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->