### PR TITLE
build: enable NullAway, scoped to packages that opt in with @NullMarked

### DIFF
--- a/build-logic/code-quality/src/main/kotlin/testng.errorprone.gradle.kts
+++ b/build-logic/code-quality/src/main/kotlin/testng.errorprone.gradle.kts
@@ -1,3 +1,4 @@
+import net.ltgt.gradle.errorprone.CheckSeverity
 import net.ltgt.gradle.errorprone.errorprone
 
 plugins {
@@ -7,14 +8,34 @@ plugins {
 
 dependencies {
     errorprone("com.google.errorprone:error_prone_core:2.50.0")
+    errorprone("com.uber.nullaway:nullaway:0.13.8")
 }
 
 tasks.withType<JavaCompile>().configureEach {
-    options.errorprone.disableWarningsInGeneratedCode.set(true)
-    // SelfAssertion only fires on TestNG's own sample/fixture classes, where trivial assertions
-    // such as assertThat("abc").isEqualTo("abc") exist solely to give the runner a passing method.
-    // Production code keeps the check enabled.
-    if (name.contains("Test")) {
-        options.errorprone.disable("SelfAssertion")
+    val testCompile = name.contains("Test")
+
+    options.errorprone {
+        disableWarningsInGeneratedCode.set(true)
+
+        // OnlyNullMarked leaves NullAway inert until a package-info.java opts in with JSpecify's
+        // @NullMarked, so the check can be turned on before any package is ready for it.
+        //
+        // Both lines are unconditional on purpose. Error Prone instantiates NullAway as soon as
+        // its jar is on the processor path, even for a task that disables the check below, and
+        // NullAway refuses to start unless one of OnlyNullMarked or AnnotatedPackages is set.
+        // Moving them into an else branch fails every test compile.
+        check("NullAway", CheckSeverity.ERROR)
+        option("NullAway:OnlyNullMarked", true)
+
+        if (testCompile) {
+            // SelfAssertion only fires on TestNG's own sample/fixture classes, where trivial
+            // assertions such as assertThat("abc").isEqualTo("abc") exist solely to give the
+            // runner a passing method. Production code keeps the check enabled.
+            //
+            // NullAway is off here because @NullMarked applies to a package, not a source set:
+            // nine test packages share a name with a main one, so marking org.testng or
+            // org.testng.internal would sweep in their test halves too.
+            disable("SelfAssertion", "NullAway")
+        }
     }
 }

--- a/build-logic/jvm/src/main/kotlin/testng.java-library.gradle.kts
+++ b/build-logic/jvm/src/main/kotlin/testng.java-library.gradle.kts
@@ -6,6 +6,13 @@ plugins {
     id("testng.testing")
 }
 
+dependencies {
+    // The annotations NullAway reads. JSpecify asks for a regular dependency rather than
+    // compileOnly: the annotations are runtime-retained, so hiding them would strip nullness
+    // information from the published artifact that consumers and their own checkers can use.
+    api("org.jspecify:jspecify:1.0.0")
+}
+
 tasks.withType<Javadoc>().configureEach {
     excludes.add("org/testng/internal/**")
 }

--- a/testng-core-api/src/main/java/org/testng/log4testng/Logger.java
+++ b/testng-core-api/src/main/java/org/testng/log4testng/Logger.java
@@ -2,6 +2,7 @@ package org.testng.log4testng;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.LoggerFactory;
 
 /**
@@ -48,7 +49,7 @@ public class Logger {
    *
    * @param message the message object to log.
    */
-  public void trace(Object message) {
+  public void trace(@Nullable Object message) {
     logger.trace("{}", message);
   }
 
@@ -59,7 +60,7 @@ public class Logger {
    * @param message the message object to log.
    * @param t the exception to log, including its stack trace.
    */
-  public void trace(Object message, Throwable t) {
+  public void trace(@Nullable Object message, Throwable t) {
     logger.trace("{}", message, t);
   }
 
@@ -78,7 +79,7 @@ public class Logger {
    *
    * @param message the message object to log.
    */
-  public void debug(Object message) {
+  public void debug(@Nullable Object message) {
     logger.debug("{}", message);
   }
 
@@ -89,7 +90,7 @@ public class Logger {
    * @param message the message object to log.
    * @param t the exception to log, including its stack trace.
    */
-  public void debug(Object message, Throwable t) {
+  public void debug(@Nullable Object message, Throwable t) {
     logger.debug("{}", message, t);
   }
 
@@ -108,7 +109,7 @@ public class Logger {
    *
    * @param message the message object to log.
    */
-  public void info(Object message) {
+  public void info(@Nullable Object message) {
     logger.info("{}", message);
   }
 
@@ -119,7 +120,7 @@ public class Logger {
    * @param message the message object to log.
    * @param t the exception to log, including its stack trace.
    */
-  public void info(Object message, Throwable t) {
+  public void info(@Nullable Object message, Throwable t) {
     logger.info("{}", message, t);
   }
 
@@ -129,7 +130,7 @@ public class Logger {
    *
    * @param message the message object to log.
    */
-  public void warn(Object message) {
+  public void warn(@Nullable Object message) {
     logger.warn("{}", message);
   }
 
@@ -140,7 +141,7 @@ public class Logger {
    * @param message the message object to log.
    * @param t the exception to log, including its stack trace.
    */
-  public void warn(Object message, Throwable t) {
+  public void warn(@Nullable Object message, Throwable t) {
     logger.warn("{}", message, t);
   }
 
@@ -150,7 +151,7 @@ public class Logger {
    *
    * @param message the message object to log.
    */
-  public void error(Object message) {
+  public void error(@Nullable Object message) {
     logger.error("{}", message);
   }
 
@@ -161,7 +162,7 @@ public class Logger {
    * @param message the message object to log.
    * @param t the exception to log, including its stack trace.
    */
-  public void error(Object message, Throwable t) {
+  public void error(@Nullable Object message, Throwable t) {
     logger.error("{}", message, t);
   }
 
@@ -171,7 +172,7 @@ public class Logger {
    *
    * @param message the message object to log.
    */
-  public void fatal(Object message) {
+  public void fatal(@Nullable Object message) {
     logger.error("{}", message);
   }
 
@@ -182,7 +183,7 @@ public class Logger {
    * @param message the message object to log.
    * @param t the exception to log, including its stack trace.
    */
-  public void fatal(Object message, Throwable t) {
+  public void fatal(@Nullable Object message, Throwable t) {
     logger.error("{}", message, t);
   }
 

--- a/testng-core-api/src/main/java/org/testng/log4testng/package-info.java
+++ b/testng-core-api/src/main/java/org/testng/log4testng/package-info.java
@@ -1,0 +1,5 @@
+/** TestNG's minimal internal logger. */
+@NullMarked
+package org.testng.log4testng;
+
+import org.jspecify.annotations.NullMarked;

--- a/testng/testng-build.gradle.kts
+++ b/testng/testng-build.gradle.kts
@@ -111,6 +111,7 @@ val verifyPublishedPomDependencies = tasks.register("verifyPublishedPomDependenc
     val expected = listOf(
         "com.google.inject:guice scope=compile optional=true",
         "org.jcommander:jcommander scope=compile optional=false",
+        "org.jspecify:jspecify scope=compile optional=false",
         "org.slf4j:slf4j-api scope=compile optional=false",
         "org.testng:testng-asserts scope=compile optional=false",
         "org.yaml:snakeyaml scope=runtime optional=true",


### PR DESCRIPTION
TestNG has no nullness checking, so whether a method may return null is only discoverable by reading it. This wires up NullAway and takes the first package through it.

Supersedes #2941, which used the Checker Framework. That branch is now three years and 336 commits behind, 35 of its 59 files conflict, and `testng-asserts` has since left the repository. More importantly the Checker Framework analyses every file of the compilation unit regardless of what a package opted into, so the change could not be split — the branch stalled on the size of the diff.

## Commit 1 — the wiring

NullAway plugs into the Error Prone pass that already runs on every module, so there is no new Gradle plugin. `OnlyNullMarked` confines it to code declaring JSpecify `@NullMarked`, which makes this commit report nothing and touch no Java source.

That scoping is the point: nullness can be adopted one package at a time, each step green on its own, instead of as one sweep over the whole API.

JSpecify ships as a regular `api` dependency rather than `compileOnly`. Its annotations are runtime-retained, so hiding them would strip nullness information from the published artifact instead of passing it to consumers. `verifyPublishedPomDependencies` is updated accordingly.

## Commit 2 — the first package

`org.testng.log4testng`, picked for being small and confined to one module. That last part matters: `@NullMarked` applies to a *package*, and 10 of TestNG's 25 main-source packages appear in more than one module, so marking one half marks the other through the compile classpath. `org.testng.internal` alone spans four modules.

Every `Logger` method hands its message straight to SLF4J as a `{}` argument, which renders null as the string `"null"` and never dereferences it — verified against slf4j-simple 2.0.18. So the parameters are `@Nullable`. The `Throwable` overloads keep a non-null throwable.

## Verification

Full build green on both commits: 15726 tests in testng-core, 0 failures, including `testng-test-osgi`, which exercises the bundle with the new dependency.

The wiring was checked to be a real no-op rather than an inert one: a throwaway `@NullMarked` package with a `return null` made NullAway fail the compile as expected, and was removed.

## Follow-up

Enabling the check on `org.testng.internal.reflect` surfaced a live NullPointerException, reported as #3361 and fixed separately in #3362.

The follow-on packages are stacked on this branch rather than folded in, so each stays green on its own: #3365 takes `org.testng.collections`, `org.testng.cli` and `org.testng.cli.jcommander`.

*Replaces #3363, which was opened from a fork branch. GitHub requires a pull request's base to be a branch of the target repository, so the stack above it could not point at it. Identical commits, same SHAs.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added null-safety annotations across logging APIs to clarify when messages may be absent.
  * Published nullness annotations for improved compatibility with tools and IDEs.
  * Enabled additional checks to detect potential null-related issues during development.
  * Marked the logging package as non-null by default while preserving nullable logging message parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->