### PR TITLE
fix(internal): give every primitive an entry in the widening table

### DIFF
--- a/testng-core/src/main/java/org/testng/internal/reflect/ReflectionRecipes.java
+++ b/testng-core/src/main/java/org/testng/internal/reflect/ReflectionRecipes.java
@@ -25,11 +25,22 @@ import org.testng.xml.XmlTest;
 public final class ReflectionRecipes {
 
   private static final Map<Class<?>, Class<?>> PRIMITIVE_MAPPING = new HashMap<>();
+
+  /**
+   * Boxed types that widen to each primitive. Keyed by exactly the primitives of {@link
+   * #PRIMITIVE_MAPPING}, so a lookup never returns null; one with no widening source maps to an
+   * empty list.
+   */
   private static final Map<Class<?>, List<Class<?>>> ASSIGNABLE_MAPPING = new HashMap<>();
 
   static {
     initPrimitiveMapping();
     initAssignableMapping();
+    // Primitives nothing widens to are left out above; give them an entry so the two tables share
+    // one key set and callers never have to guard the lookup.
+    for (final Class<?> primitive : PRIMITIVE_MAPPING.keySet()) {
+      ASSIGNABLE_MAPPING.putIfAbsent(primitive, Collections.emptyList());
+    }
   }
 
   private static void initPrimitiveMapping() {

--- a/testng-core/src/test/java/test/reflect/ReflectionRecipesTest.java
+++ b/testng-core/src/test/java/test/reflect/ReflectionRecipesTest.java
@@ -201,6 +201,49 @@ public class ReflectionRecipesTest {
     assertThat(isOrImplementsInterface(ITestContext.class, clazz)).isFalse();
   }
 
+  @DataProvider
+  public Object[][] primitives() {
+    return new Object[][] {
+      {boolean.class},
+      {byte.class},
+      {char.class},
+      {short.class},
+      {int.class},
+      {long.class},
+      {float.class},
+      {double.class},
+      {void.class}
+    };
+  }
+
+  @Test(dataProvider = "primitives")
+  public void testIsInstanceOfRejectsUnrelatedObject(final Class<?> primitive) {
+    assertThat(ReflectionRecipes.isInstanceOf(primitive, "not-a-" + primitive.getName())).isFalse();
+  }
+
+  @DataProvider
+  public Object[][] primitiveAndArgument() {
+    return new Object[][] {
+      // Boxed type of the primitive itself.
+      {int.class, 1, true},
+      {boolean.class, true, true},
+      {char.class, 'a', true},
+      // Widens to the primitive.
+      {int.class, (byte) 1, true},
+      {long.class, 1, true},
+      {double.class, 1.0f, true},
+      // Would narrow, so it does not match.
+      {int.class, 1L, false},
+      {float.class, 1.0d, false},
+    };
+  }
+
+  @Test(dataProvider = "primitiveAndArgument")
+  public void testIsInstanceOfHonoursWidening(
+      final Class<?> primitive, final Object argument, final boolean expected) {
+    assertThat(ReflectionRecipes.isInstanceOf(primitive, argument)).isEqualTo(expected);
+  }
+
   private interface T {
     void s0(TestContextJustForTesting testContext, int i, Boolean b);
 


### PR DESCRIPTION
`ReflectionRecipes.isInstanceOf` threw a `NullPointerException` for `boolean`, `byte`, `char` and `void` reference types instead of returning `false`.

`PRIMITIVE_MAPPING` covers all eight primitives plus `void`; `initAssignableMapping` only fills in the five widening-conversion targets (`double`, `float`, `long`, `int`, `short`). The lookup into the second table was dereferenced without checking for a miss.

The reachable path is data-provider parameter matching: a parameter declared `byte`, `boolean` or `char` receiving a non-assignable value surfaced as an NPE rather than the intended mismatch message.

Rather than have the reader compensate for the hole at the call site, the two tables now share one key set — the static block gives every primitive without a widening source an empty list. The lookup stays an unguarded `get`, because a null there is now a wiring error rather than an expected case.

## Test

Two data providers in `ReflectionRecipesTest`:

- `testIsInstanceOfRejectsUnrelatedObject` passes a `String` for all nine primitives. This is also what enforces the totality invariant: a missing key NPEs rather than silently returning false. Removing the four entries fails exactly four rows, with the original NPE.
- `testIsInstanceOfHonoursWidening` covers the positive side, which had no direct coverage before: the boxed type itself, a widening source, and a narrowing one that must not match. Without it, replacing the whole table with empty lists would leave the suite green.

Full build green: 16152 tests in testng-core, 0 failures.

Fix #3361