### PR TITLE
refactor: declare org.testng.internal.invokers null-marked

### DIFF
--- a/testng-core/src/main/java/org/testng/internal/invokers/AbstractParallelWorker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/AbstractParallelWorker.java
@@ -4,6 +4,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 import org.testng.ClassMethodMap;
 import org.testng.IClassListener;
 import org.testng.ITestContext;
@@ -26,16 +28,29 @@ public abstract class AbstractParallelWorker {
   public abstract List<IWorker<ITestNGMethod>> createWorkers(Arguments arguments);
 
   public static class Arguments {
-    private List<ITestNGMethod> methods;
-    private IInvoker invoker;
-    private ConfigurationGroupMethods configMethods;
-    private ClassMethodMap classMethodMap;
-    private List<IClassListener> listeners;
-    private ITestContext testContext;
-    private IAnnotationFinder finder;
+    private final List<ITestNGMethod> methods;
+    private final IInvoker invoker;
+    private final ConfigurationGroupMethods configMethods;
+    private final ClassMethodMap classMethodMap;
+    private final List<IClassListener> listeners;
+    private final ITestContext testContext;
+    private final IAnnotationFinder finder;
 
-    private Arguments() {
-      // We have a builder. Defeat instantiation via constructors.
+    private Arguments(
+        List<ITestNGMethod> methods,
+        IInvoker invoker,
+        ConfigurationGroupMethods configMethods,
+        ClassMethodMap classMethodMap,
+        List<IClassListener> listeners,
+        ITestContext testContext,
+        IAnnotationFinder finder) {
+      this.methods = methods;
+      this.invoker = invoker;
+      this.configMethods = configMethods;
+      this.classMethodMap = classMethodMap;
+      this.listeners = listeners;
+      this.testContext = testContext;
+      this.finder = finder;
     }
 
     public List<ITestNGMethod> getMethods() {
@@ -67,49 +82,58 @@ public abstract class AbstractParallelWorker {
     }
 
     public static class Builder {
-      private final Arguments instance;
-
-      public Builder() {
-        instance = new Arguments();
-      }
+      private @Nullable List<ITestNGMethod> methods;
+      private @Nullable IInvoker invoker;
+      private @Nullable ConfigurationGroupMethods configMethods;
+      private @Nullable ClassMethodMap classMethodMap;
+      private @Nullable List<IClassListener> listeners;
+      private @Nullable ITestContext testContext;
+      private @Nullable IAnnotationFinder finder;
 
       public Builder methods(List<ITestNGMethod> methods) {
-        instance.methods = methods;
+        this.methods = methods;
         return this;
       }
 
       public Builder invoker(IInvoker invoker) {
-        instance.invoker = invoker;
+        this.invoker = invoker;
         return this;
       }
 
       public Builder configMethods(ConfigurationGroupMethods configMethods) {
-        instance.configMethods = configMethods;
+        this.configMethods = configMethods;
         return this;
       }
 
       public Builder classMethodMap(ClassMethodMap classMethodMap) {
-        instance.classMethodMap = classMethodMap;
+        this.classMethodMap = classMethodMap;
         return this;
       }
 
       public Builder listeners(Collection<IClassListener> listeners) {
-        instance.listeners = new LinkedList<>(listeners);
+        this.listeners = new LinkedList<>(listeners);
         return this;
       }
 
       public Builder testContext(ITestContext testContext) {
-        instance.testContext = testContext;
+        this.testContext = testContext;
         return this;
       }
 
       public Builder finder(IAnnotationFinder finder) {
-        instance.finder = finder;
+        this.finder = finder;
         return this;
       }
 
       public Arguments build() {
-        return instance;
+        return new Arguments(
+            Objects.requireNonNull(methods),
+            Objects.requireNonNull(invoker),
+            Objects.requireNonNull(configMethods),
+            Objects.requireNonNull(classMethodMap),
+            Objects.requireNonNull(listeners),
+            Objects.requireNonNull(testContext),
+            Objects.requireNonNull(finder));
       }
     }
   }

--- a/testng-core/src/main/java/org/testng/internal/invokers/Arguments.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/Arguments.java
@@ -1,25 +1,27 @@
 package org.testng.internal.invokers;
 
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 import org.testng.ITestNGMethod;
 
 public class Arguments {
 
-  protected final Object instance;
-  protected final ITestNGMethod tm;
+  protected final @Nullable Object instance;
+  protected final @Nullable ITestNGMethod tm;
   protected final Map<String, String> params;
 
-  protected Arguments(Object instance, ITestNGMethod tm, Map<String, String> params) {
+  protected Arguments(
+      @Nullable Object instance, @Nullable ITestNGMethod tm, Map<String, String> params) {
     this.instance = instance;
     this.tm = tm;
     this.params = params;
   }
 
-  public Object getInstance() {
+  public @Nullable Object getInstance() {
     return instance;
   }
 
-  public ITestNGMethod getTestMethod() {
+  public @Nullable ITestNGMethod getTestMethod() {
     return tm;
   }
 

--- a/testng-core/src/main/java/org/testng/internal/invokers/ClassBasedParallelWorker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/ClassBasedParallelWorker.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.testng.IMethodInstance;
@@ -54,17 +55,20 @@ class ClassBasedParallelWorker extends AbstractParallelWorker {
         params = getParameters(im);
         prevClass = c;
       }
+      // prevClass starts out null, so the first iteration always takes the branch above.
+      Map<String, String> currentParams = Objects.requireNonNull(params);
       if (shouldRunSequentially(c, sequentialClasses)) {
         if (!processedClasses.contains(c)) {
           processedClasses.add(c);
           // Sequential class: all methods in one worker
-          TestMethodWorker worker = createTestMethodWorker(arguments, methodInstances, params, c);
+          TestMethodWorker worker =
+              createTestMethodWorker(arguments, methodInstances, currentParams, c);
           result.add(worker);
         }
       } else {
         // Parallel class: each method in its own worker
         TestMethodWorker worker =
-            createTestMethodWorker(arguments, Collections.singletonList(im), params, c);
+            createTestMethodWorker(arguments, Collections.singletonList(im), currentParams, c);
         result.add(worker);
       }
     }

--- a/testng-core/src/main/java/org/testng/internal/invokers/ConfigInvoker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/ConfigInvoker.java
@@ -9,8 +9,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import org.jspecify.annotations.Nullable;
 import org.testng.ConfigurationNotInvokedException;
 import org.testng.IClass;
 import org.testng.IConfigurable;
@@ -87,17 +89,20 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
    *     least one of these methods failed.
    */
   public boolean hasConfigurationFailureFor(
-      ITestNGMethod testNGMethod, String[] groups, IClass testClass, Object instance) {
+      @Nullable ITestNGMethod testNGMethod,
+      String[] groups,
+      IClass testClass,
+      @Nullable Object instance) {
     return hasConfigurationFailureFor(null, testNGMethod, groups, testClass, instance);
   }
 
   @Override
   public boolean hasConfigurationFailureFor(
-      ITestNGMethod configMethod,
-      ITestNGMethod testNGMethod,
+      @Nullable ITestNGMethod configMethod,
+      @Nullable ITestNGMethod testNGMethod,
       String[] groups,
       IClass testClass,
-      Object instance) {
+      @Nullable Object instance) {
     boolean result = false;
 
     Class<?> cls = testClass.getRealClass();
@@ -124,8 +129,13 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
     }
     // if method is BeforeClass, currentTestMethod will be null
     if ((m_continueOnFailedConfiguration || annotationFound) && hasConfigFailure(testNGMethod)) {
-      Object key = TestNgMethodUtils.getMethodInvocationToken(testNGMethod, instance);
-      result = m_methodInvocationResults.get(testNGMethod).contains(key);
+      // hasConfigFailure() is false for a null method, and a set of arguments that carries a test
+      // method carries its instance too, so both are present on this branch.
+      Object key =
+          TestNgMethodUtils.getMethodInvocationToken(
+              Objects.requireNonNull(testNGMethod), Objects.requireNonNull(instance));
+      // hasConfigFailure() has just established that the map holds this key.
+      result = Objects.requireNonNull(m_methodInvocationResults.get(testNGMethod)).contains(key);
     } else if (!(m_continueOnFailedConfiguration || annotationFound)) {
       for (Class<?> clazz : m_classInvocationResults.keySet()) {
         if (clazz.isAssignableFrom(cls) && m_classInvocationResults.get(clazz).contains(instance)) {
@@ -241,6 +251,8 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
       if (null == arguments.getTestClass()) {
         arguments.setTestClass(tm.getTestClass());
       }
+      // Defaulted just above, so it is set from here on.
+      IClass testClass = Objects.requireNonNull(arguments.getTestClass());
 
       ITestResult testResult = TestResult.newContextAwareTestResult(tm, m_testContext);
       testResult.setStatus(ITestResult.STARTED);
@@ -251,7 +263,8 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
         if (inst == null) {
           inst = arguments.getInstance();
         }
-        Class<?> objectClass = inst.getClass();
+        // Either the configuration method carries its own instance or the caller supplied one.
+        Class<?> objectClass = Objects.requireNonNull(inst).getClass();
         ConstructorOrMethod method = tm.getConstructorOrMethod();
 
         // Only run the configuration if
@@ -276,11 +289,7 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
           continue;
         }
         if (hasConfigurationFailureFor(
-                tm,
-                arguments.getTestMethod(),
-                tm.getGroups(),
-                arguments.getTestClass(),
-                arguments.getInstance())
+                tm, arguments.getTestMethod(), tm.getGroups(), testClass, arguments.getInstance())
             && !alwaysRun) {
           log(3, "Skipping " + Utils.detailedMethodName(tm, true));
           InvokedMethod invokedMethod = new InvokedMethod(System.currentTimeMillis(), testResult);
@@ -438,7 +447,8 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
         : m_configuration.getConfigurable();
   }
 
-  private void runConfigurationListeners(ITestResult tr, ITestNGMethod tm, boolean before) {
+  private void runConfigurationListeners(
+      ITestResult tr, @Nullable ITestNGMethod tm, boolean before) {
     ListenerComparator comparator = m_configuration.getListenerComparator();
     if (before) {
       TestListenerHelper.runPreConfigurationListeners(
@@ -462,8 +472,8 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
       ITestNGMethod tm,
       ITestResult testResult,
       IConfigurationAnnotation annotation,
-      ITestNGMethod currentTestMethod,
-      Object instance,
+      @Nullable ITestNGMethod currentTestMethod,
+      @Nullable Object instance,
       XmlSuite suite) {
     recordConfigurationInvocationFailed(
         tm, testResult.getTestClass(), annotation, currentTestMethod, instance, suite);
@@ -471,7 +481,7 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
     runConfigurationListeners(testResult, currentTestMethod, false /* after */);
   }
 
-  private boolean hasConfigFailure(ITestNGMethod currentTestMethod) {
+  private boolean hasConfigFailure(@Nullable ITestNGMethod currentTestMethod) {
     return currentTestMethod != null && m_methodInvocationResults.containsKey(currentTestMethod);
   }
 
@@ -479,15 +489,16 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
       Throwable ite,
       ITestNGMethod tm,
       ITestResult testResult,
-      IConfigurationAnnotation annotation,
-      ITestNGMethod currentTestMethod,
-      Object instance,
+      @Nullable IConfigurationAnnotation annotation,
+      @Nullable ITestNGMethod currentTestMethod,
+      @Nullable Object instance,
       XmlSuite suite) {
     Throwable cause = ite.getCause() != null ? ite.getCause() : ite;
 
     if (isSkipExceptionAndSkip(cause)) {
       testResult.setThrowable(cause);
-      handleConfigurationSkip(tm, testResult, annotation, currentTestMethod, instance, suite);
+      handleConfigurationSkip(
+          tm, testResult, Objects.requireNonNull(annotation), currentTestMethod, instance, suite);
       return;
     }
     Utils.log(
@@ -523,7 +534,7 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
   }
 
   /** @return true if this class or a parent class failed to initialize. */
-  private boolean classConfigurationFailed(Class<?> cls, Object instance) {
+  private boolean classConfigurationFailed(Class<?> cls, @Nullable Object instance) {
     return m_classInvocationResults.entrySet().stream()
         .anyMatch(
             classSetEntry -> {
@@ -537,7 +548,7 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
   }
 
   private static void copyAttributesFromNativelyInjectedTestResult(
-      Object[] source, ITestResult target) {
+      Object[] source, @Nullable ITestResult target) {
     if (source == null || target == null) {
       return;
     }
@@ -547,17 +558,21 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
         .ifPresent(eachSource -> TestResult.copyAttributes((ITestResult) eachSource, target));
   }
 
-  private void setMethodInvocationFailure(ITestNGMethod method, Object instance) {
+  private void setMethodInvocationFailure(
+      @Nullable ITestNGMethod method, @Nullable Object instance) {
     if (method == null) {
       return;
     }
     Set<Object> instances = m_methodInvocationResults.computeIfAbsent(method, k -> new HashSet<>());
-    instances.add(TestNgMethodUtils.getMethodInvocationToken(method, instance));
+    // Both come from one set of arguments, and a set that carries a test method carries its
+    // instance too, so a non-null method means a non-null instance.
+    instances.add(
+        TestNgMethodUtils.getMethodInvocationToken(method, Objects.requireNonNull(instance)));
   }
 
   private final AutoCloseableLock internalLock = new AutoCloseableLock();
 
-  private void setClassInvocationFailure(Class<?> clazz, Object instance) {
+  private void setClassInvocationFailure(Class<?> clazz, @Nullable Object instance) {
     try (AutoCloseableLock ignore = internalLock.lock()) {
       Set<Object> instances = m_classInvocationResults.computeIfAbsent(clazz, k -> new HashSet<>());
       Object objectToAdd = instance == null ? NULL_OBJECT : instance;
@@ -573,8 +588,8 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
       ITestNGMethod tm,
       IClass testClass,
       IConfigurationAnnotation annotation,
-      ITestNGMethod currentTestMethod,
-      Object instance,
+      @Nullable ITestNGMethod currentTestMethod,
+      @Nullable Object instance,
       XmlSuite suite) {
     // If beforeTestClass or afterTestClass failed, mark either the config method's
     // entire class as failed, or the class under tests as failed, depending on
@@ -630,7 +645,7 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
     }
   }
 
-  private static Object computeInstance(Object instance, Object inst, ITestNGMethod tm) {
+  private static Object computeInstance(@Nullable Object instance, Object inst, ITestNGMethod tm) {
     if (instance == null
         || !tm.getConstructorOrMethod().getDeclaringClass().isAssignableFrom(instance.getClass())) {
       return inst;
@@ -671,7 +686,7 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
     return method.isIgnoreFailure();
   }
 
-  private boolean canIgnoreConfigFailure(IClass testClass, ITestNGMethod configMethod) {
+  private boolean canIgnoreConfigFailure(IClass testClass, @Nullable ITestNGMethod configMethod) {
     boolean instanceMatch = testClass instanceof ITestClass;
     if (!instanceMatch) {
       return false;

--- a/testng-core/src/main/java/org/testng/internal/invokers/ConfigMethodArguments.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/ConfigMethodArguments.java
@@ -2,6 +2,8 @@ package org.testng.internal.invokers;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 import org.testng.IClass;
 import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
@@ -9,20 +11,20 @@ import org.testng.xml.XmlSuite;
 
 public class ConfigMethodArguments extends MethodArguments {
 
-  private IClass testClass;
+  private @Nullable IClass testClass;
   private final ITestNGMethod[] allMethods;
   private final XmlSuite suite;
-  private final ITestResult testMethodResult;
+  private final @Nullable ITestResult testMethodResult;
 
   private ConfigMethodArguments(
-      IClass testClass,
-      ITestNGMethod currentTestMethod,
+      @Nullable IClass testClass,
+      @Nullable ITestNGMethod currentTestMethod,
       ITestNGMethod[] allMethods,
       XmlSuite suite,
       Map<String, String> params,
-      Object[] parameterValues,
-      Object instance,
-      ITestResult testMethodResult) {
+      Object @Nullable [] parameterValues,
+      @Nullable Object instance,
+      @Nullable ITestResult testMethodResult) {
     super(instance, currentTestMethod, params, parameterValues);
     this.testClass = testClass;
     this.allMethods = allMethods;
@@ -30,7 +32,7 @@ public class ConfigMethodArguments extends MethodArguments {
     this.testMethodResult = testMethodResult;
   }
 
-  public IClass getTestClass() {
+  public @Nullable IClass getTestClass() {
     return testClass;
   }
 
@@ -42,7 +44,7 @@ public class ConfigMethodArguments extends MethodArguments {
     return suite;
   }
 
-  public ITestResult getTestMethodResult() {
+  public @Nullable ITestResult getTestMethodResult() {
     return testMethodResult;
   }
 
@@ -52,14 +54,14 @@ public class ConfigMethodArguments extends MethodArguments {
 
   public static class Builder {
 
-    private IClass testClass;
-    private ITestNGMethod currentTestMethod;
-    private ITestNGMethod[] allMethods;
-    private XmlSuite suite;
-    private Map<String, String> params;
-    private Object[] parameterValues;
-    private Object instance;
-    private ITestResult testMethodResult;
+    private @Nullable IClass testClass;
+    private @Nullable ITestNGMethod currentTestMethod;
+    private ITestNGMethod @Nullable [] allMethods;
+    private @Nullable XmlSuite suite;
+    private @Nullable Map<String, String> params;
+    private Object @Nullable [] parameterValues;
+    private @Nullable Object instance;
+    private @Nullable ITestResult testMethodResult;
 
     public Builder forTestClass(IClass testClass) {
       this.testClass = testClass;
@@ -93,7 +95,7 @@ public class ConfigMethodArguments extends MethodArguments {
       return this;
     }
 
-    public Builder usingParameterValues(Object[] parameterValues) {
+    public Builder usingParameterValues(Object @Nullable [] parameterValues) {
       this.parameterValues = parameterValues;
       return this;
     }
@@ -112,9 +114,9 @@ public class ConfigMethodArguments extends MethodArguments {
       return new ConfigMethodArguments(
           testClass,
           currentTestMethod,
-          allMethods,
-          suite,
-          params,
+          Objects.requireNonNull(allMethods),
+          Objects.requireNonNull(suite),
+          Objects.requireNonNull(params),
           parameterValues,
           instance,
           testMethodResult);

--- a/testng-core/src/main/java/org/testng/internal/invokers/ExceptionUtils.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/ExceptionUtils.java
@@ -1,6 +1,7 @@
 package org.testng.internal.invokers;
 
 import java.util.Set;
+import org.jspecify.annotations.Nullable;
 import org.testng.IInvokedMethod;
 import org.testng.ITestContext;
 import org.testng.ITestNGMethod;
@@ -12,7 +13,7 @@ final class ExceptionUtils {
     // Utility class. Defeat instantiation.
   }
 
-  static Throwable getExceptionDetails(ITestContext context, Object instance) {
+  static @Nullable Throwable getExceptionDetails(ITestContext context, Object instance) {
     Set<ITestResult> configResults = context.getFailedConfigurations().getAllResults();
     if (configResults.isEmpty()) {
       configResults = context.getSkippedConfigurations().getAllResults();
@@ -41,7 +42,7 @@ final class ExceptionUtils {
     return instance.equals(configResult.getInstance());
   }
 
-  private static Throwable getConfigFailureException(ITestContext context) {
+  private static @Nullable Throwable getConfigFailureException(ITestContext context) {
     for (IInvokedMethod method : context.getSuite().getAllInvokedMethods()) {
       ITestNGMethod m = method.getTestMethod();
       if (m.isBeforeSuiteConfiguration() && (!method.getTestResult().isSuccess())) {

--- a/testng-core/src/main/java/org/testng/internal/invokers/ExpectedExceptionsHolder.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/ExpectedExceptionsHolder.java
@@ -1,6 +1,7 @@
 package org.testng.internal.invokers;
 
 import java.util.Arrays;
+import org.jspecify.annotations.Nullable;
 import org.testng.IExpectedExceptionsHolder;
 import org.testng.ITestNGMethod;
 import org.testng.TestException;
@@ -70,7 +71,7 @@ public class ExpectedExceptionsHolder {
     }
   }
 
-  public TestException noException(ITestNGMethod testMethod) {
+  public @Nullable TestException noException(ITestNGMethod testMethod) {
     if (hasNoExpectedClasses()) {
       return null;
     }

--- a/testng-core/src/main/java/org/testng/internal/invokers/GroupConfigMethodArguments.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/GroupConfigMethodArguments.java
@@ -1,6 +1,8 @@
 package org.testng.internal.invokers;
 
 import java.util.Map;
+import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 import org.testng.ITestNGMethod;
 import org.testng.internal.ConfigurationGroupMethods;
 import org.testng.xml.XmlSuite;
@@ -22,16 +24,32 @@ public class GroupConfigMethodArguments extends Arguments {
     return groupMethods;
   }
 
+  /**
+   * A group configuration is always tied to the test method that triggered it, so this narrows the
+   * inherited contract back. See {@link TestMethodArguments#getTestMethod()} for why the base is
+   * nullable at all.
+   */
+  @Override
+  public ITestNGMethod getTestMethod() {
+    return Objects.requireNonNull(super.getTestMethod());
+  }
+
+  /** Always present, for the same reason as {@link #getTestMethod()}. */
+  @Override
+  public Object getInstance() {
+    return Objects.requireNonNull(super.getInstance());
+  }
+
   public XmlSuite getSuite() {
     return getTestMethod().getXmlTest().getSuite();
   }
 
   public static class Builder {
 
-    private ITestNGMethod testMethod;
-    private ConfigurationGroupMethods groupMethods;
-    private Map<String, String> params;
-    private Object instance;
+    private @Nullable ITestNGMethod testMethod;
+    private @Nullable ConfigurationGroupMethods groupMethods;
+    private @Nullable Map<String, String> params;
+    private @Nullable Object instance;
 
     public Builder forTestMethod(ITestNGMethod testMethod) {
       this.testMethod = testMethod;
@@ -54,7 +72,11 @@ public class GroupConfigMethodArguments extends Arguments {
     }
 
     public GroupConfigMethodArguments build() {
-      return new GroupConfigMethodArguments(testMethod, groupMethods, params, instance);
+      return new GroupConfigMethodArguments(
+          Objects.requireNonNull(testMethod),
+          Objects.requireNonNull(groupMethods),
+          Objects.requireNonNull(params),
+          Objects.requireNonNull(instance));
     }
   }
 }

--- a/testng-core/src/main/java/org/testng/internal/invokers/IConfigInvoker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/IConfigInvoker.java
@@ -1,5 +1,6 @@
 package org.testng.internal.invokers;
 
+import org.jspecify.annotations.Nullable;
 import org.testng.IClass;
 import org.testng.ITestNGMethod;
 import org.testng.internal.IConfiguration;
@@ -7,14 +8,23 @@ import org.testng.internal.IConfiguration;
 public interface IConfigInvoker {
 
   boolean hasConfigurationFailureFor(
-      ITestNGMethod testNGMethod, String[] groups, IClass testClass, Object instance);
-
-  boolean hasConfigurationFailureFor(
-      ITestNGMethod configMethod,
-      ITestNGMethod testNGMethod,
+      @Nullable ITestNGMethod testNGMethod,
       String[] groups,
       IClass testClass,
-      Object instance);
+      @Nullable Object instance);
+
+  /**
+   * @param configMethod the configuration method being scrutinised, or null to ask about the class
+   *     as a whole
+   * @param testNGMethod null when the configuration is a class or suite level one, which has no
+   *     current test method
+   */
+  boolean hasConfigurationFailureFor(
+      @Nullable ITestNGMethod configMethod,
+      @Nullable ITestNGMethod testNGMethod,
+      String[] groups,
+      IClass testClass,
+      @Nullable Object instance);
 
   void invokeBeforeGroupsConfigurations(GroupConfigMethodArguments arguments);
 

--- a/testng-core/src/main/java/org/testng/internal/invokers/ITestInvoker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/ITestInvoker.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.jspecify.annotations.Nullable;
 import org.testng.IInvokedMethod;
 import org.testng.ITestContext;
 import org.testng.ITestNGMethod;
@@ -43,12 +44,19 @@ public interface ITestInvoker {
   void runTestResultListener(ITestResult tr);
 
   default ITestResult registerSkippedTestResult(
-      ITestNGMethod testMethod, long start, Throwable throwable) {
+      ITestNGMethod testMethod, long start, @Nullable Throwable throwable) {
     return registerSkippedTestResult(testMethod, start, throwable, null);
   }
 
+  /**
+   * @param source the result to copy attributes and parameters from, or null when the skip has no
+   *     originating result
+   */
   ITestResult registerSkippedTestResult(
-      ITestNGMethod testMethod, long start, Throwable throwable, ITestResult source);
+      ITestNGMethod testMethod,
+      long start,
+      @Nullable Throwable throwable,
+      @Nullable ITestResult source);
 
   void invokeListenersForSkippedTestResult(ITestResult r, IInvokedMethod invokedMethod);
 

--- a/testng-core/src/main/java/org/testng/internal/invokers/InvokeMethodRunnable.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/InvokeMethodRunnable.java
@@ -2,6 +2,7 @@ package org.testng.internal.invokers;
 
 import java.util.Optional;
 import java.util.concurrent.Callable;
+import org.jspecify.annotations.Nullable;
 import org.testng.IHookable;
 import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
@@ -12,7 +13,7 @@ public class InvokeMethodRunnable implements Callable<Boolean> {
   private final ITestNGMethod m_method;
   private final Object m_instance;
   private final Object[] m_parameters;
-  private final IHookable m_hookable;
+  private final @Nullable IHookable m_hookable;
   private final ITestResult m_testResult;
 
   /**
@@ -26,7 +27,7 @@ public class InvokeMethodRunnable implements Callable<Boolean> {
       ITestNGMethod thisMethod,
       Object instance,
       Object[] parameters,
-      IHookable hookable,
+      @Nullable IHookable hookable,
       ITestResult testResult) {
     m_method = thisMethod;
     m_instance = instance;

--- a/testng-core/src/main/java/org/testng/internal/invokers/MethodArguments.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/MethodArguments.java
@@ -1,19 +1,23 @@
 package org.testng.internal.invokers;
 
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 import org.testng.ITestNGMethod;
 
 public class MethodArguments extends Arguments {
 
-  protected final Object[] parameterValues;
+  protected final Object @Nullable [] parameterValues;
 
   protected MethodArguments(
-      Object instance, ITestNGMethod tm, Map<String, String> params, Object[] parameterValues) {
+      @Nullable Object instance,
+      @Nullable ITestNGMethod tm,
+      Map<String, String> params,
+      Object @Nullable [] parameterValues) {
     super(instance, tm, params);
     this.parameterValues = parameterValues;
   }
 
-  public Object[] getParameterValues() {
+  public Object @Nullable [] getParameterValues() {
     return parameterValues;
   }
 }

--- a/testng-core/src/main/java/org/testng/internal/invokers/MethodInvocationHelper.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/MethodInvocationHelper.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -16,9 +17,9 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
+import org.jspecify.annotations.Nullable;
 import org.testng.IConfigurable;
 import org.testng.IConfigureCallBack;
 import org.testng.IHookCallBack;
@@ -256,7 +257,7 @@ public class MethodInvocationHelper {
       final ITestResult testResult)
       throws Throwable {
     final Throwable[] error = new Throwable[1];
-    AtomicReference<Boolean> wasCalled = new AtomicReference<>(false);
+    AtomicBoolean wasCalled = new AtomicBoolean(false);
 
     IHookCallBack callback =
         new IHookCallBack() {
@@ -305,7 +306,7 @@ public class MethodInvocationHelper {
       Object instance,
       Object[] parameterValues,
       ITestResult testResult,
-      IHookable hookable)
+      @Nullable IHookable hookable)
       throws InterruptedException, ThreadExecutionException {
     if (ThreadUtil.isTestNGThread()
         && testResult.getTestContext().getCurrentXmlTest().getParallel()
@@ -324,7 +325,7 @@ public class MethodInvocationHelper {
       Object instance,
       Object[] parameterValues,
       ITestResult testResult,
-      IHookable hookable) {
+      @Nullable IHookable hookable) {
 
     Consumer<Throwable> failureMarker =
         t -> {
@@ -392,7 +393,7 @@ public class MethodInvocationHelper {
       Object instance,
       Object[] parameterValues,
       ITestResult testResult,
-      IHookable hookable)
+      @Nullable IHookable hookable)
       throws InterruptedException, ThreadExecutionException {
     ExecutorService exec = ThreadUtil.createExecutor(configuration, 1, tm.getMethodName());
 
@@ -467,7 +468,9 @@ public class MethodInvocationHelper {
       testResult.setStatus(ITestResult.SUCCESS); // if no exception till here then SUCCESS.
       return flag;
     } catch (ExecutionException e) {
-      throw new ThreadExecutionException(e.getCause());
+      // FutureTask never completes exceptionally without a cause, and the only handler of this
+      // wrapper reads the cause straight back out.
+      throw new ThreadExecutionException(Objects.requireNonNull(e.getCause()));
     }
   }
 
@@ -488,7 +491,7 @@ public class MethodInvocationHelper {
         + "size.";
   }
 
-  private static StackTraceElement[] getRunningMethodStackTrace(ExecutorService exec) {
+  private static StackTraceElement @Nullable [] getRunningMethodStackTrace(ExecutorService exec) {
     if (!(exec instanceof ThreadPoolExecutor)) {
       return null;
     }
@@ -517,7 +520,7 @@ public class MethodInvocationHelper {
       final ITestResult testResult)
       throws Throwable {
     final Throwable[] error = new Throwable[1];
-    AtomicReference<Boolean> wasCalled = new AtomicReference<>(false);
+    AtomicBoolean wasCalled = new AtomicBoolean(false);
 
     IConfigureCallBack callback =
         new IConfigureCallBack() {

--- a/testng-core/src/main/java/org/testng/internal/invokers/ParameterHandler.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/ParameterHandler.java
@@ -4,6 +4,7 @@ import static org.testng.internal.Parameters.MethodParameters;
 
 import java.util.Map;
 import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 import org.testng.DataProviderHolder;
 import org.testng.IDataProviderMethod;
 import org.testng.ITestContext;
@@ -47,7 +48,7 @@ class ParameterHandler {
       Map<String, String> parameters,
       Map<String, String> allParameterNames,
       ITestContext testContext,
-      Object fedInstance) {
+      @Nullable Object fedInstance) {
     return handleParameters(
         testMethod,
         testMethod.getInstance(),
@@ -63,7 +64,7 @@ class ParameterHandler {
       Map<String, String> allParameterNames,
       Map<String, String> parameters,
       ITestContext testContext,
-      Object fedInstance) {
+      @Nullable Object fedInstance) {
     XmlSuite suite = testContext.getCurrentXmlTest().getSuite();
     try {
       MethodParameters methodParams =
@@ -104,8 +105,8 @@ class ParameterHandler {
    * TestResult} containing the cause
    */
   static class ParameterBag {
-    final ParameterHolder parameterHolder;
-    final ITestResult errorResult;
+    final @Nullable ParameterHolder parameterHolder;
+    final @Nullable ITestResult errorResult;
     boolean bubbleUpFailures = false;
 
     ParameterBag(ParameterHolder parameterHolder) {

--- a/testng-core/src/main/java/org/testng/internal/invokers/ParameterHolder.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/ParameterHolder.java
@@ -1,6 +1,7 @@
 package org.testng.internal.invokers;
 
 import java.util.Iterator;
+import org.jspecify.annotations.Nullable;
 import org.testng.IDataProviderMethod;
 import org.testng.internal.collections.CloseableIterator;
 
@@ -27,7 +28,7 @@ public class ParameterHolder implements AutoCloseable {
    * original resource is released regardless of how the exposed iterator was wrapped or how much of
    * it was consumed.
    */
-  private final CloseableIterator<Object[]> closeableSource;
+  private final @Nullable CloseableIterator<Object[]> closeableSource;
 
   public ParameterHolder(
       Iterator<Object[]> parameters, ParameterOrigin origin, IDataProviderMethod dph) {
@@ -38,7 +39,7 @@ public class ParameterHolder implements AutoCloseable {
       Iterator<Object[]> parameters,
       ParameterOrigin origin,
       IDataProviderMethod dph,
-      CloseableIterator<Object[]> closeableSource) {
+      @Nullable CloseableIterator<Object[]> closeableSource) {
     super();
     this.parameters = parameters;
     this.origin = origin;

--- a/testng-core/src/main/java/org/testng/internal/invokers/SuiteRunnerMap.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/SuiteRunnerMap.java
@@ -3,6 +3,7 @@ package org.testng.internal.invokers;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 import org.testng.ISuite;
 import org.testng.TestNGException;
 import org.testng.xml.XmlSuite;
@@ -19,7 +20,7 @@ public class SuiteRunnerMap {
     m_map.put(name, suite);
   }
 
-  public ISuite get(XmlSuite xmlSuite) {
+  public @Nullable ISuite get(XmlSuite xmlSuite) {
     return m_map.get(xmlSuite.getName());
   }
 

--- a/testng-core/src/main/java/org/testng/internal/invokers/TestInvoker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/TestInvoker.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import org.jspecify.annotations.Nullable;
 import org.testng.DataProviderHolder;
 import org.testng.IClassListener;
 import org.testng.IDataProviderListener;
@@ -344,7 +345,7 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
    * @param testMethod test method being checked for
    * @return error message or null if dependencies have been run successfully
    */
-  private String checkDependencies(ITestNGMethod testMethod) {
+  private @Nullable String checkDependencies(ITestNGMethod testMethod) {
     // If this method is marked alwaysRun, no need to check for its dependencies
     if (testMethod.isAlwaysRun()) {
       return null;
@@ -687,8 +688,11 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
   // pass both paramValues and paramIndex to be thread safe in case parallel=true + dataprovider.
   private ITestResult invokeMethod(
       TestMethodArguments arguments, XmlSuite suite, FailureContext failureContext) {
+    // Every route in here rebuilds the arguments with the values for this one invocation; the
+    // template object the invocation loop starts from never reaches this method.
+    Object[] parameterValues = Objects.requireNonNull(arguments.getParameterValues());
     TestResult testResult =
-        TestResult.newTestResult(arguments.getParameterValues(), arguments.getParametersIndex());
+        TestResult.newTestResult(parameterValues, arguments.getParametersIndex());
     testResult.setHost(m_testContext.getHost());
 
     GroupConfigMethodArguments cfgArgs =
@@ -783,14 +787,13 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
           willfullyIgnored =
               !MethodInvocationHelper.invokeHookable(
                   arguments.getInstance(),
-                  arguments.getParameterValues(),
+                  parameterValues,
                   hookableInstance,
                   thisMethod,
                   testResult);
         } else {
           // Not a IHookable, invoke directly
-          MethodInvocationHelper.invokeMethod(
-              thisMethod, arguments.getInstance(), arguments.getParameterValues());
+          MethodInvocationHelper.invokeMethod(thisMethod, arguments.getInstance(), parameterValues);
         }
         if (!willfullyIgnored) {
           setTestStatus(testResult, ITestResult.SUCCESS);
@@ -802,7 +805,7 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
                 m_configuration,
                 arguments.getTestMethod(),
                 arguments.getInstance(),
-                arguments.getParameterValues(),
+                parameterValues,
                 testResult,
                 hookableInstance);
       }
@@ -820,7 +823,8 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
       testResult.setThrowable(ite.getCause());
       setTestStatus(testResult, ITestResult.FAILURE);
     } catch (ThreadExecutionException tee) { // wrapper for TestNGRuntimeException
-      Throwable cause = tee.getCause();
+      // The wrapper is only ever constructed around a cause that is already known to be present.
+      Throwable cause = Objects.requireNonNull(tee.getCause());
       if (TestNGRuntimeException.class.equals(cause.getClass())) {
         testResult.setThrowable(cause.getCause());
       } else {
@@ -866,9 +870,7 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
       // instance a @Factory produced is a separate axis, recorded by FailedReporter as the
       // factory-instances attribute; writing it here used to overwrite the row index and make the
       // regenerated suite re-run the wrong ones.
-      if (testResult.getThrowable() != null
-          && arguments.getParameterValues().length > 0
-          && !willRetryMethod) {
+      if (testResult.getThrowable() != null && parameterValues.length > 0 && !willRetryMethod) {
         arguments.getTestMethod().addFailedInvocationNumber(arguments.getParametersIndex());
       }
 
@@ -941,7 +943,10 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
 
   @Override
   public ITestResult registerSkippedTestResult(
-      ITestNGMethod testMethod, long start, Throwable throwable, ITestResult source) {
+      ITestNGMethod testMethod,
+      long start,
+      @Nullable Throwable throwable,
+      @Nullable ITestResult source) {
     ITestResult result =
         TestResult.newEndTimeAwareTestResult(testMethod, m_testContext, throwable, start);
     if (source != null) {

--- a/testng-core/src/main/java/org/testng/internal/invokers/TestMethodArguments.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/TestMethodArguments.java
@@ -1,6 +1,8 @@
 package org.testng.internal.invokers;
 
 import java.util.Map;
+import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 import org.testng.ITestClass;
 import org.testng.ITestNGMethod;
 import org.testng.internal.ConfigurationGroupMethods;
@@ -14,9 +16,9 @@ public class TestMethodArguments extends MethodArguments {
   private final ConfigurationGroupMethods groupMethods;
 
   private TestMethodArguments(
-      Object instance,
-      ITestNGMethod tm,
-      Object[] parameterValues,
+      @Nullable Object instance,
+      @Nullable ITestNGMethod tm,
+      Object @Nullable [] parameterValues,
       int parametersIndex,
       Map<String, String> params,
       ITestClass testClass,
@@ -51,17 +53,33 @@ public class TestMethodArguments extends MethodArguments {
     return testClass;
   }
 
+  /**
+   * The inherited getter is nullable only to serve {@link ConfigMethodArguments}, which stands for
+   * suite and test level configurations that have no current test method. A test method invocation
+   * always has one, so this narrows the contract back.
+   */
+  @Override
+  public ITestNGMethod getTestMethod() {
+    return Objects.requireNonNull(super.getTestMethod());
+  }
+
+  /** Always present, for the same reason as {@link #getTestMethod()}. */
+  @Override
+  public Object getInstance() {
+    return Objects.requireNonNull(super.getInstance());
+  }
+
   public static class Builder {
 
-    private Object instance;
-    private ITestNGMethod tm;
-    private Object[] parameterValues;
+    private @Nullable Object instance;
+    private @Nullable ITestNGMethod tm;
+    private Object @Nullable [] parameterValues;
     private int parametersIndex;
-    private Map<String, String> params;
-    private ITestClass testClass;
-    private ITestNGMethod[] beforeMethods;
-    private ITestNGMethod[] afterMethods;
-    private ConfigurationGroupMethods groupMethods;
+    private @Nullable Map<String, String> params;
+    private @Nullable ITestClass testClass;
+    private ITestNGMethod @Nullable [] beforeMethods;
+    private ITestNGMethod @Nullable [] afterMethods;
+    private @Nullable ConfigurationGroupMethods groupMethods;
 
     public Builder usingInstance(Object instance) {
       this.instance = instance;
@@ -73,7 +91,7 @@ public class TestMethodArguments extends MethodArguments {
       return this;
     }
 
-    public Builder withParameterValues(Object[] parameterValues) {
+    public Builder withParameterValues(Object @Nullable [] parameterValues) {
       this.parameterValues = parameterValues;
       return this;
     }
@@ -126,11 +144,11 @@ public class TestMethodArguments extends MethodArguments {
           tm,
           parameterValues,
           parametersIndex,
-          params,
-          testClass,
-          beforeMethods,
-          afterMethods,
-          groupMethods);
+          Objects.requireNonNull(params),
+          Objects.requireNonNull(testClass),
+          Objects.requireNonNull(beforeMethods),
+          Objects.requireNonNull(afterMethods),
+          Objects.requireNonNull(groupMethods));
     }
   }
 }

--- a/testng-core/src/main/java/org/testng/internal/invokers/TestMethodWorker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/TestMethodWorker.java
@@ -12,7 +12,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.Nullable;
 import org.testng.ClassMethodMap;
 import org.testng.IClassListener;
 import org.testng.IMethodInstance;
@@ -49,7 +49,7 @@ public class TestMethodWorker implements IWorker<ITestNGMethod> {
   private final Map<String, String> m_parameters;
   private final List<ITestResult> m_testResults = new ArrayList<>();
   private final ConfigurationGroupMethods m_groupMethods;
-  private final ClassMethodMap m_classMethodMap;
+  private final @Nullable ClassMethodMap m_classMethodMap;
   private final ITestContext m_testContext;
   private final List<IClassListener> m_listeners;
   private long currentThreadId;
@@ -66,7 +66,7 @@ public class TestMethodWorker implements IWorker<ITestNGMethod> {
       List<IMethodInstance> testMethods,
       Map<String, String> parameters,
       ConfigurationGroupMethods groupMethods,
-      ClassMethodMap classMethodMap,
+      @Nullable ClassMethodMap classMethodMap,
       ITestContext testContext,
       List<IClassListener> listeners) {
     this.m_testInvoker = testInvoker;
@@ -191,8 +191,9 @@ public class TestMethodWorker implements IWorker<ITestNGMethod> {
 
   /** Invoke the @BeforeClass methods if not done already */
   protected void invokeBeforeClassMethods(ITestClass testClass, IMethodInstance mi) {
+    // Guarded by canInvokeBeforeClassMethods().
     Map<ITestClass, Set<Object>> invokedBeforeClassMethods =
-        m_classMethodMap.getInvokedBeforeClassMethods();
+        Objects.requireNonNull(m_classMethodMap).getInvokedBeforeClassMethods();
     Set<Object> instances =
         invokedBeforeClassMethods.computeIfAbsent(testClass, key -> ConcurrentHashMap.newKeySet());
     Object instance = mi.getInstance();
@@ -274,7 +275,7 @@ public class TestMethodWorker implements IWorker<ITestNGMethod> {
    *     when the method is not identity-aware (in which case the per-instance config lookup yields
    *     none).
    */
-  private static UUID instanceIdOf(IMethodInstance mi) {
+  private static @Nullable UUID instanceIdOf(IMethodInstance mi) {
     ITestNGMethod method = mi.getMethod();
     return method instanceof IInstanceIdentity
         ? ((IInstanceIdentity) method).getInstanceId()
@@ -285,7 +286,7 @@ public class TestMethodWorker implements IWorker<ITestNGMethod> {
    * @return - The throwable raised while lazily constructing the instance this method is bound to,
    *     or {@code null} if there is none (eager instance, successful construction, or no factory).
    */
-  private static Throwable lazyInstantiationFailure(IMethodInstance mi) {
+  private static @Nullable Throwable lazyInstantiationFailure(IMethodInstance mi) {
     // A lazy-instantiation detail, so it is read from the internal factory metadata rather than
     // from the public IFactoryInstance the method hands out.
     ITestNGMethod method = mi.getMethod();
@@ -327,7 +328,7 @@ public class TestMethodWorker implements IWorker<ITestNGMethod> {
   }
 
   @Override
-  public int compareTo(@Nonnull IWorker<ITestNGMethod> other) {
+  public int compareTo(IWorker<ITestNGMethod> other) {
     if (m_methodInstances.isEmpty()) {
       return 0;
     }

--- a/testng-core/src/main/java/org/testng/internal/invokers/TestNgMethodUtils.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/TestNgMethodUtils.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
+import org.jspecify.annotations.Nullable;
 import org.testng.IClass;
 import org.testng.ITestClass;
 import org.testng.ITestNGMethod;
@@ -84,8 +85,8 @@ class TestNgMethodUtils {
 
   /** @return Only the ITestNGMethods applicable for this testClass */
   static ITestNGMethod[] filterMethods(
-      Object instance,
-      IClass testClass,
+      @Nullable Object instance,
+      @Nullable IClass testClass,
       ITestNGMethod[] methods,
       BiPredicate<ITestNGMethod, IClass> predicate) {
     List<ITestNGMethod> vResult = new ArrayList<>();
@@ -104,7 +105,7 @@ class TestNgMethodUtils {
     return vResult.toArray(new ITestNGMethod[0]);
   }
 
-  private static boolean isSameInstance(ITestNGMethod tm, Object instance) {
+  private static boolean isSameInstance(ITestNGMethod tm, @Nullable Object instance) {
     if (instance == null) {
       return true;
     }

--- a/testng-runner-api/src/main/java/org/testng/internal/invokers/package-info.java
+++ b/testng-runner-api/src/main/java/org/testng/internal/invokers/package-info.java
@@ -1,0 +1,5 @@
+/** Runs test and configuration methods: argument assembly, timeouts, listeners and results. */
+@NullMarked
+package org.testng.internal.invokers;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
Continues the JSpecify/NullAway stack. Base is #3380.

One package: `org.testng.internal.invokers` -- thirty main files in `testng-core` and
`IInvocationStatus` in `testng-runner-api`. It is the last package whose minority half is a single
file; everything left after it changes a variable, so this closes out the technique #3380
established rather than opening a new one. `org.testng.internal.invokers.objects` was marked in
#3374 while its parent was not: `@NullMarked` does not descend into sub-packages, so that green
child said nothing about this package.

## The coverage was proved, not assumed

`testng-core` declares `implementation(projects.testngRunnerApi)`, so the `package-info.java` goes
in `testng-runner-api` and the mark travels downstream. That is what needed proving, not assuming --
put it on the wrong side and the thirty-file majority compiles **unchecked**, which looks exactly
like success.

Per the procedure now in `AGENTS.md`, the negative control runs once per module traversed. A
throwaway

```java
private static Object nullAwayProbe() { return null; }
```

went into one file of each module. Before the `package-info.java` both compile clean, zero NullAway.
After it both fail with `[NullAway] returning @Nullable expression from method with @NonNull return
type`:

| module | probe fails at |
|---|---|
| `testng-runner-api` | `IInvocationStatus.java:13` |
| `testng-core` | `BaseInvoker.java:24` |

Both reverted. The `testng-core` row is the one that matters, and it is red, so the counts below
mean something. Test sources are out of scope -- the convention plugin disables NullAway for test
compiles -- so `ParameterHandlerTest` is untouched and 31 main files is the whole job.

The minority half then needed no annotation at all: `IInvocationStatus` is two primitive accessors.

## What the check reported

| | count |
|---|---|
| errors | **49** |
| `@Nullable` | 107 |
| of which (E) | 102 |
| of which (C) | 5 |
| `Objects.requireNonNull` | 35 |
| restructured | 5 |

**Every annotation is classified by deletion and recompilation** -- one at a time, each stripped and
the module recompiled. 102 bring back a named error. Nine more did not and are gone: seven builder
setters whose callers never pass null, and two guards over parameters no real caller leaves empty.
Those two guards are residue and stay exactly as they are.

The five that remain without a demand are the `IConfigInvoker` parameters. NullAway does not check
an implementation widening an interface parameter, so removing them is silent -- but `ConfigInvoker`'s
matching five are all demanded, and it passes a literal `null` to its own overload. Dropping them
would leave the interface contradicting its only implementation, so they are (C).

One caveat worth recording: **incremental compilation hid errors.** Three checks that were clean
incrementally failed under `--rerun-tasks`, one of them a spurious error caused by an annotation
that turned out to be unnecessary. Every number above is from a full recompile.

## The argument hierarchy decided everything else

`Arguments` -> `MethodArguments` -> the three leaf types, each built by a builder. The nullity is
real and it is not uniform.

`ConfigMethodArguments` genuinely carries nulls: `TestRunner` and `SuiteRunner` build it for
`@BeforeTest` and `@BeforeSuite` **without** a test method, an instance or a class. The code already
says so in three places -- `ConfigInvoker` tests `getTestMethodResult()` for null, defaults
`getTestClass()` inside its loop, and carries two comments reading *"currentTestMethod is null for
BeforeClass methods"* and *"if method is BeforeClass, currentTestMethod will be null"*.

So `instance` and `tm` are `@Nullable` on the shared base. Doing only that took the count from 49 to
**87**: `TestMethodArguments` and `GroupConfigMethodArguments` always carry both, and every consumer
of those two was suddenly asked to handle a null that cannot reach it. Narrowing the contract back
where it is really narrower -- non-null overrides of `getTestMethod()` and `getInstance()` on those
two leaves -- returns it to 49 and keeps the fact in one place instead of spreading `requireNonNull`
across forty call sites.

The builders are the other half. Their staging fields are `@Nullable` because a builder starts empty
-- a fact about the builder, not about the object it builds. `build()` then either passes the value
through, when callers really do omit it, or records the invariant with `requireNonNull` when every
caller sets it. `AbstractParallelWorker.Arguments` was the one builder that mutated the object it
was building, so it could not express that at all; it now takes its seven values through a
constructor and its fields are `final`.

## `ThreadExecutionException`: fixed at the call site, not on the parameter

#3380 left this deliberately, and marking this package makes it visible. The decision is the call
site, and the compiler is what settles it:

| site | why it errors |
|---|---|
| `MethodInvocationHelper.java:470` | `@Nullable` argument into a `@NonNull` parameter |
| `TestInvoker.java:824` | dereference of `tee.getCause()` -- the **JDK model**, not the field |

Annotating `ThreadExecutionException(Throwable)` would have silenced the first and left the second
standing, since `Throwable.getCause()` is `@Nullable` in NullAway 0.13.8's own library models
regardless of what the constructor says. It would also publish a nullity contract the sole reader
cannot honour: there is exactly one construction site and one consumer, and the consumer reads the
cause straight back out with no guard. `FutureTask` never completes exceptionally without a cause,
so `Objects.requireNonNull` at both ends records that, keeps the NPE at the same statement, and
keeps the change inside this package instead of reopening one #3380 closed.

## #3380's two contracts hold

Both were (C) claims last round and both are confirmed: neither `MethodInvocationHelper:375`
(`ThreadTimeoutException(tm, timeout, @Nullable cause)`) nor `ParameterHandler:87`
(`Strings.isNotNullAndNotEmpty(@Nullable String)`) reports anything, in the first report or the
last.

## Restructured rather than annotated

- Two `AtomicReference<Boolean>` flags become `AtomicBoolean` -- removes the unboxing instead of
  annotating around it, and is the right type for a boolean flag.
- `AbstractParallelWorker.Arguments` gets a constructor, as above.
- `ClassBasedParallelWorker` and `TestInvoker.invokeMethod` each bind a value once into a local
  rather than re-reading a getter, which is not a stable expression.

## Deferred: three findings, none reproduced

No behaviour change here. All three are recorded rather than filed, because **none of them
reproduces** and two are provably unreachable today. Saying so is the point -- they are latent
asymmetries worth knowing about, not bugs.

1. **`ConfigInvoker` dereferences the resolved instance** (`Objects.requireNonNull(inst).getClass()`).
   Needs `tm.getInstance()` null *and* `arguments.getInstance()` null. The second happens on the
   `@BeforeTest`/`@BeforeSuite` paths that omit `usingInstance`, and on
   `invokeAfterClassConfigurations`. The first needs a method bound to a `@Factory` instance that
   was never constructed -- `BaseTestMethod.getInstance()` returns null when the `IParameterInfo`
   has no embedded instance. **What blocks it:** I could not construct a case where TestNG schedules
   a configuration method for a factory instance that does not exist; every factory path I tried
   creates the instance first. Same family as #3377, different site.

2. **`handleConfigurationFailure` treats one value two ways.** It guards `null != annotation` before
   `recordConfigurationInvocationFailed` on its normal path, but on the skip path it hands the same
   value to `handleConfigurationSkip`, which forwards it into that identical call unguarded.
   **Unreachable today:** the annotation is only
   null if the throw beat `AnnotationHelper.findConfiguration`, and the three statements that
   precede it (`tm.getInstance()`, the instance dereference, `tm.getConstructorOrMethod()`) cannot
   raise a `SkipException`, which the branch also requires. A reordering would turn it into a bug.

3. **`m_executedConfigMethods.add(arguments.getTestMethod())`** on a `ConcurrentHashMap` key set,
   which rejects null. NullAway does not model `KeySetView.add`, so it never flagged this.
   **Unreachable today:** it is guarded by `isBeforeMethodConfiguration()`, and the only builders
   that omit `forTestMethod` carry class-, test- or suite-level configuration methods.

## Verification

- Two negative controls, before and after, one per module, both reverted.
- 113 deletion-and-recompile probes for the classification above.
- `./gradlew build` -- `BUILD SUCCESSFUL in 5m 41s`, **16,374 tests, 0 failures, 0 errors**, and no
  `<failure>` or `<error>` element in any result XML.
- `autostyleApply` run separately from the build, as ever.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added comprehensive nullability information across invocation and configuration APIs, improving IDE inspections and static analysis.
  * Strengthened validation for required invocation, configuration, parameter, and worker data.
  * Clarified which values may be absent, including optional hooks, exceptions, results, test methods, and instances.
  * Improved runtime safety by rejecting invalid or incomplete invocation state earlier.
  * Refined internal invocation handling without changing expected test execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->