### PR TITLE
refactor: declare org.testng.internal.annotations null-marked

### DIFF
--- a/testng-core-api/src/main/java/org/testng/internal/annotations/IAnnotationFinder.java
+++ b/testng-core-api/src/main/java/org/testng/internal/annotations/IAnnotationFinder.java
@@ -3,6 +3,7 @@ package org.testng.internal.annotations;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.util.List;
+import org.jspecify.annotations.Nullable;
 import org.testng.ITestNGMethod;
 import org.testng.annotations.IAnnotation;
 import org.testng.internal.ConstructorOrMethod;
@@ -19,7 +20,7 @@ public interface IAnnotationFinder {
    * @param <A> The expected {@link IAnnotation} type
    * @return The annotation on the class or null if none found.
    */
-  <A extends IAnnotation> A findAnnotation(Class<?> cls, Class<A> annotationClass);
+  <A extends IAnnotation> @Nullable A findAnnotation(Class<?> cls, Class<A> annotationClass);
 
   /**
    * @param m - The corresponding {@link Method}
@@ -28,14 +29,15 @@ public interface IAnnotationFinder {
    * @return The annotation on the method. If not found, return the annotation on the declaring
    *     class. If not found, return null.
    */
-  <A extends IAnnotation> A findAnnotation(Method m, Class<A> annotationClass);
+  <A extends IAnnotation> @Nullable A findAnnotation(Method m, Class<A> annotationClass);
 
-  <A extends IAnnotation> A findAnnotation(ITestNGMethod m, Class<A> annotationClass);
+  <A extends IAnnotation> @Nullable A findAnnotation(ITestNGMethod m, Class<A> annotationClass);
 
-  <A extends IAnnotation> A findAnnotation(ConstructorOrMethod com, Class<A> annotationClass);
+  <A extends IAnnotation> @Nullable A findAnnotation(
+      ConstructorOrMethod com, Class<A> annotationClass);
 
-  <A extends IAnnotation> A findAnnotation(
-      Class<?> clazz, Method m, java.lang.Class<A> annotationClass);
+  <A extends IAnnotation> @Nullable A findAnnotation(
+      @Nullable Class<?> clazz, Method m, java.lang.Class<A> annotationClass);
 
   /**
    * @param cons - The corresponding {@link Constructor}
@@ -44,7 +46,7 @@ public interface IAnnotationFinder {
    * @return The annotation on the method. If not found, return the annotation on the declaring
    *     class. If not found, return null.
    */
-  <A extends IAnnotation> A findAnnotation(Constructor<?> cons, Class<A> annotationClass);
+  <A extends IAnnotation> @Nullable A findAnnotation(Constructor<?> cons, Class<A> annotationClass);
 
   /**
    * @param cls - The corresponding class.

--- a/testng-core-api/src/main/java/org/testng/internal/annotations/IDataProvidable.java
+++ b/testng-core-api/src/main/java/org/testng/internal/annotations/IDataProvidable.java
@@ -1,14 +1,18 @@
 package org.testng.internal.annotations;
 
+import org.jspecify.annotations.Nullable;
+
 /** A trait shared by all the annotations that have dataProvider/dataProviderClass attributes. */
 public interface IDataProvidable {
   String getDataProvider();
 
   void setDataProvider(String v);
 
+  /** @return The class holding the data provider, or {@code null} when none was named. */
+  @Nullable
   Class<?> getDataProviderClass();
 
-  void setDataProviderClass(Class<?> v);
+  void setDataProviderClass(@Nullable Class<?> v);
 
   String getDataProviderDynamicClass();
 

--- a/testng-core-api/src/main/java/org/testng/internal/annotations/package-info.java
+++ b/testng-core-api/src/main/java/org/testng/internal/annotations/package-info.java
@@ -1,0 +1,5 @@
+/** Reads TestNG's annotations off classes, methods and constructors, and models what they say. */
+@NullMarked
+package org.testng.internal.annotations;
+
+import org.jspecify.annotations.NullMarked;

--- a/testng-core/src/main/java/org/testng/internal/annotations/AnnotationHelper.java
+++ b/testng-core/src/main/java/org/testng/internal/annotations/AnnotationHelper.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Predicate;
+import org.jspecify.annotations.Nullable;
 import org.testng.ITestNGMethod;
 import org.testng.ITestObjectFactory;
 import org.testng.annotations.IAnnotation;
@@ -63,27 +64,32 @@ public class AnnotationHelper {
     // Utility class.defeat instantiation.
   }
 
-  public static ITestAnnotation findTest(IAnnotationFinder finder, Class<?> cls) {
+  public static @Nullable ITestAnnotation findTest(IAnnotationFinder finder, Class<?> cls) {
     return finder.findAnnotation(cls, ITestAnnotation.class);
   }
 
-  public static ITestAnnotation findTest(IAnnotationFinder finder, Method m) {
+  public static @Nullable ITestAnnotation findTest(IAnnotationFinder finder, Method m) {
     return finder.findAnnotation(m, ITestAnnotation.class);
   }
 
-  public static ITestAnnotation findTest(IAnnotationFinder finder, ITestNGMethod m) {
+  public static @Nullable ITestAnnotation findTest(IAnnotationFinder finder, ITestNGMethod m) {
     return finder.findAnnotation(m, ITestAnnotation.class);
   }
 
-  public static IFactoryAnnotation findFactory(IAnnotationFinder finder, Method m) {
+  public static @Nullable IFactoryAnnotation findFactory(IAnnotationFinder finder, Method m) {
     return finder.findAnnotation(m, IFactoryAnnotation.class);
   }
 
-  public static IFactoryAnnotation findFactory(IAnnotationFinder finder, Constructor<?> c) {
+  public static @Nullable IFactoryAnnotation findFactory(
+      IAnnotationFinder finder, Constructor<?> c) {
     return finder.findAnnotation(c, IFactoryAnnotation.class);
   }
 
-  public static IConfigurationAnnotation findConfiguration(
+  /**
+   * @return The configuration annotation carried by the method, or {@code null} when it carries
+   *     none.
+   */
+  public static @Nullable IConfigurationAnnotation findConfiguration(
       IAnnotationFinder finder, ConstructorOrMethod m) {
     IConfigurationAnnotation result = null;
     boolean ignoreFailure = false;
@@ -137,21 +143,22 @@ public class AnnotationHelper {
     return result;
   }
 
-  public static IConfigurationAnnotation findConfiguration(IAnnotationFinder finder, Method m) {
+  public static @Nullable IConfigurationAnnotation findConfiguration(
+      IAnnotationFinder finder, Method m) {
     return findConfiguration(finder, new ConstructorOrMethod(m));
   }
 
   private static IConfigurationAnnotation createConfiguration(
-      IConfigurationAnnotation bs,
-      IConfigurationAnnotation as,
-      IConfigurationAnnotation bt,
-      IConfigurationAnnotation at,
-      IConfigurationAnnotation bg,
-      IConfigurationAnnotation ag,
-      IConfigurationAnnotation bc,
-      IConfigurationAnnotation ac,
-      IConfigurationAnnotation bm,
-      IConfigurationAnnotation am) {
+      @Nullable IConfigurationAnnotation bs,
+      @Nullable IConfigurationAnnotation as,
+      @Nullable IConfigurationAnnotation bt,
+      @Nullable IConfigurationAnnotation at,
+      @Nullable IConfigurationAnnotation bg,
+      @Nullable IConfigurationAnnotation ag,
+      @Nullable IConfigurationAnnotation bc,
+      @Nullable IConfigurationAnnotation ac,
+      @Nullable IConfigurationAnnotation bm,
+      @Nullable IConfigurationAnnotation am) {
     ConfigurationAnnotation result = new ConfigurationAnnotation();
 
     if (bs != null) {
@@ -306,7 +313,7 @@ public class AnnotationHelper {
     return vResult.values().toArray(new ITestNGMethod[0]);
   }
 
-  public static <A extends Annotation> A findAnnotationSuperClasses(
+  public static <A extends Annotation> @Nullable A findAnnotationSuperClasses(
       Class<A> annotationClass, Class<?> parameterClass) {
     Class<?> c = parameterClass;
     while (c != null) {

--- a/testng-core/src/main/java/org/testng/internal/annotations/BaseAnnotation.java
+++ b/testng-core/src/main/java/org/testng/internal/annotations/BaseAnnotation.java
@@ -2,14 +2,15 @@ package org.testng.internal.annotations;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import org.jspecify.annotations.Nullable;
 
 public class BaseAnnotation {
 
-  private Class<?> m_testClass;
-  private Method m_method;
-  private Constructor m_constructor;
+  private @Nullable Class<?> m_testClass;
+  private @Nullable Method m_method;
+  private @Nullable Constructor m_constructor;
 
-  public Constructor getConstructor() {
+  public @Nullable Constructor getConstructor() {
     return m_constructor;
   }
 
@@ -17,7 +18,7 @@ public class BaseAnnotation {
     m_constructor = constructor;
   }
 
-  public Method getMethod() {
+  public @Nullable Method getMethod() {
     return m_method;
   }
 
@@ -25,7 +26,7 @@ public class BaseAnnotation {
     m_method = method;
   }
 
-  public Class<?> getTestClass() {
+  public @Nullable Class<?> getTestClass() {
     return m_testClass;
   }
 

--- a/testng-core/src/main/java/org/testng/internal/annotations/BaseBeforeAfter.java
+++ b/testng-core/src/main/java/org/testng/internal/annotations/BaseBeforeAfter.java
@@ -1,22 +1,24 @@
 package org.testng.internal.annotations;
 
+import org.jspecify.annotations.Nullable;
+
 public class BaseBeforeAfter extends TestOrConfiguration implements IBaseBeforeAfter {
 
   private boolean m_alwaysRun = false;
   private boolean m_inheritGroups = true;
   private String[] m_beforeGroups = {};
   private String[] m_afterGroups = {};
-  private String m_description;
+  private @Nullable String m_description;
 
   /** @return the description */
   @Override
-  public String getDescription() {
+  public @Nullable String getDescription() {
     return m_description;
   }
 
   /** @param description the description to set */
   @Override
-  public void setDescription(String description) {
+  public void setDescription(@Nullable String description) {
     m_description = description;
   }
 

--- a/testng-core/src/main/java/org/testng/internal/annotations/DataProviderAnnotation.java
+++ b/testng-core/src/main/java/org/testng/internal/annotations/DataProviderAnnotation.java
@@ -1,5 +1,6 @@
 package org.testng.internal.annotations;
 
+import java.util.Collections;
 import java.util.List;
 import org.testng.IRetryDataProvider;
 import org.testng.annotations.IDataProviderAnnotation;
@@ -7,11 +8,12 @@ import org.testng.annotations.IDataProviderAnnotation;
 /** An implementation of IDataProvider. */
 public class DataProviderAnnotation extends BaseAnnotation implements IDataProviderAnnotation {
 
-  private String m_name;
+  private String m_name = "";
   private boolean m_parallel;
-  private List<Integer> m_indices;
+  private List<Integer> m_indices = Collections.emptyList();
   private boolean m_bubbleUpFailures = false;
-  private Class<? extends IRetryDataProvider> retryUsing;
+  private Class<? extends IRetryDataProvider> retryUsing =
+      IRetryDataProvider.DisableDataProviderRetries.class;
 
   private boolean cachedDataForTestRetries = true;
 

--- a/testng-core/src/main/java/org/testng/internal/annotations/DefaultAnnotationTransformer.java
+++ b/testng-core/src/main/java/org/testng/internal/annotations/DefaultAnnotationTransformer.java
@@ -2,6 +2,7 @@ package org.testng.internal.annotations;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import org.jspecify.annotations.Nullable;
 import org.testng.IAnnotationTransformer;
 import org.testng.annotations.ITestAnnotation;
 
@@ -15,7 +16,11 @@ public class DefaultAnnotationTransformer extends IgnoreListener implements IAnn
 
   @Override
   public void transform(
-      ITestAnnotation annotation, Class testClass, Constructor cons, Method tm, Class<?> clazz) {
+      ITestAnnotation annotation,
+      @Nullable Class testClass,
+      @Nullable Constructor cons,
+      @Nullable Method tm,
+      @Nullable Class<?> clazz) {
     super.transform(annotation, testClass, cons, tm, clazz);
   }
 }

--- a/testng-core/src/main/java/org/testng/internal/annotations/FactoryAnnotation.java
+++ b/testng-core/src/main/java/org/testng/internal/annotations/FactoryAnnotation.java
@@ -1,17 +1,18 @@
 package org.testng.internal.annotations;
 
 import java.util.List;
+import org.jspecify.annotations.Nullable;
 import org.testng.annotations.IFactoryAnnotation;
 import org.testng.annotations.Lazy;
 
 /** An implementation of IFactory */
 public class FactoryAnnotation extends BaseAnnotation implements IFactoryAnnotation {
 
-  private String m_dataProvider = null;
-  private Class<?> m_dataProviderClass;
-  private String m_dataProviderDynamicClass;
+  private String m_dataProvider = "";
+  private @Nullable Class<?> m_dataProviderClass;
+  private String m_dataProviderDynamicClass = "";
   private boolean m_enabled = true;
-  private List<Integer> m_indices;
+  private @Nullable List<Integer> m_indices;
   private Lazy m_lazy = Lazy.UNSET;
 
   @Override
@@ -24,12 +25,12 @@ public class FactoryAnnotation extends BaseAnnotation implements IFactoryAnnotat
     m_dataProvider = dataProvider;
   }
 
-  public void setDataProviderClass(Class<?> dataProviderClass) {
+  public void setDataProviderClass(@Nullable Class<?> dataProviderClass) {
     m_dataProviderClass = dataProviderClass;
   }
 
   @Override
-  public Class<?> getDataProviderClass() {
+  public @Nullable Class<?> getDataProviderClass() {
     return m_dataProviderClass;
   }
 
@@ -54,7 +55,7 @@ public class FactoryAnnotation extends BaseAnnotation implements IFactoryAnnotat
   }
 
   @Override
-  public List<Integer> getIndices() {
+  public @Nullable List<Integer> getIndices() {
     return m_indices;
   }
 
@@ -69,7 +70,7 @@ public class FactoryAnnotation extends BaseAnnotation implements IFactoryAnnotat
   }
 
   @Override
-  public void setLazy(Lazy lazy) {
+  public void setLazy(@Nullable Lazy lazy) {
     m_lazy = lazy == null ? Lazy.UNSET : lazy;
   }
 }

--- a/testng-core/src/main/java/org/testng/internal/annotations/IAnnotationTransformer.java
+++ b/testng-core/src/main/java/org/testng/internal/annotations/IAnnotationTransformer.java
@@ -2,6 +2,7 @@ package org.testng.internal.annotations;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import org.jspecify.annotations.Nullable;
 import org.testng.annotations.ITestAnnotation;
 
 /** For backward compatibility. */
@@ -9,10 +10,10 @@ public interface IAnnotationTransformer extends org.testng.IAnnotationTransforme
 
   default void transform(
       ITestAnnotation annotation,
-      Class testClass,
-      Constructor testConstructor,
-      Method testMethod,
-      Class<?> occurringClazz) {
+      @Nullable Class testClass,
+      @Nullable Constructor testConstructor,
+      @Nullable Method testMethod,
+      @Nullable Class<?> occurringClazz) {
     // not implemented
   }
 }

--- a/testng-core/src/main/java/org/testng/internal/annotations/IBaseBeforeAfter.java
+++ b/testng-core/src/main/java/org/testng/internal/annotations/IBaseBeforeAfter.java
@@ -1,5 +1,6 @@
 package org.testng.internal.annotations;
 
+import org.jspecify.annotations.Nullable;
 import org.testng.annotations.ITestOrConfiguration;
 
 /** Base interface for IBeforeSuite, IAfterSuite, etc... */
@@ -46,6 +47,7 @@ public interface IBaseBeforeAfter extends ITestOrConfiguration {
    * The description for this method. The string used will appear in the HTML report and also on
    * standard output if verbose &gt; 2.
    */
+  @Nullable
   String getDescription();
 
   default boolean ignoreFailure() {

--- a/testng-core/src/main/java/org/testng/internal/annotations/IgnoreListener.java
+++ b/testng-core/src/main/java/org/testng/internal/annotations/IgnoreListener.java
@@ -3,6 +3,7 @@ package org.testng.internal.annotations;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import org.jspecify.annotations.Nullable;
 import org.testng.annotations.ITestAnnotation;
 import org.testng.annotations.Ignore;
 import org.testng.internal.reflect.ReflectionHelper;
@@ -18,10 +19,10 @@ public class IgnoreListener implements IAnnotationTransformer {
   @Override
   public void transform(
       ITestAnnotation annotation,
-      Class testClass,
-      Constructor tc,
-      Method testMethod,
-      Class<?> clazz) {
+      @Nullable Class testClass,
+      @Nullable Constructor tc,
+      @Nullable Method testMethod,
+      @Nullable Class<?> clazz) {
     if (!annotation.getEnabled()) {
       return;
     }
@@ -34,7 +35,7 @@ public class IgnoreListener implements IAnnotationTransformer {
     ignoreTestAtClass(clazz, annotation);
   }
 
-  private static void ignoreTestAtClass(Class<?> clazz, ITestAnnotation annotation) {
+  private static void ignoreTestAtClass(@Nullable Class<?> clazz, ITestAnnotation annotation) {
     if (clazz != null) {
       ignoreTest(annotation, ReflectionHelper.findAnnotation(clazz, Ignore.class));
       Package testPackage = clazz.getPackage();
@@ -44,7 +45,7 @@ public class IgnoreListener implements IAnnotationTransformer {
     }
   }
 
-  private static void ignoreTest(ITestAnnotation annotation, Ignore ignore) {
+  private static void ignoreTest(ITestAnnotation annotation, @Nullable Ignore ignore) {
     if (ignore == null) {
       return;
     }
@@ -66,7 +67,7 @@ public class IgnoreListener implements IAnnotationTransformer {
   }
 
   @SuppressWarnings("deprecation")
-  private static Ignore findAnnotation(Package testPackage) {
+  private static @Nullable Ignore findAnnotation(@Nullable Package testPackage) {
     if (testPackage == null) {
       return null;
     }

--- a/testng-core/src/main/java/org/testng/internal/annotations/JDK15AnnotationFinder.java
+++ b/testng-core/src/main/java/org/testng/internal/annotations/JDK15AnnotationFinder.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import org.jspecify.annotations.Nullable;
 import org.testng.IAnnotationTransformer;
 import org.testng.ITestNGMethod;
 import org.testng.annotations.AfterClass;
@@ -75,7 +76,8 @@ public class JDK15AnnotationFinder implements IAnnotationFinder {
     m_annotationMap.put(IAfterMethod.class, AfterMethod.class);
   }
 
-  private <A extends Annotation> A findAnnotationInSuperClasses(Class<?> cls, Class<A> a) {
+  private <A extends Annotation> @Nullable A findAnnotationInSuperClasses(
+      Class<?> cls, Class<A> a) {
     // Hack for @Listeners: we don't look in superclasses for this annotation
     // because inheritance of this annotation causes aggregation instead of
     // overriding
@@ -98,13 +100,13 @@ public class JDK15AnnotationFinder implements IAnnotationFinder {
   }
 
   @Override
-  public <A extends IAnnotation> A findAnnotation(Method m, Class<A> annotationClass) {
+  public <A extends IAnnotation> @Nullable A findAnnotation(Method m, Class<A> annotationClass) {
     return findAnnotation(null, m, annotationClass);
   }
 
   @Override
-  public <A extends IAnnotation> A findAnnotation(
-      Class<?> clazz, Method m, Class<A> annotationClass) {
+  public <A extends IAnnotation> @Nullable A findAnnotation(
+      @Nullable Class<?> clazz, Method m, Class<A> annotationClass) {
     final Class<? extends Annotation> a = m_annotationMap.get(annotationClass);
     if (a == null) {
       throw new IllegalArgumentException(
@@ -123,7 +125,8 @@ public class JDK15AnnotationFinder implements IAnnotationFinder {
   }
 
   @Override
-  public <A extends IAnnotation> A findAnnotation(ITestNGMethod tm, Class<A> annotationClass) {
+  public <A extends IAnnotation> @Nullable A findAnnotation(
+      ITestNGMethod tm, Class<A> annotationClass) {
     final Class<? extends Annotation> a = m_annotationMap.get(annotationClass);
     if (a == null) {
       throw new IllegalArgumentException(
@@ -147,7 +150,7 @@ public class JDK15AnnotationFinder implements IAnnotationFinder {
   }
 
   @Override
-  public <A extends IAnnotation> A findAnnotation(
+  public <A extends IAnnotation> @Nullable A findAnnotation(
       ConstructorOrMethod com, Class<A> annotationClass) {
     if (com.getConstructor() != null) {
       return findAnnotation(com.getConstructor(), annotationClass);
@@ -159,11 +162,11 @@ public class JDK15AnnotationFinder implements IAnnotationFinder {
   }
 
   private void transform(
-      IAnnotation a,
-      Class<?> testClass,
-      Constructor<?> testConstructor,
-      Method testMethod,
-      Class<?> whichClass) {
+      @Nullable IAnnotation a,
+      @Nullable Class<?> testClass,
+      @Nullable Constructor<?> testConstructor,
+      @Nullable Method testMethod,
+      @Nullable Class<?> whichClass) {
     if (!m_transformer.isEnabled()) {
       return;
     }
@@ -192,19 +195,24 @@ public class JDK15AnnotationFinder implements IAnnotationFinder {
   }
 
   @Override
-  public <A extends IAnnotation> A findAnnotation(Class<?> cls, Class<A> annotationClass) {
+  public <A extends IAnnotation> @Nullable A findAnnotation(
+      Class<?> cls, Class<A> annotationClass) {
     final Class<? extends Annotation> a = m_annotationMap.get(annotationClass);
     if (a == null) {
       throw new IllegalArgumentException(
           "Java @Annotation class for '" + annotationClass + "' not found.");
     }
     Annotation annotation = findAnnotationInSuperClasses(cls, a);
+    if (annotation == null) {
+      return null;
+    }
     return findAnnotation(
         cls, annotation, annotationClass, cls, null, null, new Pair<>(annotation, cls), null);
   }
 
   @Override
-  public <A extends IAnnotation> A findAnnotation(Constructor<?> cons, Class<A> annotationClass) {
+  public <A extends IAnnotation> @Nullable A findAnnotation(
+      Constructor<?> cons, Class<A> annotationClass) {
     final Class<? extends Annotation> a = m_annotationMap.get(annotationClass);
     if (a == null) {
       throw new IllegalArgumentException(
@@ -266,15 +274,15 @@ public class JDK15AnnotationFinder implements IAnnotationFinder {
     }
   }
 
-  private <A extends IAnnotation> A findAnnotation(
+  private <A extends IAnnotation> @Nullable A findAnnotation(
       Class<?> cls,
-      Annotation a,
+      @Nullable Annotation a,
       Class<A> annotationClass,
-      Class<?> testClass,
-      Constructor<?> testConstructor,
-      Method testMethod,
+      @Nullable Class<?> testClass,
+      @Nullable Constructor<?> testConstructor,
+      @Nullable Method testMethod,
       Pair<Annotation, ?> p,
-      Class<?> whichClass) {
+      @Nullable Class<?> whichClass) {
     if (a == null) {
       return null;
     }

--- a/testng-core/src/main/java/org/testng/internal/annotations/JDK15TagFactory.java
+++ b/testng-core/src/main/java/org/testng/internal/annotations/JDK15TagFactory.java
@@ -6,7 +6,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
+import org.jspecify.annotations.Nullable;
 import org.testng.TestNGException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterGroups;
@@ -41,13 +43,15 @@ import org.testng.log4testng.Logger;
  */
 public class JDK15TagFactory {
 
-  public <A extends IAnnotation> A createTag(
-      Class<?> cls, Method method, Annotation a, Class<A> annotationClass) {
+  public <A extends IAnnotation> @Nullable A createTag(
+      Class<?> cls, @Nullable Method method, Annotation a, Class<A> annotationClass) {
     IAnnotation result = null;
 
     if (a != null) {
       if (annotationClass == IDataProviderAnnotation.class) {
-        result = createDataProviderTag(method, a);
+        Method dataProviderMethod =
+            Objects.requireNonNull(method, "@DataProvider is only ever looked up on a method");
+        result = createDataProviderTag(dataProviderMethod, a);
       } else if (annotationClass == IFactoryAnnotation.class) {
         result = createFactoryTag(cls, a);
       } else if (annotationClass == IParametersAnnotation.class) {
@@ -80,7 +84,8 @@ public class JDK15TagFactory {
     return (A) result;
   }
 
-  private IAnnotation maybeCreateNewConfigurationTag(Annotation a, Class<?> annotationClass) {
+  private @Nullable IAnnotation maybeCreateNewConfigurationTag(
+      Annotation a, Class<?> annotationClass) {
     IAnnotation result = null;
 
     if (annotationClass == IBeforeSuite.class) {
@@ -577,7 +582,7 @@ public class JDK15TagFactory {
    * annotation don't allow nulls, so each type has a different way of defining its own default.
    */
   interface Default<T> {
-    boolean isDefault(T t);
+    boolean isDefault(@Nullable T t);
   }
 
   private static final Default<Class<?>> DEFAULT_CLASS = c -> c == Object.class;
@@ -590,7 +595,7 @@ public class JDK15TagFactory {
    * the hierarchy (Object).
    */
   @SuppressWarnings("unchecked")
-  private <T> T findInherited(
+  private <T> @Nullable T findInherited(
       T methodValue,
       Class<?> cls,
       Class<? extends Annotation> annotationClass,
@@ -642,7 +647,7 @@ public class JDK15TagFactory {
     return result.toArray(new String[0]);
   }
 
-  private Object invokeMethod(Annotation test, String methodName) {
+  private @Nullable Object invokeMethod(Annotation test, String methodName) {
     Object result = null;
     try {
       // Note:  we should cache methods already looked up

--- a/testng-core/src/main/java/org/testng/internal/annotations/ListenersAnnotation.java
+++ b/testng-core/src/main/java/org/testng/internal/annotations/ListenersAnnotation.java
@@ -5,7 +5,12 @@ import org.testng.annotations.IAnnotation;
 
 public class ListenersAnnotation implements IListeners, IAnnotation {
 
-  private Class<? extends ITestNGListener>[] m_value;
+  @SuppressWarnings("unchecked")
+  private static final Class<? extends ITestNGListener>[] NO_LISTENERS =
+      (Class<? extends ITestNGListener>[]) new Class<?>[0];
+
+  // Listeners#value() defaults to {}; JDK15TagFactory sets the real value right after construction.
+  private Class<? extends ITestNGListener>[] m_value = NO_LISTENERS;
 
   @Override
   public Class<? extends ITestNGListener>[] getValue() {

--- a/testng-core/src/main/java/org/testng/internal/annotations/TestAnnotation.java
+++ b/testng-core/src/main/java/org/testng/internal/annotations/TestAnnotation.java
@@ -1,5 +1,6 @@
 package org.testng.internal.annotations;
 
+import org.jspecify.annotations.Nullable;
 import org.testng.IRetryAnalyzer;
 import org.testng.annotations.CustomAttribute;
 import org.testng.annotations.ITestAnnotation;
@@ -18,9 +19,9 @@ public class TestAnnotation extends TestOrConfiguration implements ITestAnnotati
   private String m_suiteName = "";
   private String m_testName = "";
   private boolean m_singleThreaded = false;
-  private Class<?> m_dataProviderClass = null;
-  private String m_dataProviderDynamicClass = null;
-  private Class<? extends IRetryAnalyzer> m_retryAnalyzerClass = null;
+  private @Nullable Class<?> m_dataProviderClass;
+  private String m_dataProviderDynamicClass = "";
+  private Class<? extends IRetryAnalyzer> m_retryAnalyzerClass = DisabledRetryAnalyzer.class;
   private boolean m_skipFailedInvocations = false;
   private boolean m_ignoreMissingDependencies = false;
   private CustomAttribute[] m_attributes = {};
@@ -58,12 +59,12 @@ public class TestAnnotation extends TestOrConfiguration implements ITestAnnotati
   }
 
   @Override
-  public Class<?> getDataProviderClass() {
+  public @Nullable Class<?> getDataProviderClass() {
     return m_dataProviderClass;
   }
 
   @Override
-  public void setDataProviderClass(Class<?> dataProviderClass) {
+  public void setDataProviderClass(@Nullable Class<?> dataProviderClass) {
     m_dataProviderClass = dataProviderClass;
   }
 

--- a/testng-core/src/main/java/org/testng/internal/annotations/TestOrConfiguration.java
+++ b/testng-core/src/main/java/org/testng/internal/annotations/TestOrConfiguration.java
@@ -1,5 +1,6 @@
 package org.testng.internal.annotations;
 
+import org.jspecify.annotations.Nullable;
 import org.testng.annotations.ITestOrConfiguration;
 
 public class TestOrConfiguration extends BaseAnnotation implements ITestOrConfiguration {
@@ -8,7 +9,7 @@ public class TestOrConfiguration extends BaseAnnotation implements ITestOrConfig
   private boolean m_enabled = true;
   private String[] m_dependsOnGroups = {};
   private String[] m_dependsOnMethods = {};
-  private String m_description = "";
+  private @Nullable String m_description = "";
   private int m_priority;
   private long m_timeOut = 0;
 
@@ -38,7 +39,7 @@ public class TestOrConfiguration extends BaseAnnotation implements ITestOrConfig
   }
 
   @Override
-  public String getDescription() {
+  public @Nullable String getDescription() {
     return m_description;
   }
 
@@ -58,7 +59,7 @@ public class TestOrConfiguration extends BaseAnnotation implements ITestOrConfig
   }
 
   @Override
-  public void setDescription(String description) {
+  public void setDescription(@Nullable String description) {
     m_description = description;
   }
 

--- a/testng-core/src/main/java/org/testng/internal/invokers/ClassBasedParallelWorker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/ClassBasedParallelWorker.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.jspecify.annotations.Nullable;
 import org.testng.IMethodInstance;
 import org.testng.ITestNGMethod;
 import org.testng.internal.MethodInstance;
@@ -112,7 +113,7 @@ class ClassBasedParallelWorker extends AbstractParallelWorker {
   }
 
   private static boolean isSequential(
-      org.testng.annotations.ITestAnnotation test, XmlTest xmlTest) {
+      org.testng.annotations.@Nullable ITestAnnotation test, XmlTest xmlTest) {
     return test != null && test.getSingleThreaded()
         || XmlSuite.ParallelMode.CLASSES.equals(xmlTest.getParallel());
   }

--- a/testng-core/src/main/java/org/testng/internal/invokers/ConfigInvoker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/ConfigInvoker.java
@@ -305,7 +305,9 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
           handleConfigurationSkip(
               tm,
               testResult,
-              configurationAnnotation,
+              Objects.requireNonNull(
+                  configurationAnnotation,
+                  "a configuration method always carries a @Before/@After annotation"),
               arguments.getTestMethod(),
               arguments.getInstance(),
               arguments.getSuite());


### PR DESCRIPTION
Continues the JSpecify/NullAway stack. Base is `master` — #3380 and #3381 are merged, so this one
stands alone.

One package: `org.testng.internal.annotations` — thirty main files in `testng-core` and three
(`DisabledRetryAnalyzer`, `IAnnotationFinder`, `IDataProvidable`) in `testng-core-api`. No
sub-packages. Two things change at once compared with #3381: the minority half is more than a single
file for the first time, and this is the first package **upstream** of packages that are already
marked and merged. `org.testng.internal.invokers` (#3381), `org.testng.internal.objects`,
`org.testng.annotations` (#3374, #3375) and `org.testng.internal.objects.pojo` all read it. Marking
a leaf could only produce errors in its own files; this one could produce them in code already
shipped.

## The coverage was proved, not assumed

`testng-core` declares `api(projects.testngCoreApi)`, so the `package-info.java` goes in
`testng-core-api` and the mark travels downstream. That is what needed proving: put it on the wrong
side and the thirty-file majority compiles **unchecked**, which looks exactly like success.

Per the procedure in `AGENTS.md`, the negative control runs once per module traversed. A throwaway

```java
private static Object nullAwayProbe() { return null; }
```

went into one file of each module. Before the `package-info.java` both compile clean, zero NullAway.
After it both fail with `[NullAway] returning @Nullable expression from method with @NonNull return
type`:

| module | probe fails at |
|---|---|
| `testng-core-api` | `DisabledRetryAnalyzer.java:14` |
| `testng-core` | `BaseAnnotation.java:9` |

Both reverted. The `testng-core` row is the one that matters, and it is red, so the counts below
mean something.

## What the check reported

| | count |
|---|---|
| errors | **49** (1 in `testng-core-api`, 48 in `testng-core`) |
| `@Nullable` | 91 |
| of which (E) | 87 |
| of which (C) | 4 |
| `Objects.requireNonNull` | 2 |
| restructured | 9 |

**Every annotation is classified by deletion and recompilation** — one at a time, each stripped and
the modules recompiled. 87 bring back a named error.

## The tag hierarchy decides the field errors

The shape is `BaseAnnotation`, then `TestOrConfiguration` and the leaves `TestAnnotation`,
`FactoryAnnotation`, `DataProviderAnnotation`, `ListenersAnnotation`, with one producer:
`JDK15TagFactory` constructs a tag and immediately fills every field from the Java annotation it
mirrors. That producer decides how the "field not initialized" errors are answered.

Where the interface already published a `@Nullable` getter the field takes the annotation. Where it
published a non-null one the field takes the default of the annotation member it mirrors, because
that is what the tag factory assigns a line later and what every reader already treats as absent:
`""` for the data provider name and the two `dataProvider` strings, an empty list for `indices`,
`DisableDataProviderRetries` for `retryUsing`, an empty array for `@Listeners`, and
`DisabledRetryAnalyzer` for `retryAnalyzer` — the value `BaseTestMethod.setRetryAnalyzerClass`
already substitutes for null. Annotating those instead would have published nullity on six getters
whose every caller dereferences them.

`IAnnotationFinder` is the other half. Its javadoc has said *"or null if none found"* since it was
written, and `JDK15AnnotationFinder` returns a literal null in two of the six overloads, so the
implementation had to be `@Nullable` — and NullAway then rejected it against the non-null interface.
Those six returns are demanded, not documentation: **NullAway is silent on type *arguments*, not on
a `@Nullable` return that happens to be a type variable.** `AnnotationHelper`'s five delegates and
both `findConfiguration` overloads follow from the same source.

## The new variable: errors in code already merged

Ten files across the four marked packages read this one. Two needed anything:

- `ClassBasedParallelWorker.isSequential` already tested its `ITestAnnotation` for null. #3380 had to
  read that guard as residue because `findAnnotation` was non-null; it is now demanded.
- `ConfigInvoker:308` passes the result of `AnnotationHelper.findConfiguration` to
  `handleConfigurationSkip`, which #3381 tightened to non-null. `requireNonNull` there records that a
  `ConfigurationMethod` only exists because `TestNGMethodFinder:130` found a configuration annotation
  on that very method, through the same lookup.

### The second deferred finding of #3381 is settled

`handleConfigurationFailure` keeps `null != annotation` on one path and `Objects.requireNonNull` on
the other. Annotating the return makes that asymmetry compiler-visible instead of a reading, and
**it does not reproduce**: the parameter is null only when the throw happened before the assignment,
and the statements that precede it can only produce an NPE (`requireNonNull` on the instance) or a
`TestNGException` (the annotation finder), neither of which passes `isSkipExceptionAndSkip` — the
sole gate to the `requireNonNull` path. The remaining guard is unreachable rather than wrong, so no
issue is opened.

## The minority half

`DisabledRetryAnalyzer` **needs nothing**, which is worth saying rather than leaving as a zero in a
table: it is public surface despite the package — `Test#retryAnalyzer()` names it — but its one
method overrides `IRetryAnalyzer.retry(ITestResult)`, which is unannotated, and NullAway never
widens an implementation against an unannotated supertype. Same situation as `RetryAnalyzerCount` in
#3380.

`IDataProvidable` needed the `getDataProviderClass` pair, which its own subinterface `ITestAnnotation`
had already declared `@Nullable` and therefore contradicted. `IAnnotationFinder` needed the six
returns plus the one class its own overload passes null for. `findOptionalValues` stays as it is:
its javadoc describes null *elements*, which NullAway does not check.

## The four that stay without a demand

Dropping any of them would leave a contract contradicting itself.

| where | why NullAway is silent |
|---|---|
| `IAnnotationFinder`'s `@Nullable Class<?>` | interface parameter; the matching one in `JDK15AnnotationFinder` is demanded by the literal null its own overload passes |
| `IDataProvidable.setDataProviderClass` | interface parameter; `ITestAnnotation` already declares it `@Nullable` and both implementations are demanded |
| `IgnoreListener.findAnnotation(Package)` | `Package.getPackage` is read optimistically by the JDK model |
| the private `findAnnotation` in `JDK15AnnotationFinder` | `Method.getAnnotation` is read optimistically |

The last two test their parameter on the first line of the body and are null on every lookup that
finds nothing.

## Restructured rather than annotated

Six of the nine are the field defaults above. The other three: `JDK15AnnotationFinder` returns early
when `findAnnotationInSuperClasses` finds nothing, which is what the private overload it calls did on
its first line, and keeps `Pair`'s constructor non-null; `JDK15TagFactory` asserts the method it was
handed when building a data provider tag — `@DataProvider` is `@Target(METHOD)`, so it is never
looked up on a class; `ListenersAnnotation` starts from a shared empty array instead of null.

## Verification

`./gradlew build` on the rebased branch: **BUILD SUCCESSFUL**, `16854 completed, 0 failed, 12
skipped` — the twelve are the pre-existing environment-dependent skips (heap-dump support and a
listener sample). Every count in this description comes from a full recompile
(`--rerun-tasks`), never an incremental one.

One trap worth recording for the next lot: a plain javac error anywhere in the module — here a
generic array creation — stops the NullAway pass entirely, so the compiler reports **zero** NullAway
errors on code full of them. A clean reading means nothing until the compile itself is clean.

No behaviour change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of optional annotation, data-provider, description, and reflective metadata values.
  * Added clearer safeguards when required configuration metadata is missing, preventing ambiguous processing failures.
* **Improvements**
  * Enhanced nullability documentation across annotation and transformation APIs, making optional values and expected behavior clearer.
  * Established more consistent defaults for data providers, retry handling, listeners, and related annotation settings.
  * Added package documentation describing annotation processing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->