### PR TITLE
refactor(reports): let a reporter declare that it reads the parameter snapshots

### DIFF
--- a/testng-core/src/main/java/org/testng/TestNG.java
+++ b/testng-core/src/main/java/org/testng/TestNG.java
@@ -49,6 +49,7 @@ import org.testng.internal.objects.Dispenser;
 import org.testng.internal.objects.IObjectDispenser;
 import org.testng.internal.objects.pojo.BasicAttributes;
 import org.testng.internal.objects.pojo.CreationAttributes;
+import org.testng.internal.reporters.ParameterSnapshotReader;
 import org.testng.internal.reporters.ParameterSnapshots;
 import org.testng.internal.thread.graph.SuiteWorkerFactory;
 import org.testng.log4testng.Logger;
@@ -1283,6 +1284,12 @@ public class TestNG {
       }
       createSuiteRunners(suiteRunnerMap, xmlSuite);
     }
+
+    // Every reporter of the run is known by now -- the ones a suite declared arrived with it, and
+    // createSuiteRunner() folded them in -- and no suite has started, which is what a reporting
+    // snapshot has to be requested before. The reporters registered on a TestRunner instead ask for
+    // themselves; see ParameterSnapshotReader.
+    ParameterSnapshotReader.requestCaptureIfAnyReads(m_reporters.values(), suiteRunnerMap.values());
 
     //
     // Run suites

--- a/testng-core/src/main/java/org/testng/internal/reporters/ParameterSnapshotReader.java
+++ b/testng-core/src/main/java/org/testng/internal/reporters/ParameterSnapshotReader.java
@@ -1,0 +1,56 @@
+package org.testng.internal.reporters;
+
+import java.util.Collection;
+import org.testng.IReporter;
+import org.testng.ISuite;
+
+/**
+ * A built-in reporter that reads the reporting snapshots and has no invocation lifecycle to ask
+ * from, so the run asks on its behalf.
+ *
+ * <p>Which of the two routes a reporter takes follows from where it is registered, not from what it
+ * reads:
+ *
+ * <ul>
+ *   <li>registered as an {@link IReporter} on the {@code TestNG} instance -- through {@code
+ *       addReporter} or {@code addListener}, which is how every built-in report of {@code
+ *       initializeDefaultListeners} arrives -- then it is only ever called once every suite has
+ *       finished, and it says so here;
+ *   <li>registered on a {@code TestRunner}, as {@code TextReporter} and {@code TestHTMLReporter}
+ *       are, then it is told when a context starts and asks for itself with {@link
+ *       ParameterSnapshots#requestCaptureFor}. Only it can: whether {@code TextReporter} reads
+ *       anything depends on how verbose it was built to be.
+ * </ul>
+ *
+ * <p>Extending {@link IReporter} is what keeps that a rule rather than a convention: the scan below
+ * only ever sees the run's reporters, so a class that is not one -- {@code XMLSuiteResultWriter}
+ * and the {@code jq} panels are the ones to watch, since they hold the reads but are not reporters
+ * -- could otherwise wear this and be quietly passed over, leaving its report to fall back to
+ * {@link org.testng.ITestResult#getParameters()} with nothing to say it had.
+ *
+ * <p>Internal, and otherwise empty: implementing it is a statement about TestNG's own reporting,
+ * not an extension point. A third party reporter that wants the snapshots implements {@link
+ * org.testng.ITestListener} and asks, exactly as {@code TextReporter} does.
+ */
+public interface ParameterSnapshotReader extends IReporter {
+
+  /**
+   * Takes the run's snapshots if any of its reporters reads them.
+   *
+   * <p>Call it from the one point where every reporter of the run is known and none of its suites
+   * has started. Asking there rather than per invocation is what keeps the guarantee worth having:
+   * the request precedes the first invocation of the whole run, so a store cannot end up holding
+   * some of a suite's invocations and re-reading the rest. It also keeps the cost where it belongs
+   * -- a run whose reporters read no snapshot renders nothing, and rendering calls the user's
+   * {@code toString()} once per invocation.
+   *
+   * @param reporters - The reporters the run will report through.
+   * @param suites - The suites about to run, none of which has started.
+   */
+  static void requestCaptureIfAnyReads(
+      Collection<? extends IReporter> reporters, Collection<ISuite> suites) {
+    if (reporters.stream().anyMatch(ParameterSnapshotReader.class::isInstance)) {
+      suites.forEach(ParameterSnapshots::requestCaptureFor);
+    }
+  }
+}

--- a/testng-core/src/test/java/org/testng/internal/reporters/ParameterSnapshotWiringTest.java
+++ b/testng-core/src/test/java/org/testng/internal/reporters/ParameterSnapshotWiringTest.java
@@ -1,0 +1,237 @@
+package org.testng.internal.reporters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.jspecify.annotations.Nullable;
+import org.testng.IReporter;
+import org.testng.ISuite;
+import org.testng.ITestContext;
+import org.testng.ITestListener;
+import org.testng.ITestResult;
+import org.testng.TestNG;
+import org.testng.annotations.Test;
+import org.testng.reporters.snapshot.DeclaringSuiteSample;
+import org.testng.reporters.snapshot.RenderingCountSample;
+import org.testng.reporters.snapshot.RenderingSample;
+import org.testng.reporters.snapshot.SnapshotReadingReporterSample;
+import org.testng.xml.XmlSuite;
+import test.SimpleBaseTest;
+import test.TestHelper;
+
+/**
+ * Who gets the suite's snapshots taken for them. A reporter that sits in the invocation lifecycle
+ * asks for itself from {@code onStart}; one that only implements {@link IReporter} runs after every
+ * invocation is over, so the run has to decide on its behalf before anything starts.
+ *
+ * <p>Every case is measured rather than predicted: {@link RenderingCountSample} counts the times a
+ * parameter was rendered, and the {@link Inspector} reads the store back from {@code
+ * generateReport}, which is the last thing that can.
+ */
+public class ParameterSnapshotWiringTest extends SimpleBaseTest {
+
+  /** One sample whose parameter counts its renderings, one with the ordinary parameter shapes. */
+  private static final Class<?>[] FIXTURE = {RenderingCountSample.class, RenderingSample.class};
+
+  @Test(description = "A run no reporter reads the snapshots of renders nothing")
+  public void aRunNobodyReadsRendersNothing() {
+    Run run = runUnder();
+
+    assertThat(run.renderings).isZero();
+    assertThat(run.snapshottedInvocations).isEmpty();
+  }
+
+  @Test(
+      description = "The wiring takes no snapshot for the built-in reporters, which read none yet")
+  public void aDefaultRunTakesNoSnapshot() throws IOException {
+    Run run = runUnderDefaultReporters(TestHelper.createRandomDirectory());
+
+    // Nothing captured, so the snapshot layer rendered nothing: captureIfAbsent is the only place
+    // it renders, and it returns before doing so while no reporter has asked.
+    assertThat(run.snapshottedInvocations).isEmpty();
+    // And not because the reporters never looked: they each render the value for themselves from
+    // generateReport, which is the reading Phase 7 replaces one reporter at a time. How many times
+    // is theirs to change -- it was 8 when this was written, and depends on which of them a run
+    // registers -- so this pins that they read at all, not how often.
+    assertThat(run.renderings).isPositive();
+  }
+
+  @Test(
+      description =
+          "A reporter with no invocation listener to ask from still gets the snapshots taken, and"
+              + " gets them from the first invocation of the run on")
+  public void aReporterThatCanOnlyReportCaptures() {
+    Run run = runUnder(new SnapshotReadingReporterSample());
+
+    assertThat(run.renderings).isEqualTo(1);
+    // The whole run, from its very first invocation on -- not just the ones a listener saw late.
+    assertThat(run.invocations)
+        .startsWith("org.testng.reporters.snapshot.RenderingCountSample.report");
+    assertThat(run.snapshottedInvocations).isEqualTo(run.invocations);
+  }
+
+  @Test(description = "A reporter that asks from the invocation lifecycle still captures")
+  public void aReporterThatListensCaptures() {
+    Run run = runUnder(new LifecycleReporter());
+
+    assertThat(run.renderings).isEqualTo(1);
+    assertThat(run.snapshottedInvocations).isEqualTo(run.invocations);
+  }
+
+  @Test(description = "Two reporters asking for the same snapshots render the value once")
+  public void twoInterestedReportersRenderOnce() {
+    Run run = runUnder(new SnapshotReadingReporterSample(), new LifecycleReporter());
+
+    assertThat(run.renderings).isEqualTo(1);
+    assertThat(run.snapshottedInvocations).isEqualTo(run.invocations);
+  }
+
+  @Test(
+      description =
+          "A reporter that arrives with the second suite still had the first suite's invocations"
+              + " snapshotted, because the question is asked before any suite runs")
+  public void aReporterDeclaredByOneSuiteCapturesTheOthers() {
+    Run run =
+        measure(
+            create(
+                createXmlSuite("reads-nothing", "counted", RenderingCountSample.class),
+                createXmlSuite("declares-a-reader", "declaring", DeclaringSuiteSample.class)));
+
+    // The first suite ran before the reporter's own suite did, and was snapshotted all the same.
+    // Only it: the declaring suite's own method takes no parameter, and an invocation with nothing
+    // to report is not stored -- see ParameterSnapshot#of.
+    assertThat(run.renderings).isEqualTo(1);
+    assertThat(run.snapshottedInvocations)
+        .containsExactly("org.testng.reporters.snapshot.RenderingCountSample.report");
+  }
+
+  /**
+   * The same, with the reporters a user gets when they ask for none: the run TestNG does by
+   * default, whose reports are written under {@code outputDirectory}.
+   */
+  private static Run runUnderDefaultReporters(Path outputDirectory) {
+    TestNG testng = createTests(outputDirectory, "snapshot-wiring", FIXTURE);
+    testng.setUseDefaultListeners(true);
+    return measure(testng);
+  }
+
+  /**
+   * Runs two {@code <test>}s under the given consumers, plus the two instruments that measure what
+   * happened. Neither instrument declares any interest in the snapshots, so a case that captures
+   * captures because of what was passed in.
+   */
+  private static Run runUnder(Object... consumers) {
+    TestNG testng = createTests("snapshot-wiring", FIXTURE);
+    for (Object consumer : consumers) {
+      testng.addListener(consumer);
+    }
+    return measure(testng);
+  }
+
+  /** Runs it under the two instruments, and reports what they saw. */
+  private static Run measure(TestNG testng) {
+    Observer observer = new Observer();
+    Inspector inspector = new Inspector(observer);
+    testng.addListener(observer);
+    testng.addListener(inspector);
+
+    int renderedBefore = RenderingCountSample.renderings();
+    testng.run();
+
+    // TestNG catches whatever a reporter throws and prints it to stderr, so an Inspector that blew
+    // up would otherwise look exactly like a run that captured nothing.
+    assertThat(inspector.failure).isNull();
+    // And nothing is to be concluded from a run that did not run.
+    assertThat(observer.results).hasSize(2);
+
+    return new Run(
+        RenderingCountSample.renderings() - renderedBefore,
+        observer.invocations(),
+        inspector.snapshottedInvocations);
+  }
+
+  /** What one run of {@link #runUnder} is judged on. */
+  private static final class Run {
+
+    final int renderings;
+
+    /** The invocations that were announced, in the order they started. */
+    final List<String> invocations;
+
+    /** Those of them the store still held when the reporters ran, in the same order. */
+    final List<String> snapshottedInvocations;
+
+    Run(int renderings, List<String> invocations, List<String> snapshottedInvocations) {
+      this.renderings = renderings;
+      this.invocations = invocations;
+      this.snapshottedInvocations = snapshottedInvocations;
+    }
+  }
+
+  /** Records what was invoked, and asks for nothing: an instrument, not a consumer. */
+  private static final class Observer implements ITestListener {
+
+    final List<ITestResult> results = new ArrayList<>();
+
+    @Override
+    public void onTestStart(ITestResult result) {
+      results.add(result);
+    }
+
+    List<String> invocations() {
+      return results.stream().map(ParameterSnapshotWiringTest::nameOf).collect(Collectors.toList());
+    }
+  }
+
+  /**
+   * Reads the store back once every context has finished, which is where an {@link IReporter} would
+   * read it -- and, deliberately, asks for nothing itself.
+   */
+  private static final class Inspector implements IReporter {
+
+    private final Observer observer;
+    final List<String> snapshottedInvocations = new ArrayList<>();
+
+    /** Whatever went wrong in here, which TestNG would otherwise print to stderr and drop. */
+    @Nullable Exception failure;
+
+    Inspector(Observer observer) {
+      this.observer = observer;
+    }
+
+    @Override
+    public void generateReport(
+        List<XmlSuite> xmlSuites, List<ISuite> suites, String outputDirectory) {
+      try {
+        for (ITestResult result : observer.results) {
+          // Each result's own suite, so that a run of several suites is read one store at a time.
+          ITestContext context = result.getTestContext();
+          ParameterSnapshots snapshots =
+              context == null ? null : ParameterSnapshots.of(context.getSuite());
+          if (snapshots != null && snapshots.find(result) != null) {
+            snapshottedInvocations.add(nameOf(result));
+          }
+        }
+      } catch (Exception inspecting) {
+        failure = inspecting;
+      }
+    }
+  }
+
+  /** The route that already worked: a reporter that is told when a context starts. */
+  private static final class LifecycleReporter implements ITestListener {
+
+    @Override
+    public void onStart(ITestContext context) {
+      ParameterSnapshots.requestCaptureFor(context.getSuite());
+    }
+  }
+
+  private static String nameOf(ITestResult result) {
+    return result.getMethod().getQualifiedName();
+  }
+}

--- a/testng-core/src/test/java/org/testng/reporters/snapshot/DeclaringSuiteSample.java
+++ b/testng-core/src/test/java/org/testng/reporters/snapshot/DeclaringSuiteSample.java
@@ -1,0 +1,16 @@
+package org.testng.reporters.snapshot;
+
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/**
+ * Brings a {@link SnapshotReadingReporterSample} into the run with the suite that holds this class,
+ * rather than with the run itself. Put it in the <em>second</em> suite to check that the first
+ * one's invocations were snapshotted too.
+ */
+@Listeners(SnapshotReadingReporterSample.class)
+public class DeclaringSuiteSample {
+
+  @Test
+  public void report() {}
+}

--- a/testng-core/src/test/java/org/testng/reporters/snapshot/SnapshotReadingReporterSample.java
+++ b/testng-core/src/test/java/org/testng/reporters/snapshot/SnapshotReadingReporterSample.java
@@ -1,0 +1,21 @@
+package org.testng.reporters.snapshot;
+
+import java.util.List;
+import org.testng.ISuite;
+import org.testng.internal.reporters.ParameterSnapshotReader;
+import org.testng.xml.XmlSuite;
+
+/**
+ * A reporter that declares it reads the parameter snapshots and has no invocation lifecycle to
+ * declare it from -- the shape this wiring exists for.
+ *
+ * <p>Top level, and public, so that a sample class can name it in {@code @Listeners}: a reporter
+ * that arrives with one suite rather than with the run is the case the decision has to be taken
+ * before <em>any</em> suite starts for.
+ */
+public class SnapshotReadingReporterSample implements ParameterSnapshotReader {
+
+  @Override
+  public void generateReport(
+      List<XmlSuite> xmlSuites, List<ISuite> suites, String outputDirectory) {}
+}

--- a/testng-core/src/test/resources/testng.xml
+++ b/testng-core/src/test/resources/testng.xml
@@ -783,6 +783,7 @@
       <class name="org.testng.internal.reporters.ParameterSnapshotsTest" />
       <class name="org.testng.internal.reporters.ParameterSnapshotLifecycleTest" />
       <class name="org.testng.internal.reporters.ParameterAnnouncementTest" />
+      <class name="org.testng.internal.reporters.ParameterSnapshotWiringTest" />
     </classes>
   </test>
 


### PR DESCRIPTION
Phase 6 of #3406.

A reporting snapshot is only taken when a consumer says it will read one, and the only way to say so is `ITestListener#onStart(ITestContext)` — which a class that implements nothing but `IReporter` never gets. Its `generateReport` runs from `TestNG#generateReports` once every suite has finished, by which point every invocation the snapshot would have described is over and the values may have been mutated. That is the whole reason snapshots exist (GITHUB-447).

This makes the question answerable at wiring time, and nothing else. **No reporter is migrated here** — that is Phase 7.

## 1. The `IReporter`-only consumers of `ITestResult#getParameters()`

Derived from `git grep -n "getParameters()" -- testng-core/src/main/java/org/testng/{reporters,internal/reporters}`, not inherited.

| Call site | Type | Arrives through | Phase |
|---|---|---|---|
| `XMLSuiteResultWriter.java:251`, behind `AbstractXmlReporter.java:21` (`XMLReporter`, `PerSuiteXMLReporter`) | `IReporter` only | TestNG-level `m_reporters`, `TestNG.java:1006-1009` | 7 |
| `jq/Model.java:155`, `jq/SuitePanel.java:77-79`, behind `jq/Main.java:19` | `IReporter` only | TestNG-level `m_reporters`, `TestNG.java:1003` | 7 |
| `EmailableReporter2.java:466,469` (`:32`) | `IReporter` only | TestNG-level `m_reporters`, `TestNG.java:1010-1012` | 7 |
| `TestHTMLReporter.java:121` (`:23 implements ITestListener`) | lifecycle listener | per-`TestRunner` under `useDefaultListeners`, `SuiteRunner.java:653-654` | 7, through the existing `onStart` route — needs nothing from this PR |
| `FailedReporter.java:107` (`:45`) | needs the parameter objects, not a rendering | TestNG-level `m_reporters`, `TestNG.java:1004` | 8 — out of scope |

`JUnitXMLReporter` and `JUnitReportReporter` do not read `getParameters()` at all.

The three populations converge, which is what makes one decision point possible: suite-level reporters (`SuiteRunner.java:404-406`, filled from `addListener` at `:493-495`, reached by an `@Listeners`-declared `IReporter` via `TestRunner.java:395-397` → `:1157`) are folded into `m_reporters` by `TestNG.java:1453-1455`, right after the constructor that created them. The third population is not made of `IReporter`s at all — `TestHTMLReporter`, `JUnitXMLReporter` and `TextReporter` are all `ITestListener`s, so they already have a lifecycle point to ask from.

## 2. The decision

**An internal marker, `org.testng.internal.reporters.ParameterSnapshotReader extends IReporter`, scanned once at wiring time** — in `runSuitesLocally()`, after every `SuiteRunner` has been created (`TestNG.java:1274-1282`) and before any of them runs (`:1287` onwards).

That point is the only one where all three hold at once: every store exists (attached in the `SuiteRunner` constructor, `SuiteRunner.java:188-190`), `m_reporters` is complete for the whole run, and no invocation has happened.

Rejected, with what each cannot do:

- **an explicit list of classes in the wiring** — cannot cover a user subclass of a built-in reporter, and makes every Phase 7 migration edit a second file to stay in step;
- **capture whenever `useDefaultListeners` is on** — cannot avoid rendering for runs whose default reporters read nothing, which is every run today; it makes the `captureRequested` guard decorative;
- **a `default` method on `IReporter`** — a public API change;
- **capture lazily, on first read** — impossible: the first read is at report time, after the value may have mutated;
- **opt in from `IExecutionListener#onExecutionStart`** — no `ISuite` argument, and it runs at `TestNG.java:1137`, before `runSuites()` at `:1142`, so no `SuiteRunner` and no store exists yet;
- **opt in from `ISuiteListener#onStart(ISuite)`** — early enough in principle, but a built-in reporter registered through `addReporter(Class)` (`TestNG.java:992-996`) lands only in `m_reporters`, never in `m_suiteListeners`, so its `onStart` would never be called.

The marker extends `IReporter` deliberately. The scan only ever sees the run's reporters, and the classes that hold the Phase 7 reads — `XMLSuiteResultWriter`, `jq/Model`, `jq/SuitePanel` — are *not* reporters. Without the bound, wearing the marker on one of them would compile, ship, and capture nothing, with the report falling back to `getParameters()` and nothing to say it had. The bound makes that a compile error instead.

**What if the request arrives after some invocations have run?** With this placement it cannot. Every `SuiteRunner` exists before `TestNG.java:1282` and nothing runs before `:1287`, so the request precedes the first invocation of the whole run. A store can therefore not end up holding some of a suite's invocations and re-reading the rest through the fallback.

**Named blind spot:** a runner that overrides `protected List<ISuite> runSuites()` (`TestNG.java:1178`) without delegating to `runSuitesLocally()` never reaches the scan. Capture is then simply not requested and reporters read through the fallback — today's behaviour, not a failure. Nothing in-tree overrides it.

## 3. A run whose reporters read no snapshot renders nothing

Measured with `RenderingCountSample`, read either side of each run, on 6 forks — never predicted. Before/after is the same test class run with the one new line in `TestNG.java` neutralised and then restored.

| Case | Before | After |
|---|---|---|
| no interested consumer | 0 renderings, empty store | 0 renderings, empty store |
| default reporters (`useDefaultListeners=true`) | 8 renderings, **empty store** | 8 renderings, **empty store** |
| an `IReporter`-only consumer that reads | **0 renderings, empty store** | **1 rendering, complete store** |
| a lifecycle reporter (today's route) | 1 rendering, complete store | 1 rendering, complete store |
| both | 1 rendering, complete store | 1 rendering, complete store |

The 8 renderings of a default run are the built-in reporters each calling `toString()` for themselves from `generateReport`; the wiring adds none of them, and takes no snapshot. Phase 7 replaces those reads one reporter at a time. The test pins the durable half of that — the store stays empty, and the reporters did read (`isPositive()`) so the empty store is not vacuous — rather than the exact 8, which is theirs to change and depends on which of them a run registers (`RuntimeBehavior.useEmailableReporter()` is a system property).

### The decision covers a reporter that arrives with a later suite

`ParameterSnapshotWiringTest#aReporterDeclaredByOneSuiteCapturesTheOthers` runs two suites: the first reads nothing, the second declares a `ParameterSnapshotReader` through `@Listeners`. The first suite's invocation is in the store anyway — every `SuiteRunner` is built, and every suite-declared reporter folded into `m_reporters`, before the scan and before either suite runs.

That test is what defends the placement rather than the mechanism: moving the same call into `createSuiteRunner` (per suite, which cannot see a later suite's reporter) fails it and leaves the other five green.

## 4. The store an `IReporter`-only consumer gets is complete

`ParameterSnapshotWiringTest#aReporterThatCanOnlyReportCaptures` runs two `<test>`s. A plain observer `ITestListener`, which requests nothing, records the invocations in the order they started; the test asserts the store held **every** one of them when the reporters ran, in that order — starting with the first invocation of the run, `org.testng.reporters.snapshot.RenderingCountSample.report`. The interested reporter implements the marker and nothing else, so it could not have taken the old route.

## 5. `reportedParametersOf`'s fallback

Untouched by this PR. #3408 narrowed it in the meantime, and this change does not narrow it further: it still covers a configuration method skipped because an earlier one failed, an invocation nothing was ever resolved for, and a result from a suite with no store — or one whose capture was never requested (`ParameterSnapshots.java:154-168`).

What this PR removes is not an entry in that list but one *reason* for landing in it: "the request arrived after the invocation had already run" is no longer reachable, because the request now provably precedes the first invocation of the run.

## 6. Public and OSGi API

Unchanged. `git diff <base> -- testng/testng-build.gradle.kts` and `git diff <base> -- '*-api/src/main/java'` are both empty. `org.testng.internal.reporters` is not in the `Export-Package` list (`testng/testng-build.gradle.kts:70-95` lists `org.testng.internal`, and the header is not recursive), so the new interface is not exported and no manifest moved. No `ITestResult`, `ITestListener`, `IConfigurationListener`, `IInvokedMethodListener`, `IReporter`, `ISuite`, `ITestContext` or public reporter signature changed.

## 7. What Phase 7 can now do

Phase 7 can migrate a display reporter that only implements `IReporter` by widening it to `implements ParameterSnapshotReader` and swapping its `getParameters()` read for `ParameterSnapshots.reportedParametersOf(...)` — one line of wiring per reporter, no new public API, no lifecycle interface bolted onto a public reporter class, and no cost on runs where none of those reporters is active. One consequence worth naming rather than leaving Phase 7 to rediscover: as soon as a *default* reporter wears the marker, capture is on for every default run. That is the intended trade — one rendering at invocation time instead of one per reporter at report time — but it does mean the opt-in stops being an escape hatch for users who register no verbose reporter.

Before this phase, `XMLSuiteResultWriter`, `jq/Model`, `jq/SuitePanel` and `EmailableReporter2` had no way to declare their interest, so migrating any of them would have read an empty store — or forced capture on every run.

## Validation

Full build on `master` as of #3408: **0 failures, 0 errors**, `BUILD SUCCESSFUL`. The only executions this PR adds are its own — `TEST-ParameterSnapshotWiringTest.xml` reports `tests=36 failures=0 errors=0` (6 methods × 6 forks); no existing test class changed.

The before/after rendering table above was measured by neutralising the single new line in `TestNG.java` and restoring it.

No `CHANGES.txt` entry: no built-in reporter implements the marker yet, so nothing a user can observe has changed. Phase 7 carries that line.

Based on `master`. #3407 and #3408 both merged while this was in review, so this stacks on nothing: it needs `ParameterSnapshots.requestCaptureFor` and `RenderingCountSample`, which #3407 landed, and it has been rebased onto #3408 and re-validated there. It is independent of #3411 (invocation cancellation), which touches no file this PR touches.
