### PR TITLE
refactor: declare org.testng.reporters.jq null-marked

### DIFF
--- a/testng-core/src/main/java/org/testng/reporters/jq/BaseMultiSuitePanel.java
+++ b/testng-core/src/main/java/org/testng/reporters/jq/BaseMultiSuitePanel.java
@@ -1,5 +1,6 @@
 package org.testng.reporters.jq;
 
+import org.jspecify.annotations.Nullable;
 import org.testng.ISuite;
 import org.testng.reporters.XMLStringBuffer;
 
@@ -30,7 +31,7 @@ public abstract class BaseMultiSuitePanel extends BasePanel implements INavigato
   }
 
   @Override
-  public String getClassName() {
+  public @Nullable String getClassName() {
     return null;
   }
 

--- a/testng-core/src/main/java/org/testng/reporters/jq/INavigatorPanel.java
+++ b/testng-core/src/main/java/org/testng/reporters/jq/INavigatorPanel.java
@@ -1,5 +1,6 @@
 package org.testng.reporters.jq;
 
+import org.jspecify.annotations.Nullable;
 import org.testng.ISuite;
 
 /** Panels that are accessible from the navigator. */
@@ -8,6 +9,8 @@ public interface INavigatorPanel extends IPanel {
 
   String getNavigatorLink(ISuite suite);
 
+  /** @return the CSS class to style the navigator link with, or {@code null} for none. */
+  @Nullable
   String getClassName();
 
   String getPrefix();

--- a/testng-core/src/main/java/org/testng/reporters/jq/Model.java
+++ b/testng-core/src/main/java/org/testng/reporters/jq/Model.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 import org.testng.IResultMap;
 import org.testng.ISuite;
 import org.testng.ISuiteResult;
@@ -114,18 +115,27 @@ public class Model {
   }
 
   public ResultsByClass getFailedResultsByClass(ISuite suite) {
-    return m_failedResultsByClass.get(suite);
+    return resultsByClass(m_failedResultsByClass, suite);
   }
 
   public ResultsByClass getSkippedResultsByClass(ISuite suite) {
-    return m_skippedResultsByClass.get(suite);
+    return resultsByClass(m_skippedResultsByClass, suite);
   }
 
   public ResultsByClass getPassedResultsByClass(ISuite suite) {
-    return m_passedResultsByClass.get(suite);
+    return resultsByClass(m_passedResultsByClass, suite);
   }
 
-  public String getTag(ITestResult tr) {
+  // init() files every suite in all three tables, so a suite the model never saw reads as empty
+  // rather than null -- the way an unknown suite name reads as "passed" in getStatusForSuite.
+  private static ResultsByClass resultsByClass(
+      Map<ISuite, ResultsByClass> resultsBySuite, ISuite suite) {
+    ResultsByClass results = resultsBySuite.get(suite);
+    return results != null ? results : new ResultsByClass();
+  }
+
+  /** @return the anchor tag of a result the model holds, or {@code null} for any other result. */
+  public @Nullable String getTag(ITestResult tr) {
     return m_testResultMap.get(tr);
   }
 

--- a/testng-core/src/main/java/org/testng/reporters/jq/NavigatorPanel.java
+++ b/testng-core/src/main/java/org/testng/reporters/jq/NavigatorPanel.java
@@ -256,29 +256,27 @@ public class NavigatorPanel extends BasePanel {
     xsb.push(D, C, "method-list-content " + type + " " + suiteName);
     int count = 0;
     List<ITestResult> testResults = provider.getResults();
-    if (testResults != null) {
-      testResults.sort(ResultsByClass.METHOD_NAME_COMPARATOR);
-      for (ITestResult tr : testResults) {
-        String testName = Model.getTestResultName(tr);
-        xsb.push(S);
-        xsb.addEmptyElement("img", "src", image, "width", "3%");
-        xsb.addRequired(
-            "a",
-            testName,
-            "href",
-            "#",
-            "hash-for-method",
-            getModel().getTag(tr),
-            "panel-name",
-            suiteName,
-            "title",
-            tr.getTestClass().getName(),
-            C,
-            "method navigator-link");
-        xsb.pop(S);
-        xsb.addEmptyElement("br");
-        count++;
-      }
+    testResults.sort(ResultsByClass.METHOD_NAME_COMPARATOR);
+    for (ITestResult tr : testResults) {
+      String testName = Model.getTestResultName(tr);
+      xsb.push(S);
+      xsb.addEmptyElement("img", "src", image, "width", "3%");
+      xsb.addRequired(
+          "a",
+          testName,
+          "href",
+          "#",
+          "hash-for-method",
+          getModel().getTag(tr),
+          "panel-name",
+          suiteName,
+          "title",
+          tr.getTestClass().getName(),
+          C,
+          "method navigator-link");
+      xsb.pop(S);
+      xsb.addEmptyElement("br");
+      count++;
     }
     xsb.pop(D);
     xsb.pop("li");

--- a/testng-core/src/main/java/org/testng/reporters/jq/package-info.java
+++ b/testng-core/src/main/java/org/testng/reporters/jq/package-info.java
@@ -1,0 +1,5 @@
+/** The default HTML report: a model built from the suites, and the panels that render it. */
+@NullMarked
+package org.testng.reporters.jq;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
Fifth step of the JSpecify/NullAway stack, after #3374 — review only the commit above
`refactor(xml.internal): declare the package null-marked`. #3374 left this package out on purpose
and named it as the next one.

`org.testng.reporters.jq` is the default HTML report: 17 `main` files, one module. It is the first
package of the stack that carries **data** rather than options — `Model` builds seven tables keyed
by suite, class and method, and every panel reads them back — so it is the first place the check had
a chance to find something other than an uninitialised field.

**No rendered output changes.** That was the constraint, and it is measured below rather than
argued.

## The annotation rule

An `@Nullable` is written only when one of two things is true, and the reason was checked by
deleting it and recompiling:

- **required (E)** — the compile fails without it;
- **contract (C)** — the method body *is* a null test, and a real caller produces the null.

Everything else stays bare. Restructuring wins over annotating when it costs nothing.

| | files | baseline errors | @Nullable (E) | @Nullable (C) |
|---|---:|---:|---:|---:|
| `org.testng.reporters.jq` | 17 | 5 | 3 | 0 |

## Why only five errors, and all of one shape

The only producer of `null` NullAway can see in this package is `java.util.Map.get`. Everything the
report reads from — `ISuite`, `ITestResult`, `XmlSuite`, `XMLStringBuffer`, `Utils` — is unmarked
and read optimistically. `org.testng.collections` *is* marked, but `MultiMap.get` is a
`computeIfAbsent` and never returns null, so the five `MultiMap` lookups in `Model`,
`ResultsByClass` and `IgnoredMethodsPanel` are silent and correctly so.

The two JDK returns that looked like candidates are not modelled by NullAway 0.13.8 — checked
against the jar, not guessed: `Class.getResourceAsStream` and `File.getParentFile` are absent from
`NULLABLE_RETURNS` (`Class.getResource` appears only as a non-null *parameter* entry), so `Main.load`
and the resource copying demand nothing and stay bare. `Throwable.getMessage` *is* modelled, but
`Logger.error` already takes a `@Nullable Object` since #3367.

No initializer error either: every field in the package is assigned inline or in a constructor.

## The restructure

`getFailedResultsByClass`, `getSkippedResultsByClass` and `getPassedResultsByClass` returned a
`Map.get` straight out — three of the five errors. Annotating them would have pushed three guards
into `SuitePanel` for a null it cannot get: `init()` files every suite of `m_suites` in all three
tables unconditionally, and `SuitePanel` only ever walks `getSuites()`.

They now share a private helper, and a suite the model never saw reads as an empty `ResultsByClass`
instead of null. That is the trade `getStatusForSuite` already makes two methods below, where an
unknown suite name reads as `"passed"` — and the same trade as `PhoneyWorker.getTasks` in #3374 and
`Input.Builder` in #3370: a different value on a path with no caller.

`NavigatorPanel.generateMethodList` also loses a dead null test. `IResultProvider` is a private
interface with one implementation, which delegates to `getMethodsByStatus` and always returns a
list. The guarded body did nothing on an empty list either — `count` stays 0 and nothing is emitted
— so the two paths were already the same.

## The two annotations

**`Model.getTag`.** Every `ITestResult` in `m_model` was registered in `m_testResultMap` in the same
loop of `init()`, so the one caller cannot reach the null. The method is public, though, and the
signature should say so — the more since `NavigatorPanel.generateMethodList` feeds the result into
the attribute varargs of `XMLStringBuffer.addRequired`, which end in `Properties.put` and would
throw on null. Unreachable today; worth stating.

**`INavigatorPanel.getClassName`** and its `BaseMultiSuitePanel` override. `NavigatorPanel.addLinkTo`
*is* the null test, and `TestPanel` is the one panel that answers with a real class. Dropping the
interface annotation alone is not enough — the override then reports
`method returns @Nullable, but superclass method ... returns @NonNull` — so both sites are (E).

## What was deliberately left bare

- `Model.getMethodName` tests its argument for null, and its only caller passes
  `ITestNGMethod.getMethodName()`. Every implementation in the repository resolves to
  `Method.getName()` or `ConstructorOrMethod.getName()`, neither of which can be null. Residue, not
  a contract.
- `TestNgXmlPanel.getNavigatorLink` guards `XmlSuite.getFileName()`, which really can be null for a
  suite built in code. But `XmlSuite` is unmarked, so an annotation here would record something the
  build does not enforce — the same call `TestNGFutureTask` got in #3374. (`getHeader` returns the
  same value into `addOptional`, which drops null silently, so nothing throws.)
- `SuitePanel`'s `getAttributes() != null` and `getThrowable() != null`, `Main`'s `header == null`
  and `is == null` — all against unmarked or unmodelled sources.

## Verification

**Negative control.** A throwaway `return null;` in `BasePanel.suiteToTag` fails the compile with a
NullAway error, so the package really is under the check and not silently skipped. Reverted.

**Classification.** Each of the three annotations was deleted on its own and the package recompiled:
`getTag` → 1 error, `INavigatorPanel.getClassName` alone → 1 error on the override,
both `getClassName` sites → the original `return null` error. All (E), none decorative.

**No output change — measured.** A fixture suite exercising every panel (passed / failed / skipped,
groups, a data provider, reporter output, a disabled method, two `<test>` tags) was run three times
against the base build and three times against this branch, driving `org.testng.TestNG` through the
Java API with the classpath resolved from Gradle. The `index.html` files were compared after
stripping the wall-clock values — the per-method durations, the total running time, the
`method-start` offsets, and the Times table row index, which is a duration rank. That normaliser is
noise-free on both sides: all three base runs are identical to each other, and so are all three
branch runs. **All nine base-vs-branch comparisons are identical**, and the raw files are the same
size to the byte.

The residual difference between two runs of the *same* build is ordering only — the chronological
panel sorts by start millis and the ignored-methods panel iterates a `SetMultiMap` — which is why
the comparison is by content and not by line order.

**Gate.** `./gradlew build` is green: **16152 tests in `testng-core`, 0 failures, 0 errors**, and
`testng-yaml` 124, `testng-jcommander` 41, `testng-collections` 38, `testng-cli` 14 — all zero.
`autostyleApply` produced no change. `compileTestKotlin` was checked explicitly: the one test in
this package is Kotlin (`TimesPanelTest`), and Kotlin 2.4 reads JSpecify off the classpath, so
`@NullMarked` hardens the platform types it sees. It compiles unchanged.

## Nothing deferred this time

One hazard was read out of `TimesPanel.time(ITestContext)`, which dereferences `ctx.getEndDate()`
while `TestRunner.m_endDate` starts null and is only set at the end of `afterRun()`. NullAway cannot
see it — `ITestContext` is unmarked — and it is the same family as GITHUB-1931, which
`TimesPanelTest` pins for the non-parallel path only.

It does not reproduce, and the reason is worth recording: `SuiteRunner.runTest` constructs the
`SuiteResult` only *after* `tr.run()` returns, so a context that never finished never enters
`suite.getResults()`. The one way to get past `afterRun()` without logging the date would be an
`@AfterTest` exception escaping `invokeTestConfigurations` — and it does not escape. Run with
`parallel="tests"` and an `@AfterTest` that throws, the failure is recorded as a configuration
failure, `m_endDate` is set, and the report generates normally. No issue filed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved default HTML report handling when suite data is unavailable.
  * Report sections now consistently display available method results instead of silently omitting them.
  * Improved handling of missing class and result labels to prevent misleading report output.
  * Report generation is now more consistent when optional or incomplete result data is encountered.

* **Documentation**
  * Added documentation clarifying report behavior when optional data is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->