### PR TITLE
refactor(reports): let TextReporter own its parameter snapshot

### DIFF
--- a/testng-core/src/main/java/org/testng/reporters/ParameterSnapshot.java
+++ b/testng-core/src/main/java/org/testng/reporters/ParameterSnapshot.java
@@ -1,0 +1,79 @@
+package org.testng.reporters;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.jspecify.annotations.Nullable;
+import org.testng.internal.Utils;
+
+/**
+ * What a reporter needs to remember about the values an invocation ran with: their rendered form,
+ * captured while the invocation was starting.
+ *
+ * <p>This is reporting state, not the arguments TestNG invoked the method with. It holds no
+ * reference to the invocation objects, so nothing that happens afterwards -- a data provider
+ * handing the same mutable row to every invocation, a test mutating what it was given -- can change
+ * what the reporter later prints. Keeping the rendering rather than a copy of the object is
+ * deliberate: it asks nothing of the user's type, where the historical {@code
+ * LegacyParameterSnapshotter} needs it to honour {@link Cloneable}.
+ *
+ * <p>The price is that {@link Object#toString()} runs as the invocation starts rather than when the
+ * report is written. See {@link ParameterSnapshots#capture} for what happens when it throws.
+ */
+final class ParameterSnapshot {
+
+  private final int suppliedCount;
+  private final int expectedCount;
+  private final List<String> renderedValues;
+
+  private ParameterSnapshot(int suppliedCount, int expectedCount, List<String> renderedValues) {
+    this.suppliedCount = suppliedCount;
+    this.expectedCount = expectedCount;
+    this.renderedValues = renderedValues;
+  }
+
+  /**
+   * @param parameters - The values an invocation ran with.
+   * @param parameterTypes - The types the method declares, which decide how a value is rendered.
+   * @return - The rendering of those values, or {@code null} when there is nothing to report.
+   */
+  static @Nullable ParameterSnapshot of(
+      Object @Nullable [] parameters, Class<?> @Nullable [] parameterTypes) {
+    if (parameters == null || parameterTypes == null || parameters.length == 0) {
+      return null;
+    }
+    if (parameters.length != parameterTypes.length) {
+      // A data provider supplied the wrong number of values: there is no type to render each value
+      // against. A reporter has both counts and reports the mismatch instead.
+      return new ParameterSnapshot(
+          parameters.length, parameterTypes.length, Collections.emptyList());
+    }
+    List<String> rendered = new ArrayList<>(parameters.length);
+    for (int i = 0; i < parameters.length; i++) {
+      rendered.add(Utils.toString(parameters[i], parameterTypes[i]));
+    }
+    return new ParameterSnapshot(
+        parameters.length, parameterTypes.length, Collections.unmodifiableList(rendered));
+  }
+
+  /**
+   * Whether the invocation received a different number of values than the method declares, which a
+   * reporter reports instead of the values -- there are none to report.
+   */
+  boolean hasCountMismatch() {
+    return suppliedCount != expectedCount;
+  }
+
+  int suppliedCount() {
+    return suppliedCount;
+  }
+
+  int expectedCount() {
+    return expectedCount;
+  }
+
+  /** The rendered values in invocation order. Empty when {@link #hasCountMismatch()}. */
+  List<String> renderedValues() {
+    return renderedValues;
+  }
+}

--- a/testng-core/src/main/java/org/testng/reporters/ParameterSnapshots.java
+++ b/testng-core/src/main/java/org/testng/reporters/ParameterSnapshots.java
@@ -1,0 +1,107 @@
+package org.testng.reporters;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.jspecify.annotations.Nullable;
+import org.testng.ITestContext;
+import org.testng.ITestResult;
+
+/**
+ * The {@link ParameterSnapshot} a reporter has captured, one per invocation it was told about.
+ *
+ * <p>Reporting owns this: it is filled from the invocation lifecycle a reporter already listens to,
+ * and it is disposable. A result whose snapshot is missing is not an error -- the reporter falls
+ * back to {@link ITestResult#getParameters()}, which is what it read before.
+ *
+ * <p>Results are held by identity. {@link ITestResult} is a public interface, so an implementation
+ * is free to define {@code equals()} in a way that makes two invocations of the same method with
+ * the same values indistinguishable, and reporting must not let that merge their snapshots.
+ *
+ * <p>One store per reporter is the shape of this slice, which migrates a single reporter. It is not
+ * the shape the rest of them should be migrated with: a store each would render every value once
+ * per reporter, running the user's {@code toString()} N times for one piece of information. The
+ * capture belongs upstream of the reporters, once per invocation and shared. Note for whoever
+ * writes it that {@link org.testng.IReporter} implementations -- {@code EmailableReporter2}, {@code
+ * XMLReporter}, {@code jq.Main} -- run after every context has finished, so a shared store cannot
+ * be discarded on {@code onFinish} the way this one is.
+ */
+final class ParameterSnapshots {
+
+  private final Map<ResultKey, ParameterSnapshot> snapshots = new ConcurrentHashMap<>();
+
+  /**
+   * Captures what {@code result} was invoked with, if there is anything worth keeping. Must be
+   * called from a lifecycle point the invocation has not run past yet.
+   *
+   * @param result - The result an invocation is starting with.
+   */
+  void capture(ITestResult result) {
+    ParameterSnapshot snapshot;
+    try {
+      snapshot =
+          ParameterSnapshot.of(result.getParameters(), result.getMethod().getParameterTypes());
+    } catch (Throwable rendering) {
+      // Rendering a value calls the user's toString(). One that throws would otherwise fail the
+      // invocation it is only being reported on; leaving the result unsnapshotted hands it back to
+      // ITestResult#getParameters(), where such a value has always thrown at reporting time.
+      return;
+    }
+    if (snapshot != null) {
+      snapshots.put(new ResultKey(result), snapshot);
+    }
+  }
+
+  /**
+   * @param result - The result being reported.
+   * @return - What was captured for it, or {@code null} if nothing was.
+   */
+  @Nullable
+  ParameterSnapshot find(ITestResult result) {
+    return snapshots.get(new ResultKey(result));
+  }
+
+  /**
+   * Drops what was captured for a result a reporter now knows it will never print. A configuration
+   * method that succeeded is the case that matters: it is announced like any other, but no reporter
+   * lists it, so its snapshot would otherwise sit here until the whole context is done.
+   *
+   * @param result - The result that will not be reported.
+   */
+  void discard(ITestResult result) {
+    snapshots.remove(new ResultKey(result));
+  }
+
+  /**
+   * Drops what was captured for a context that has finished reporting. Snapshots taken for the
+   * other contexts of a parallel run are left alone, since a reporter registered on the suite sees
+   * them all.
+   *
+   * @param context - The context whose results have been reported.
+   */
+  void discard(ITestContext context) {
+    snapshots.keySet().removeIf(key -> key.belongsTo(context));
+  }
+
+  private static final class ResultKey {
+
+    private final ITestResult result;
+
+    ResultKey(ITestResult result) {
+      this.result = result;
+    }
+
+    boolean belongsTo(ITestContext context) {
+      return result.getTestContext() == context;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      return other instanceof ResultKey && ((ResultKey) other).result == result;
+    }
+
+    @Override
+    public int hashCode() {
+      return System.identityHashCode(result);
+    }
+  }
+}

--- a/testng-core/src/main/java/org/testng/reporters/TextReporter.java
+++ b/testng-core/src/main/java/org/testng/reporters/TextReporter.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.jspecify.annotations.Nullable;
+import org.testng.IConfigurationListener;
 import org.testng.ITestContext;
 import org.testng.ITestListener;
 import org.testng.ITestNGMethod;
@@ -17,12 +18,13 @@ import org.testng.annotations.CustomAttribute;
 import org.testng.internal.Utils;
 
 /** A simple reporter that collects the results and prints them on standard out. */
-public class TextReporter implements ITestListener {
+public class TextReporter implements ITestListener, IConfigurationListener {
 
   private static final String LINE = "\n===============================================\n";
 
   private final int m_verbose;
   private final String m_testName;
+  private final ParameterSnapshots m_parameterSnapshots = new ParameterSnapshots();
 
   public TextReporter(String testName, int verbose) {
     m_testName = testName;
@@ -30,10 +32,47 @@ public class TextReporter implements ITestListener {
   }
 
   @Override
-  public void onFinish(ITestContext context) {
-    if (m_verbose >= 2) {
-      logResults(context);
+  public void onTestStart(ITestResult tr) {
+    captureParameters(tr);
+  }
+
+  @Override
+  public void beforeConfiguration(ITestResult tr) {
+    captureParameters(tr);
+  }
+
+  @Override
+  public void onConfigurationSuccess(ITestResult tr) {
+    // Only failed and skipped configurations are listed, so this one is never going to be printed.
+    m_parameterSnapshots.discard(tr);
+  }
+
+  /**
+   * Both lifecycle points run before the method body does, so what is captured here is what the
+   * invocation started with, whatever it later does to those values.
+   */
+  private void captureParameters(ITestResult tr) {
+    if (logsResults()) {
+      // Otherwise this reporter prints nothing, and rendering a value would run the user's
+      // toString() for output nobody asked for.
+      m_parameterSnapshots.capture(tr);
     }
+  }
+
+  @Override
+  public void onFinish(ITestContext context) {
+    try {
+      if (logsResults()) {
+        logResults(context);
+      }
+    } finally {
+      m_parameterSnapshots.discard(context);
+    }
+  }
+
+  /** Whether this reporter is verbose enough to print anything, and so to capture anything. */
+  private boolean logsResults() {
+    return m_verbose >= 2;
   }
 
   private static List<ITestNGMethod> resultsToMethods(Collection<ITestResult> results) {
@@ -56,8 +95,7 @@ public class TextReporter implements ITestListener {
           tr.getMethod().getDescription(),
           tr.getMethod().getAttributes(),
           stackTrace,
-          tr.getParameters(),
-          tr.getMethod().getParameterTypes());
+          reportedParametersOf(tr));
     }
 
     results = context.getSkippedConfigurations().getAllResults();
@@ -68,8 +106,7 @@ public class TextReporter implements ITestListener {
           tr.getMethod().getDescription(),
           tr.getMethod().getAttributes(),
           null,
-          tr.getParameters(),
-          tr.getMethod().getParameterTypes());
+          reportedParametersOf(tr));
     }
 
     results = context.getPassedTests().getAllResults();
@@ -137,8 +174,23 @@ public class TextReporter implements ITestListener {
         tr.getMethod().getDescription(),
         tr.getMethod().getAttributes(),
         stackTrace,
-        tr.getParameters(),
-        tr.getMethod().getParameterTypes());
+        reportedParametersOf(tr));
+  }
+
+  /**
+   * The values an invocation ran with, as this reporter saw them when it started.
+   *
+   * <p>Falls back to the result's own representation for the invocations announced before they were
+   * given their values, which leaves nothing to capture: the results {@code
+   * reportAllDataDrivenTestsAsSkipped} parameterizes after announcing them, and a configuration
+   * method skipped before its parameters were computed. Those keep reading through {@link
+   * org.testng.ITestResult#getParameters()}, exactly as every result did before.
+   */
+  private @Nullable ParameterSnapshot reportedParametersOf(ITestResult tr) {
+    ParameterSnapshot captured = m_parameterSnapshots.find(tr);
+    return captured != null
+        ? captured
+        : ParameterSnapshot.of(tr.getParameters(), tr.getMethod().getParameterTypes());
   }
 
   private void logExceptions(String status, List<ITestResult> results) {
@@ -165,33 +217,25 @@ public class TextReporter implements ITestListener {
       String description,
       CustomAttribute[] attributes,
       @Nullable String stackTrace,
-      Object[] params,
-      Class<?>[] paramTypes) {
+      @Nullable ParameterSnapshot params) {
     StringBuilder msg = new StringBuilder(name);
 
-    if (null != params && params.length > 0) {
+    if (null != params) {
       msg.append("(");
 
       // The error might be a data provider parameter mismatch, so make
       // a special case here
-      if (params.length != paramTypes.length) {
+      if (params.hasCountMismatch()) {
         msg.append(name)
             .append(": Wrong number of arguments were passed by ")
             .append("the Data Provider: found ")
-            .append(params.length)
+            .append(params.suppliedCount())
             .append(" but ")
             .append("expected ")
-            .append(paramTypes.length)
+            .append(params.expectedCount())
             .append(")");
       } else {
-        for (int i = 0; i < params.length; i++) {
-          if (i > 0) {
-            msg.append(", ");
-          }
-          msg.append(Utils.toString(params[i], paramTypes[i]));
-        }
-
-        msg.append(")");
+        msg.append(String.join(", ", params.renderedValues())).append(")");
       }
     }
     if (!Utils.isStringEmpty(description)) {

--- a/testng-core/src/test/java/org/testng/reporters/TextReporterTest.java
+++ b/testng-core/src/test/java/org/testng/reporters/TextReporterTest.java
@@ -9,29 +9,98 @@ import java.nio.charset.StandardCharsets;
 import org.testng.TestNG;
 import org.testng.annotations.Test;
 import org.testng.reporters.issue2725.TestClassSample;
+import org.testng.reporters.snapshot.ConfigurationParameterSample;
+import org.testng.reporters.snapshot.NonCloneableParameterSample;
+import org.testng.reporters.snapshot.ParallelParameterSample;
+import org.testng.reporters.snapshot.RenderingSample;
+import org.testng.reporters.snapshot.SkippedDataDrivenSample;
 import test.SimpleBaseTest;
+import test.reports.GitHub447Sample;
 
 public class TextReporterTest extends SimpleBaseTest {
   @Test(description = "GITHUB-2725")
   public void testCustomAttributes() {
-    TestNG testng = create(TestClassSample.class);
+    String content = report(TestClassSample.class);
+    String expected =
+        "Test Attributes: <code_name, [dragon_warrior-1]>, <code_name, "
+            + "[dragon_warrior-2]>, <code_name, [dragon_warrior-3]>, <code_name, [dragon_warrior-4]>,"
+            + " <code_name, [dragon_warrior-5]>, <code_name, [dragon_warrior-6]>, <code_name, "
+            + "[dragon_warrior-7]>, <code_name, [dragon_warrior-8]>, <code_name, [dragon_warrior-9]>,"
+            + " <code_name, [dragon_warrior-10]>";
+    assertThat(content).contains(expected);
+  }
+
+  @Test(description = "Ordinary parameters render as they always have")
+  public void parametersKeepTheirRenderingAndOrder() {
+    assertThat(report(RenderingSample.class)).contains("report(\"text\", 42, null)");
+  }
+
+  @Test(description = "GITHUB-447")
+  public void mutableCloneableParameterKeepsItsInvocationTimeValue() {
+    assertThat(report(GitHub447Sample.class))
+        .contains("add([], null, \"[null]\")")
+        .contains("add([null], dup, \"[null, dup]\")")
+        .contains("add([null, dup], dup, \"[null, dup, dup]\")")
+        .contains("add([null, dup, dup], str, \"[null, dup, dup, str]\")")
+        .contains("add([null, dup, dup, str], null, \"[null, dup, dup, str, null]\")");
+  }
+
+  @Test(
+      description =
+          "GITHUB-447: a mutable parameter no reflective clone can copy is still reported with the"
+              + " value its own invocation ran with")
+  public void mutableNonCloneableParameterKeepsItsInvocationTimeValue() {
+    assertThat(report(NonCloneableParameterSample.class))
+        .contains("report(invocation-1)")
+        .contains("report(invocation-2)")
+        .contains("report(invocation-3)")
+        .doesNotContain("report(invocation-4)");
+  }
+
+  @Test(description = "A configuration method is reported with what it was announced with")
+  public void configurationParametersKeepTheirInvocationTimeValue() {
+    assertThat(report(ConfigurationParameterSample.class))
+        .contains("prepare([before-configuration])")
+        .doesNotContain("prepare([mutated])");
+  }
+
+  @Test(description = "Snapshots stay with their own result when the invocations overlap")
+  public void parallelInvocationsDoNotShareSnapshots() {
+    String content = report(ParallelParameterSample.class);
+    for (int row = 0; row < ParallelParameterSample.ROWS; row++) {
+      assertThat(content).contains("report(row-" + row + ")");
+    }
+    assertThat(content).doesNotContain("report(mutated)");
+  }
+
+  @Test(
+      description =
+          "A result announced before it was given its values still reports them, through the"
+              + " result itself")
+  public void resultsWithNothingToSnapshotStillReportTheirParameters() {
+    TestNG testng = create(SkippedDataDrivenSample.class);
+    testng.setReportAllDataDrivenTestsAsSkipped(true);
+
+    assertThat(report(testng)).contains("skipped(\"first\")").contains("skipped(\"second\")");
+  }
+
+  /**
+   * Runs the class under a {@link TextReporter} verbose enough to log, and returns what it said.
+   */
+  private static String report(Class<?> testClass) {
+    return report(create(testClass));
+  }
+
+  private static String report(TestNG testng) {
     PrintStream currentStream = System.out;
     final Charset charset = StandardCharsets.UTF_8;
     try {
       ByteArrayOutputStream baos = new ByteArrayOutputStream();
       PrintStream ps = new PrintStream(baos, true, charset);
       System.setOut(ps);
-      TextReporter reporter = new TextReporter("Example_Test", 2);
-      testng.addListener(reporter);
+      testng.addListener(new TextReporter("Example_Test", 2));
       testng.run();
-      String content = baos.toString(charset);
-      String expected =
-          "Test Attributes: <code_name, [dragon_warrior-1]>, <code_name, "
-              + "[dragon_warrior-2]>, <code_name, [dragon_warrior-3]>, <code_name, [dragon_warrior-4]>,"
-              + " <code_name, [dragon_warrior-5]>, <code_name, [dragon_warrior-6]>, <code_name, "
-              + "[dragon_warrior-7]>, <code_name, [dragon_warrior-8]>, <code_name, [dragon_warrior-9]>,"
-              + " <code_name, [dragon_warrior-10]>";
-      assertThat(content).contains(expected);
+      return baos.toString(charset);
     } finally {
       System.setOut(currentStream);
     }

--- a/testng-core/src/test/java/org/testng/reporters/snapshot/ConfigurationParameterSample.java
+++ b/testng-core/src/test/java/org/testng/reporters/snapshot/ConfigurationParameterSample.java
@@ -1,0 +1,28 @@
+package org.testng.reporters.snapshot;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * A configuration method that is handed the values its test method will run with, mutates them, and
+ * then fails -- so a reporter has to have kept what it was announced with to report it.
+ */
+public class ConfigurationParameterSample {
+
+  private static final MutableParameter SHARED = new MutableParameter("before-configuration");
+
+  @DataProvider(name = "shared")
+  public static Object[][] shared() {
+    return new Object[][] {{SHARED}};
+  }
+
+  @BeforeMethod
+  public void prepare(Object[] parameters) {
+    ((MutableParameter) parameters[0]).set("mutated");
+    throw new IllegalStateException("this configuration method fails on purpose");
+  }
+
+  @Test(dataProvider = "shared")
+  public void report(MutableParameter parameter) {}
+}

--- a/testng-core/src/test/java/org/testng/reporters/snapshot/MutableParameter.java
+++ b/testng-core/src/test/java/org/testng/reporters/snapshot/MutableParameter.java
@@ -1,0 +1,23 @@
+package org.testng.reporters.snapshot;
+
+/**
+ * A parameter a test can change under a reporter's feet: mutable, and nothing else -- in particular
+ * not {@link Cloneable}, so the historical clone-if-{@code Cloneable} rule cannot help.
+ */
+public final class MutableParameter {
+
+  private String value;
+
+  MutableParameter(String value) {
+    this.value = value;
+  }
+
+  void set(String value) {
+    this.value = value;
+  }
+
+  @Override
+  public String toString() {
+    return value;
+  }
+}

--- a/testng-core/src/test/java/org/testng/reporters/snapshot/NonCloneableParameterSample.java
+++ b/testng-core/src/test/java/org/testng/reporters/snapshot/NonCloneableParameterSample.java
@@ -1,0 +1,29 @@
+package org.testng.reporters.snapshot;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * A data provider that hands the same mutable object to every invocation, each of which leaves it
+ * holding the value the next one is expected to report.
+ *
+ * <p>{@link MutableParameter} is not {@link Cloneable}, so the historical {@code
+ * LegacyParameterSnapshotter} cannot help: by the time a reporter reads {@code
+ * ITestResult#getParameters()}, every result points at the same object in its final state.
+ */
+public class NonCloneableParameterSample {
+
+  private int invocation = 1;
+
+  @DataProvider(name = "shared")
+  public static Object[][] shared() {
+    MutableParameter parameter = new MutableParameter("invocation-1");
+    return new Object[][] {{parameter}, {parameter}, {parameter}};
+  }
+
+  @Test(dataProvider = "shared")
+  public void report(MutableParameter parameter) {
+    invocation++;
+    parameter.set("invocation-" + invocation);
+  }
+}

--- a/testng-core/src/test/java/org/testng/reporters/snapshot/ParallelParameterSample.java
+++ b/testng-core/src/test/java/org/testng/reporters/snapshot/ParallelParameterSample.java
@@ -1,0 +1,36 @@
+package org.testng.reporters.snapshot;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Every row gets its own mutable object, and no invocation mutates its own until all of them are in
+ * flight. A reporter that mixed up which snapshot belongs to which result would report a value some
+ * other invocation ran with, or the mutated one.
+ */
+public class ParallelParameterSample {
+
+  public static final int ROWS = 4;
+
+  private static final CountDownLatch ALL_STARTED = new CountDownLatch(ROWS);
+
+  @DataProvider(name = "rows", parallel = true)
+  public static Object[][] rows() {
+    Object[][] rows = new Object[ROWS][1];
+    for (int i = 0; i < ROWS; i++) {
+      rows[i][0] = new MutableParameter("row-" + i);
+    }
+    return rows;
+  }
+
+  @Test(dataProvider = "rows")
+  public void report(MutableParameter parameter) throws InterruptedException {
+    ALL_STARTED.countDown();
+    // A timeout rather than a plain await: should the rows not run concurrently, the sample
+    // degrades to a sequential one instead of hanging, and still asserts what it is here for.
+    ALL_STARTED.await(30, TimeUnit.SECONDS);
+    parameter.set("mutated");
+  }
+}

--- a/testng-core/src/test/java/org/testng/reporters/snapshot/RenderingSample.java
+++ b/testng-core/src/test/java/org/testng/reporters/snapshot/RenderingSample.java
@@ -1,0 +1,16 @@
+package org.testng.reporters.snapshot;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/** The ordinary parameter shapes a reporter renders: a quoted string, a number, and a null. */
+public class RenderingSample {
+
+  @DataProvider(name = "values")
+  public static Object[][] values() {
+    return new Object[][] {{"text", 42, null}};
+  }
+
+  @Test(dataProvider = "values")
+  public void report(String text, int number, Object nothing) {}
+}

--- a/testng-core/src/test/java/org/testng/reporters/snapshot/SkippedDataDrivenSample.java
+++ b/testng-core/src/test/java/org/testng/reporters/snapshot/SkippedDataDrivenSample.java
@@ -1,0 +1,25 @@
+package org.testng.reporters.snapshot;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Under {@code reportAllDataDrivenTestsAsSkipped}, a data-driven method skipped by a dependency
+ * gets one result per row -- announced before it is given its values, so there is nothing for a
+ * reporter to capture and it has to fall back to reading the result.
+ */
+public class SkippedDataDrivenSample {
+
+  @Test
+  public void failing() {
+    throw new IllegalStateException("this test fails on purpose");
+  }
+
+  @DataProvider(name = "rows")
+  public static Object[][] rows() {
+    return new Object[][] {{"first"}, {"second"}};
+  }
+
+  @Test(dataProvider = "rows", dependsOnMethods = "failing")
+  public void skipped(String row) {}
+}


### PR DESCRIPTION
Stacked on #3401 — review that one first. The diff against its branch is two new reporting classes, the `TextReporter` change, and its tests.

## Problem

`TestResult#setParameters` has cloned every `Cloneable` parameter since GITHUB-447: a reporter reads a result long after the invocation ended, and a data provider that hands the same mutable row to every invocation would otherwise be reported in its final state. #3401 gave that rule a name — `LegacyParameterSnapshotter` — and called it what it is, a compatibility layer. What the name describes is still true:

- execution state is shaped by a reporting requirement;
- a parameter the rule cannot copy — anything not `Cloneable`, or that merely inherits `clone()` — is still reported with the value it ended up with rather than the one it ran with.

This PR builds the reporting half of the target architecture, on one reporter, deliberately:

```
                      ┌─ ITestResult ─ LegacyParameterSnapshotter ─> every other reporter
invocation params ────┤
                      └─ invocation lifecycle ─ reporting snapshot ─> TextReporter
```

## Where the snapshot is captured, and why that point is safe

`TextReporter` already implements `ITestListener`; it now also implements `IConfigurationListener`, as `VerboseReporter` does, and captures in:

- **`onTestStart`** — `TestInvoker` builds the result with its parameters (`TestResult.newTestResult`), sets `STARTED`, and only then runs the listeners, all before the method body;
- **`beforeConfiguration`** — `ConfigInvoker` calls `testResult.setParameters(...)` immediately before `runConfigurationListeners(..., before = true)`, again before the method body.

`TestRunner.addListener` already routes an `IConfigurationListener` to `addConfigurationListener`, so registration is unchanged. No new hook, no event bus, and the runner learns nothing about `TextReporter`.

Two kinds of invocation are announced *before* they are given their values, which leaves nothing to capture; they keep reading through `ITestResult#getParameters()`, exactly as every result did before:

- the results `reportAllDataDrivenTestsAsSkipped` parameterizes after announcing them (`registerSkippedTestResult` then `result.setParameters(...)`, `TestInvoker:164-167`);
- a configuration method skipped before its parameters were computed (`ConfigInvoker:308-317` announces it, `:351` is where the values would have come from).

## The representation

`ParameterSnapshot` (package-private, `org.testng.reporters`) is immutable and holds the *rendering*, not the objects: the supplied and expected counts, plus the values already run through the `Utils.toString(value, type)` the reporter called anyway. It is deliberately **not** a second clone-if-`Cloneable` mechanism, which would only move the problem: strings ask nothing of the user's type and retain no invocation object.

`ParameterSnapshots` is the reporter's own store. Nothing is written to `ITestResult` — no attribute, no internal field — so none of this is publicly observable or user-modifiable.

Naming keeps the distinction explicit: these are reporting snapshots, disposable reporting state, not the arguments the method was invoked with.

## Parallel execution

- Results are keyed **by identity** (`==` plus `System.identityHashCode`), never by `equals()`: `ITestResult` is a public interface and an implementation is free to make two invocations of the same method with the same values compare equal.
- The store is a `ConcurrentHashMap`; capture happens on the invocation's own thread, reading only that invocation's result.
- Snapshots are dropped as soon as they cannot be printed: per result on `onConfigurationSuccess` (only failed and skipped configurations are listed, and `@BeforeMethod`/`@AfterMethod` invocations are the most frequent events in a run), and on `onFinish` for the finished context **only** — so a reporter instance registered on the suite and shared by parallel `<test>` runs does not wipe another context's snapshots mid-run.
- Below verbose 2 nothing is captured at all: the reporter prints nothing there, and running the user's `toString()` for output nobody asked for would be pure cost.

## Tests

`TextReporterTest` runs each sample under a `TextReporter` and asserts what it printed:

| test | proves |
| --- | --- |
| `mutableNonCloneableParameterKeepsItsInvocationTimeValue` | **the point of the PR**: a mutable parameter that no reflective `clone()` can copy is reported with its own invocation's value |
| `mutableCloneableParameterKeepsItsInvocationTimeValue` | the GITHUB-447 guarantee still holds through the reporter |
| `configurationParametersKeepTheirInvocationTimeValue` | a configuration method that mutates what it was handed and then fails is reported with what it was announced with |
| `parallelInvocationsDoNotShareSnapshots` | four rows held in flight together by a latch each report their own value |
| `parametersKeepTheirRenderingAndOrder` | ordinary parameters — quoted string, number, `null`, order — render exactly as before |
| `resultsWithNothingToSnapshotStillReportTheirParameters` | pins the fallback: under `reportAllDataDrivenTestsAsSkipped`, results announced before they were given their values still print them |
| `testCustomAttributes` | unchanged GITHUB-2725 coverage |

Reverting only the lookup in `TextReporter` (falling back to `ITestResult#getParameters()` for every result) turns three of them red — the non-cloneable one, the configuration one and the parallel one — and leaves the other four green; removing only the fallback turns exactly one red, the one that pins it. That is the split the PR is after: reporter correctness no longer follows from `LegacyParameterSnapshotter` cloning.

`test.reports.ReportTest` (GITHUB-447), `test.inject.issue1994.IssueTest` and `org.testng.internal.TestResultParametersTest` are untouched and green.

## Compatibility

- No public API changes: no new interface, no new annotation, nothing added to the OSGi surface. `ITestResult`, `ITestListener`, `IReporter`, `IConfigurationListener` and `LegacyParameterSnapshotter` are untouched, and `ITestResult#getParameters()` still exposes the historical representation to third-party code and to every other built-in reporter.
- The one observable change, for `TextReporter` at verbose ≥ 2 only: **`toString()` now runs as the invocation starts rather than when the report is written.** So a value that mutates afterwards — an injected `XmlTest` included, now that #3401 keeps it by reference — is reported as it was at invocation time. That is the intended behaviour, and the reason this reporter can now be correct without cloning.
- A `toString()` that throws leaves the result unsnapshotted and hands it back to the legacy path, where such a value has always thrown at reporting time. The invocation is not failed for the sake of its own report.

## Next

1. **Make the snapshot a shared reporting datum before migrating anything else.** One store per reporter is right for a one-reporter slice and wrong as a pattern: giving `VerboseReporter` its own `new ParameterSnapshots()` would run every user `toString()` twice, and N reporters would run it N times for one piece of information. The capture belongs upstream of the reporters, once per invocation, shared by the internal ones. Two constraints for that design: it must be visible from `org.testng.reporters.jq` (so package-private in `org.testng.reporters` no longer does — `org.testng.internal` is the honest home), and `IReporter` implementations (`EmailableReporter2`, `XMLReporter`, `jq.Main`) run *after* every context has finished, so a shared store cannot be discarded on `onFinish` the way this one is. `ParameterSnapshots`' javadoc carries this note so the shape is not copied by accident.
2. Then migrate the remaining reporters onto it. `VerboseReporter` still inlines the same rendering rule (`VerboseReporter:185-204`), so the "wrong number of arguments" decision currently lives in two files in this package. `FailedReporter` is out of scope by construction — it needs the parameter *objects*, not their rendering.
3. Fix the announce-before-parameters ordering at its source. `TestInvoker:164-167` calls `registerSkippedTestResult` — which announces the result — and only then `setParameters`, while the four-arg overload of that same method already does it the other way round (`:952-957`). Passing the values in would make the fallback here unnecessary, and would also stop third-party `ITestListener`s from seeing a parameterless result in `onTestStart`. Left out deliberately: it changes execution, not reporting.
4. Confirm no internal reporter depends on the legacy `ITestResult` cloning.
5. Only then consider changing the historical cloning, with a major-version compatibility strategy.

## Verification

`./gradlew build` — BUILD SUCCESSFUL, 17064 tests in `testng-core`, 0 failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text reports to preserve parameter values as they appeared when each test or configuration ran.
  * Maintained parameter order and formatting, including null values and mismatched parameter counts.
  * Ensured accurate reporting for mutable parameters, parallel data-driven tests, configuration methods, and skipped results.
* **Tests**
  * Added coverage for parameter rendering, invocation-time values, parallel execution, configuration parameters, and skipped data-driven results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->