### PR TITLE
docs: record the pull request splitting convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,6 +138,22 @@ gh pr create --repo testng-team/testng --base master --head <fork-owner>:<branch
 Conventional Commits. Record user-visible changes in `CHANGES.txt`, newest first, under the current
 version heading.
 
+Split a pull request that mixes a large mechanical sweep with changes that need judgement. The two
+halves have different review costs: a tool's output — an OpenRewrite run, a formatter pass, a
+rename across hundreds of files — is re-derivable from the recipe that produced it and needs little
+more than green CI, while the design decisions around it need a maintainer's attention. Bundled,
+the small half queues behind the large one and a reviewer becomes the bottleneck for both.
+
+Send the mechanical half first, then stack the reviewed half on its branch:
+
+```bash
+gh pr create --repo testng-team/testng --base <mechanical-branch> --head <fork-owner>:<branch>
+```
+
+The pull request then shows only the delta, and GitHub retargets it to `master` when the first one
+merges. Within each pull request, keep the machine output in its own commit, separate from the hand
+edits that follow it, so a reviewer can tell which hunks a human actually judged.
+
 ## Working style
 
 - **Verify claims before acting on them** — including your own. A pull request description, an issue


### PR DESCRIPTION
## What

Adds a pull request splitting convention to `AGENTS.md`, under `## Git`.

## Why

Asked for by @krmahadevan while reviewing #3347:

> For PRs such as this, can we please split it into multiple PRs [...] That way, I wont end up
> being the bottle neck on the things that you are working on proactively to push and get it merged.

That PR bundled a 234-file mechanical rewrite — the output of a one-shot OpenRewrite recipe — with
a 16-file deprecation that genuinely needed a maintainer's judgement. The two halves have very
different review costs, and bundling them meant the small half queued behind the large one.

## The rule

Split when a large mechanical sweep is mixed with changes that need judgement. Send the mechanical
half first, then stack the reviewed half on its branch with
`gh pr create --base <mechanical-branch>`, so the second pull request shows only the delta and
GitHub retargets it to `master` once the first merges. Within each pull request, keep the machine
output in its own commit, separate from the hand edits that follow it.

Mechanical means re-derivable from the recipe or script that produced it: an OpenRewrite run, a
formatter pass, a rename across hundreds of files. Green CI is the bar for those; a maintainer's
attention is for the rest.

## Note

I checked whether the CodeRabbit file limit was a second argument for splitting, as suggested on
\#3347. It is not: on that PR CodeRabbit listed all 248 files with no sign of truncation. The rule
is written on reviewer bandwidth alone.

Documentation only — no code, no build change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Git workflow guidance for separating mechanical updates from judgment-based changes.
  * Documented practices for creating stacked pull requests and keeping generated output separate from manual edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->