### PR TITLE
fix(build): configure Error Prone in testng-collections only when it is applied

### DIFF
--- a/testng-collections/testng-collections-build.gradle.kts
+++ b/testng-collections/testng-collections-build.gradle.kts
@@ -4,13 +4,20 @@ plugins {
     id("testng.java-library")
 }
 
-tasks.withType<JavaCompile>().configureEach {
-    // The deprecated factories are one-line wrappers over a JDK constructor, so InlineMeSuggester
-    // fires on every one of them -- twenty warnings that say the same thing. Acting on them means
-    // annotating with @InlineMe, which needs error_prone_annotations on the compile classpath, and
-    // anything reachable from :testng-core lands in the published pom, where
-    // verifyPublishedPomDependencies would reject it. The javadoc names the replacement instead.
-    options.errorprone.disable("InlineMeSuggester")
+// Error Prone is optional: testng.java only applies it when -PskipErrorProne is off, and the
+// OpenRewrite job turns it off because Error Prone is a javac plugin OpenRewrite never sees.
+// Reaching for options.errorprone unconditionally fails task configuration in those builds, so the
+// opt-out is registered only once the plugin that owns the extension is there.
+pluginManager.withPlugin("net.ltgt.errorprone") {
+    tasks.withType<JavaCompile>().configureEach {
+        // The deprecated factories are one-line wrappers over a JDK constructor, so
+        // InlineMeSuggester fires on every one of them -- twenty warnings that say the same thing.
+        // Acting on them means annotating with @InlineMe, which needs error_prone_annotations on
+        // the compile classpath, and anything reachable from :testng-core lands in the published
+        // pom, where verifyPublishedPomDependencies would reject it. The javadoc names the
+        // replacement instead.
+        options.errorprone.disable("InlineMeSuggester")
+    }
 }
 
 dependencies {


### PR DESCRIPTION
No issue — this fixes the `OpenRewrite` job, red on `master` since 4944fad04 ([failing run](https://github.com/testng-team/testng/actions/runs/31695656331/job/94432728258)).

`testng-collections` disabled `InlineMeSuggester` through an unconditional `options.errorprone` access, but Error Prone is optional: `testng.java` applies it only when `-PskipErrorProne` is off, and the OpenRewrite job turns it off — so the extension is missing and every `JavaCompile` in the module fails at *configuration* time, which is why the job's `-x compileTestJava` did not help (the task must still be created for `rewriteDryRun`'s dependency graph). Registering the opt-out inside `pluginManager.withPlugin("net.ltgt.errorprone")` ties it to the plugin that owns the extension instead of restating the `skipErrorProne` condition in a second place where the two could drift. Any local build passing `-PskipErrorProne=true` was broken the same way.

Verified locally: the reduced repro (`:testng-collections:compileJava -PskipErrorProne=true`) fails before and passes after; the exact CI invocation (`rewriteDryRun -x compileTestJava -x compileTestKotlin -PfailOnRewriteDryRun=true -PskipErrorProne=true -PjdkBuildVersion=25`) is green; on the normal path Error Prone still runs (`EffectivelyPrivate`/`JdkObsolete` still reported) with zero `InlineMeSuggester` warnings; and the full `./gradlew build` passes.

### Did you remember to?

- [ ] Add test case(s) — n/a, a build-script configuration fix with no product surface; the regression gate is the `OpenRewrite` job itself, reproducible locally with the command above
- [ ] Update `CHANGES.txt` — n/a, build infrastructure only, no user-visible change
- [x] Auto applied styling via `./gradlew autostyleApply`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Improved compatibility by applying Error Prone configuration only when the corresponding plugin is available.
  * Existing Java compilation settings and warning suppression remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->