### PR TITLE
refactor: declare four cross-module packages null-marked

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,32 @@ look: the `branches: ['*']` filter in `test.yml` does not match `/`, so pushing 
 exact dependency set of the published pom, versions ignored. When it fails, either the change is
 wrong or the expected list needs updating — decide which, do not just update the list.
 
+## Declaring a package null-marked
+
+How the check is scoped is documented where it is configured, in
+`build-logic/code-quality/src/main/kotlin/testng.errorprone.gradle.kts`. What that comment cannot
+say is that a green build proves nothing on its own: it is also what an unchecked package looks
+like.
+
+Several of the main packages span several modules, and there the placement decides the coverage.
+Module A's `package-info.class` reaches B's compile classpath only if B depends on A, so putting the
+file on the wrong side leaves the other half compiling **unchecked**.
+
+Prove the coverage per module traversed, not once per package. Drop a throwaway
+
+```java
+private static Object nullAwayProbe() { return null; }
+```
+
+into one file of **each** module the package lives in, and compile those modules. Before the
+`package-info.java` every probe must compile clean; after it every probe must fail with
+`[NullAway] returning @Nullable expression from method with @NonNull return type`. A probe that
+still passes marks a half that is not under the check, and the error count for that package means
+nothing until it does.
+
+`@NullMarked` does not descend into sub-packages: `org.testng.internal.thread.graph` was marked long
+before `org.testng.internal.thread`.
+
 ## Layout
 
 Modules are listed in `settings.gradle.kts`; only `:testng` is published, as a shaded jar merging

--- a/testng-collections/src/main/java/org/testng/util/Strings.java
+++ b/testng-collections/src/main/java/org/testng/util/Strings.java
@@ -5,17 +5,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import org.jspecify.annotations.Nullable;
 
 public final class Strings {
   private Strings() {
     // Utility class. Defeat instantiation.
   }
 
-  public static boolean isNullOrEmpty(String string) {
+  public static boolean isNullOrEmpty(@Nullable String string) {
     return Optional.ofNullable(string).orElse("").trim().isEmpty();
   }
 
-  public static boolean isNotNullAndNotEmpty(String string) {
+  public static boolean isNotNullAndNotEmpty(@Nullable String string) {
     return !isNullOrEmpty(string);
   }
 

--- a/testng-collections/src/main/java/org/testng/util/package-info.java
+++ b/testng-collections/src/main/java/org/testng/util/package-info.java
@@ -1,0 +1,5 @@
+/** Utilities users see: string predicates, a clock, and the retry analyzer they extend. */
+@NullMarked
+package org.testng.util;
+
+import org.jspecify.annotations.NullMarked;

--- a/testng-core-api/src/main/java/org/testng/internal/objects/InstanceCreator.java
+++ b/testng-core-api/src/main/java/org/testng/internal/objects/InstanceCreator.java
@@ -6,6 +6,7 @@ import java.lang.invoke.MethodType;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 import org.testng.TestNGException;
 import org.testng.internal.ClassHelper;
 
@@ -36,7 +37,7 @@ public final class InstanceCreator {
     }
   }
 
-  public static <T> T newInstance(Constructor<T> constructor, Object... parameters) {
+  public static <T> T newInstance(Constructor<T> constructor, @Nullable Object... parameters) {
     try {
       return constructor.newInstance(parameters);
     } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {

--- a/testng-core-api/src/main/java/org/testng/internal/objects/package-info.java
+++ b/testng-core-api/src/main/java/org/testng/internal/objects/package-info.java
@@ -1,0 +1,5 @@
+/** Instantiation of test classes and listeners, with and without Guice. */
+@NullMarked
+package org.testng.internal.objects;
+
+import org.jspecify.annotations.NullMarked;

--- a/testng-core-api/src/main/java/org/testng/internal/thread/ThreadTimeoutException.java
+++ b/testng-core-api/src/main/java/org/testng/internal/thread/ThreadTimeoutException.java
@@ -1,5 +1,6 @@
 package org.testng.internal.thread;
 
+import org.jspecify.annotations.Nullable;
 import org.testng.ITestNGMethod;
 
 /** Exception used to signal a thread timeout. */
@@ -11,7 +12,7 @@ public class ThreadTimeoutException extends Exception {
     this(msg, null);
   }
 
-  public ThreadTimeoutException(String msg, Throwable cause) {
+  public ThreadTimeoutException(String msg, @Nullable Throwable cause) {
     super(msg, cause);
   }
 
@@ -23,7 +24,7 @@ public class ThreadTimeoutException extends Exception {
     this(tm, timeout, null);
   }
 
-  public ThreadTimeoutException(ITestNGMethod tm, long timeout, Throwable cause) {
+  public ThreadTimeoutException(ITestNGMethod tm, long timeout, @Nullable Throwable cause) {
     this(
         "Method " + tm.getQualifiedName() + "() didn't finish within the time-out " + timeout,
         cause);

--- a/testng-core-api/src/main/java/org/testng/internal/thread/package-info.java
+++ b/testng-core-api/src/main/java/org/testng/internal/thread/package-info.java
@@ -1,0 +1,5 @@
+/** The threads TestNG runs work on, and the exceptions a worker reports back through. */
+@NullMarked
+package org.testng.internal.thread;
+
+import org.jspecify.annotations.NullMarked;

--- a/testng-core/src/main/java/org/testng/internal/objects/Dispenser.java
+++ b/testng-core/src/main/java/org/testng/internal/objects/Dispenser.java
@@ -11,8 +11,6 @@ public final class Dispenser {
 
   /** @return - An {@link IObjectDispenser} that backed by the chain of responsibilities. */
   public static IObjectDispenser newInstance(ITestObjectFactory objectFactory) {
-    GuiceBasedObjectDispenser dispenser = new GuiceBasedObjectDispenser();
-    dispenser.setNextDispenser(new SimpleObjectDispenser(objectFactory));
-    return dispenser;
+    return new GuiceBasedObjectDispenser(new SimpleObjectDispenser(objectFactory));
   }
 }

--- a/testng-core/src/main/java/org/testng/internal/objects/GuiceBasedObjectDispenser.java
+++ b/testng-core/src/main/java/org/testng/internal/objects/GuiceBasedObjectDispenser.java
@@ -1,7 +1,10 @@
 package org.testng.internal.objects;
 
 import com.google.inject.Injector;
+import java.util.Objects;
 import java.util.concurrent.locks.ReentrantLock;
+import org.jspecify.annotations.Nullable;
+import org.testng.IClass;
 import org.testng.ITestContext;
 import org.testng.annotations.Guice;
 import org.testng.internal.annotations.AnnotationHelper;
@@ -15,13 +18,17 @@ class GuiceBasedObjectDispenser implements IObjectDispenser {
   private IObjectDispenser dispenser;
   private static final ReentrantLock lock = new ReentrantLock();
 
+  GuiceBasedObjectDispenser(IObjectDispenser dispenser) {
+    this.dispenser = dispenser;
+  }
+
   @Override
   public void setNextDispenser(IObjectDispenser dispenser) {
     this.dispenser = dispenser;
   }
 
   @Override
-  public Object dispense(CreationAttributes attributes) {
+  public @Nullable Object dispense(CreationAttributes attributes) {
     if (attributes.getBasicAttributes() == null) {
       // We don't have the ability to process object creation with elaborate attributes
       return this.dispenser.dispense(attributes);
@@ -34,38 +41,40 @@ class GuiceBasedObjectDispenser implements IObjectDispenser {
     }
   }
 
-  private Object dispenseObject(CreationAttributes attributes) {
+  private @Nullable Object dispenseObject(CreationAttributes attributes) {
     BasicAttributes sa = attributes.getBasicAttributes();
-    Class<?> cls = sa.getTestClass() == null ? sa.getRawClass() : sa.getTestClass().getRealClass();
+    Class<?> rawClass = sa.getRawClass();
+    IClass testClass = sa.getTestClass();
+    // BasicAttributes lets both halves be null, but no construction site leaves both out:
+    // ClassImpl is the only one that omits the raw class, and it supplies itself as the IClass.
+    Class<?> cls = testClass == null ? Objects.requireNonNull(rawClass) : testClass.getRealClass();
     if (cannotDispense(cls)) {
       return this.dispenser.dispense(attributes);
     }
     ITestContext ctx = attributes.getContext();
-    GuiceContext suiteCtx = attributes.getSuiteContext();
-    GuiceHelper helper;
+    Injector injector;
     // TODO: remove unused entries from helpers
     if (ctx == null) {
-      helper = new GuiceHelper(suiteCtx);
+      // No test context means a suite context instead. Nothing enforces that, and one caller
+      // reaches here with neither -- see #3377.
+      GuiceContext suite = Objects.requireNonNull(attributes.getSuiteContext());
+      injector = new GuiceHelper(suite).getInjector(cls, suite.getInjectorFactory());
     } else {
-      helper = (GuiceHelper) ctx.getAttribute(GUICE_HELPER);
+      GuiceHelper helper = (GuiceHelper) ctx.getAttribute(GUICE_HELPER);
       if (helper == null) {
         helper = new GuiceHelper(ctx);
         ctx.setAttribute(GUICE_HELPER, helper);
       }
-    }
-    Injector injector;
-    if (ctx == null) {
-      injector = helper.getInjector(cls, suiteCtx.getInjectorFactory());
-    } else {
       injector = helper.getInjector(cls, ctx.getInjectorFactory());
     }
     if (injector == null) {
       return null;
     }
-    if (sa.getRawClass() == null) {
-      return injector.getInstance(sa.getTestClass().getRealClass());
+    if (rawClass != null) {
+      return injector.getInstance(rawClass);
     }
-    return injector.getInstance(sa.getRawClass());
+    // Without a raw class, cls already resolved to the test class above.
+    return injector.getInstance(cls);
   }
 
   private static boolean cannotDispense(Class<?> clazz) {

--- a/testng-core/src/main/java/org/testng/internal/objects/GuiceHelper.java
+++ b/testng-core/src/main/java/org/testng/internal/objects/GuiceHelper.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.function.BiPredicate;
 import java.util.stream.StreamSupport;
+import org.jspecify.annotations.Nullable;
 import org.testng.IClass;
 import org.testng.IInjectorFactory;
 import org.testng.IModule;
@@ -39,7 +40,7 @@ class GuiceHelper {
   private final String parentModule;
   private final String stageString;
   private final String testName;
-  private final ITestContext context;
+  private final @Nullable ITestContext context;
 
   private static final BiPredicate<Module, Module> CLASS_EQUALITY =
       (m, n) -> m.getClass().equals(n.getClass());
@@ -58,10 +59,12 @@ class GuiceHelper {
     this.context = null;
   }
 
+  @Nullable
   Injector getInjector(IClass iClass, IInjectorFactory injectorFactory) {
     return getInjector(iClass.getRealClass(), injectorFactory);
   }
 
+  @Nullable
   Injector getInjector(Class<?> cls, IInjectorFactory injectorFactory) {
     Guice guice = AnnotationHelper.findAnnotationSuperClasses(Guice.class, cls);
     if (guice == null) {
@@ -110,6 +113,7 @@ class GuiceHelper {
     m_injectors.put(moduleInstances, injector);
   }
 
+  @Nullable
   Injector getInjector(List<Module> moduleInstances) {
     return m_injectors.get(moduleInstances);
   }
@@ -127,7 +131,7 @@ class GuiceHelper {
     return m_guiceModules.get(cls);
   }
 
-  private Module getParentModule() {
+  private @Nullable Module getParentModule() {
     Class<? extends Module> parentModule = getParentModuleClass();
     if (parentModule == null) {
       return null;
@@ -153,7 +157,7 @@ class GuiceHelper {
   }
 
   @SuppressWarnings("unchecked")
-  private Class<? extends Module> getParentModuleClass() {
+  private @Nullable Class<? extends Module> getParentModuleClass() {
     if (isStringEmpty(this.parentModule)) {
       return null;
     }
@@ -168,7 +172,7 @@ class GuiceHelper {
   }
 
   private Injector createInjector(
-      Injector parent, IInjectorFactory injectorFactory, List<Module> moduleInstances) {
+      @Nullable Injector parent, IInjectorFactory injectorFactory, List<Module> moduleInstances) {
     Stage stage = Stage.DEVELOPMENT;
     if (isStringNotEmpty(stageString)) {
       stage = Stage.valueOf(stageString);

--- a/testng-core/src/main/java/org/testng/internal/objects/IObjectDispenser.java
+++ b/testng-core/src/main/java/org/testng/internal/objects/IObjectDispenser.java
@@ -1,5 +1,6 @@
 package org.testng.internal.objects;
 
+import org.jspecify.annotations.Nullable;
 import org.testng.internal.objects.pojo.CreationAttributes;
 
 /**
@@ -10,6 +11,7 @@ public interface IObjectDispenser {
 
   String GUICE_HELPER = "testng.guice-helper";
 
+  @Nullable
   Object dispense(CreationAttributes attributes);
 
   /** @param dispenser - The {@link IObjectDispenser} to dispense */

--- a/testng-core/src/main/java/org/testng/internal/objects/ObjectFactoryImpl.java
+++ b/testng-core/src/main/java/org/testng/internal/objects/ObjectFactoryImpl.java
@@ -1,6 +1,7 @@
 package org.testng.internal.objects;
 
 import java.lang.reflect.Constructor;
+import org.jspecify.annotations.Nullable;
 import org.testng.ITestObjectFactory;
 import org.testng.TestNGException;
 
@@ -13,7 +14,7 @@ import org.testng.TestNGException;
 public class ObjectFactoryImpl implements ITestObjectFactory {
 
   @Override
-  public <T> T newInstance(Constructor<T> constructor, Object... params) {
+  public <T> @Nullable T newInstance(Constructor<T> constructor, Object... params) {
     if (constructor == null) {
       throw new IllegalArgumentException("Constructor cannot be null.");
     }
@@ -30,7 +31,7 @@ public class ObjectFactoryImpl implements ITestObjectFactory {
     }
   }
 
-  private static <T> T tryOtherConstructor(Class<T> declaringClass) {
+  private static <T> @Nullable T tryOtherConstructor(Class<T> declaringClass) {
     T result;
     try {
       // Special case for inner classes

--- a/testng-core/src/main/java/org/testng/internal/objects/SimpleObjectDispenser.java
+++ b/testng-core/src/main/java/org/testng/internal/objects/SimpleObjectDispenser.java
@@ -3,6 +3,8 @@ package org.testng.internal.objects;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 import java.util.Map;
+import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 import org.testng.IClass;
 import org.testng.ITestObjectFactory;
 import org.testng.TestNGException;
@@ -35,7 +37,7 @@ class SimpleObjectDispenser implements IObjectDispenser {
   }
 
   @Override
-  public Object dispense(CreationAttributes attributes) {
+  public @Nullable Object dispense(CreationAttributes attributes) {
     DetailedAttributes detailed = attributes.getDetailedAttributes();
     if (detailed != null) {
       return createInstance(
@@ -53,7 +55,9 @@ class SimpleObjectDispenser implements IObjectDispenser {
     }
     if (basic.getRawClass() == null) {
       try {
-        return objectFactory.newInstance(basic.getTestClass().getRealClass());
+        // See GuiceBasedObjectDispenser: no construction site leaves both halves out.
+        return objectFactory.newInstance(
+            Objects.requireNonNull(basic.getTestClass()).getRealClass());
       } catch (TestNGException e) {
         return null;
       }
@@ -62,7 +66,7 @@ class SimpleObjectDispenser implements IObjectDispenser {
   }
 
   /* Create an instance for the given class. */
-  static <T> T createInstance(
+  static <T> @Nullable T createInstance(
       Class<T> declaringClass,
       Map<Class<?>, IClass> classes,
       XmlTest xmlTest,
@@ -120,7 +124,7 @@ class SimpleObjectDispenser implements IObjectDispenser {
     return result;
   }
 
-  private static <T> T instantiateUsingParameterizedConstructor(
+  private static <T> @Nullable T instantiateUsingParameterizedConstructor(
       IAnnotationFinder finder,
       Constructor<T> constructor,
       XmlTest xmlTest,
@@ -196,7 +200,7 @@ class SimpleObjectDispenser implements IObjectDispenser {
   }
 
   /** Find the best constructor given the parameters found on the annotation */
-  private static <T> Constructor<T> findAnnotatedConstructor(
+  private static <T> @Nullable Constructor<T> findAnnotatedConstructor(
       IAnnotationFinder finder, Class<T> declaringClass) {
     Constructor<T>[] constructors = (Constructor<T>[]) declaringClass.getDeclaredConstructors();
 

--- a/testng-core/src/main/java/org/testng/internal/reflect/AbstractMethodMatcher.java
+++ b/testng-core/src/main/java/org/testng/internal/reflect/AbstractMethodMatcher.java
@@ -1,9 +1,11 @@
 package org.testng.internal.reflect;
 
+import org.jspecify.annotations.Nullable;
+
 public abstract class AbstractMethodMatcher implements MethodMatcher {
 
   private final MethodMatcherContext context;
-  private Boolean conforms = null;
+  private @Nullable Boolean conforms = null;
 
   public AbstractMethodMatcher(final MethodMatcherContext context) {
     this.context = context;
@@ -13,7 +15,7 @@ public abstract class AbstractMethodMatcher implements MethodMatcher {
     return context;
   }
 
-  protected Boolean getConforms() {
+  protected @Nullable Boolean getConforms() {
     return conforms;
   }
 

--- a/testng-core/src/main/java/org/testng/internal/reflect/AbstractNodeMethodMatcher.java
+++ b/testng-core/src/main/java/org/testng/internal/reflect/AbstractNodeMethodMatcher.java
@@ -3,16 +3,17 @@ package org.testng.internal.reflect;
 import java.lang.reflect.Parameter;
 import java.util.List;
 import java.util.Set;
+import org.jspecify.annotations.Nullable;
 
 public abstract class AbstractNodeMethodMatcher extends AbstractMethodMatcher {
 
-  private Parameter[] conformingParameters = null;
+  private Parameter @Nullable [] conformingParameters = null;
 
   public AbstractNodeMethodMatcher(final MethodMatcherContext context) {
     super(context);
   }
 
-  protected Parameter[] getConformingParameters() {
+  protected Parameter @Nullable [] getConformingParameters() {
     return conformingParameters;
   }
 
@@ -50,7 +51,9 @@ public abstract class AbstractNodeMethodMatcher extends AbstractMethodMatcher {
     if (getConforms() == null) {
       conforms();
     }
-    if (getConformingParameters() == null) {
+    // Bound once: NullAway cannot refine across two getter calls.
+    final Parameter[] parameters = getConformingParameters();
+    if (parameters == null) {
       throw new MethodMatcherException(
           this.getClass().getSimpleName() + " mismatch",
           getContext().getMethod(),
@@ -60,7 +63,7 @@ public abstract class AbstractNodeMethodMatcher extends AbstractMethodMatcher {
     return ReflectionRecipes.inject(
         getContext().getMethodParameter(),
         InjectableParameter.Assistant.ALL_INJECTS,
-        matchingArguments(getConformingParameters(), getContext().getArguments()),
+        matchingArguments(parameters, getContext().getArguments()),
         getContext().getMethod(),
         getContext().getTestContext(),
         getContext().getTestResult());

--- a/testng-core/src/main/java/org/testng/internal/reflect/DataProviderMethodMatcher.java
+++ b/testng-core/src/main/java/org/testng/internal/reflect/DataProviderMethodMatcher.java
@@ -1,11 +1,13 @@
 package org.testng.internal.reflect;
 
+import org.jspecify.annotations.Nullable;
+
 /** Checks the conformance as per data-provide specifications. */
 public class DataProviderMethodMatcher extends AbstractMethodMatcher {
 
   private final DirectMethodMatcher directMethodMatcher;
   private final ArrayEndingMethodMatcher arrayEndingMethodMatcher;
-  private MethodMatcher matchingMatcher = null;
+  private @Nullable MethodMatcher matchingMatcher = null;
 
   public DataProviderMethodMatcher(final MethodMatcherContext context) {
     super(context);

--- a/testng-core/src/main/java/org/testng/internal/reflect/MethodMatcherException.java
+++ b/testng-core/src/main/java/org/testng/internal/reflect/MethodMatcherException.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.util.Arrays;
+import org.jspecify.annotations.Nullable;
 import org.testng.TestNGException;
 
 /**
@@ -17,7 +18,7 @@ public class MethodMatcherException extends TestNGException {
     this(generateMessage(message, method, args));
   }
 
-  public MethodMatcherException(String message) {
+  public MethodMatcherException(@Nullable String message) {
     super(message);
   }
 
@@ -31,29 +32,29 @@ public class MethodMatcherException extends TestNGException {
 
   static String generateMessage(
       final String message, final Constructor constructor, final Object[] args) {
-    Parameter[] parameter = null;
-    String name = null;
-    if (constructor != null) {
-      parameter = ReflectionRecipes.getConstructorParameters(constructor);
-      name = constructor.getName();
-    }
-    return generateMessage(message, name, "Constructor", parameter, args);
+    // Both parameter accessors answer an empty array for a null input, so only the name is
+    // nullable.
+    return generateMessage(
+        message,
+        constructor != null ? constructor.getName() : null,
+        "Constructor",
+        ReflectionRecipes.getConstructorParameters(constructor),
+        args);
   }
 
   public static String generateMessage(
       final String message, final Method method, final Object[] args) {
-    Parameter[] parameter = null;
-    String name = null;
-    if (method != null) {
-      parameter = ReflectionRecipes.getMethodParameters(method);
-      name = method.getName();
-    }
-    return generateMessage(message, name, "Method", parameter, args);
+    return generateMessage(
+        message,
+        method != null ? method.getName() : null,
+        "Method",
+        ReflectionRecipes.getMethodParameters(method),
+        args);
   }
 
   private static String generateMessage(
       final String message,
-      final String name,
+      final @Nullable String name,
       final String prefix,
       Parameter[] parameter,
       final Object[] args) {

--- a/testng-core/src/main/java/org/testng/internal/reflect/ReflectionRecipes.java
+++ b/testng-core/src/main/java/org/testng/internal/reflect/ReflectionRecipes.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import org.testng.ITestContext;
 import org.testng.ITestResult;
@@ -87,9 +88,12 @@ public final class ReflectionRecipes {
     boolean isInstanceOf;
     final boolean directInstance = reference.isInstance(object);
     if (!directInstance && reference.isPrimitive()) {
-      isInstanceOf = PRIMITIVE_MAPPING.get(reference).isInstance(object);
+      // Both tables share one key set (see the static initialiser) and isPrimitive() was just
+      // checked, so neither lookup misses.
+      isInstanceOf = Objects.requireNonNull(PRIMITIVE_MAPPING.get(reference)).isInstance(object);
       if (!isInstanceOf) {
-        isInstanceOf = ASSIGNABLE_MAPPING.get(reference).contains(object.getClass());
+        isInstanceOf =
+            Objects.requireNonNull(ASSIGNABLE_MAPPING.get(reference)).contains(object.getClass());
       }
 
     } else {

--- a/testng-reflection-utils/src/main/java/org/testng/internal/reflect/ReflectionHelper.java
+++ b/testng-reflection-utils/src/main/java/org/testng/internal/reflect/ReflectionHelper.java
@@ -10,6 +10,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.jspecify.annotations.Nullable;
 
 public class ReflectionHelper {
   /**
@@ -66,7 +67,7 @@ public class ReflectionHelper {
    * @param <T> - The annotation type
    * @return - Either the annotation if found (or) <code>null.</code>
    */
-  public static <T extends Annotation> T findAnnotation(
+  public static <T extends Annotation> @Nullable T findAnnotation(
       Class<?> typedTestClass, Class<T> annotation) {
     if (typedTestClass == null || annotation == null) {
       return null;

--- a/testng-reflection-utils/src/main/java/org/testng/internal/reflect/package-info.java
+++ b/testng-reflection-utils/src/main/java/org/testng/internal/reflect/package-info.java
@@ -1,0 +1,5 @@
+/** Matching the parameters of a method against the arguments a caller produced. */
+@NullMarked
+package org.testng.internal.reflect;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
Continues the JSpecify/NullAway stack. Base is #3375.

After #3375 there is no single-module package left in the published modules. All ten survivors span
several Gradle modules at once, which is the constraint the stack had been routing around, so the
technique changes here: both halves of a package go in the same commit. This PR takes the four whose
minority half is a single file -- 28 main files, one commit per package, smallest first.

No file moves. `testng-reflection-utils` and `testng-runner-api` exist to publish exactly those
types; emptying them would undo a deliberate split.

## The coverage had to be proved, not assumed

On a single-module package, dropping a `package-info.java` guarantees the whole package is checked.
On a split package the direction of the dependency decides: module A's `package-info.class` reaches
B's compile classpath only if B depends on A. Put it on the wrong side and the majority half compiles
**without being checked** -- green build, zero errors, a false negative shaped exactly like a success.

So the negative control is per module traversed, not once per package. A throwaway

```java
private static Object nullAwayProbe() { return null; }
```

went into one file per module, eight in all, and each module was compiled on its own. Before the
`package-info.java`: `BUILD SUCCESSFUL`, zero NullAway errors -- the probes are inert on their own.
After it, every one of the eight fails with
`[NullAway] returning @Nullable expression from method with @NonNull return type`. The four that
matter are the `testng-core` ones, since that is the half the mark has to travel to:

| package | `package-info.java` in | proved in `testng-core` at |
|---|---|---|
| `org.testng.util` | `testng-collections` | `TimeUtils.java:60` |
| `org.testng.internal.thread` | `testng-core-api` | `ThreadUtil.java:100` |
| `org.testng.internal.objects` | `testng-core-api` | `Dispenser.java:22` |
| `org.testng.internal.reflect` | `testng-reflection-utils` | `DirectMethodMatcher.java:46` |

A `package-info.class` from an upstream module does reach the downstream compile, so one file per
package is enough and no second `package-info.java` was needed. The error counts below therefore
mean something.

## What the check reported

| package | errors | `@Nullable` | of which (E) | of which (C) | `requireNonNull` | restructured |
|---|---|---|---|---|---|---|
| `org.testng.util` | **0** | 2 | 0 | 2 | 0 | 0 |
| `org.testng.internal.thread` | 2 | 2 | 2 | 2 (the same two) | 0 | 0 |
| `org.testng.internal.objects` | 21 (+3 cascading) | 17 | 17 | 0 | 3 | 2 |
| `org.testng.internal.reflect` | 12 | 8 | 8 | 0 | 2 | 2 |

Twenty-nine annotations for thirty-eight errors. The classification is proven by deletion, not
asserted: `org.testng.util` reports nothing either way, which is what makes its two (C) rather than
(E); the two `internal.thread` annotations are both, forced by a literal `null` and independently
justified by a real caller; and every one in the last two packages was added against a named error at
that exact line. The two in `internal.reflect` that land on a public surface were deleted and
recompiled one more time to be sure -- both errors come back, at `AbstractMethodMatcher.java:19` and
`ReflectionRecipes.java:449`.

## `RetryAnalyzerCount` needs nothing

Stating it plainly rather than leaving it as a zero in a table, because it is the one class here that
users extend and a `@Nullable` on it would publish a nullity contract that could never be withdrawn.
Nothing forces one: its only field has an inline initialiser, no method returns a reference type, and
`retry(ITestResult)` overrides an unannotated supertype, which NullAway never widens. The package now
records both of its parameters as non-null, which is what TestNG has always passed.

## Deferred

Two behaviour findings reproduce and are fixed elsewhere, not here.

**#3377 -- `org.testng.internal.objects`.** Both constats #3374 deferred. `dispenseObject`
dereferences the suite context without a guard, and the invariant that made it safe does not hold: a
`@Guice`-annotated listener registered through `setListenerClasses` or the CLI `-listener` arrives
with neither a test context nor a suite context and throws `NullPointerException`. Reproduced. This
PR records the invariant with `Objects.requireNonNull`, so the failure stays an NPE at the same
point and nothing moves. The second constat -- both dispensers testing `getBasicAttributes()` for
null -- **does not reproduce**: the field is `final`, declared non-null in an already-marked class,
and all seven construction sites pass a fresh `BasicAttributes`, so neither branch is reachable. It
is in the issue only so the dead code is removed deliberately, with a warning about the tempting
wrong fix.

**#3378 -- `org.testng.internal.reflect`.** This is the package #3361 came out of, and it had never
been marked. Four findings, all reproduced. The first is a wrong entry in the very table #3362
repaired: `char` does not widen to `short` (JLS 5.1.2), so `isInstanceOf(short.class, 'a')` answers
true and a data provider feeding a `Character` to a `short` parameter is accepted and then fails
inside `Method.invoke` with `argument type mismatch`. The other three each corrupt a diagnostic --
`stringify` throws `ClassCastException` on a primitive array while formatting a mismatch message,
`nativelyInject` throws with a `null` message when the injection target is a constructor, and
`lenientMatch` is dead code that goes out of bounds on its own javadoc example.

## One more commit: the convention was written nowhere

Nine of the packages marked so far were single-module, where a `package-info.java` is self-evidently
enough. The ten that remain are not, and nothing in the repository said so -- the discipline lived
entirely in commit messages and PR bodies. A fifth commit puts the per-module control in `AGENTS.md`,
next to the other verification gates, together with the fact that `@NullMarked` does not descend into
sub-packages. Without it the next split package repeats the trap, and the trap is silent.

Prose is the stopgap, not the end state. It only fires when someone is deliberately marking a
package, and the worse case is unattended drift -- a new file added to a module that does not depend
on the one holding the `package-info.java` compiles unchecked with nothing to notice. That invariant
is mechanically checkable from what is already in the tree (for each marked package, every module
with sources in it must carry that `package-info.class` on its compile classpath), in the same shape
as `verifyPublishedPomDependencies`. Worth doing while six split packages are still unmarked, but it
is a build change, not a null-marking one -- happy to open an issue if that reads right.

## Verification

- Eight negative controls, before and after, four of them in `testng-core`. All reverted.
- `./gradlew build` -- `BUILD SUCCESSFUL in 5m 40s`, 16,373 tests, 0 failures, 0 errors, and no
  `<failure>` or `<error>` element in any result XML.
- `autostyleApply` run separately from the build, as ever.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added comprehensive nullability annotations across collection, object creation, threading, reflection, and method-matching APIs.
  * Clarified when APIs may accept or return `null`, improving static analysis and developer guidance.
  * Improved object creation validation and handling of missing test or suite context.
  * Strengthened reflection error handling for unsupported primitive mappings.

* **Documentation**
  * Added package-level documentation describing nullness behavior and worker-thread responsibilities.
  * Documented procedures for verifying nullness coverage across modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->