### PR TITLE
test(config): stop SuiteRunnerIssueTestSample from re-entering itself

### DIFF
--- a/testng-core/src/test/java/test/configuration/ConfigurationTest.java
+++ b/testng-core/src/test/java/test/configuration/ConfigurationTest.java
@@ -58,7 +58,7 @@ public class ConfigurationTest extends ConfigurationBaseTest {
     assertThat(asList(1, 2, 3, 4, 5)).isEqualTo(SuiteTestSample.m_order);
   }
 
-  @Test
+  @Test(description = "GITHUB-2743")
   public void testSuiteRunnerWithDefaultConfiguration() {
     TestNG testNG = create(SuiteRunnerIssueTestSample.class);
     testNG.run();

--- a/testng-core/src/test/java/test/configuration/issue2743/SuiteRunnerIssueNestedSample.java
+++ b/testng-core/src/test/java/test/configuration/issue2743/SuiteRunnerIssueNestedSample.java
@@ -1,0 +1,9 @@
+package test.configuration.issue2743;
+
+import org.testng.annotations.Test;
+
+public class SuiteRunnerIssueNestedSample {
+
+  @Test
+  public void nestedSample() {}
+}

--- a/testng-core/src/test/java/test/configuration/issue2743/SuiteRunnerIssueTestSample.java
+++ b/testng-core/src/test/java/test/configuration/issue2743/SuiteRunnerIssueTestSample.java
@@ -29,7 +29,7 @@ public class SuiteRunnerIssueTestSample {
     XmlTest test = new XmlTest(suite);
     test.setName("ChildTests");
     List<XmlClass> classes = new ArrayList<>();
-    classes.add(new XmlClass("test.configuration.issue2743.SuiteRunnerIssueTestSample"));
+    classes.add(new XmlClass(SuiteRunnerIssueNestedSample.class));
     test.setXmlClasses(classes);
 
     final IConfiguration configuration = new Configuration();


### PR DESCRIPTION
## Summary

`SuiteRunnerIssueTestSample` built a nested `XmlSuite` whose only `XmlClass` was itself. Running the sample re-entered `suiteRunnerSample` unbounded, hit `StackOverflowError` (sometimes inside `XMLStringBuffer`'s static initializer), and left `ConfigurationTest.testSuiteRunnerWithDefaultConfiguration` failing with status 1 when run in isolation.

The nested suite now points at a separate trivial sample so the `SuiteRunner` plus default listeners path from #2743 actually terminates.

Fixes #3360

## Test plan

- [x] `./gradlew :testng-core:test --tests test.configuration.ConfigurationTest.testSuiteRunnerWithDefaultConfiguration` — RED (`expected: 0 but was: 1`) then GREEN (1/1)
- [x] `./gradlew :testng-core:test --tests test.configuration.ConfigurationTest` — 19/19 GREEN
- [x] `./gradlew autostyleCheck` GREEN
- [x] `./gradlew rewriteDryRun` — recipes would make no changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved suite configuration coverage for nested test execution.
  * Updated suite setup to correctly register nested sample tests.
* **Tests**
  * Added coverage for nested suite runner scenarios.
  * Linked the relevant test case to issue GITHUB-2743.
  * Added a dedicated nested test sample to validate suite registration and execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->