### PR TITLE
refactor: declare org.testng.xml null-marked

### DIFF
--- a/testng-core-api/src/main/java/org/testng/xml/DefaultXmlWeaver.java
+++ b/testng-core-api/src/main/java/org/testng/xml/DefaultXmlWeaver.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import javax.xml.XMLConstants;
+import org.jspecify.annotations.Nullable;
 import org.testng.TestNGException;
 import org.testng.internal.Utils;
 import org.testng.reporters.XMLStringBuffer;
@@ -80,7 +81,7 @@ public class DefaultXmlWeaver implements IWeaveXml {
   /** Immutable, so a single instance can serve every {@code asXmlFragment} call. */
   private static final DefaultXmlWeaver LEGACY_FRAGMENT_WEAVER = new DefaultXmlWeaver();
 
-  private final String defaultComment;
+  private final @Nullable String defaultComment;
 
   /** Writes the name of each named tag as a trailing XML comment, as TestNG always has. */
   public DefaultXmlWeaver() {
@@ -92,7 +93,7 @@ public class DefaultXmlWeaver implements IWeaveXml {
    *     tag's own {@code name} attribute. Pass the empty string to write no comment at all, which
    *     is what {@link CommentDisabledXmlWeaver} does.
    */
-  protected DefaultXmlWeaver(String defaultComment) {
+  protected DefaultXmlWeaver(@Nullable String defaultComment) {
     this.defaultComment = defaultComment;
   }
 

--- a/testng-core-api/src/main/java/org/testng/xml/XmlClass.java
+++ b/testng-core-api/src/main/java/org/testng/xml/XmlClass.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 import org.testng.TestNGException;
 import org.testng.collections.Objects;
 import org.testng.internal.ClassHelper;
@@ -13,22 +14,24 @@ public class XmlClass implements Cloneable {
 
   private List<XmlInclude> m_includedMethods = new ArrayList<>();
   private List<String> m_excludedMethods = new ArrayList<>();
-  private String m_name = null;
-  private Class m_class = null;
+  // Assigned by init, which every constructor calls directly: NullAway traces an initializer
+  // helper one hop only, so reaching init through a delegating overload stops it seeing this.
+  private String m_name;
+  private @Nullable Class m_class;
   /** The index of this class in the &lt;test&gt; tag */
   private int m_index;
   /** True if the classes need to be loaded */
   private boolean m_loadClasses = true;
 
   private Map<String, String> m_parameters = new HashMap<>();
-  private XmlTest m_xmlTest;
+  private @Nullable XmlTest m_xmlTest;
 
   public XmlClass() {
     init("", null, 0, false /* load classes */);
   }
 
   public XmlClass(String name) {
-    init(name, null, 0);
+    init(name, null, 0, true /* load classes */);
   }
 
   public XmlClass(String name, boolean loadClasses) {
@@ -51,11 +54,7 @@ public class XmlClass implements Cloneable {
     init(className, null, index, loadClasses);
   }
 
-  private void init(String className, Class cls, int index) {
-    init(className, cls, index, true /* load classes */);
-  }
-
-  private void init(String className, Class cls, int index, boolean resolveClass) {
+  private void init(String className, @Nullable Class cls, int index, boolean resolveClass) {
     m_name = className;
     m_class = cls;
     m_index = index;
@@ -65,20 +64,21 @@ public class XmlClass implements Cloneable {
     }
   }
 
-  private void loadClass() {
-    m_class = ClassHelper.forName(m_name);
+  /** Resolves {@link #m_name}, caches it in {@link #m_class} and hands it back. */
+  private Class<?> loadClass() {
+    Class<?> cls = ClassHelper.forName(m_name);
 
-    if (null == m_class) {
+    if (null == cls) {
       throw new TestNGException("Cannot find class in classpath: " + m_name);
     }
+    m_class = cls;
+    return cls;
   }
 
   /** @return Returns the className. */
   public Class<?> getSupportClass() {
-    if (m_class == null) {
-      loadClass();
-    }
-    return m_class;
+    Class<?> cls = m_class;
+    return cls == null ? loadClass() : cls;
   }
 
   /** @param className The className to set. */

--- a/testng-core-api/src/main/java/org/testng/xml/XmlDefine.java
+++ b/testng-core-api/src/main/java/org/testng/xml/XmlDefine.java
@@ -2,16 +2,17 @@ package org.testng.xml;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.jspecify.annotations.Nullable;
 
 public class XmlDefine {
 
-  private String m_name;
+  private @Nullable String m_name;
 
-  public void setName(String name) {
+  public void setName(@Nullable String name) {
     m_name = name;
   }
 
-  public String getName() {
+  public @Nullable String getName() {
     return m_name;
   }
 

--- a/testng-core-api/src/main/java/org/testng/xml/XmlGroups.java
+++ b/testng-core-api/src/main/java/org/testng/xml/XmlGroups.java
@@ -2,11 +2,12 @@ package org.testng.xml;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.jspecify.annotations.Nullable;
 
 public class XmlGroups {
 
   private List<XmlDefine> m_defines = new ArrayList<>();
-  private XmlRun m_run;
+  private @Nullable XmlRun m_run;
   private List<XmlDependencies> m_dependencies = new ArrayList<>();
 
   public List<XmlDefine> getDefines() {
@@ -21,11 +22,15 @@ public class XmlGroups {
     m_defines = defines;
   }
 
-  public XmlRun getRun() {
+  /**
+   * @return the {@code <run>} element, or {@code null} when none has been set. A {@code <groups>}
+   *     can legitimately carry only {@code <define>} or {@code <dependencies>} elements.
+   */
+  public @Nullable XmlRun getRun() {
     return m_run;
   }
 
-  public void setRun(XmlRun run) {
+  public void setRun(@Nullable XmlRun run) {
     m_run = run;
   }
 

--- a/testng-core-api/src/main/java/org/testng/xml/XmlInclude.java
+++ b/testng-core-api/src/main/java/org/testng/xml/XmlInclude.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import org.jspecify.annotations.Nullable;
 
 public class XmlInclude {
 
@@ -17,10 +18,10 @@ public class XmlInclude {
   // out as "17 1". The generated suite should not depend on that.
   private final Set<Integer> m_factoryInstances = new TreeSet<>();
   private final int m_index;
-  private String m_description;
+  private @Nullable String m_description;
   private final Map<String, String> m_parameters = new HashMap<>();
 
-  private XmlClass m_xmlClass;
+  private @Nullable XmlClass m_xmlClass;
 
   public XmlInclude() {
     this("", 0);
@@ -40,7 +41,7 @@ public class XmlInclude {
     m_index = index;
   }
 
-  public void setDescription(String description) {
+  public void setDescription(@Nullable String description) {
     m_description = description;
   }
 
@@ -49,7 +50,7 @@ public class XmlInclude {
     m_parameters.putAll(parameters);
   }
 
-  public String getDescription() {
+  public @Nullable String getDescription() {
     return m_description;
   }
 

--- a/testng-core-api/src/main/java/org/testng/xml/XmlMethodSelector.java
+++ b/testng-core-api/src/main/java/org/testng/xml/XmlMethodSelector.java
@@ -1,5 +1,7 @@
 package org.testng.xml;
 
+import org.jspecify.annotations.Nullable;
+
 /** This class describes the tag <code>&lt;method-selector&gt;</code> in testng.xml. */
 public class XmlMethodSelector {
 
@@ -7,18 +9,18 @@ public class XmlMethodSelector {
   public static final int DEFAULT_PRIORITY = 0;
 
   // Either this:
-  private String m_className;
+  private @Nullable String m_className;
   private int m_priority = DEFAULT_PRIORITY;
 
   // Or that:
-  private XmlScript m_script;
+  private @Nullable XmlScript m_script;
 
   // For YAML
-  public void setClassName(String s) {
+  public void setClassName(@Nullable String s) {
     m_className = s;
   }
 
-  public String getClassName() {
+  public @Nullable String getClassName() {
     return m_className;
   }
 
@@ -32,11 +34,11 @@ public class XmlMethodSelector {
     m_className = name;
   }
 
-  public XmlScript getScript() {
+  public @Nullable XmlScript getScript() {
     return m_script;
   }
 
-  public void setScript(XmlScript script) {
+  public void setScript(@Nullable XmlScript script) {
     m_script = script;
   }
 

--- a/testng-core-api/src/main/java/org/testng/xml/XmlPackage.java
+++ b/testng-core-api/src/main/java/org/testng/xml/XmlPackage.java
@@ -3,6 +3,7 @@ package org.testng.xml;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import org.jspecify.annotations.Nullable;
 import org.testng.internal.PackageUtils;
 import org.testng.internal.Utils;
 import org.testng.internal.protocols.UnhandledIOException;
@@ -10,10 +11,10 @@ import org.testng.internal.protocols.UnhandledIOException;
 /** This class describes the tag <code>&lt;package&gt;</code> in testng.xml. */
 public class XmlPackage {
 
-  private String m_name;
+  private @Nullable String m_name;
   private List<String> m_include = new ArrayList<>();
   private List<String> m_exclude = new ArrayList<>();
-  private List<XmlClass> m_xmlClasses = null;
+  private @Nullable List<XmlClass> m_xmlClasses;
 
   public XmlPackage() {}
 
@@ -43,21 +44,23 @@ public class XmlPackage {
   }
 
   /** @return the name */
-  public String getName() {
+  public @Nullable String getName() {
     return m_name;
   }
 
   /** @param name the name to set */
-  public void setName(String name) {
+  public void setName(@Nullable String name) {
     m_name = name;
   }
 
   public List<XmlClass> getXmlClasses() {
-    if (null == m_xmlClasses) {
-      m_xmlClasses = initializeXmlClasses();
+    List<XmlClass> xmlClasses = m_xmlClasses;
+    if (null == xmlClasses) {
+      xmlClasses = initializeXmlClasses();
+      m_xmlClasses = xmlClasses;
     }
 
-    return m_xmlClasses;
+    return xmlClasses;
   }
 
   private List<XmlClass> initializeXmlClasses() {

--- a/testng-core-api/src/main/java/org/testng/xml/XmlScript.java
+++ b/testng-core-api/src/main/java/org/testng/xml/XmlScript.java
@@ -1,23 +1,25 @@
 package org.testng.xml;
 
+import org.jspecify.annotations.Nullable;
+
 public class XmlScript {
 
-  private String language;
-  private String expression;
+  private @Nullable String language;
+  private @Nullable String expression;
 
-  public void setLanguage(String language) {
+  public void setLanguage(@Nullable String language) {
     this.language = language;
   }
 
-  public void setExpression(String expression) {
+  public void setExpression(@Nullable String expression) {
     this.expression = expression;
   }
 
-  public String getExpression() {
+  public @Nullable String getExpression() {
     return expression;
   }
 
-  public String getLanguage() {
+  public @Nullable String getLanguage() {
     return language;
   }
 }

--- a/testng-core-api/src/main/java/org/testng/xml/XmlSuite.java
+++ b/testng-core-api/src/main/java/org/testng/xml/XmlSuite.java
@@ -9,6 +9,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import org.jspecify.annotations.Nullable;
 import org.testng.ITestObjectFactory;
 import org.testng.internal.RuntimeBehavior;
 import org.testng.internal.Utils;
@@ -87,7 +88,7 @@ public class XmlSuite implements Cloneable {
       this.name = name;
     }
 
-    public static FailurePolicy getValidPolicy(String policy) {
+    public static @Nullable FailurePolicy getValidPolicy(@Nullable String policy) {
       if (policy == null) {
         return null;
       }
@@ -104,7 +105,8 @@ public class XmlSuite implements Cloneable {
     }
   }
 
-  private String m_test;
+  /** Never assigned; {@link #getTest()} has always returned null. */
+  private @Nullable String m_test;
 
   /** The default suite name TODO CQ is this OK as a default name. */
   private static final String DEFAULT_SUITE_NAME = "Default Suite";
@@ -115,7 +117,7 @@ public class XmlSuite implements Cloneable {
   /** The suite verbose flag (0 to 10). */
   public static final Integer DEFAULT_VERBOSE = 1;
 
-  private Integer m_verbose = null;
+  private @Nullable Integer m_verbose;
 
   public static final ParallelMode DEFAULT_PARALLEL = ParallelMode.NONE;
   private ParallelMode m_parallel = DEFAULT_PARALLEL;
@@ -162,7 +164,7 @@ public class XmlSuite implements Cloneable {
    * Whether {@code @Factory} produced instances are created lazily. {@code null} means "unset at
    * the suite level" so the {@link org.testng.TestNG} configuration decides (default eager).
    */
-  private Boolean m_lazyFactory = null;
+  private @Nullable Boolean m_lazyFactory;
 
   public static final Boolean DEFAULT_ALLOW_RETURN_VALUES = Boolean.FALSE;
   private Boolean m_allowReturnValues = DEFAULT_ALLOW_RETURN_VALUES;
@@ -180,27 +182,27 @@ public class XmlSuite implements Cloneable {
   private Map<String, String> m_parameters = new HashMap<>();
 
   /** Name of the XML file. */
-  private String m_fileName;
+  private @Nullable String m_fileName;
 
   /** Time out for methods/tests. */
-  private String m_timeOut;
+  private @Nullable String m_timeOut;
 
   /** List of child XML suites specified using <suite-file> tags. */
   private final List<XmlSuite> m_childSuites = new ArrayList<>();
 
   /** Parent XML suite if this suite was specified in another suite using <suite-file> tag. */
-  private XmlSuite m_parentSuite;
+  private @Nullable XmlSuite m_parentSuite;
 
   private List<String> m_suiteFiles = new ArrayList<>();
 
-  private Class<? extends ITestObjectFactory> m_objectFactoryClass;
+  private @Nullable Class<? extends ITestObjectFactory> m_objectFactoryClass;
 
   private List<String> m_listeners = new ArrayList<>();
 
   public static final Boolean DEFAULT_PRESERVE_ORDER = Boolean.TRUE;
   private Boolean m_preserveOrder = DEFAULT_PRESERVE_ORDER;
 
-  private XmlMethodSelectors m_xmlMethodSelectors;
+  private @Nullable XmlMethodSelectors m_xmlMethodSelectors;
   private boolean parsed = false;
 
   public void setParsed(boolean parsed) {
@@ -213,12 +215,12 @@ public class XmlSuite implements Cloneable {
   }
 
   /** @return The fileName. */
-  public String getFileName() {
+  public @Nullable String getFileName() {
     return m_fileName;
   }
 
   /** @param fileName The fileName to set. */
-  public void setFileName(String fileName) {
+  public void setFileName(@Nullable String fileName) {
     m_fileName = fileName;
   }
 
@@ -239,7 +241,7 @@ public class XmlSuite implements Cloneable {
     return m_guiceStage;
   }
 
-  public Class<? extends ITestObjectFactory> getObjectFactoryClass() {
+  public @Nullable Class<? extends ITestObjectFactory> getObjectFactoryClass() {
     return m_objectFactoryClass;
   }
 
@@ -259,7 +261,8 @@ public class XmlSuite implements Cloneable {
     return shareThreadPoolForDataProviders;
   }
 
-  public void setObjectFactoryClass(Class<? extends ITestObjectFactory> objectFactoryClass) {
+  public void setObjectFactoryClass(
+      @Nullable Class<? extends ITestObjectFactory> objectFactoryClass) {
     m_objectFactoryClass = objectFactoryClass;
   }
 
@@ -342,7 +345,7 @@ public class XmlSuite implements Cloneable {
    *
    * @return The test.
    */
-  public String getTest() {
+  public @Nullable String getTest() {
     return m_test;
   }
 
@@ -440,9 +443,10 @@ public class XmlSuite implements Cloneable {
    * Returns the parameter defined in this suite only.
    *
    * @param name The parameter name.
-   * @return The parameter defined in this suite only.
+   * @return The parameter defined in this suite only, or {@code null} if this suite does not define
+   *     it. Unlike {@link XmlTest#getParameter(String)} this does not consult a parent suite.
    */
-  public String getParameter(String name) {
+  public @Nullable String getParameter(String name) {
     return m_parameters.get(name);
   }
 
@@ -491,7 +495,7 @@ public class XmlSuite implements Cloneable {
     return getXmlPackages();
   }
 
-  public void setMethodSelectors(XmlMethodSelectors xms) {
+  public void setMethodSelectors(@Nullable XmlMethodSelectors xms) {
     m_xmlMethodSelectors = xms;
   }
 
@@ -510,11 +514,11 @@ public class XmlSuite implements Cloneable {
     return m_listeners;
   }
 
-  public void setXmlMethodSelectors(XmlMethodSelectors xms) {
+  public void setXmlMethodSelectors(@Nullable XmlMethodSelectors xms) {
     m_xmlMethodSelectors = xms;
   }
 
-  public XmlMethodSelectors getXmlMethodSelectors() {
+  public @Nullable XmlMethodSelectors getXmlMethodSelectors() {
     return m_xmlMethodSelectors;
   }
 
@@ -590,7 +594,7 @@ public class XmlSuite implements Cloneable {
    *
    * @param timeOut The timeout.
    */
-  public void setTimeOut(String timeOut) {
+  public void setTimeOut(@Nullable String timeOut) {
     m_timeOut = timeOut;
   }
 
@@ -599,7 +603,7 @@ public class XmlSuite implements Cloneable {
    *
    * @return The timeout.
    */
-  public String getTimeOut() {
+  public @Nullable String getTimeOut() {
     return m_timeOut;
   }
 
@@ -662,12 +666,12 @@ public class XmlSuite implements Cloneable {
     return m_dataProviderThreadCount;
   }
 
-  public void setParentSuite(XmlSuite parentSuite) {
+  public void setParentSuite(@Nullable XmlSuite parentSuite) {
     m_parentSuite = parentSuite;
     updateParameters();
   }
 
-  public XmlSuite getParentSuite() {
+  public @Nullable XmlSuite getParentSuite() {
     return m_parentSuite;
   }
 
@@ -850,32 +854,41 @@ public class XmlSuite implements Cloneable {
     }
   }
 
-  private void initGroupsRun() {
-    if (m_xmlGroups == null) {
-      m_xmlGroups = new XmlGroups();
+  /** Creates the {@code <groups>} and {@code <run>} pair on first use, and returns the run. */
+  private XmlRun groupsRun() {
+    XmlGroups groups = groups();
+    XmlRun run = groups.getRun();
+    if (run == null) {
+      run = new XmlRun();
+      groups.setRun(run);
     }
-    if (m_xmlGroups.getRun() == null) {
-      m_xmlGroups.setRun(new XmlRun());
+    return run;
+  }
+
+  /** Creates the {@code <groups>} element on first use, and returns it. */
+  private XmlGroups groups() {
+    XmlGroups groups = m_xmlGroups;
+    if (groups == null) {
+      groups = new XmlGroups();
+      m_xmlGroups = groups;
     }
+    return groups;
   }
 
   public void addIncludedGroup(String g) {
-    initGroupsRun();
-    m_xmlGroups.getRun().onInclude(g);
+    groupsRun().onInclude(g);
   }
 
   /** @param g - The list of groups to include. */
   public void setIncludedGroups(List<String> g) {
-    initGroupsRun();
-    List<String> includes = m_xmlGroups.getRun().getIncludes();
+    List<String> includes = groupsRun().getIncludes();
     includes.clear();
     includes.addAll(g);
   }
 
   /** @param g The excludedGrousps to set. */
   public void setExcludedGroups(List<String> g) {
-    initGroupsRun();
-    List<String> excludes = m_xmlGroups.getRun().getExcludes();
+    List<String> excludes = groupsRun().getExcludes();
     excludes.clear();
     excludes.addAll(g);
   }
@@ -895,8 +908,7 @@ public class XmlSuite implements Cloneable {
   }
 
   public void addExcludedGroup(String g) {
-    initGroupsRun();
-    m_xmlGroups.getRun().onExclude(g);
+    groupsRun().onExclude(g);
   }
 
   public Boolean getGroupByInstances() {
@@ -913,11 +925,11 @@ public class XmlSuite implements Cloneable {
    *     at the suite level, in which case the {@link org.testng.TestNG} configuration decides
    *     (default eager).
    */
-  public Boolean getLazyFactory() {
+  public @Nullable Boolean getLazyFactory() {
     return m_lazyFactory;
   }
 
-  public void setLazyFactory(Boolean lazyFactory) {
+  public void setLazyFactory(@Nullable Boolean lazyFactory) {
     m_lazyFactory = lazyFactory;
   }
 
@@ -933,9 +945,9 @@ public class XmlSuite implements Cloneable {
     m_allowReturnValues = allowReturnValues;
   }
 
-  private XmlGroups m_xmlGroups;
+  private @Nullable XmlGroups m_xmlGroups;
 
-  public void setGroups(XmlGroups xmlGroups) {
+  public void setGroups(@Nullable XmlGroups xmlGroups) {
     m_xmlGroups = xmlGroups;
   }
 
@@ -959,7 +971,8 @@ public class XmlSuite implements Cloneable {
     System.out.println("Language:" + language);
   }
 
-  public XmlGroups getGroups() {
+  /** @return the {@code <groups>} element, or {@code null} if the suite declares none. */
+  public @Nullable XmlGroups getGroups() {
     return m_xmlGroups;
   }
 

--- a/testng-core-api/src/main/java/org/testng/xml/XmlTest.java
+++ b/testng-core-api/src/main/java/org/testng/xml/XmlTest.java
@@ -6,9 +6,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.regex.Pattern;
+import org.jspecify.annotations.Nullable;
 import org.testng.TestNGException;
 
 /** This class describes the tag &lt;test&gt; in testng.xml. */
@@ -16,31 +18,31 @@ public class XmlTest implements Cloneable {
 
   public static final int DEFAULT_TIMEOUT_MS = Integer.MAX_VALUE;
 
-  private XmlSuite m_suite;
-  private String m_name;
+  private @Nullable XmlSuite m_suite;
+  private @Nullable String m_name;
   private Integer m_verbose = XmlSuite.DEFAULT_VERBOSE;
   private int m_threadCount = -1;
 
   private List<XmlClass> m_xmlClasses = new ArrayList<>();
 
   private Map<String, String> m_parameters = new HashMap<>();
-  private XmlSuite.ParallelMode m_parallel;
+  private XmlSuite.@Nullable ParallelMode m_parallel;
 
   private List<XmlMethodSelector> m_methodSelectors = new ArrayList<>();
   // test level packages
   private List<XmlPackage> m_xmlPackages = new ArrayList<>();
 
-  private String m_timeOut;
+  private @Nullable String m_timeOut;
   private Boolean m_skipFailedInvocationCounts = XmlSuite.DEFAULT_SKIP_FAILED_INVOCATION_COUNTS;
-  private Map<String, List<Integer>> m_failedInvocationNumbers = null; // lazily initialized
+  private @Nullable Map<String, List<Integer>> m_failedInvocationNumbers; // lazily initialized
 
   private Boolean m_preserveOrder = XmlSuite.DEFAULT_PRESERVE_ORDER;
 
   private int m_index;
 
-  private Boolean m_groupByInstances;
+  private @Nullable Boolean m_groupByInstances;
 
-  private Boolean m_allowReturnValues = null;
+  private @Nullable Boolean m_allowReturnValues;
 
   private Map<String, String> m_xmlDependencyGroups = new HashMap<>();
 
@@ -148,12 +150,12 @@ public class XmlTest implements Cloneable {
   }
 
   /** @return Returns the name. */
-  public String getName() {
+  public @Nullable String getName() {
     return m_name;
   }
 
   /** @param name The name to set. */
-  public void setName(String name) {
+  public void setName(@Nullable String name) {
     m_name = name;
   }
 
@@ -170,26 +172,35 @@ public class XmlTest implements Cloneable {
     m_threadCount = threadCount;
   }
 
+  /** Creates the {@code <groups>} and {@code <run>} pair on first use, and returns the run. */
+  private XmlRun groupsRun() {
+    XmlGroups groups = groups();
+    XmlRun run = groups.getRun();
+    if (run == null) {
+      run = new XmlRun();
+      groups.setRun(run);
+    }
+    return run;
+  }
+
+  /** Creates the {@code <groups>} element on first use, and returns it. */
+  private XmlGroups groups() {
+    XmlGroups groups = m_xmlGroups;
+    if (groups == null) {
+      groups = new XmlGroups();
+      m_xmlGroups = groups;
+    }
+    return groups;
+  }
+
   public void setIncludedGroups(List<String> g) {
-    if (m_xmlGroups == null) {
-      m_xmlGroups = new XmlGroups();
-    }
-    if (m_xmlGroups.getRun() == null) {
-      m_xmlGroups.setRun(new XmlRun());
-    }
-    List<String> includes = m_xmlGroups.getRun().getIncludes();
+    List<String> includes = groupsRun().getIncludes();
     includes.clear();
     includes.addAll(g);
   }
 
   public void setExcludedGroups(List<String> g) {
-    if (m_xmlGroups == null) {
-      m_xmlGroups = new XmlGroups();
-    }
-    if (m_xmlGroups.getRun() == null) {
-      m_xmlGroups.setRun(new XmlRun());
-    }
-    List<String> excludes = m_xmlGroups.getRun().getExcludes();
+    List<String> excludes = groupsRun().getExcludes();
     excludes.clear();
     excludes.addAll(g);
   }
@@ -204,21 +215,21 @@ public class XmlTest implements Cloneable {
   }
 
   public void addIncludedGroup(String g) {
-    if (m_xmlGroups == null) {
-      m_xmlGroups = new XmlGroups();
-      m_xmlGroups.setRun(new XmlRun());
+    XmlGroups groups = m_xmlGroups;
+    if (groups == null) {
+      groups = new XmlGroups();
+      groups.setRun(new XmlRun());
+      m_xmlGroups = groups;
     }
-    m_xmlGroups.getRun().getIncludes().add(g);
+    // Unlike addExcludedGroup, a <groups> element that has no <run> yet is not repaired here. The
+    // asymmetry is kept: setGroups and addMetaGroup can both leave one in that state, and calling
+    // this method afterwards has always thrown.
+    Objects.requireNonNull(groups.getRun(), "<groups> has no <run> to add an included group to")
+        .onInclude(g);
   }
 
   public void addExcludedGroup(String g) {
-    if (m_xmlGroups == null) {
-      m_xmlGroups = new XmlGroups();
-    }
-    if (m_xmlGroups.getRun() == null) {
-      m_xmlGroups.setRun(new XmlRun());
-    }
-    m_xmlGroups.getRun().getExcludes().add(g);
+    groupsRun().onExclude(g);
   }
 
   /** @return Returns the verbose. */
@@ -259,13 +270,10 @@ public class XmlTest implements Cloneable {
   }
 
   public void addMetaGroup(String name, List<String> metaGroup) {
-    if (m_xmlGroups == null) {
-      m_xmlGroups = new XmlGroups();
-    }
     XmlDefine define = new XmlDefine();
     define.setName(name);
     define.getIncludes().addAll(metaGroup);
-    m_xmlGroups.getDefines().add(define);
+    groups().getDefines().add(define);
   }
 
   public void addMetaGroup(String name, String... metaGroup) {
@@ -301,7 +309,7 @@ public class XmlTest implements Cloneable {
     m_parameters.put(key, value);
   }
 
-  public String getParameter(String name) {
+  public @Nullable String getParameter(String name) {
     String result = m_parameters.get(name);
     if (null == result) {
       result = getSuite().getParameter(name);
@@ -334,7 +342,7 @@ public class XmlTest implements Cloneable {
     return Optional.ofNullable(m_parallel).orElse(getSuite().getParallel());
   }
 
-  public String getTimeOut() {
+  public @Nullable String getTimeOut() {
     String result = getSuite().getTimeOut();
     if (null != m_timeOut) {
       result = m_timeOut;
@@ -356,11 +364,11 @@ public class XmlTest implements Cloneable {
     m_timeOut = Long.toString(timeOut);
   }
 
-  private void setTimeOut(String timeOut) {
+  private void setTimeOut(@Nullable String timeOut) {
     m_timeOut = timeOut;
   }
 
-  public void setScript(XmlScript script) {
+  public void setScript(@Nullable XmlScript script) {
     List<XmlMethodSelector> selectors = getMethodSelectors();
     if (!selectors.isEmpty()) {
       XmlMethodSelector xms = selectors.get(0);
@@ -372,7 +380,8 @@ public class XmlTest implements Cloneable {
     }
   }
 
-  public XmlScript getScript() {
+  /** @return the script of the first method selector, or {@code null} if none carries one. */
+  public @Nullable XmlScript getScript() {
     List<XmlMethodSelector> selectors = getMethodSelectors();
     if (selectors.isEmpty()) {
       return null;
@@ -423,20 +432,23 @@ public class XmlTest implements Cloneable {
    * @return The invocation numbers of the method
    */
   public List<Integer> getInvocationNumbers(String method) {
-    if (m_failedInvocationNumbers == null) {
-      m_failedInvocationNumbers = new HashMap<>();
+    Map<String, List<Integer>> cached = m_failedInvocationNumbers;
+    if (cached == null) {
+      cached = new HashMap<>();
+      m_failedInvocationNumbers = cached;
       for (XmlClass c : getXmlClasses()) {
         for (XmlInclude xi : c.getIncludedMethods()) {
           List<Integer> invocationNumbers = xi.getInvocationNumbers();
           if (!invocationNumbers.isEmpty()) {
             String methodName = c.getName() + "." + xi.getName();
-            m_failedInvocationNumbers.put(methodName, invocationNumbers);
+            cached.put(methodName, invocationNumbers);
           }
         }
       }
     }
 
-    return Optional.ofNullable(m_failedInvocationNumbers.get(method)).orElse(new ArrayList<>());
+    List<Integer> numbers = cached.get(method);
+    return numbers != null ? numbers : new ArrayList<>();
   }
 
   public void setPreserveOrder(Boolean preserveOrder) {
@@ -532,20 +544,27 @@ public class XmlTest implements Cloneable {
         return XmlSuite.f();
       }
     } else {
-      if (other.m_xmlGroups == null) {
+      XmlGroups otherGroups = other.m_xmlGroups;
+      if (otherGroups == null) {
         return false;
       }
-      if ((m_xmlGroups.getRun() == null && other.m_xmlGroups != null)
-          || m_xmlGroups.getRun() != null && other.m_xmlGroups == null) {
+      // Was a two-armed condition whose second arm re-tested other.m_xmlGroups, already known
+      // non-null one line above; only the first arm could ever fire.
+      XmlRun run = m_xmlGroups.getRun();
+      if (run == null) {
         return false;
       }
-      if (!m_xmlGroups.getRun().getExcludes().equals(other.m_xmlGroups.getRun().getExcludes())) {
+      // The other side's <run> is not tested, exactly as before: comparing against a <groups>
+      // that has none has always thrown here.
+      XmlRun otherRun =
+          Objects.requireNonNull(otherGroups.getRun(), "the compared <groups> has no <run>");
+      if (!run.getExcludes().equals(otherRun.getExcludes())) {
         return XmlSuite.f();
       }
-      if (!m_xmlGroups.getRun().getIncludes().equals(other.m_xmlGroups.getRun().getIncludes())) {
+      if (!run.getIncludes().equals(otherRun.getIncludes())) {
         return XmlSuite.f();
       }
-      if (!m_xmlGroups.getDefines().equals(other.m_xmlGroups.getDefines())) {
+      if (!m_xmlGroups.getDefines().equals(otherGroups.getDefines())) {
         return false;
       }
     }
@@ -665,13 +684,13 @@ public class XmlTest implements Cloneable {
     m_suite = suite;
   }
 
-  private XmlGroups m_xmlGroups;
+  private @Nullable XmlGroups m_xmlGroups;
 
   public void setGroups(XmlGroups xmlGroups) {
     m_xmlGroups = xmlGroups;
   }
 
-  public XmlGroups getXmlGroups() {
+  public @Nullable XmlGroups getXmlGroups() {
     return m_xmlGroups;
   }
 

--- a/testng-core-api/src/main/java/org/testng/xml/XmlWeaver.java
+++ b/testng-core-api/src/main/java/org/testng/xml/XmlWeaver.java
@@ -1,5 +1,7 @@
 package org.testng.xml;
 
+import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 import org.testng.TestNGException;
 import org.testng.internal.ClassHelper;
 import org.testng.internal.RuntimeBehavior;
@@ -7,7 +9,7 @@ import org.testng.internal.objects.InstanceCreator;
 
 /** A Utility class that helps represent a {@link XmlSuite} and {@link XmlTest} as String. */
 final class XmlWeaver {
-  private static IWeaveXml instance = null;
+  private static @Nullable IWeaveXml instance;
   private static final boolean testMode = RuntimeBehavior.isTestMode();
 
   private XmlWeaver() {}
@@ -16,7 +18,11 @@ final class XmlWeaver {
     if (testMode) {
       // Do not resort to caching when running Unit tests for TestNG, because we have to check
       // both implementations. If we cache the instance, then its not possible to do that.
-      return attemptDefaultImplementationInstantiation();
+      // The requireNonNull records what the callers have always assumed: in test mode a third
+      // party weaver is not instantiated, and dereferencing the result threw here already.
+      return Objects.requireNonNull(
+          attemptDefaultImplementationInstantiation(),
+          "test mode does not instantiate a third party weaver named by -Dtestng.xml.weaver");
     }
     return instantiateIfRequired();
   }
@@ -70,7 +76,7 @@ final class XmlWeaver {
     return getInstance().asXml(xmlTest, indent);
   }
 
-  private static IWeaveXml attemptDefaultImplementationInstantiation() {
+  private static @Nullable IWeaveXml attemptDefaultImplementationInstantiation() {
     String clazz = getClassName();
     if (clazz.equals(DefaultXmlWeaver.class.getName())) {
       return new DefaultXmlWeaver();

--- a/testng-core-api/src/main/java/org/testng/xml/package-info.java
+++ b/testng-core-api/src/main/java/org/testng/xml/package-info.java
@@ -1,0 +1,5 @@
+/** The suite model that testng.xml describes, its parser, and the weaver that writes it back. */
+@NullMarked
+package org.testng.xml;
+
+import org.jspecify.annotations.NullMarked;

--- a/testng-core/src/main/java/org/testng/reporters/jq/BaseMultiSuitePanel.java
+++ b/testng-core/src/main/java/org/testng/reporters/jq/BaseMultiSuitePanel.java
@@ -6,7 +6,7 @@ import org.testng.reporters.XMLStringBuffer;
 
 public abstract class BaseMultiSuitePanel extends BasePanel implements INavigatorPanel {
 
-  abstract String getHeader(ISuite suite);
+  abstract @Nullable String getHeader(ISuite suite);
 
   abstract String getContent(ISuite suite, XMLStringBuffer xsb);
 

--- a/testng-core/src/main/java/org/testng/reporters/jq/TestNgXmlPanel.java
+++ b/testng-core/src/main/java/org/testng/reporters/jq/TestNgXmlPanel.java
@@ -1,5 +1,6 @@
 package org.testng.reporters.jq;
 
+import org.jspecify.annotations.Nullable;
 import org.testng.ISuite;
 import org.testng.internal.Utils;
 import org.testng.reporters.XMLStringBuffer;
@@ -16,7 +17,7 @@ public class TestNgXmlPanel extends BaseMultiSuitePanel {
   }
 
   @Override
-  public String getHeader(ISuite suite) {
+  public @Nullable String getHeader(ISuite suite) {
     return suite.getXmlSuite().getFileName();
   }
 

--- a/testng-core/src/main/java/org/testng/xml/IFileParser.java
+++ b/testng-core/src/main/java/org/testng/xml/IFileParser.java
@@ -1,9 +1,14 @@
 package org.testng.xml;
 
 import java.io.InputStream;
+import org.jspecify.annotations.Nullable;
 import org.testng.TestNGException;
 
 public interface IFileParser<T> {
 
-  T parse(String filePath, InputStream is, boolean loadClasses) throws TestNGException;
+  /**
+   * @param is the file's contents, or {@code null} for a parser that reads a source of its own --
+   *     {@code Parser} only opens a stream for a {@code file:} scheme.
+   */
+  T parse(String filePath, @Nullable InputStream is, boolean loadClasses) throws TestNGException;
 }

--- a/testng-core/src/main/java/org/testng/xml/SuiteXmlParser.java
+++ b/testng-core/src/main/java/org/testng/xml/SuiteXmlParser.java
@@ -2,6 +2,8 @@ package org.testng.xml;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 import org.testng.TestNGException;
 import org.testng.xml.internal.Parser;
 import org.xml.sax.SAXException;
@@ -9,13 +11,20 @@ import org.xml.sax.SAXException;
 public class SuiteXmlParser extends XMLParser<XmlSuite> implements ISuiteParser {
 
   @Override
-  public XmlSuite parse(String currentFile, InputStream inputStream, boolean loadClasses) {
+  public XmlSuite parse(
+      String currentFile, @Nullable InputStream inputStream, boolean loadClasses) {
     TestNGContentHandler contentHandler = new TestNGContentHandler(currentFile, loadClasses);
 
     try {
-      parse(inputStream, contentHandler);
+      // Nullable on the interface for the parsers that read a source of their own. This one is
+      // reached either through accept(), which requires a file: scheme and so a stream, or as
+      // Parser's fallback for a scheme nothing claims -- which has never been readable here.
+      parse(
+          Objects.requireNonNull(inputStream, "a file: suite is read from an open stream"),
+          contentHandler);
 
-      return contentHandler.getSuite();
+      return Objects.requireNonNull(
+          contentHandler.getSuite(), "the document declares no <suite> element");
     } catch (SAXException | IOException e) {
       throw new TestNGException(e);
     }

--- a/testng-core/src/main/java/org/testng/xml/TestNGContentHandler.java
+++ b/testng-core/src/main/java/org/testng/xml/TestNGContentHandler.java
@@ -18,9 +18,11 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Stack;
 import javax.xml.XMLConstants;
+import org.jspecify.annotations.Nullable;
 import org.testng.ITestObjectFactory;
 import org.testng.TestNGException;
 import org.testng.internal.RuntimeBehavior;
@@ -46,22 +48,25 @@ import org.xml.sax.helpers.DefaultHandler;
 public class TestNGContentHandler extends DefaultHandler implements LexicalHandler {
   private static final int DTD_CONNECTION_TIMEOUT_MILLIS = 10_000;
 
-  private XmlSuite m_currentSuite = null;
-  private XmlTest m_currentTest = null;
-  private XmlDefine m_currentDefine = null;
-  private XmlRun m_currentRun = null;
-  private List<XmlClass> m_currentClasses = null;
+  /** Only the end tag half of the {@code xml*} methods below is called without attributes. */
+  private static final String START_TAG_ATTRIBUTES = "a start tag carries its attributes";
+
+  private @Nullable XmlSuite m_currentSuite;
+  private @Nullable XmlTest m_currentTest;
+  private @Nullable XmlDefine m_currentDefine;
+  private @Nullable XmlRun m_currentRun;
+  private @Nullable List<XmlClass> m_currentClasses;
   private int m_currentTestIndex = 0;
   private int m_currentClassIndex = 0;
   private int m_currentIncludeIndex = 0;
-  private List<XmlPackage> m_currentPackages = null;
-  private XmlPackage m_currentPackage = null;
+  private @Nullable List<XmlPackage> m_currentPackages;
+  private @Nullable XmlPackage m_currentPackage;
   private final List<XmlSuite> m_suites = new ArrayList<>();
-  private XmlGroups m_currentGroups = null;
-  private Map<String, String> m_currentTestParameters = null;
-  private Map<String, String> m_currentSuiteParameters = null;
-  private Map<String, String> m_currentClassParameters = null;
-  private Include m_currentInclude;
+  private @Nullable XmlGroups m_currentGroups;
+  private @Nullable Map<String, String> m_currentTestParameters;
+  private @Nullable Map<String, String> m_currentSuiteParameters;
+  private @Nullable Map<String, String> m_currentClassParameters;
+  private @Nullable Include m_currentInclude;
 
   // Borrowed this implementation from this SO post : https://stackoverflow.com/a/29751441/679824
   private final EntityResolver m_redirectionAwareResolver =
@@ -126,16 +131,16 @@ public class TestNGContentHandler extends DefaultHandler implements LexicalHandl
   private final Stack<Location> m_locations = new Stack<>();
   private boolean isSuiteFileTag = false;
 
-  private XmlClass m_currentClass = null;
-  private ArrayList<XmlInclude> m_currentIncludedMethods = null;
-  private List<String> m_currentExcludedMethods = null;
-  private ArrayList<XmlMethodSelector> m_currentSelectors = null;
-  private XmlMethodSelector m_currentSelector = null;
-  private String m_currentLanguage = null;
-  private String m_currentExpression = null;
+  private @Nullable XmlClass m_currentClass;
+  private @Nullable ArrayList<XmlInclude> m_currentIncludedMethods;
+  private @Nullable List<String> m_currentExcludedMethods;
+  private @Nullable ArrayList<XmlMethodSelector> m_currentSelectors;
+  private @Nullable XmlMethodSelector m_currentSelector;
+  private @Nullable String m_currentLanguage;
+  private @Nullable String m_currentExpression;
   private final List<String> m_suiteFiles = new ArrayList<>();
   private boolean m_enabledTest;
-  private List<String> m_listeners;
+  private @Nullable List<String> m_listeners;
 
   private final String m_fileName;
   private final boolean m_loadClasses;
@@ -281,36 +286,82 @@ public class TestNGContentHandler extends DefaultHandler implements LexicalHandl
     return Thread.currentThread().getContextClassLoader().getResourceAsStream(Parser.TESTNG_DTD);
   }
 
+  // Every m_currentXxx field declared above is set when its element's start tag is seen and cleared
+  // at the matching end tag, so it is non-null for the whole of that element's body. A null means
+  // the document is not well formed, which SAX reports separately. The accessors below assert it so
+  // the failure names the element instead of arriving as a bare NullPointerException.
+  private XmlSuite currentSuite() {
+    return Objects.requireNonNull(m_currentSuite, "no <suite> is being parsed");
+  }
+
+  private XmlTest currentTest() {
+    return Objects.requireNonNull(m_currentTest, "no <test> is being parsed");
+  }
+
+  private XmlClass currentClass() {
+    return Objects.requireNonNull(m_currentClass, "no <class> is being parsed");
+  }
+
+  private XmlGroups currentGroups() {
+    return Objects.requireNonNull(m_currentGroups, "no <groups> is being parsed");
+  }
+
+  private XmlMethodSelector currentSelector() {
+    return Objects.requireNonNull(m_currentSelector, "no <method-selector> is being parsed");
+  }
+
+  private List<XmlMethodSelector> currentSelectors() {
+    return Objects.requireNonNull(m_currentSelectors, "no <method-selectors> is being parsed");
+  }
+
+  private Include currentInclude() {
+    return Objects.requireNonNull(m_currentInclude, "no <include> is being parsed");
+  }
+
+  private Map<String, String> currentSuiteParameters() {
+    return Objects.requireNonNull(m_currentSuiteParameters, "no <suite> is being parsed");
+  }
+
+  private Map<String, String> currentTestParameters() {
+    return Objects.requireNonNull(m_currentTestParameters, "no <test> is being parsed");
+  }
+
+  private Map<String, String> currentClassParameters() {
+    return Objects.requireNonNull(m_currentClassParameters, "no <class> is being parsed");
+  }
+
   /** Parse <suite-file> */
-  private void xmlSuiteFile(boolean start, Attributes attributes) {
+  private void xmlSuiteFile(boolean start, @Nullable Attributes startAttributes) {
     if (start) {
-      String path = attributes.getValue("path");
+      String path = Objects.requireNonNull(startAttributes, START_TAG_ATTRIBUTES).getValue("path");
       pushLocation(Location.SUITE);
       m_suiteFiles.add(path);
       isSuiteFileTag = true;
     } else {
-      m_currentSuite.setSuiteFiles(m_suiteFiles);
+      currentSuite().setSuiteFiles(m_suiteFiles);
       popLocation();
       isSuiteFileTag = false;
     }
   }
 
   /** Parse <suite> */
-  private void xmlSuite(boolean start, Attributes attributes) {
+  private void xmlSuite(boolean start, @Nullable Attributes startAttributes) {
     if (start) {
       pushLocation(Location.SUITE);
+      Attributes attributes = Objects.requireNonNull(startAttributes, START_TAG_ATTRIBUTES);
       String name = attributes.getValue("name");
       if (isStringBlank(name)) {
         throw new TestNGException("The <suite> tag must define the name attribute");
       }
-      m_currentSuite = new XmlSuite();
-      m_currentSuite.setFileName(m_fileName);
-      m_currentSuite.setName(name);
+      XmlSuite suite = new XmlSuite();
+      m_currentSuite = suite;
+      suite.setFileName(m_fileName);
+      suite.setName(name);
       m_currentSuiteParameters = new HashMap<>();
 
       String verbose = attributes.getValue("verbose");
       if (null != verbose) {
-        m_currentSuite.setVerbose(Integer.parseInt(verbose));
+        suite.setVerbose(Integer.parseInt(verbose));
       }
       String jUnit = attributes.getValue("junit");
       if (null != jUnit) {
@@ -320,7 +371,7 @@ public class TestNGContentHandler extends DefaultHandler implements LexicalHandl
       if (parallel != null) {
         XmlSuite.ParallelMode mode = XmlSuite.ParallelMode.getValidParallel(parallel);
         if (mode != null) {
-          m_currentSuite.setParallel(mode);
+          suite.setParallel(mode);
         } else {
           Utils.log(
               "Parser",
@@ -330,36 +381,36 @@ public class TestNGContentHandler extends DefaultHandler implements LexicalHandl
       }
       String parentModule = attributes.getValue("parent-module");
       if (parentModule != null) {
-        m_currentSuite.setParentModule(parentModule);
+        suite.setParentModule(parentModule);
       }
       String guiceStage = attributes.getValue("guice-stage");
       if (guiceStage != null) {
-        m_currentSuite.setGuiceStage(guiceStage);
+        suite.setGuiceStage(guiceStage);
       }
       XmlSuite.FailurePolicy configFailurePolicy =
           XmlSuite.FailurePolicy.getValidPolicy(attributes.getValue("configfailurepolicy"));
       if (null != configFailurePolicy) {
-        m_currentSuite.setConfigFailurePolicy(configFailurePolicy);
+        suite.setConfigFailurePolicy(configFailurePolicy);
       }
       String groupByInstances = attributes.getValue("group-by-instances");
       if (groupByInstances != null) {
-        m_currentSuite.setGroupByInstances(Boolean.parseBoolean(groupByInstances));
+        suite.setGroupByInstances(Boolean.parseBoolean(groupByInstances));
       }
       String lazyFactory = attributes.getValue("lazy-factory");
       if (lazyFactory != null) {
-        m_currentSuite.setLazyFactory(Boolean.parseBoolean(lazyFactory));
+        suite.setLazyFactory(Boolean.parseBoolean(lazyFactory));
       }
       String skip = attributes.getValue("skipfailedinvocationcounts");
       if (skip != null) {
-        m_currentSuite.setSkipFailedInvocationCounts(Boolean.parseBoolean(skip));
+        suite.setSkipFailedInvocationCounts(Boolean.parseBoolean(skip));
       }
       String threadCount = attributes.getValue("thread-count");
       if (null != threadCount) {
-        m_currentSuite.setThreadCount(Integer.parseInt(threadCount));
+        suite.setThreadCount(Integer.parseInt(threadCount));
       }
       String dataProviderThreadCount = attributes.getValue("data-provider-thread-count");
       if (null != dataProviderThreadCount) {
-        m_currentSuite.setDataProviderThreadCount(Integer.parseInt(dataProviderThreadCount));
+        suite.setDataProviderThreadCount(Integer.parseInt(dataProviderThreadCount));
       }
 
       String shareThreadPoolForDataProviders =
@@ -367,24 +418,22 @@ public class TestNGContentHandler extends DefaultHandler implements LexicalHandl
       Optional.ofNullable(shareThreadPoolForDataProviders)
           .ifPresent(
               it ->
-                  m_currentSuite.setShareThreadPoolForDataProviders(
+                  suite.setShareThreadPoolForDataProviders(
                       Boolean.parseBoolean(shareThreadPoolForDataProviders)));
 
       String useGlobalThreadPool = attributes.getValue("use-global-thread-pool");
       Optional.ofNullable(useGlobalThreadPool)
           .ifPresent(
-              it ->
-                  m_currentSuite.shouldUseGlobalThreadPool(
-                      Boolean.parseBoolean(useGlobalThreadPool)));
+              it -> suite.shouldUseGlobalThreadPool(Boolean.parseBoolean(useGlobalThreadPool)));
 
       String timeOut = attributes.getValue("time-out");
       if (null != timeOut) {
-        m_currentSuite.setTimeOut(timeOut);
+        suite.setTimeOut(timeOut);
       }
       String objectFactory = attributes.getValue("object-factory");
       if (null != objectFactory && m_loadClasses) {
         try {
-          m_currentSuite.setObjectFactoryClass(
+          suite.setObjectFactoryClass(
               (Class<? extends ITestObjectFactory>) Class.forName(objectFactory));
         } catch (Exception e) {
           Utils.log(
@@ -395,45 +444,50 @@ public class TestNGContentHandler extends DefaultHandler implements LexicalHandl
       }
       String preserveOrder = attributes.getValue("preserve-order");
       if (preserveOrder != null) {
-        m_currentSuite.setPreserveOrder(Boolean.valueOf(preserveOrder));
+        suite.setPreserveOrder(Boolean.valueOf(preserveOrder));
       }
       String allowReturnValues = attributes.getValue("allow-return-values");
       if (allowReturnValues != null) {
-        m_currentSuite.setAllowReturnValues(Boolean.valueOf(allowReturnValues));
+        suite.setAllowReturnValues(Boolean.valueOf(allowReturnValues));
       }
     } else {
-      m_currentSuite.setParameters(m_currentSuiteParameters);
-      m_suites.add(m_currentSuite);
+      XmlSuite suite = currentSuite();
+      suite.setParameters(currentSuiteParameters());
+      m_suites.add(suite);
       m_currentSuiteParameters = null;
       popLocation();
     }
   }
 
   /** Parse <define> */
-  private void xmlDefine(boolean start, Attributes attributes) {
+  private void xmlDefine(boolean start, @Nullable Attributes startAttributes) {
     if (start) {
-      String name = attributes.getValue("name");
-      m_currentDefine = new XmlDefine();
-      m_currentDefine.setName(name);
+      String name = Objects.requireNonNull(startAttributes, START_TAG_ATTRIBUTES).getValue("name");
+      XmlDefine define = new XmlDefine();
+      define.setName(name);
+      m_currentDefine = define;
     } else {
       // define is only defined within the context of XmlGroups
-      m_currentGroups.addDefine(m_currentDefine);
+      currentGroups()
+          .addDefine(Objects.requireNonNull(m_currentDefine, "no <define> is being parsed"));
       m_currentDefine = null;
     }
   }
 
   /** Parse <script> */
-  private void xmlScript(boolean start, Attributes attributes) {
+  private void xmlScript(boolean start, @Nullable Attributes startAttributes) {
     if (start) {
-      m_currentLanguage = attributes.getValue("language");
+      m_currentLanguage =
+          Objects.requireNonNull(startAttributes, START_TAG_ATTRIBUTES).getValue("language");
       m_currentExpression = "";
     } else {
       XmlScript script = new XmlScript();
-      script.setExpression(m_currentExpression);
+      script.setExpression(
+          Objects.requireNonNull(m_currentExpression, "no <script> is being parsed"));
       script.setLanguage(m_currentLanguage);
-      m_currentSelector.setScript(script);
+      currentSelector().setScript(script);
       if (m_locations.peek() == Location.TEST) {
-        m_currentTest.setScript(script);
+        currentTest().setScript(script);
       }
       m_currentLanguage = null;
       m_currentExpression = null;
@@ -441,19 +495,21 @@ public class TestNGContentHandler extends DefaultHandler implements LexicalHandl
   }
 
   /** Parse &lt;test&gt; */
-  private void xmlTest(boolean start, Attributes attributes) {
+  private void xmlTest(boolean start, @Nullable Attributes startAttributes) {
     if (start) {
-      m_currentTest = new XmlTest(m_currentSuite, m_currentTestIndex++);
+      XmlTest test = new XmlTest(currentSuite(), m_currentTestIndex++);
+      m_currentTest = test;
       pushLocation(Location.TEST);
       m_currentTestParameters = new HashMap<>();
+      Attributes attributes = Objects.requireNonNull(startAttributes, START_TAG_ATTRIBUTES);
       final String testName = attributes.getValue("name");
       if (isStringBlank(testName)) {
         throw new TestNGException("The <test> tag must define the name attribute");
       }
-      m_currentTest.setName(attributes.getValue("name"));
+      test.setName(attributes.getValue("name"));
       String verbose = attributes.getValue("verbose");
       if (null != verbose) {
-        m_currentTest.setVerbose(Integer.parseInt(verbose));
+        test.setVerbose(Integer.parseInt(verbose));
       }
       String jUnit = attributes.getValue("junit");
       if (null != jUnit) {
@@ -461,21 +517,21 @@ public class TestNGContentHandler extends DefaultHandler implements LexicalHandl
       }
       String skip = attributes.getValue("skipfailedinvocationcounts");
       if (skip != null) {
-        m_currentTest.setSkipFailedInvocationCounts(Boolean.parseBoolean(skip));
+        test.setSkipFailedInvocationCounts(Boolean.parseBoolean(skip));
       }
       String groupByInstances = attributes.getValue("group-by-instances");
       if (groupByInstances != null) {
-        m_currentTest.setGroupByInstances(Boolean.parseBoolean(groupByInstances));
+        test.setGroupByInstances(Boolean.parseBoolean(groupByInstances));
       }
       String preserveOrder = attributes.getValue("preserve-order");
       if (preserveOrder != null) {
-        m_currentTest.setPreserveOrder(Boolean.valueOf(preserveOrder));
+        test.setPreserveOrder(Boolean.valueOf(preserveOrder));
       }
       String parallel = attributes.getValue("parallel");
       if (parallel != null) {
         XmlSuite.ParallelMode mode = XmlSuite.ParallelMode.getValidParallel(parallel);
         if (mode != null) {
-          m_currentTest.setParallel(mode);
+          test.setParallel(mode);
         } else {
           Utils.log(
               "Parser",
@@ -489,11 +545,11 @@ public class TestNGContentHandler extends DefaultHandler implements LexicalHandl
       }
       String threadCount = attributes.getValue("thread-count");
       if (null != threadCount) {
-        m_currentTest.setThreadCount(Integer.parseInt(threadCount));
+        test.setThreadCount(Integer.parseInt(threadCount));
       }
       String timeOut = attributes.getValue("time-out");
       if (null != timeOut) {
-        m_currentTest.setTimeOut(Long.parseLong(timeOut));
+        test.setTimeOut(Long.parseLong(timeOut));
       }
       m_enabledTest = true;
       String enabledTestString = attributes.getValue("enabled");
@@ -501,18 +557,19 @@ public class TestNGContentHandler extends DefaultHandler implements LexicalHandl
         m_enabledTest = Boolean.parseBoolean(enabledTestString);
       }
     } else {
+      XmlTest test = currentTest();
       if (null != m_currentTestParameters && !m_currentTestParameters.isEmpty()) {
-        m_currentTest.setParameters(m_currentTestParameters);
+        test.setParameters(m_currentTestParameters);
       }
       if (null != m_currentClasses) {
-        m_currentTest.setXmlClasses(m_currentClasses);
+        test.setXmlClasses(m_currentClasses);
       }
       m_currentClasses = null;
       m_currentTest = null;
       m_currentTestParameters = null;
       popLocation();
       if (!m_enabledTest) {
-        List<XmlTest> tests = m_currentSuite.getTests();
+        List<XmlTest> tests = currentSuite().getTests();
         tests.remove(tests.size() - 1);
       }
     }
@@ -523,7 +580,8 @@ public class TestNGContentHandler extends DefaultHandler implements LexicalHandl
       m_currentClasses = new ArrayList<>();
       m_currentClassIndex = 0;
     } else {
-      m_currentTest.setXmlClasses(m_currentClasses);
+      currentTest()
+          .setXmlClasses(Objects.requireNonNull(m_currentClasses, "no <classes> is being parsed"));
       m_currentClasses = null;
     }
   }
@@ -533,7 +591,7 @@ public class TestNGContentHandler extends DefaultHandler implements LexicalHandl
       m_listeners = new ArrayList<>();
     } else {
       if (null != m_listeners) {
-        m_currentSuite.setListeners(m_listeners);
+        currentSuite().setListeners(m_listeners);
         m_listeners = null;
       }
     }
@@ -542,7 +600,7 @@ public class TestNGContentHandler extends DefaultHandler implements LexicalHandl
   public void xmlListener(boolean start, Attributes attributes) {
     if (start) {
       String listener = attributes.getValue("class-name");
-      m_listeners.add(listener);
+      Objects.requireNonNull(m_listeners, "no <listeners> is being parsed").add(listener);
     }
   }
 
@@ -554,10 +612,10 @@ public class TestNGContentHandler extends DefaultHandler implements LexicalHandl
         Location location = m_locations.peek();
         switch (location) {
           case TEST:
-            m_currentTest.setXmlPackages(m_currentPackages);
+            currentTest().setXmlPackages(m_currentPackages);
             break;
           case SUITE:
-            m_currentSuite.setXmlPackages(m_currentPackages);
+            currentSuite().setXmlPackages(m_currentPackages);
             break;
           case CLASS:
             throw new UnsupportedOperationException("CLASS");
@@ -576,20 +634,23 @@ public class TestNGContentHandler extends DefaultHandler implements LexicalHandl
       m_currentSelectors = new ArrayList<>();
       return;
     }
+    List<XmlMethodSelector> selectors = currentSelectors();
     if (m_locations.peek() == Location.TEST) {
-      m_currentTest.setMethodSelectors(m_currentSelectors);
+      currentTest().setMethodSelectors(selectors);
     } else {
-      m_currentSuite.setMethodSelectors(m_currentSelectors);
+      currentSuite().setMethodSelectors(selectors);
     }
 
     m_currentSelectors = null;
   }
 
-  public void xmlSelectorClass(boolean start, Attributes attributes) {
+  public void xmlSelectorClass(boolean start, @Nullable Attributes startAttributes) {
     if (start) {
-      m_currentSelector.setName(attributes.getValue("name"));
+      Attributes attributes = Objects.requireNonNull(startAttributes, START_TAG_ATTRIBUTES);
+      XmlMethodSelector selector = currentSelector();
+      selector.setName(attributes.getValue("name"));
       String priority = attributes.getValue("priority");
-      m_currentSelector.setPriority(
+      selector.setPriority(
           priority == null ? XmlMethodSelector.DEFAULT_PRIORITY : Integer.parseInt(priority));
     }
   }
@@ -598,7 +659,7 @@ public class TestNGContentHandler extends DefaultHandler implements LexicalHandl
     if (start) {
       m_currentSelector = new XmlMethodSelector();
     } else {
-      m_currentSelectors.add(m_currentSelector);
+      currentSelectors().add(currentSelector());
       m_currentSelector = null;
     }
   }
@@ -609,8 +670,11 @@ public class TestNGContentHandler extends DefaultHandler implements LexicalHandl
       m_currentExcludedMethods = new ArrayList<>();
       m_currentIncludeIndex = 0;
     } else {
-      m_currentClass.setIncludedMethods(m_currentIncludedMethods);
-      m_currentClass.setExcludedMethods(m_currentExcludedMethods);
+      XmlClass xmlClass = currentClass();
+      xmlClass.setIncludedMethods(
+          Objects.requireNonNull(m_currentIncludedMethods, "no <methods> is being parsed"));
+      xmlClass.setExcludedMethods(
+          Objects.requireNonNull(m_currentExcludedMethods, "no <methods> is being parsed"));
       m_currentIncludedMethods = null;
       m_currentExcludedMethods = null;
     }
@@ -621,15 +685,15 @@ public class TestNGContentHandler extends DefaultHandler implements LexicalHandl
       m_currentRun = new XmlRun();
     } else {
       // Xml run is only defined in the context of groups
-      m_currentGroups.setRun(m_currentRun);
+      currentGroups().setRun(Objects.requireNonNull(m_currentRun, "no <run> is being parsed"));
       m_currentRun = null;
     }
   }
 
   public void xmlGroup(boolean start, Attributes attributes) {
     if (start) {
-      m_currentTest.addXmlDependencyGroup(
-          attributes.getValue("name"), attributes.getValue("depends-on"));
+      currentTest()
+          .addXmlDependencyGroup(attributes.getValue("name"), attributes.getValue("depends-on"));
     }
   }
 
@@ -637,10 +701,11 @@ public class TestNGContentHandler extends DefaultHandler implements LexicalHandl
     if (start) {
       m_currentGroups = new XmlGroups();
     } else {
+      XmlGroups groups = currentGroups();
       if (m_currentTest == null) {
-        m_currentSuite.setGroups(m_currentGroups);
+        currentSuite().setGroups(groups);
       } else {
-        m_currentTest.setGroups(m_currentGroups);
+        currentTest().setGroups(groups);
       }
 
       m_currentGroups = null;
@@ -689,10 +754,11 @@ public class TestNGContentHandler extends DefaultHandler implements LexicalHandl
       // will complain, but in the meantime, dodge the NPE so SAX
       // can finish parsing the file.
       if (null != m_currentClasses) {
-        m_currentClass = new XmlClass(name, m_currentClassIndex++, m_loadClasses);
-        m_currentClass.setXmlTest(m_currentTest);
+        XmlClass xmlClass = new XmlClass(name, m_currentClassIndex++, m_loadClasses);
+        m_currentClass = xmlClass;
+        xmlClass.setXmlTest(currentTest());
         m_currentClassParameters = new HashMap<>();
-        m_currentClasses.add(m_currentClass);
+        m_currentClasses.add(xmlClass);
         pushLocation(Location.CLASS);
       }
     } else if ("package".equals(qName)) {
@@ -727,16 +793,16 @@ public class TestNGContentHandler extends DefaultHandler implements LexicalHandl
       Location location = m_locations.peek();
       switch (location) {
         case TEST:
-          m_currentTestParameters.put(name, value);
+          currentTestParameters().put(name, value);
           break;
         case SUITE:
-          m_currentSuiteParameters.put(name, value);
+          currentSuiteParameters().put(name, value);
           break;
         case CLASS:
-          m_currentClassParameters.put(name, value);
+          currentClassParameters().put(name, value);
           break;
         case INCLUDE:
-          m_currentInclude.parameters.put(name, value);
+          currentInclude().parameters.put(name, value);
           break;
         default:
           throw new AssertionError("Unexpected value: " + location);
@@ -748,7 +814,7 @@ public class TestNGContentHandler extends DefaultHandler implements LexicalHandl
     String name;
     String invocationNumbers;
     String factoryInstances;
-    String description;
+    @Nullable String description;
     Map<String, String> parameters = new HashMap<>();
 
     Include(String name, String numbers, String factoryInstances) {
@@ -758,34 +824,37 @@ public class TestNGContentHandler extends DefaultHandler implements LexicalHandl
     }
   }
 
-  private void xmlInclude(boolean start, Attributes attributes) {
+  private void xmlInclude(boolean start, @Nullable Attributes startAttributes) {
     if (start) {
       m_locations.push(Location.INCLUDE);
-      m_currentInclude =
+      Attributes attributes = Objects.requireNonNull(startAttributes, START_TAG_ATTRIBUTES);
+      Include current =
           new Include(
               attributes.getValue("name"),
               attributes.getValue("invocation-numbers"),
               attributes.getValue("factory-instances"));
-      m_currentInclude.description = attributes.getValue("description");
+      current.description = attributes.getValue("description");
+      m_currentInclude = current;
     } else {
-      String name = m_currentInclude.name;
+      Include current = currentInclude();
+      String name = current.name;
       if (null != m_currentIncludedMethods) {
-        String in = m_currentInclude.invocationNumbers;
+        String in = current.invocationNumbers;
         XmlInclude include;
         if (!Utils.isStringEmpty(in)) {
           include = new XmlInclude(name, stringToList(in), m_currentIncludeIndex++);
         } else {
           include = new XmlInclude(name, m_currentIncludeIndex++);
         }
-        String factoryInstances = m_currentInclude.factoryInstances;
+        String factoryInstances = current.factoryInstances;
         if (!Utils.isStringEmpty(factoryInstances)) {
           include.addFactoryInstances(stringToList(factoryInstances));
         }
-        for (Map.Entry<String, String> entry : m_currentInclude.parameters.entrySet()) {
+        for (Map.Entry<String, String> entry : current.parameters.entrySet()) {
           include.addParameter(entry.getKey(), entry.getValue());
         }
 
-        include.setDescription(m_currentInclude.description);
+        include.setDescription(current.description);
         m_currentIncludedMethods.add(include);
       } else if (null != m_currentDefine) {
         m_currentDefine.onElement(name);
@@ -800,10 +869,10 @@ public class TestNGContentHandler extends DefaultHandler implements LexicalHandl
     }
   }
 
-  private void xmlExclude(boolean start, Attributes attributes) {
+  private void xmlExclude(boolean start, @Nullable Attributes startAttributes) {
     if (start) {
       m_locations.push(Location.EXCLUDE);
-      String name = attributes.getValue("name");
+      String name = Objects.requireNonNull(startAttributes, START_TAG_ATTRIBUTES).getValue("name");
       if (null != m_currentExcludedMethods) {
         m_currentExcludedMethods.add(name);
       } else if (null != m_currentRun) {
@@ -854,7 +923,7 @@ public class TestNGContentHandler extends DefaultHandler implements LexicalHandl
     } else if ("packages".equals(qName)) {
       xmlPackages(false);
     } else if ("class".equals(qName)) {
-      m_currentClass.setParameters(m_currentClassParameters);
+      currentClass().setParameters(currentClassParameters());
       m_currentClassParameters = null;
       popLocation();
     } else if ("listeners".equals(qName)) {
@@ -976,7 +1045,7 @@ public class TestNGContentHandler extends DefaultHandler implements LexicalHandl
     }
   }
 
-  public XmlSuite getSuite() {
+  public @Nullable XmlSuite getSuite() {
     return m_currentSuite;
   }
 

--- a/testng-core/src/main/java/org/testng/xml/XMLParser.java
+++ b/testng-core/src/main/java/org/testng/xml/XMLParser.java
@@ -12,6 +12,7 @@ import javax.xml.parsers.SAXParserFactory;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
+import org.jspecify.annotations.Nullable;
 import org.testng.TestNGException;
 import org.testng.log4testng.Logger;
 import org.xml.sax.SAXException;
@@ -157,9 +158,9 @@ public abstract class XMLParser<T> implements IFileParser<T> {
    * a repackaged jar that dropped the resource should still run suites.
    */
   private static final class BundledSchema {
-    private static final Schema INSTANCE = compile();
+    private static final @Nullable Schema INSTANCE = compile();
 
-    private static Schema compile() {
+    private static @Nullable Schema compile() {
       URL url = XMLParser.class.getClassLoader().getResource(TESTNG_XSD);
       if (url == null) {
         Logger.getLogger(XMLParser.class)

--- a/testng-jcommander/src/main/java/org/testng/cli/jcommander/Converter.java
+++ b/testng-jcommander/src/main/java/org/testng/cli/jcommander/Converter.java
@@ -11,6 +11,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import org.testng.TestNGException;
 import org.testng.internal.Yaml;
@@ -66,7 +67,10 @@ public class Converter {
         findAllSuites(parser.parse(), allSuites);
 
         for (XmlSuite suite : allSuites) {
-          String fileName = suite.getFileName();
+          // Every suite here was read from a file the converter was given, and both parsers set
+          // the name: TestNGContentHandler for XML, Yaml for YAML.
+          String fileName =
+              Objects.requireNonNull(suite.getFileName(), "a parsed suite names its file");
           int ind = fileName.lastIndexOf(".");
           String bn = fileName.substring(0, ind);
           int ind2 = bn.lastIndexOf(File.separatorChar);

--- a/testng-test-kit/src/main/java/org/testng/xml/SuiteDigest.java
+++ b/testng-test-kit/src/main/java/org/testng/xml/SuiteDigest.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
 import java.util.TreeMap;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A canonical, human-readable dump of everything a suite file can express, used by the round trip
@@ -96,7 +97,7 @@ public final class SuiteDigest {
     }
   }
 
-  private static void appendGroups(StringBuilder sb, String prefix, XmlGroups groups) {
+  private static void appendGroups(StringBuilder sb, String prefix, @Nullable XmlGroups groups) {
     if (groups == null) {
       append(sb, prefix + ".groups", null);
       return;
@@ -144,7 +145,7 @@ public final class SuiteDigest {
     }
   }
 
-  private static void appendScript(StringBuilder sb, String prefix, XmlScript script) {
+  private static void appendScript(StringBuilder sb, String prefix, @Nullable XmlScript script) {
     if (script == null) {
       return;
     }
@@ -156,7 +157,7 @@ public final class SuiteDigest {
     return new TreeMap<>(map);
   }
 
-  private static void append(StringBuilder sb, String key, Object value) {
+  private static void append(StringBuilder sb, String key, @Nullable Object value) {
     sb.append(key).append('=').append(render(value)).append('\n');
   }
 
@@ -167,7 +168,7 @@ public final class SuiteDigest {
    * parameter valued {@code a,b}. Two different suites sharing a digest is a round trip test that
    * passes for the wrong reason, which is the one thing this class must not do.
    */
-  private static String render(Object value) {
+  private static String render(@Nullable Object value) {
     if (value instanceof Map) {
       StringJoiner rendered = new StringJoiner(", ", "{", "}");
       ((Map<?, ?>) value).forEach((k, v) -> rendered.add(render(k) + '=' + render(v)));
@@ -186,7 +187,7 @@ public final class SuiteDigest {
    * structure and never data. That is what makes the output unambiguous while keeping it readable
    * -- the point of the digest is that a difference shows up as a diff on a single line.
    */
-  private static String escape(Object value) {
+  private static String escape(@Nullable Object value) {
     StringBuilder result = new StringBuilder();
     for (char c : String.valueOf(value).toCharArray()) {
       if (c == '\\' || c == ',' || c == '=' || c == '[' || c == ']' || c == '{' || c == '}') {


### PR DESCRIPTION
Continues the JSpecify/NullAway stack. Base is `master` — #3382 merged while this was being
prepared, so this one stands alone. Rebasing dropped its commit as a duplicate rather than
reapplying it, and the merged version is byte-identical to the commit this was written on.

One package: `org.testng.xml` — the suite model, its parser and its weaver. 27 main files, 5112
lines, and the first batch where three things are true at once:

- it spans **three modules** — 17 files in `testng-core-api`, 9 in `testng-core`, 1 (`SuiteDigest`)
  in `testng-test-kit`, the last reached only through a `compileOnly` edge;
- 17 of those files are **published API**: `XmlSuite`, `XmlTest` and `XmlClass` are what users build
  suites with programmatically, so a `@Nullable` here is a published contract;
- the ripple lands in **ten packages that are already marked and merged**, so errors show up in
  shipped code — `org.testng.internal.invokers`, `xml.internal`, `reporters.jq`, `cli`,
  `cli.jcommander` and five others.

`org.testng.xml.internal` was marked in #3374. `@NullMarked` neither descends into sub-packages nor
climbs out of them, so that green said nothing about the parent.

## The coverage was proved in all three modules

`testng-core` declares `api(projects.testngCoreApi)` and `testng-test-kit` declares
`compileOnly(projects.testngCore)`, so the `package-info.java` goes in `testng-core-api`. The
`compileOnly` edge is the new variable: it puts `testng-core` *and its `api` dependencies* on the
compile classpath, but no `package-info.class` had ever been asked to travel it.

`testng-test-kit` is also easy to write off as out of scope — it is named "test-kit" and it is never
published — but the convention only disables NullAway for tasks whose **name** contains `Test`, and
its task is `compileJava`. It is under the check.

Per the procedure in `AGENTS.md`, the negative control runs once per module traversed. A throwaway

```java
private static Object nullAwayProbe() { return null; }
```

went into one file of each. Before the `package-info.java` all three compiled clean, zero NullAway.
After it all three failed with `[NullAway] returning @Nullable expression from method with @NonNull
return type`:

| module | reached via | probe fails at |
|---|---|---|
| `testng-core-api` | holds the `package-info.java` | `XmlUtils.java:9` |
| `testng-core` | `api(projects.testngCoreApi)` | `TestNGURLs.java:10` |
| `testng-test-kit` | `compileOnly(projects.testngCore)` | `SuiteDigest.java:23` |

All three reverted. The third row is the one that had to be measured rather than assumed, and it is
red — so a second `package-info.java` in `testng-test-kit` is not needed, and the counts below cover
the whole package. `SuiteDigest` then produced 16 real errors of its own, which is the same fact
arriving a second way.

## What the check reported

| | count |
|---|---|
| errors | **112** (44 `testng-core-api`, 51 `testng-core`, 16 `testng-test-kit`, 1 `testng-jcommander`) |
| `@Nullable` | 118 |
| of which (E) demanded by NullAway | **110** |
| of which demanded by the Kotlin compiler | **7** |
| of which (C) contract | **1** |
| `Objects.requireNonNull` | 31 |
| restructured instead of annotated | 10 |

**Every annotation is classified by deletion and recompilation** — each one stripped on its own and
the five modules force-recompiled, 111 times, then 79 of them a second time after the cleanup pass
below. 110 bring back a named NullAway error; the 7 Kotlin ones bring back a Kotlin error (see the
next section); 1 brings back nothing and is argued below. The files were copied to a separate
directory first, restored from that copy, and checked byte-identical per file afterwards.

Every number above comes from a forced recompile. The fast form —
`:testng-core-api:compileJava --rerun` and the four other modules by name — was validated once by
deleting an annotation known to be demanded and confirming the error came back.

## Restructured rather than annotated

The lazy `<groups>`/`<run>` initialisation was written four times in `XmlTest` and three times in
`XmlSuite`, each copy followed by `m_xmlGroups.getRun().getX()`. A private `groupsRun()` that returns
the `XmlRun` it just guaranteed replaces all of them and removes seven dereferences with no
annotation and no assertion.

The parser is the other half. `TestNGContentHandler` keeps eighteen `m_currentXxx` fields set at a
start tag and cleared at the matching end tag; seven accessors now read them, so the invariant is
stated once instead of at twenty-five call sites.

The rest: `XmlClass` drops a redundant `= null` on `m_name` (every constructor calls `init`, which
assigns it) and its three-argument `init` overload, which had one caller and hid the assignment from
NullAway's initializer analysis; `loadClass()` returns the class it resolved so `getSupportClass()`
needs no assertion; `XmlPackage.getXmlClasses` and `XmlTest.getInvocationNumbers` cache through a
local; and `XmlTest.equals` loses a two-armed condition whose second arm re-tested a value the line
above had already established, so only the first arm could ever fire.

## A `@Nullable` getter without its setter is a Kotlin source break

Seven setters here are annotated for a reason that has nothing to do with NullAway, and it is worth
recording because it will recur in every later batch that touches a bean.

Kotlin synthesises a mutable property from a Java getter/setter pair **only when the two agree on
nullability**. Annotate `getName()` `@Nullable` and leave `setName(String)` alone, and
`XmlPackage.name` silently stops being a `var` and becomes a `val` — so `XmlPackage().apply { name = p }`
no longer compiles. That is a source-incompatible change to published API, and this repository has a
Kotlin consumer of exactly that shape: `testng-test-kit/src/main/kotlin/test/SimpleBaseTest.kt`.

The pairs, all seven of them proved by a throwaway Kotlin file that assigns each property — with the
annotations it compiles, without them it reports 7 errors, one per line:

| class | property |
|---|---|
| `XmlDefine` | `name` |
| `XmlPackage` | `name` |
| `XmlGroups` | `run` |
| `XmlMethodSelector` | `className`, `script` |
| `XmlScript` | `expression` |
| `XmlTest` | `script` |

Each is truthful independently of Kotlin — every backing field is `@Nullable`, and `XmlTest.setScript`
already had an explicit `else if (script != null)` branch, so null was always its contract.

**The trap worth passing on:** `./gradlew build` does not catch this. Kotlin's incremental compilation
treats a type-use annotation change on the Java classpath as non-ABI, so `:testng-test-kit:compileKotlin`
runs, reports nothing, and stays green on code that cannot compile from clean. It took
`--rerun-tasks` to see it. The guard set for a batch that annotates a bean must include
`:testng-test-kit:compileKotlin --rerun-tasks`, not just the Java compiles.

## The one annotation without a compiler demand

`XmlSuite.FailurePolicy.getValidPolicy(@Nullable String policy)` — the **parameter**. Its return is
demanded twice over; the parameter is not, and it would be easy to read that as decoration.

The null is real and routine: `TestNGContentHandler:378` calls it with
`attributes.getValue("configfailurepolicy")`, which is null for every suite file that omits the
attribute — the normal case. NullAway cannot see it because `org.xml.sax.Attributes` is unannotated
and read optimistically. The body has tested `policy == null` on its first line since it was written.

Worth recording: `CliConfigurer:170` looked like the demanding caller and is not. It guards
`cli.configFailurePolicy != null` first, so NullAway sees a non-null value there.

## The ripple

Ten merged packages read this one. Four needed something:

- `org.testng.xml.internal` — `Parser:154` passes no stream when the suite is not a `file:` URL, so
  `IFileParser.parse`'s stream parameter is `@Nullable`. `SuiteXmlParser` then had to widen to match:
  NullAway does check that an implementation does not narrow a `@Nullable` interface parameter. It is
  reached either through `accept()`, which requires a `file:` scheme and so a stream, or as
  `Parser.getParser`'s fallback for a scheme nothing claims — which has never been readable here, so
  the `requireNonNull` is the throw that was already happening rather than a new precondition.
- `org.testng.reporters.jq` — `TestNgXmlPanel.getHeader` returns `XmlSuite.getFileName()`, absent for
  a suite built in code. `XMLStringBuffer.addOptional` already declares its value `@Nullable` and
  skips null, so the abstract `getHeader` in `BaseMultiSuitePanel` follows; the other six overrides
  stay non-null.
- `org.testng.cli.jcommander` — `Converter:70` derives an output name from `getFileName()`. Every
  suite it sees was read from a file and both readers set the name (`TestNGContentHandler` for XML,
  `Yaml` for YAML), which the `requireNonNull` records.
- `org.testng.internal.invokers` and the six others needed nothing.

One item for whoever takes the next batch: `YamlParser` (`testng-yaml`) and the test
`FakeHttpXmlParser` implement `IFileParser` with a non-`@Nullable` stream parameter. Both are in
unmarked packages so nothing checks them today, and both will report the narrowing the moment their
package is marked.

## Two latent NullPointerExceptions, recorded and not fixed

An `XmlGroups` on an `XmlTest` can have no `XmlRun` — `setGroups(new XmlGroups())` and `addMetaGroup`
both leave one that way — and two methods dereference `getRun()` without testing it:

| site | reproduction |
|---|---|
| `XmlTest.addIncludedGroup` | `t.addMetaGroup("m", List.of("a")); t.addIncludedGroup("g")` |
| `XmlTest.equals` | `t1.addExcludedGroup("x")` against `t2.setGroups(new XmlGroups())` |

Both were run against these sources and against the pre-change sources: same
`NullPointerException` either way, only the message differs. `addExcludedGroup`,
`setIncludedGroups` and `setExcludedGroups` all repair a missing `<run>`, and every `XmlSuite`
equivalent does too, so the asymmetry is `XmlTest`-only. Repairing it would turn a long-standing
throw into a silent success, which is a behaviour change and does not belong in this batch —
`requireNonNull` keeps the throw and makes the asymmetry compiler-visible. Filed as #3385.

Also noted, not reproducible from the suite: `XmlWeaver.getInstance()` returned null in test mode
when `-Dtestng.xml.weaver` names a third-party class, and the callers dereferenced it. TestNG's own
tests only ever select the two bundled weavers. And `XmlSuite.m_test` has no writer anywhere in the
repository, so `getTest()` has always returned null — annotated truthfully rather than removed, since
it is published API.

Residue left alone, as agreed for this stack: `== null` guards on values NullAway now proves
non-null, in `XmlClass.equals`/`hashCode` and `XmlInclude.equals`/`hashCode`.

## Verification

`./gradlew build --rerun-tasks`: **BUILD SUCCESSFUL**, `16854 completed, 0 failed, 12 skipped` — the
twelve are the pre-existing environment-dependent skips, unchanged from #3382. `--rerun-tasks` rather
than a plain `build` for the reason given in the Kotlin section: the plain form went green on a tree
that did not compile from clean. `autostyleApply` run as its own invocation.

No behaviour change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved XML parsing validation with clearer errors for missing input streams, suite declarations, and required suite filenames.
  - Added safer handling for optional XML configuration values and nullable headers.
  - Improved lazy initialization and access to suite, test, and group configuration.

- **Documentation**
  - Added comprehensive nullability information to XML configuration APIs.
  - Documented parser behavior for XML sources and optional configuration elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->