### PR TITLE
refactor(reports): let VerboseReporter read the shared parameter snapshot

### DIFF
--- a/testng-core/src/main/java/org/testng/SuiteRunner.java
+++ b/testng-core/src/main/java/org/testng/SuiteRunner.java
@@ -207,9 +207,10 @@ public class SuiteRunner implements ISuite, ISuiteRunnerListener {
               this.holder);
 
       // One recorder for the whole suite, on every runner. Registered through the narrow methods
-      // rather than addListener(), which would fan it back out over the suite.
-      tr.addTestListener(parameterSnapshotRecorder);
-      tr.addConfigurationListener(parameterSnapshotRecorder);
+      // rather than addListener(), which would fan it back out over the suite, and ahead of the
+      // listeners the runner was given: they are the ones that read what it records.
+      tr.addInternalTestListener(parameterSnapshotRecorder);
+      tr.addInternalConfigurationListener(parameterSnapshotRecorder);
 
       //
       // Install the method interceptor, if any was passed

--- a/testng-core/src/main/java/org/testng/TestRunner.java
+++ b/testng-core/src/main/java/org/testng/TestRunner.java
@@ -89,7 +89,13 @@ public class TestRunner
   /** ITestListeners support. */
   private final List<ITestListener> m_testListeners = new ArrayList<>();
 
-  private final Set<IConfigurationListener> m_configurationListeners = new LinkedHashSet<>();
+  /**
+   * Ordered, not a set: registration order decides dispatch order, and what may be registered twice
+   * is settled by the class check in {@link #insertConfigurationListener} -- which is stricter than
+   * a set's, and which {@link #getConfigurationListeners()} applies once more on the way out.
+   */
+  private final List<IConfigurationListener> m_configurationListeners = new ArrayList<>();
+
   private final Set<IExecutionVisualiser> visualisers = new HashSet<>();
 
   private final IConfigurationListener m_confListener = new ConfigurationListener();
@@ -1090,11 +1096,31 @@ public class TestRunner
   // TODO: This method needs to be removed and we need to be leveraging addListener().
   // Investigate and fix this.
   void addTestListener(ITestListener listener) {
+    insertTestListener(listener, m_testListeners.size());
+  }
+
+  /**
+   * Registers one of TestNG's own listeners ahead of the ones it was given, because what it records
+   * is what the others read. {@code onTestStart} is dispatched in registration order, and
+   * everything a runner is handed is appended, so a listener added like the rest would be told an
+   * invocation is starting only once every reporter had already looked for what it was supposed to
+   * have recorded.
+   *
+   * <p>Only the position differs from {@link #addTestListener}: a {@link ListenerComparator} is
+   * applied to the whole list afterwards and can still move it.
+   *
+   * @param listener - An internal listener the other listeners depend on.
+   */
+  void addInternalTestListener(ITestListener listener) {
+    insertTestListener(listener, 0);
+  }
+
+  private void insertTestListener(ITestListener listener, int index) {
     boolean found =
         m_testListeners.stream()
             .anyMatch(iTestListener -> iTestListener.getClass().equals(listener.getClass()));
     if (!found) {
-      m_testListeners.add(listener);
+      m_testListeners.add(index, listener);
     }
   }
 
@@ -1142,10 +1168,29 @@ public class TestRunner
   }
 
   void addConfigurationListener(IConfigurationListener icl) {
+    insertConfigurationListener(icl, m_configurationListeners.size());
+  }
+
+  /**
+   * The {@link #addInternalTestListener} of configuration listeners: {@code beforeConfiguration} is
+   * dispatched in registration order too, so a listener the others read has to come first.
+   *
+   * <p>Being first here also means being last once {@code
+   * TestListenerHelper#runPostConfigurationListeners} reverses the order, which is where it
+   * belongs: whatever an internal listener drops about a finished configuration, it drops after the
+   * reporters have had it.
+   *
+   * @param icl - An internal listener the other listeners depend on.
+   */
+  void addInternalConfigurationListener(IConfigurationListener icl) {
+    insertConfigurationListener(icl, 0);
+  }
+
+  private void insertConfigurationListener(IConfigurationListener icl, int index) {
     boolean alreadyAdded =
         m_configurationListeners.stream().anyMatch(each -> each.getClass().equals(icl.getClass()));
     if (!alreadyAdded) {
-      m_configurationListeners.add(icl);
+      m_configurationListeners.add(index, icl);
     }
   }
 

--- a/testng-core/src/main/java/org/testng/internal/reporters/ParameterSnapshotRecorder.java
+++ b/testng-core/src/main/java/org/testng/internal/reporters/ParameterSnapshotRecorder.java
@@ -19,8 +19,9 @@ import org.testng.ITestResult;
  *       before it runs the configuration listeners.
  * </ul>
  *
- * <p>It is installed on every {@code TestRunner} of the suite as an ordinary listener, so no
- * invoker has to know that reporting snapshots exist.
+ * <p>It is installed on every {@code TestRunner} of the suite as a listener, so no invoker has to
+ * know that reporting snapshots exist -- ahead of the ones the runner was given, since a reporter
+ * being told that an invocation is starting has to find its snapshot already taken.
  */
 public final class ParameterSnapshotRecorder implements ITestListener, IConfigurationListener {
 
@@ -42,7 +43,9 @@ public final class ParameterSnapshotRecorder implements ITestListener, IConfigur
 
   @Override
   public void onConfigurationSuccess(ITestResult result) {
-    // Only failed and skipped configurations are listed, so this one is never going to be printed.
+    // Only failed and skipped configurations are listed, so nothing will read this one again -- and
+    // the reporters that print a configuration as it passes already have: a configuration finishing
+    // is dispatched in reverse, which makes this listener, registered first, the last one told.
     snapshots.discard(result);
   }
 }

--- a/testng-core/src/main/java/org/testng/internal/reporters/ParameterSnapshots.java
+++ b/testng-core/src/main/java/org/testng/internal/reporters/ParameterSnapshots.java
@@ -86,6 +86,25 @@ public final class ParameterSnapshots {
   }
 
   /**
+   * The same, for a reporter that has a suite rather than a store: a suite without one is a suite
+   * whose snapshots nobody is going to take, which is not the reporter's business.
+   *
+   * <p>Call it from {@link org.testng.ITestListener#onStart(org.testng.ITestContext)}, which is
+   * early enough: a context starts before its own {@code @BeforeTest} configurations and before any
+   * of its invocations. The only thing announced earlier is a suite level configuration method, and
+   * those are handed no injected value at all -- only {@code @Parameters} strings, which read the
+   * same whenever they are rendered.
+   *
+   * @param suite - The suite about to run the invocations the caller will report.
+   */
+  public static void requestCaptureFor(@Nullable ISuite suite) {
+    ParameterSnapshots snapshots = of(suite);
+    if (snapshots != null) {
+      snapshots.requestCapture();
+    }
+  }
+
+  /**
    * Captures what {@code result} was invoked with, unless it already has been. Must be called from
    * a lifecycle point the invocation has not run past yet.
    *
@@ -129,12 +148,37 @@ public final class ParameterSnapshots {
   }
 
   /**
-   * Drops what was captured for a result no reporter will print -- a configuration method that
-   * succeeded, which is announced like any other but listed by nobody. Guarded like {@link
-   * #captureIfAbsent}: {@code @BeforeMethod} / {@code @AfterMethod} invocations are the most
-   * frequent events in a run, and there is nothing to drop when nothing is being captured.
+   * What a reporter prints for a result: the values its invocation ran with, as TestNG captured
+   * them when it started.
    *
-   * @param result - The result that will not be reported.
+   * <p>Falls back to the result's own representation for the invocations announced before they were
+   * given their values, which leaves nothing to capture: the results {@code
+   * reportAllDataDrivenTestsAsSkipped} parameterizes after announcing them, and a configuration
+   * method skipped before its parameters were computed. Those keep reading through {@link
+   * ITestResult#getParameters()}, exactly as every result did before -- as does a result from a
+   * suite that has no snapshots at all.
+   *
+   * @param snapshots - The store of the suite being reported, or {@code null} if it has none.
+   * @param result - The result being reported.
+   * @return - Its rendering, or {@code null} when there is nothing to report.
+   */
+  public static @Nullable ParameterSnapshot reportedParametersOf(
+      @Nullable ParameterSnapshots snapshots, ITestResult result) {
+    ParameterSnapshot captured = snapshots != null ? snapshots.find(result) : null;
+    return captured != null
+        ? captured
+        : ParameterSnapshot.of(result.getParameters(), result.getMethod().getParameterTypes());
+  }
+
+  /**
+   * Drops what was captured for a result nothing will be reported about anymore -- a configuration
+   * method that succeeded, which no reporter lists once the run is over. It is the caller's
+   * business to know that the live reporters are done with it; see {@link
+   * ParameterSnapshotRecorder#onConfigurationSuccess}. Guarded like {@link #captureIfAbsent}:
+   * {@code @BeforeMethod} / {@code @AfterMethod} invocations are the most frequent events in a run,
+   * and there is nothing to drop when nothing is being captured.
+   *
+   * @param result - The result nothing will be reported about anymore.
    */
   public void discard(ITestResult result) {
     if (!captureRequested) {

--- a/testng-core/src/main/java/org/testng/reporters/TextReporter.java
+++ b/testng-core/src/main/java/org/testng/reporters/TextReporter.java
@@ -34,19 +34,11 @@ public class TextReporter implements ITestListener {
   /**
    * Below verbose 2 this reporter prints nothing, so it asks for the suite's snapshots only when it
    * will read them.
-   *
-   * <p>Early enough: a context starts before its own {@code @BeforeTest} configurations and before
-   * any of its invocations. The only thing announced earlier is a suite level configuration method,
-   * and those are handed no injected value at all -- only {@code @Parameters} strings, which read
-   * the same whenever they are rendered.
    */
   @Override
   public void onStart(ITestContext context) {
     if (logsResults()) {
-      ParameterSnapshots snapshots = ParameterSnapshots.of(context.getSuite());
-      if (snapshots != null) {
-        snapshots.requestCapture();
-      }
+      ParameterSnapshots.requestCaptureFor(context.getSuite());
     }
   }
 
@@ -86,7 +78,7 @@ public class TextReporter implements ITestListener {
           method.getDescription(),
           method.getAttributes(),
           stackTrace,
-          reportedParametersOf(snapshots, tr));
+          ParameterSnapshots.reportedParametersOf(snapshots, tr));
     }
 
     results = context.getSkippedConfigurations().getAllResults();
@@ -98,7 +90,7 @@ public class TextReporter implements ITestListener {
           method.getDescription(),
           method.getAttributes(),
           null,
-          reportedParametersOf(snapshots, tr));
+          ParameterSnapshots.reportedParametersOf(snapshots, tr));
     }
 
     results = context.getPassedTests().getAllResults();
@@ -171,25 +163,7 @@ public class TextReporter implements ITestListener {
         method.getDescription(),
         method.getAttributes(),
         stackTrace,
-        reportedParametersOf(snapshots, tr));
-  }
-
-  /**
-   * The values an invocation ran with, as TestNG captured them when it started.
-   *
-   * <p>Falls back to the result's own representation for the invocations announced before they were
-   * given their values, which leaves nothing to capture: the results {@code
-   * reportAllDataDrivenTestsAsSkipped} parameterizes after announcing them, and a configuration
-   * method skipped before its parameters were computed. Those keep reading through {@link
-   * org.testng.ITestResult#getParameters()}, exactly as every result did before -- as does a result
-   * from a suite that has no snapshots at all.
-   */
-  private @Nullable ParameterSnapshot reportedParametersOf(
-      @Nullable ParameterSnapshots snapshots, ITestResult tr) {
-    ParameterSnapshot captured = snapshots != null ? snapshots.find(tr) : null;
-    return captured != null
-        ? captured
-        : ParameterSnapshot.of(tr.getParameters(), tr.getMethod().getParameterTypes());
+        ParameterSnapshots.reportedParametersOf(snapshots, tr));
   }
 
   private void logExceptions(

--- a/testng-core/src/main/java/org/testng/reporters/VerboseReporter.java
+++ b/testng-core/src/main/java/org/testng/reporters/VerboseReporter.java
@@ -12,6 +12,8 @@ import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
 import org.testng.annotations.CustomAttribute;
 import org.testng.internal.Utils;
+import org.testng.internal.reporters.ParameterSnapshot;
+import org.testng.internal.reporters.ParameterSnapshots;
 
 /**
  * Reporter printing out detailed messages about what TestNG is going to run and what is the status
@@ -94,9 +96,15 @@ public class VerboseReporter implements IConfigurationListener, ITestListener {
     logTestResult(Status.SUCCESS, tr, false);
   }
 
+  /**
+   * This reporter prints every invocation it is told about, so it always reads the suite's
+   * snapshots and asks for them unconditionally -- where {@link TextReporter} only does so above
+   * verbose 2.
+   */
   @Override
   public void onStart(ITestContext ctx) {
     suiteName = ctx.getName();
+    ParameterSnapshots.requestCaptureFor(ctx.getSuite());
     log(
         "RUNNING: Suite: \""
             + suiteName
@@ -182,24 +190,18 @@ public class VerboseReporter implements IConfigurationListener, ITestListener {
     ITestNGMethod tm = itr.getMethod();
     int identLevel = sb.length();
     sb.append(getMethodDeclaration(tm));
-    Object[] params = itr.getParameters();
-    Class<?>[] paramTypes = tm.getParameterTypes();
-    if (null != params && params.length > 0) {
+    ParameterSnapshot params = reportedParametersOf(itr);
+    if (null != params) {
       // The error might be a data provider parameter mismatch, so make
       // a special case here
-      if (params.length != paramTypes.length) {
+      if (params.hasCountMismatch()) {
         sb.append("Wrong number of arguments were passed by the Data Provider: found ");
-        sb.append(params.length);
+        sb.append(params.suppliedCount());
         sb.append(" but expected ");
-        sb.append(paramTypes.length);
+        sb.append(params.expectedCount());
       } else {
         sb.append("(value(s): ");
-        for (int i = 0; i < params.length; i++) {
-          if (i > 0) {
-            sb.append(", ");
-          }
-          sb.append(Utils.toString(params[i], paramTypes[i]));
-        }
+        sb.append(String.join(", ", params.renderedValues()));
         sb.append(")");
       }
     }
@@ -243,6 +245,20 @@ public class VerboseReporter implements IConfigurationListener, ITestListener {
       sb.append("\n").append(text);
     }
     log(sb.toString());
+  }
+
+  /**
+   * Looked up per result: printing as a run happens, there is no one moment to resolve a store.
+   *
+   * <p>A result carries no context when it was built outside one -- the parameter carrier a
+   * configuration method is handed, which exists before the invocation it reports on is bound to a
+   * context. There is no suite to ask, so such a result reads through itself, like any other the
+   * snapshots have nothing for.
+   */
+  private static @Nullable ParameterSnapshot reportedParametersOf(ITestResult itr) {
+    ITestContext context = itr.getTestContext();
+    return ParameterSnapshots.reportedParametersOf(
+        context != null ? ParameterSnapshots.of(context.getSuite()) : null, itr);
   }
 
   protected void log(String message) {

--- a/testng-core/src/test/java/org/testng/internal/reporters/ParameterSnapshotsTest.java
+++ b/testng-core/src/test/java/org/testng/internal/reporters/ParameterSnapshotsTest.java
@@ -15,8 +15,8 @@ import org.testng.annotations.Test;
 import org.testng.internal.TestResult;
 
 /**
- * The store on its own, with results built by hand: no TestNG run, so nothing but this test ever
- * touches the values it counts renderings of.
+ * The store and what it holds, on their own, with results built by hand: no TestNG run, so nothing
+ * but this test ever touches the values it counts renderings of.
  */
 public class ParameterSnapshotsTest {
 
@@ -81,6 +81,26 @@ public class ParameterSnapshotsTest {
     snapshots.discard(result);
 
     assertThat(snapshots.find(result)).isNull();
+  }
+
+  @Test(
+      description =
+          "A data provider that supplied the wrong number of values leaves the counts to report"
+              + " instead of the values")
+  public void aCountMismatchIsReportedInsteadOfTheValues() {
+    CountingParameter parameter = new CountingParameter("value");
+
+    ParameterSnapshot snapshot =
+        requireNonNull(
+            ParameterSnapshot.of(
+                new Object[] {parameter, parameter}, new Class<?>[] {Object.class}));
+
+    assertThat(snapshot.hasCountMismatch()).isTrue();
+    assertThat(snapshot.suppliedCount()).isEqualTo(2);
+    assertThat(snapshot.expectedCount()).isEqualTo(1);
+    assertThat(snapshot.renderedValues()).isEmpty();
+    // There is no type to render a value against, so nothing was rendered.
+    assertThat(parameter.renderings()).isZero();
   }
 
   private static ParameterSnapshots requestedSnapshots() {

--- a/testng-core/src/test/java/org/testng/reporters/ReportedOutput.java
+++ b/testng-core/src/test/java/org/testng/reporters/ReportedOutput.java
@@ -1,0 +1,40 @@
+package org.testng.reporters;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import org.testng.ITestNGListener;
+import org.testng.TestNG;
+
+/**
+ * What a reporter printed. The built-in reporters write to {@link System#out}, so reading one back
+ * means standing in for the stream while a run happens -- the one part of these tests that leaks
+ * into the whole JVM if the restore is missed, which is why there is one copy of it.
+ */
+final class ReportedOutput {
+
+  private static final Charset CHARSET = StandardCharsets.UTF_8;
+
+  private ReportedOutput() {
+    // Utility class. Defeat instantiation.
+  }
+
+  /**
+   * @param testng - The run to report on, ready but not started.
+   * @param reporter - The reporter to run it under.
+   * @return - Everything written to standard output while it ran.
+   */
+  static String of(TestNG testng, ITestNGListener reporter) {
+    PrintStream currentStream = System.out;
+    try {
+      ByteArrayOutputStream captured = new ByteArrayOutputStream();
+      System.setOut(new PrintStream(captured, true, CHARSET));
+      testng.addListener(reporter);
+      testng.run();
+      return captured.toString(CHARSET);
+    } finally {
+      System.setOut(currentStream);
+    }
+  }
+}

--- a/testng-core/src/test/java/org/testng/reporters/TextReporterTest.java
+++ b/testng-core/src/test/java/org/testng/reporters/TextReporterTest.java
@@ -2,10 +2,6 @@ package org.testng.reporters;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import org.testng.TestNG;
 import org.testng.annotations.Test;
 import org.testng.reporters.issue2725.TestClassSample;
@@ -110,17 +106,6 @@ public class TextReporterTest extends SimpleBaseTest {
   }
 
   private static String report(TestNG testng) {
-    PrintStream currentStream = System.out;
-    final Charset charset = StandardCharsets.UTF_8;
-    try {
-      ByteArrayOutputStream baos = new ByteArrayOutputStream();
-      PrintStream ps = new PrintStream(baos, true, charset);
-      System.setOut(ps);
-      testng.addListener(new TextReporter("Example_Test", 2));
-      testng.run();
-      return baos.toString(charset);
-    } finally {
-      System.setOut(currentStream);
-    }
+    return ReportedOutput.of(testng, new TextReporter("Example_Test", 2));
   }
 }

--- a/testng-core/src/test/java/org/testng/reporters/VerboseReporterTest.java
+++ b/testng-core/src/test/java/org/testng/reporters/VerboseReporterTest.java
@@ -1,0 +1,133 @@
+package org.testng.reporters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.testng.TestNG;
+import org.testng.annotations.Test;
+import org.testng.reporters.snapshot.ConfigurationParameterSample;
+import org.testng.reporters.snapshot.NonCloneableParameterSample;
+import org.testng.reporters.snapshot.ParallelParameterSample;
+import org.testng.reporters.snapshot.PassingConfigurationParameterSample;
+import org.testng.reporters.snapshot.RenderingCountSample;
+import org.testng.reporters.snapshot.RenderingSample;
+import org.testng.reporters.snapshot.SkippedDataDrivenSample;
+import org.testng.reporters.snapshot.WrongArgumentCountSample;
+import test.SimpleBaseTest;
+import test.reports.GitHub447Sample;
+
+/**
+ * What this reporter says an invocation ran with. Unlike {@link TextReporter} it prints as the run
+ * happens, twice per invocation: once as it starts and once as it finishes. The assertions below
+ * are on the second line -- the one ending in {@code finished in} -- since that is the one the
+ * shared snapshot exists for: by then the test has had every chance to change what it was given.
+ */
+public class VerboseReporterTest extends SimpleBaseTest {
+
+  @Test(description = "Ordinary parameters render as they always have")
+  public void parametersKeepTheirRenderingAndOrder() {
+    assertThat(report(RenderingSample.class))
+        .contains("(value(s): \"text\", 42, null) finished in");
+  }
+
+  @Test(
+      description =
+          "GITHUB-447: a mutable parameter no reflective clone can copy is still reported with the"
+              + " value its own invocation ran with")
+  public void mutableNonCloneableParameterKeepsItsInvocationTimeValue() {
+    assertThat(report(NonCloneableParameterSample.class))
+        .contains("(value(s): invocation-1) finished in")
+        .contains("(value(s): invocation-2) finished in")
+        .contains("(value(s): invocation-3) finished in")
+        .doesNotContain("invocation-4");
+  }
+
+  @Test(description = "GITHUB-447")
+  public void mutableCloneableParameterKeepsItsInvocationTimeValue() {
+    assertThat(report(GitHub447Sample.class))
+        .contains("(value(s): [], null, \"[null]\") finished in")
+        .contains("(value(s): [null], dup, \"[null, dup]\") finished in")
+        .contains("(value(s): [null, dup], dup, \"[null, dup, dup]\") finished in")
+        .contains("(value(s): [null, dup, dup], str, \"[null, dup, dup, str]\") finished in")
+        .contains(
+            "(value(s): [null, dup, dup, str], null, \"[null, dup, dup, str, null]\") finished in");
+  }
+
+  @Test(
+      description =
+          "A configuration method that failed is reported with what it was announced" + " with")
+  public void failedConfigurationParametersKeepTheirInvocationTimeValue() {
+    assertThat(report(ConfigurationParameterSample.class))
+        .contains("FAILED CONFIGURATION")
+        .contains("prepare([Ljava.lang.Object;)(value(s): [before-configuration]) finished in")
+        .doesNotContain("prepare([Ljava.lang.Object;)(value(s): [mutated])");
+  }
+
+  @Test(
+      description =
+          "A configuration method that passed is reported with what it was announced with too: its"
+              + " snapshot is dropped only once every reporter has been told")
+  public void passedConfigurationParametersKeepTheirInvocationTimeValue() {
+    assertThat(report(PassingConfigurationParameterSample.class))
+        .contains("PASSED CONFIGURATION")
+        .contains("prepare([Ljava.lang.Object;)(value(s): [before-configuration]) finished in")
+        .doesNotContain("prepare([Ljava.lang.Object;)(value(s): [mutated])");
+  }
+
+  @Test(description = "Snapshots stay with their own result when the invocations overlap")
+  public void parallelInvocationsDoNotShareSnapshots() {
+    String content = report(ParallelParameterSample.class);
+    for (int row = 0; row < ParallelParameterSample.ROWS; row++) {
+      assertThat(content).contains("(value(s): row-" + row + ") finished in");
+    }
+    assertThat(content).doesNotContain("(value(s): mutated)");
+  }
+
+  @Test(
+      description =
+          "A result announced before it was given its values still reports them, through the"
+              + " result itself")
+  public void resultsWithNothingToSnapshotStillReportTheirParameters() {
+    TestNG testng = create(SkippedDataDrivenSample.class);
+    testng.setReportAllDataDrivenTestsAsSkipped(true);
+
+    assertThat(report(testng))
+        .contains("(value(s): \"first\") finished in")
+        .contains("(value(s): \"second\") finished in");
+  }
+
+  @Test(
+      description =
+          "A data provider handing over the wrong number of values fails the method before it is"
+              + " given any, so there is nothing to report for it")
+  public void aResultThatNeverGotItsValuesReportsNone() {
+    assertThat(report(WrongArgumentCountSample.class))
+        .contains("Data provider mismatch")
+        .contains("WrongArgumentCountSample.report(java.lang.String) finished in")
+        .doesNotContain("value(s)");
+  }
+
+  @Test(
+      description =
+          "Both built-in reporters print what an invocation ran with, and between them the value is"
+              + " rendered once")
+  public void bothReportersReadTheOneSnapshot() {
+    TestNG testng = create(RenderingCountSample.class);
+    testng.addListener(new TextReporter("Example_Test", 2));
+    int renderedBefore = RenderingCountSample.renderings();
+
+    String content = report(testng);
+
+    // Three printed mentions of the value: this reporter's two lines, and TextReporter's one.
+    assertThat(content).contains("(value(s): counted) finished in").contains("report(counted)");
+    assertThat(RenderingCountSample.renderings() - renderedBefore).isEqualTo(1);
+  }
+
+  /** Runs the class under a {@link VerboseReporter}, and returns what it said. */
+  private static String report(Class<?> testClass) {
+    return report(create(testClass));
+  }
+
+  private static String report(TestNG testng) {
+    return ReportedOutput.of(testng, new VerboseReporter(VerboseReporter.LISTENER_PREFIX));
+  }
+}

--- a/testng-core/src/test/java/org/testng/reporters/snapshot/OverlappingContextsSample.java
+++ b/testng-core/src/test/java/org/testng/reporters/snapshot/OverlappingContextsSample.java
@@ -10,6 +10,11 @@ import org.testng.annotations.Test;
  * Run as two {@code <test>} contexts of one parallel suite, each naming its own value after the
  * context it belongs to. No invocation mutates the value it was given until both contexts are
  * running, so one of them finishes reporting while the other still needs its snapshots.
+ *
+ * <p>Its latch has to span two instances of this class, so unlike its siblings here it cannot be
+ * per-instance state, and a second run in the same JVM finds it spent -- passing without the
+ * contexts ever having overlapped. One reporter at a time, then: give a second one its own sample
+ * rather than adding a run to this one.
  */
 public class OverlappingContextsSample {
 

--- a/testng-core/src/test/java/org/testng/reporters/snapshot/ParallelParameterSample.java
+++ b/testng-core/src/test/java/org/testng/reporters/snapshot/ParallelParameterSample.java
@@ -9,12 +9,15 @@ import org.testng.annotations.Test;
  * Every row gets its own mutable object, and no invocation mutates its own until all of them are in
  * flight. A reporter that mixed up which snapshot belongs to which result would report a value some
  * other invocation ran with, or the mutated one.
+ *
+ * <p>The latch belongs to the instance, not the class: a spent one lets a second run pass without
+ * its invocations ever having overlapped, which is the whole point of the sample.
  */
 public class ParallelParameterSample {
 
   public static final int ROWS = 4;
 
-  private static final CountDownLatch ALL_STARTED = new CountDownLatch(ROWS);
+  private final CountDownLatch allStarted = new CountDownLatch(ROWS);
 
   @DataProvider(name = "rows", parallel = true)
   public static Object[][] rows() {
@@ -27,10 +30,10 @@ public class ParallelParameterSample {
 
   @Test(dataProvider = "rows")
   public void report(MutableParameter parameter) throws InterruptedException {
-    ALL_STARTED.countDown();
+    allStarted.countDown();
     // A timeout rather than a plain await: should the rows not run concurrently, the sample
     // degrades to a sequential one instead of hanging, and still asserts what it is here for.
-    ALL_STARTED.await(30, TimeUnit.SECONDS);
+    allStarted.await(30, TimeUnit.SECONDS);
     parameter.set("mutated");
   }
 }

--- a/testng-core/src/test/java/org/testng/reporters/snapshot/PassingConfigurationParameterSample.java
+++ b/testng-core/src/test/java/org/testng/reporters/snapshot/PassingConfigurationParameterSample.java
@@ -6,12 +6,10 @@ import org.testng.annotations.Test;
 
 /**
  * A configuration method that is handed the values its test method will run with, mutates them, and
- * then fails -- so a reporter has to have kept what it was announced with to report it.
- *
- * <p>The value is made per run rather than held by the class: mutating it is the point, and a
- * sample every run leaves spent is one only the first reporter to use it can assert on.
+ * passes -- so a reporter which prints a configuration as it succeeds has to have kept what it was
+ * announced with, and the snapshot has to still be there when it does.
  */
-public class ConfigurationParameterSample {
+public class PassingConfigurationParameterSample {
 
   @DataProvider(name = "shared")
   public static Object[][] shared() {
@@ -21,7 +19,6 @@ public class ConfigurationParameterSample {
   @BeforeMethod
   public void prepare(Object[] parameters) {
     ((MutableParameter) parameters[0]).set("mutated");
-    throw new IllegalStateException("this configuration method fails on purpose");
   }
 
   @Test(dataProvider = "shared")

--- a/testng-core/src/test/java/org/testng/reporters/snapshot/RenderingCountSample.java
+++ b/testng-core/src/test/java/org/testng/reporters/snapshot/RenderingCountSample.java
@@ -1,0 +1,43 @@
+package org.testng.reporters.snapshot;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * A parameter that counts the times it was rendered, which is how a test tells one reporting
+ * representation of an invocation from two.
+ */
+public class RenderingCountSample {
+
+  private static final AtomicInteger RENDERINGS = new AtomicInteger();
+
+  /**
+   * The count is of the class, since nothing outside a run holds the parameter a data provider
+   * made. A caller reads it either side of the run it is measuring and takes the difference, rather
+   * than zeroing it and depending on being the only run.
+   *
+   * @return - How many times a parameter of this sample has been rendered, ever.
+   */
+  public static int renderings() {
+    return RENDERINGS.get();
+  }
+
+  @DataProvider(name = "counted")
+  public static Object[][] counted() {
+    return new Object[][] {{new CountedParameter()}};
+  }
+
+  @Test(dataProvider = "counted")
+  public void report(CountedParameter parameter) {}
+
+  /** Reports being rendered, and is otherwise the plainest parameter there is. */
+  public static final class CountedParameter {
+
+    @Override
+    public String toString() {
+      RENDERINGS.incrementAndGet();
+      return "counted";
+    }
+  }
+}

--- a/testng-core/src/test/java/org/testng/reporters/snapshot/WrongArgumentCountSample.java
+++ b/testng-core/src/test/java/org/testng/reporters/snapshot/WrongArgumentCountSample.java
@@ -1,0 +1,16 @@
+package org.testng.reporters.snapshot;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/** A data provider that supplies more values than the method it feeds declares. */
+public class WrongArgumentCountSample {
+
+  @DataProvider(name = "tooMany")
+  public static Object[][] tooMany() {
+    return new Object[][] {{"first", "second"}};
+  }
+
+  @Test(dataProvider = "tooMany")
+  public void report(String only) {}
+}

--- a/testng-core/src/test/resources/testng.xml
+++ b/testng-core/src/test/resources/testng.xml
@@ -150,6 +150,7 @@
       <class name="test.EclipseTest" />
       <class name="test.ReporterApiTest" />
       <class name="org.testng.reporters.TextReporterTest"/>
+      <class name="org.testng.reporters.VerboseReporterTest"/>
       <class name="test.reports.UniqueReporterInjectionTest"/>
       <class name="test.junitreports.JUnitReportsTest"/>
       <class name="test.abstractmethods.AbstractTest" />


### PR DESCRIPTION
Rebased onto `master` now that #3402 and #3405 have merged; this is a single commit against master, no longer a stack.

One conflict came out of it, and one thing master changed under the branch:

- `VerboseReporter.getMethodDeclaration(tm, itr)` became `getMethodDeclaration(tm)` in master, in the exact hunk this PR rewrites — master's signature is kept.
- `ITestResult#getTestContext()` is now `@Nullable`, and documents why: the parameter carrier a configuration method is handed exists before the invocation is bound to a context. Resolving the store per result handles that, and such a result falls back like any other the snapshots have nothing for.

Part of #3406.

## Problem

#3405 gave the suite a `ParameterSnapshot` per invocation, rendered once while the invocation was starting, and made `TextReporter` read it. `VerboseReporter` was deliberately left alone, and still renders `ITestResult#getParameters()` at the moment it prints:

```java
sb.append(Utils.toString(params[i], paramTypes[i]));
```

For every status but `STARTED` that moment is *after* the method body has run. A data provider handing the same mutable row to each invocation therefore makes every finished line report that row's final state:

```
PASSED: …NonCloneableParameterSample.report(…)(value(s): invocation-4)   <- three times
```

GITHUB-447 only ever held here for values honouring `Cloneable`, through `LegacyParameterSnapshotter`. This PR makes `VerboseReporter` the second consumer of the shared store — consumption only. No new store, no capture in the reporter, no public or OSGi API change.

## What changed in the reporter

It asks the suite to take snapshots once per context (unconditionally — unlike `TextReporter` it always prints), and reads one per result. The rendering block loses its loop and its `Utils.toString`; the counts of a data-provider arity mismatch come off the snapshot instead of being recomputed from `params.length != paramTypes.length`.

The output format is byte-identical. The snapshot carries reporting facts, so the reporter keeps `"(value(s): "`, its separators, and its own mismatch wording — which, unlike `TextReporter`'s, has no enclosing parentheses.

What the two reporters now do the same way moves to `ParameterSnapshots` as two statics: `reportedParametersOf(store, result)` (snapshot, else fall back to the result, exactly as every result read before) and `requestCaptureFor(suite)`. The lifecycle prose about `onStart` being early enough now lives on the method it describes rather than in each reporter.

## Why the registration order had to move

`SuiteRunner` added the recorder once the runner was built — i.e. **last**. `onTestStart` and `beforeConfiguration` are dispatched in registration order, so a reporter told an invocation was starting looked for a snapshot that had not been taken yet and rendered the values a second time. The recorder now goes in first, through two narrow package-private methods on `TestRunner`.

Being first also means being **last** where the order is reversed, which is where `ParameterSnapshotRecorder.onConfigurationSuccess`'s `discard()` belongs — after the reporters that print a passing configuration have had it, not before. `PASSED CONFIGURATION` consequently reports its invocation-time values too, and the memory optimisation survives untouched.

| dispatch point | order | recorder runs |
|---|---|---|
| `onTestStart`, `beforeConfiguration` | insertion | first — snapshot taken before any reporter looks |
| finished test statuses | reversed | last — no-op, reporters have already read |
| `onConfigurationSuccess` | reversed | last — discards after the reporters |

**Known limit:** `ListenerOrderDeterminer.order` applies a user `ListenerComparator` to the whole list before it partitions, so a comparator can still move the recorder. The cost of that is one extra rendering, never a wrong value; it is documented on the method. Making the guarantee unconditional means a third bucket in `ListenerOrderDeterminer` keyed on an internal marker, or widening the single internal slot `TestListenerHelper.runPreConfigurationListeners` already has — both are changes to how *every* listener is dispatched, which does not belong in a reporter-consumption PR. Happy to do either as a follow-up if you prefer it now.

While in there: `TestRunner.m_configurationListeners` becomes a `List`. Its `LinkedHashSet` dedup was unreachable behind a class check that is strictly stricter, and `getConfigurationListeners()` applies that check once more on the way out — so putting a listener first is one call instead of a clear-and-rebuild.

## Tests

`VerboseReporter` had **no test at all**. `VerboseReporterTest` asserts on the finished line — the one ending in `finished in` — rather than the `INVOKING` one, since that is the line the shared snapshot exists for.

| test | what it pins |
|---|---|
| `mutableNonCloneableParameterKeepsItsInvocationTimeValue` | `invocation-1..3`, never `invocation-4` — the PR's point |
| `mutableCloneableParameterKeepsItsInvocationTimeValue` | GITHUB-447 holds without `LegacyParameterSnapshotter` |
| `parametersKeepTheirRenderingAndOrder` | `"text", 42, null` — string, number, null, in order |
| `failedConfigurationParametersKeepTheirInvocationTimeValue` | `FAILED CONFIGURATION` reports `[before-configuration]`, not `[mutated]` |
| `passedConfigurationParametersKeepTheirInvocationTimeValue` | so does `PASSED CONFIGURATION` — the snapshot outlives the reporters that read it |
| `parallelInvocationsDoNotShareSnapshots` | four overlapping invocations each print their own row |
| `resultsWithNothingToSnapshotStillReportTheirParameters` | `reportAllDataDrivenTestsAsSkipped` still reports, through the fallback |
| `aResultThatNeverGotItsValuesReportsNone` | a data-provider count mismatch fails the method before it has any values |
| `bothReportersReadTheOneSnapshot` | **one rendering per invocation, measured** |

The last one is the architectural invariant, and it is counted rather than argued: a parameter that increments on `toString()`, printed three times by the two reporters together, is rendered **once**. Without the registration-order change it is rendered twice.

`aResultThatNeverGotItsValuesReportsNone` is a characterization test — TestNG raises `MethodMatcherException` before assigning the values, so the mismatch branch is unreachable end to end. The counts it reports are covered directly on `ParameterSnapshot`.

Two samples from #3405 kept their state in a `static` field and were spent after their first run, which a second reporter cannot assert on; they hold it per instance now. `OverlappingContextsSample`'s latch has to span two contexts and could not follow, so it says so — and that scenario stays with `TextReporterTest`.

## Verification

`./gradlew build` on the rebased branch — BUILD SUCCESSFUL, **17485 tests, 0 failures, 0 errors**.

Green throughout: `ParameterSnapshotsTest`, `ParameterSnapshotLifecycleTest`, `TextReporterTest`, GITHUB-447 and GITHUB-1994.

The dispatch mechanisms this change depends on were checked against the new master rather than assumed: `ListenerOrderDeterminer` and `TestListenerHelper` are untouched, and `ConfigInvoker` still assigns a configuration method's parameters before it notifies.

## Still reading `ITestResult#getParameters()` for textual reporting

`EmailableReporter2`, `XMLSuiteResultWriter`, `TestHTMLReporter`, `jq.SuitePanel` / `jq.Model`. `FailedReporter` reads it too, but to rebuild an invocation rather than to print one — it needs the objects, not their rendering, and should not be forced into this model.

## Next

The fallback exists only for results announced before they were given their values: `reportAllDataDrivenTestsAsSkipped`, and a configuration method skipped before its parameters were computed. Assigning parameters *before* the public "invocation starting" notification on those paths would let it be removed from both migrated reporters.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parameter reporting so values reflect invocation-time state, including mutable parameters and parallel executions.
  * Improved handling and display of data-provider argument-count mismatches.
  * Prevented duplicate or inconsistent parameter rendering across text and verbose reports.
  * Improved handling of optional runtime values and listener registration.

* **Tests**
  * Added coverage for parameter snapshots, configuration outcomes, parallel runs, skipped results, and reporter output consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
