### PR TITLE
refactor: declare org.testng.annotations and org.testng.internal.protocols null-marked

### DIFF
--- a/testng-core-api/src/main/java/org/testng/annotations/IFactoryAnnotation.java
+++ b/testng-core-api/src/main/java/org/testng/annotations/IFactoryAnnotation.java
@@ -1,11 +1,17 @@
 package org.testng.annotations;
 
 import java.util.List;
+import org.jspecify.annotations.Nullable;
 import org.testng.internal.annotations.IDataProvidable;
 
 /** Encapsulate the @Factory / @testng.factory annotation */
 public interface IFactoryAnnotation extends IParameterizable, IDataProvidable {
 
+  /**
+   * @return - The indices to keep out of the data provider rows, or {@code null} when none were
+   *     given.
+   */
+  @Nullable
   List<Integer> getIndices();
 
   void setIndices(List<Integer> indices);
@@ -13,5 +19,5 @@ public interface IFactoryAnnotation extends IParameterizable, IDataProvidable {
   /** @return - The lazy instantiation preference declared on the {@code @Factory}. */
   Lazy getLazy();
 
-  void setLazy(Lazy lazy);
+  void setLazy(@Nullable Lazy lazy);
 }

--- a/testng-core-api/src/main/java/org/testng/annotations/ITestAnnotation.java
+++ b/testng-core-api/src/main/java/org/testng/annotations/ITestAnnotation.java
@@ -1,5 +1,6 @@
 package org.testng.annotations;
 
+import org.jspecify.annotations.Nullable;
 import org.testng.IRetryAnalyzer;
 import org.testng.internal.annotations.IDataProvidable;
 
@@ -68,9 +69,14 @@ public interface ITestAnnotation extends ITestOrConfiguration, IDataProvidable {
 
   void setDataProvider(String v);
 
+  /**
+   * @return The class holding the data provider, or {@code null} when neither the method nor
+   *     anything it inherits from names one.
+   */
+  @Nullable
   Class<?> getDataProviderClass();
 
-  void setDataProviderClass(Class<?> v);
+  void setDataProviderClass(@Nullable Class<?> v);
 
   String getDataProviderDynamicClass();
 

--- a/testng-core-api/src/main/java/org/testng/annotations/ITestOrConfiguration.java
+++ b/testng-core-api/src/main/java/org/testng/annotations/ITestOrConfiguration.java
@@ -1,5 +1,7 @@
 package org.testng.annotations;
 
+import org.jspecify.annotations.Nullable;
+
 /** This interface captures methods common to @Test and @Configuration */
 public interface ITestOrConfiguration extends IParameterizable {
   /**
@@ -36,8 +38,12 @@ public interface ITestOrConfiguration extends IParameterizable {
 
   void setDependsOnMethods(String[] dependsOnMethods);
 
-  /** @return The description for this method, which will be shown in the reports. */
+  /**
+   * @return The description for this method, which will be shown in the reports, or {@code null}
+   *     when neither the method nor anything it inherits from carries one.
+   */
+  @Nullable
   String getDescription();
 
-  void setDescription(String description);
+  void setDescription(@Nullable String description);
 }

--- a/testng-core-api/src/main/java/org/testng/annotations/package-info.java
+++ b/testng-core-api/src/main/java/org/testng/annotations/package-info.java
@@ -1,0 +1,5 @@
+/** The annotations that drive TestNG, and the interfaces that expose them to listeners. */
+@NullMarked
+package org.testng.annotations;
+
+import org.jspecify.annotations.NullMarked;

--- a/testng-core-api/src/main/java/org/testng/internal/protocols/Input.java
+++ b/testng-core-api/src/main/java/org/testng/internal/protocols/Input.java
@@ -46,12 +46,12 @@ public class Input {
   }
 
   public static final class Builder {
-    private List<String> included;
-    private List<String> excluded;
-    private String packageWithoutWildCards;
+    private List<String> included = List.of();
+    private List<String> excluded = List.of();
+    private String packageWithoutWildCards = "";
     private boolean recursive;
-    private String packageDirName;
-    private String packageName;
+    private String packageDirName = "";
+    private String packageName = "";
 
     private Builder() {}
 

--- a/testng-core-api/src/main/java/org/testng/internal/protocols/package-info.java
+++ b/testng-core-api/src/main/java/org/testng/internal/protocols/package-info.java
@@ -1,0 +1,5 @@
+/** Per-URL-protocol strategies for listing the classes a package name resolves to. */
+@NullMarked
+package org.testng.internal.protocols;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
Stacked on #3365 — review only the two commits above `refactor(jcommander): declare the package null-marked`.

These are the last two packages of `testng-core-api` that live in exactly one module, which is the
constraint the whole stack is built on: `@NullMarked` applies to a *package*, and a package split
across modules gets its unmarked half marked anyway through `package-info.class` on the compile
classpath. Between them they are the 41 files left in that module that could be taken without
dragging in a second one.

## The annotation rule

An `@Nullable` is written only when one of two things is true, and the reason was checked by
deleting it and recompiling:

- **required** — the compile fails without it;
- **contract** — the method body *is* a null test, or the field really is null in normal operation.

Everything else stays bare. Restructuring wins over annotating when it costs nothing.

| | required | contract | total |
|---|---|---|---|
| `org.testng.annotations` | 0 | 6 | 6 |
| `org.testng.internal.protocols` | 0 | 0 | 0 |

Zero required is not the check going quiet. Between them these two packages contain three method
bodies — `IConfigurationAnnotation.isBeforeGroups`, `isAfterGroups`, both returning `boolean`, and
the `Processor` hierarchy — and the one thing NullAway does demand is answered without an
annotation. See the negative control below.

## Commit 1 — `org.testng.annotations`

Thirty-four files: 22 annotation types, 11 interfaces, one enum. Annotation types and enums carry
no method body, so `package-info.java` lands green on its own.

The six annotations are all contract, and they go on the interfaces because that is the only place
the nullness is stated at all. The implementations live in `org.testng.internal.annotations`, which
spans `testng-core-api` and `testng-core` and so cannot be marked one half at a time. NullAway does
not check it, and no already marked package references these types — so annotating here cannot
break anything today, and becomes binding the day that package is marked. Which is exactly why each
one had to be true rather than decorative:

| Signature | Why |
|---|---|
| `ITestOrConfiguration.getDescription` / `setDescription` | `JDK15TagFactory.findInherited` returns `null` and `createTestTag` feeds it straight in — the null that `TestNGMethod.getDescription` and `IgnoreListener.onBeforeClass` already test for |
| `ITestAnnotation.getDataProviderClass` / `setDataProviderClass` | same `findInherited` path; `TestAnnotation` leaves the field `null` and `Parameters` guards it four times |
| `IFactoryAnnotation.getIndices` | `FactoryAnnotation` never initialises the field; `FactoryMethod` tests `indices == null` twice |
| `IFactoryAnnotation.setLazy` | `FactoryAnnotation.setLazy` *is* the null test: `m_lazy = lazy == null ? Lazy.UNSET : lazy`. The getter stays non-null |

Dropping all six compiles green, so none of them is there to satisfy the compiler.

What stays bare is the more interesting half. Every getter whose field starts out `null` but is
always assigned before anyone can read it keeps its non-null contract:
`getRetryAnalyzerClass`, `IDataProviderAnnotation.getIndices` (unlike its `IFactoryAnnotation`
namesake — that asymmetry is real, `createDataProviderTag` sets it and `createFactoryTag` is the
one that can be overridden to null), `getName`, `getDataProvider`, `retryUsing`, `getSuiteName`,
`getTestName`, `getExpectedExceptionsMessageRegExp`, `IFactoryAnnotation.getLazy`, and every array
getter — those either initialise to `{}` or take their value from a Java annotation member, which
cannot be null.

## Commit 2 — `org.testng.internal.protocols`

Seven files, and the check demands one thing that is not an annotation:

```
Input.java:56: error: [NullAway] initializer method does not guarantee @NonNull fields
'included' (line 49), 'excluded' (line 50), 'packageWithoutWildCards' (line 51),
'packageDirName' (line 53), 'packageName' (line 54) are initialized along all control-flow paths
```

`Input.Builder` declares five reference fields with no initialiser and a constructor that assigns
nothing. Annotating them would be a lie, the same lie `Converter.m_files` would have been in #3365:
`PackageUtils.findClassesInPackage` is the only caller in the repository, it calls all six setters,
and no test builds an `Input`. They are seeded with empty values instead — five initialisers, zero
annotations, and none of the cascade that `@Nullable` on those fields would have pushed into
`Input`'s constructor and on into all four processors.

The one difference is what `build()` yields when a setter is skipped: a `NullPointerException` out
of `Collections.unmodifiableList` before, empty values now. No caller takes that path.

Nothing else in the package reports, and three near-misses are worth recording because they look
like they should. `File.listFiles` and `Method.invoke` are not in NullAway 0.13.8's JDK models, so
the existing `dirfiles == null` test in `findClassesInDirPackage` stands unremarked and
`BundledResourceProcessor` keeps dereferencing the reflected `URL`. `Utils.log` and the `java.net`
calls cross into unmarked code, which NullAway reads optimistically. `NullAway:JSpecifyMode` is off,
so `List<String>` type arguments are not checked either.

## Verification

`./gradlew build` green: 15948 tests, 0 failures, 12 skipped, `testng-test-osgi` included.

The check was proved live rather than inert on each package separately. A throwaway
`default String probe() { return null; }` on `IAnnotation`, and a throwaway `return null;` in
`NoOpProcessor.process`, each failed the compile:

```
IAnnotation.java:6: error: [NullAway] returning @Nullable expression from method with @NonNull return type
NoOpProcessor.java:10: error: [NullAway] returning @Nullable expression from method with @NonNull return type
```

Both were removed. The six contract annotations were deleted together and recompiled green.

## Noticed, not fixed

`FactoryAnnotation.getDataProviderDynamicClass()` returns `null` for every `@Factory`, while
`IDataProvidable` declares it non-null and `TestAnnotation` holds `""`. Filed as #3369. It does not
NPE today only because `Parameters` short-circuits on `dataProviderClass == null`, which
`createFactoryTag` happens to guarantee — a guarantee an `IAnnotationTransformer` can remove. The
fix is one initialiser, but it is a behaviour change, so it does not belong here.

That is also why `IDataProvidable` itself is untouched: it sits in `org.testng.internal.annotations`,
the split package, and marking it is a later step.

No `CHANGES.txt` entry: no behaviour changes on any reachable path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added clear nullability annotations and documentation across annotation APIs.
  * Clarified when optional descriptions, provider classes, indices, and lazy settings may be absent.
  * Applied package-wide nullness checking to annotation and protocol APIs.
  * Protocol builders now initialize optional collections and text fields with safe empty defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->