### PR TITLE
build(errorprone): promote the ten checks that have no sites left

### DIFF
--- a/build-logic/code-quality/src/main/kotlin/testng.errorprone.gradle.kts
+++ b/build-logic/code-quality/src/main/kotlin/testng.errorprone.gradle.kts
@@ -22,7 +22,7 @@ tasks.withType<JavaCompile>().configureEach {
         // its jar is on the processor path, even for a task that disables the check below, and
         // NullAway refuses to start unless one of OnlyNullMarked or AnnotatedPackages is set.
         // Moving them into an else branch fails every test compile.
-        check("NullAway", CheckSeverity.ERROR)
+        error("NullAway")
         option("NullAway:OnlyNullMarked", true)
 
         // Without JSpecifyMode, NullAway reads declarations only and never looks inside a generic
@@ -30,6 +30,31 @@ tasks.withType<JavaCompile>().configureEach {
         // container is free to claim non-null elements while yielding null ones. Turning it on is
         // what makes @NullMarked mean what JSpecify says it means rather than roughly half of it.
         option("NullAway:JSpecifyMode", true)
+
+        // Checks measured at zero unsuppressed sites, promoted from warning so the next
+        // violation stops the build instead of joining an output nobody reads. The sites that
+        // remain carry a @SuppressWarnings saying why. Finalize is here on new violations alone --
+        // both of its sites are suppressed, because the finalizers are what the leak test watches.
+        //
+        // Measure before adding one: javac caps at 100 warnings per compile task and several
+        // tasks here are past that, so an ordinary build undercounts. Nothing raises the cap, so
+        // count from a throwaway init script that adds -Xmaxwarns rather than from a plain build.
+        //
+        // Promoting also takes a check out of disableWarningsInGeneratedCode above: Error Prone
+        // only honours that exemption while the check is below ERROR. Nothing here generates Java
+        // today, so the list costs nothing; a module that adds a processor pays for it.
+        error(
+            "BadImport",
+            "BooleanLiteral",
+            "Finalize",
+            "InconsistentCapitalization",
+            "MissingOverride",
+            "NotJavadoc",
+            "StringCaseLocaleUsage",
+            "TypeParameterUnusedInFormals",
+            "UnnecessaryParentheses",
+            "UnusedVariable",
+        )
 
         // Which compiles carry test code. The Error Prone plugin derives compilingTestOnlyCode
         // from the *source set* name and lets a module override it, so a module whose main source

--- a/build-logic/code-quality/src/main/kotlin/testng.errorprone.gradle.kts
+++ b/build-logic/code-quality/src/main/kotlin/testng.errorprone.gradle.kts
@@ -12,8 +12,6 @@ dependencies {
 }
 
 tasks.withType<JavaCompile>().configureEach {
-    val testCompile = name.contains("Test")
-
     options.errorprone {
         disableWarningsInGeneratedCode.set(true)
 
@@ -33,22 +31,24 @@ tasks.withType<JavaCompile>().configureEach {
         // what makes @NullMarked mean what JSpecify says it means rather than roughly half of it.
         option("NullAway:JSpecifyMode", true)
 
-        if (testCompile) {
-            // SelfAssertion only fires on TestNG's own sample/fixture classes, where trivial
-            // assertions such as assertThat("abc").isEqualTo("abc") exist solely to give the
-            // runner a passing method. Production code keeps the check enabled.
-            disable("SelfAssertion")
+        // Which compiles carry test code. The Error Prone plugin derives compilingTestOnlyCode
+        // from the *source set* name and lets a module override it, so a module whose main source
+        // set holds test fixtures can declare that rather than be classified by whether its task
+        // name happens to contain "Test". testng-test-kit is exactly that module.
+        //
+        // orElse: a JavaCompile task that belongs to no source set gets no convention, and feeding
+        // an absent provider to the options below would make them unresolvable.
+        val testCode = compilingTestOnlyCode.orElse(false)
 
-            // NullAway stays on here: @NullMarked is per package, not per source set, so twelve
-            // test packages are already marked by the main package-info.class on their compile
-            // classpath.
-            //
-            // HandleTestAssertionLibraries teaches NullAway that assertThat(x).isNotNull() refines
-            // x. It is keyed on the task name, so testng-test-kit -- test code that lives in a main
-            // source set -- does not get it, even though its org.testng.xml half is marked and
-            // checked today. That is inert only because the AssertJ use in that module sits in the
-            // unmarked test package, so nothing there refines a nullable value yet.
-            option("NullAway:HandleTestAssertionLibraries", true)
-        }
+        // SelfAssertion only fires on TestNG's own sample/fixture classes, where trivial
+        // assertions such as assertThat("abc").isEqualTo("abc") exist solely to give the runner a
+        // passing method. Production code keeps the check enabled.
+        check("SelfAssertion", testCode.map { if (it) CheckSeverity.OFF else CheckSeverity.DEFAULT })
+
+        // NullAway stays on for test code: @NullMarked is per package, not per source set, so the
+        // test half of every marked main package is already marked by the package-info.class on
+        // its compile classpath. HandleTestAssertionLibraries is what teaches NullAway that
+        // assertThat(x).isNotNull() refines x.
+        option("NullAway:HandleTestAssertionLibraries", testCode.map { it.toString() })
     }
 }

--- a/testng-core-api/src/main/java/org/testng/ITestObjectFactory.java
+++ b/testng-core-api/src/main/java/org/testng/ITestObjectFactory.java
@@ -11,6 +11,12 @@ public interface ITestObjectFactory {
     return InstanceCreator.newInstance(cls, parameters);
   }
 
+  // The sibling overloads take Class<T> or Constructor<T>, so T is inferred from the argument.
+  // This one identifies the class by name, so nothing in the formals carries T and the caller
+  // picks it by assignment -- newInstance("com.acme.Bar") will happily fill a Foo variable and
+  // fail with a ClassCastException at the call site. That is what the check flags, and it is
+  // published API, so it is suppressed rather than obeyed.
+  @SuppressWarnings("TypeParameterUnusedInFormals")
   default <T> T newInstance(String clsName, Object... parameters) {
     return InstanceCreator.newInstance(clsName, parameters);
   }

--- a/testng-core-api/src/main/java/org/testng/annotations/ITestAnnotation.java
+++ b/testng-core-api/src/main/java/org/testng/annotations/ITestAnnotation.java
@@ -65,21 +65,27 @@ public interface ITestAnnotation extends ITestOrConfiguration, IDataProvidable {
 
   void setSingleThreaded(boolean f);
 
+  @Override
   String getDataProvider();
 
+  @Override
   void setDataProvider(String v);
 
   /**
    * @return The class holding the data provider, or {@code null} when neither the method nor
    *     anything it inherits from names one.
    */
+  @Override
   @Nullable
   Class<?> getDataProviderClass();
 
+  @Override
   void setDataProviderClass(@Nullable Class<?> v);
 
+  @Override
   String getDataProviderDynamicClass();
 
+  @Override
   void setDataProviderDynamicClass(String v);
 
   void setRetryAnalyzer(Class<? extends IRetryAnalyzer> c);

--- a/testng-core-api/src/main/java/org/testng/internal/PackageUtils.java
+++ b/testng-core-api/src/main/java/org/testng/internal/PackageUtils.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Spliterator;
 import java.util.Spliterators;
@@ -108,8 +109,8 @@ public class PackageUtils {
 
     for (int i = 0; i < classpathFragments.length; i++) {
       String path;
-      if (classpathFragments[i].toLowerCase().endsWith(".jar")
-          || classpathFragments[i].toLowerCase().endsWith(".zip")) {
+      String fragment = classpathFragments[i].toLowerCase(Locale.ROOT);
+      if (fragment.endsWith(".jar") || fragment.endsWith(".zip")) {
         path = classpathFragments[i] + "!/";
       } else {
         if (classpathFragments[i].endsWith(File.separator)) {

--- a/testng-core-api/src/main/java/org/testng/internal/objects/InstanceCreator.java
+++ b/testng-core-api/src/main/java/org/testng/internal/objects/InstanceCreator.java
@@ -19,6 +19,10 @@ public final class InstanceCreator {
     // Hide Constructor
   }
 
+  // Named by String rather than by Class<T>, so T appears only in the return type and the cast
+  // below is unchecked -- which is the check's complaint. It implements the ITestObjectFactory
+  // overload of the same shape, so the signature is not ours to change.
+  @SuppressWarnings("TypeParameterUnusedInFormals")
   public static <T> T newInstance(String className, Object... parameters) {
     Class<?> clazz = ClassHelper.forName(className);
     Objects.requireNonNull(clazz, "Could not find a valid class");

--- a/testng-core-api/src/main/java/org/testng/internal/protocols/Processor.java
+++ b/testng-core-api/src/main/java/org/testng/internal/protocols/Processor.java
@@ -47,8 +47,8 @@ public abstract class Processor {
         dir.listFiles(
             file ->
                 (recursive && file.isDirectory())
-                    || (file.getName().endsWith(".class"))
-                    || (file.getName().endsWith(".groovy")));
+                    || file.getName().endsWith(".class")
+                    || file.getName().endsWith(".groovy"));
 
     Utils.log(CLS_NAME, 4, "Looking for test classes in the directory: " + dir);
     if (dirfiles == null) {

--- a/testng-core-api/src/main/java/org/testng/internal/protocols/Processor.java
+++ b/testng-core-api/src/main/java/org/testng/internal/protocols/Processor.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.regex.Pattern;
 import org.testng.internal.Utils;
 
@@ -13,7 +14,7 @@ public abstract class Processor {
 
   public static Processor newInstance(String protocol) {
     Processor instance;
-    switch (protocol.toLowerCase()) {
+    switch (protocol.toLowerCase(Locale.ROOT)) {
       case "file":
         instance = new FileProcessor();
         break;

--- a/testng-core/src/main/java/org/testng/JarFileUtils.java
+++ b/testng-core/src/main/java/org/testng/JarFileUtils.java
@@ -9,6 +9,7 @@ import java.util.Collection;
 import java.util.Enumeration;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
@@ -94,7 +95,7 @@ class JarFileUtils {
       while (entries.hasMoreElements()) {
         JarEntry je = entries.nextElement();
         String jeName = je.getName();
-        if (Parser.canParse(jeName.toLowerCase())) {
+        if (Parser.canParse(jeName.toLowerCase(Locale.ROOT))) {
           InputStream inputStream = jf.getInputStream(je);
           File copyFile = new File(file, jeName);
           if (!copyFile.toPath().normalize().startsWith(file.toPath().normalize())) {

--- a/testng-core/src/main/java/org/testng/SuiteRunner.java
+++ b/testng-core/src/main/java/org/testng/SuiteRunner.java
@@ -155,6 +155,7 @@ public class SuiteRunner implements ISuite, ISuiteRunnerListener {
             }
 
             @Override
+            @SuppressWarnings("TypeParameterUnusedInFormals") // signature fixed by the interface
             public <T> T newInstance(String clsName, Object... parameters) {
               try {
                 return suiteObjectFactory.newInstance(clsName, parameters);
@@ -262,12 +263,9 @@ public class SuiteRunner implements ISuite, ISuiteRunnerListener {
     }
   }
 
-  private void setOutputDir(String outputDir) {
-    if (isStringBlank(outputDir) && useDefaultListeners) {
-      outputDir = DEFAULT_OUTPUT_DIR;
-    }
-
-    this.outputDir = null != outputDir ? new File(outputDir).getAbsolutePath() : null;
+  private void setOutputDir(String dir) {
+    String resolved = isStringBlank(dir) && useDefaultListeners ? DEFAULT_OUTPUT_DIR : dir;
+    outputDir = null != resolved ? new File(resolved).getAbsolutePath() : null;
   }
 
   private ITestRunnerFactory buildRunnerFactory(Comparator<ITestNGMethod> comparator) {

--- a/testng-core/src/main/java/org/testng/SuiteRunner.java
+++ b/testng-core/src/main/java/org/testng/SuiteRunner.java
@@ -12,7 +12,6 @@ import org.jspecify.annotations.Nullable;
 import org.testng.internal.*;
 import org.testng.internal.annotations.IAnnotationFinder;
 import org.testng.internal.invokers.ConfigMethodArguments;
-import org.testng.internal.invokers.ConfigMethodArguments.Builder;
 import org.testng.internal.invokers.IInvocationStatus;
 import org.testng.internal.invokers.IInvoker;
 import org.testng.internal.invokers.InvokedMethod;
@@ -241,6 +240,7 @@ public class SuiteRunner implements ISuite, ISuiteRunnerListener {
     useDefaultListeners = reportResults;
   }
 
+  @Override
   public ITestListener getExitCodeListener() {
     return exitCodeListener;
   }
@@ -262,12 +262,12 @@ public class SuiteRunner implements ISuite, ISuiteRunnerListener {
     }
   }
 
-  private void setOutputDir(String outputdir) {
-    if (isStringBlank(outputdir) && useDefaultListeners) {
-      outputdir = DEFAULT_OUTPUT_DIR;
+  private void setOutputDir(String outputDir) {
+    if (isStringBlank(outputDir) && useDefaultListeners) {
+      outputDir = DEFAULT_OUTPUT_DIR;
     }
 
-    outputDir = null != outputdir ? new File(outputdir).getAbsolutePath() : null;
+    this.outputDir = null != outputDir ? new File(outputDir).getAbsolutePath() : null;
   }
 
   private ITestRunnerFactory buildRunnerFactory(Comparator<ITestNGMethod> comparator) {
@@ -361,7 +361,7 @@ public class SuiteRunner implements ISuite, ISuiteRunnerListener {
     if (invoker != null) {
       if (!beforeSuiteMethods.values().isEmpty()) {
         ConfigMethodArguments arguments =
-            new Builder()
+            new ConfigMethodArguments.Builder()
                 .usingConfigMethodsAs(beforeSuiteMethods.values())
                 .forSuite(xmlSuite)
                 .usingParameters(xmlSuite.getParameters())
@@ -389,7 +389,7 @@ public class SuiteRunner implements ISuite, ISuiteRunnerListener {
       //
       if (!afterSuiteMethods.values().isEmpty()) {
         ConfigMethodArguments arguments =
-            new Builder()
+            new ConfigMethodArguments.Builder()
                 .usingConfigMethodsAs(afterSuiteMethods.values())
                 .forSuite(xmlSuite)
                 .usingParameters(xmlSuite.getAllParameters())

--- a/testng-core/src/main/java/org/testng/TestNG.java
+++ b/testng-core/src/main/java/org/testng/TestNG.java
@@ -878,9 +878,9 @@ public class TestNG {
 
   private Integer m_suiteThreadPoolSize = CommandLineArgs.SUITE_THREAD_POOL_SIZE_DEFAULT;
 
-  private boolean m_randomizeSuites = Boolean.FALSE;
+  private boolean m_randomizeSuites = false;
 
-  private boolean m_alwaysRun = Boolean.TRUE;
+  private boolean m_alwaysRun = true;
 
   private Boolean m_preserveOrder = XmlSuite.DEFAULT_PRESERVE_ORDER;
   private @Nullable Boolean m_groupByInstances;
@@ -1807,7 +1807,7 @@ public class TestNG {
         (String)
             cmdLineArgs.getOrDefault(
                 CommandLineArgs.XML_PATH_IN_JAR, CommandLineArgs.XML_PATH_IN_JAR_DEFAULT);
-    result.mixed = (Boolean) cmdLineArgs.getOrDefault(CommandLineArgs.MIXED, Boolean.FALSE);
+    result.mixed = (Boolean) cmdLineArgs.getOrDefault(CommandLineArgs.MIXED, false);
     Object tmpValue = cmdLineArgs.get(CommandLineArgs.INCLUDE_ALL_DATA_DRIVEN_TESTS_WHEN_SKIPPING);
     if (tmpValue != null) {
       result.includeAllDataDrivenTestsWhenSkipping = Boolean.parseBoolean(tmpValue.toString());
@@ -1816,9 +1816,7 @@ public class TestNG {
         (Boolean) cmdLineArgs.get(CommandLineArgs.SKIP_FAILED_INVOCATION_COUNTS);
     result.failIfAllTestsSkipped =
         Boolean.parseBoolean(
-            cmdLineArgs
-                .getOrDefault(CommandLineArgs.FAIL_IF_ALL_TESTS_SKIPPED, Boolean.FALSE)
-                .toString());
+            cmdLineArgs.getOrDefault(CommandLineArgs.FAIL_IF_ALL_TESTS_SKIPPED, false).toString());
     result.spiListenersToSkip =
         (String) cmdLineArgs.getOrDefault(CommandLineArgs.LISTENERS_TO_SKIP_VIA_SPI, "");
     String parallelMode = (String) cmdLineArgs.get(CommandLineArgs.PARALLEL);

--- a/testng-core/src/main/java/org/testng/TestRunner.java
+++ b/testng-core/src/main/java/org/testng/TestRunner.java
@@ -53,7 +53,6 @@ import org.testng.internal.XmlMethodSelector;
 import org.testng.internal.annotations.IAnnotationFinder;
 import org.testng.internal.invokers.AbstractParallelWorker;
 import org.testng.internal.invokers.ConfigMethodArguments;
-import org.testng.internal.invokers.ConfigMethodArguments.Builder;
 import org.testng.internal.invokers.IInvoker;
 import org.testng.internal.invokers.Invoker;
 import org.testng.internal.objects.IObjectDispenser;
@@ -668,7 +667,7 @@ public class TestRunner
   private void invokeTestConfigurations(ITestNGMethod[] testConfigurationMethods) {
     if (null != testConfigurationMethods && testConfigurationMethods.length > 0) {
       ConfigMethodArguments arguments =
-          new Builder()
+          new ConfigMethodArguments.Builder()
               .usingConfigMethodsAs(testConfigurationMethods)
               .forSuite(m_xmlTest.getSuite())
               .usingParameters(m_xmlTest.getAllParameters())

--- a/testng-core/src/main/java/org/testng/internal/BaseTestMethod.java
+++ b/testng-core/src/main/java/org/testng/internal/BaseTestMethod.java
@@ -777,11 +777,11 @@ public abstract class BaseTestMethod
     m_retryAnalyzerClass = clazz == null ? DisabledRetryAnalyzer.class : clazz;
   }
 
-  @Override
   /**
    * @return the retry analyzer class, never null: it is {@link DisabledRetryAnalyzer} until a retry
    *     analyzer is set, and the setter normalises null back to it.
    */
+  @Override
   public Class<? extends IRetryAnalyzer> getRetryAnalyzerClass() {
     return m_retryAnalyzerClass;
   }

--- a/testng-core/src/main/java/org/testng/internal/DataProviderLoader.java
+++ b/testng-core/src/main/java/org/testng/internal/DataProviderLoader.java
@@ -2,12 +2,8 @@ package org.testng.internal;
 
 import java.io.IOException;
 import java.io.InputStream;
-import org.testng.log4testng.Logger;
 
 public class DataProviderLoader extends ClassLoader {
-  private static final int BUFFER_SIZE = 1 << 20;
-  private static final Logger log = Logger.getLogger(DataProviderLoader.class);
-
   public Class loadClazz(String path) throws ClassNotFoundException {
     Class clazz = findLoadedClass(path);
     if (clazz == null) {

--- a/testng-core/src/main/java/org/testng/internal/DynamicGraph.java
+++ b/testng-core/src/main/java/org/testng/internal/DynamicGraph.java
@@ -26,6 +26,7 @@ public class DynamicGraph<T> implements IDynamicGraph<T> {
   private Set<IExecutionVisualiser> visualisers = new HashSet<>();
 
   /** Add a node to the graph. */
+  @Override
   public boolean addNode(T node) {
     return m_nodesReady.add(node);
   }
@@ -36,15 +37,18 @@ public class DynamicGraph<T> implements IDynamicGraph<T> {
    * @param from - Represents the edge that depends on another edge.
    * @param to - Represents the edge on which another edge depends upon.
    */
+  @Override
   public void addEdge(int weight, T from, T to) {
     m_edges.addEdge(weight, from, to, false);
   }
 
+  @Override
   public void setVisualisers(Set<IExecutionVisualiser> listener) {
     visualisers = listener;
   }
 
   /** Add an edge between two nodes. */
+  @Override
   public void addEdges(int weight, T from, Iterable<T> tos) {
     for (T to : tos) {
       addEdge(weight, from, to);
@@ -52,6 +56,7 @@ public class DynamicGraph<T> implements IDynamicGraph<T> {
   }
 
   /** @return a set of all the nodes that don't depend on any other nodes. */
+  @Override
   public List<T> getFreeNodes() {
     // Get a list of nodes that are ready and have no outgoing edges.
     Set<T> free = new LinkedHashSet<>(m_nodesReady);
@@ -85,6 +90,7 @@ public class DynamicGraph<T> implements IDynamicGraph<T> {
     return dependencies(m_edges.from(node));
   }
 
+  @Override
   public List<T> getDependenciesFor(T node) {
     return dependencies(m_edges.to(node));
   }
@@ -96,6 +102,7 @@ public class DynamicGraph<T> implements IDynamicGraph<T> {
   }
 
   /** Set the status for a set of nodes. */
+  @Override
   public void setStatus(Collection<T> nodes, Status status) {
     for (T n : nodes) {
       setStatus(n, status);
@@ -103,6 +110,7 @@ public class DynamicGraph<T> implements IDynamicGraph<T> {
   }
 
   /** Set the status for a node. */
+  @Override
   public void setStatus(T node, Status status) {
     switch (status) {
       case RUNNING:
@@ -149,14 +157,17 @@ public class DynamicGraph<T> implements IDynamicGraph<T> {
   }
 
   /** @return the number of nodes in this graph. */
+  @Override
   public int getNodeCount() {
     return m_nodesReady.size() + m_nodesRunning.size() + m_nodesFinished.size();
   }
 
+  @Override
   public int getNodeCountWithStatus(Status status) {
     return getNodesWithStatus(status).size();
   }
 
+  @Override
   public Set<T> getNodesWithStatus(Status status) {
     switch (status) {
       case READY:
@@ -191,6 +202,7 @@ public class DynamicGraph<T> implements IDynamicGraph<T> {
   }
 
   /** @return a .dot file (GraphViz) version of this graph. */
+  @Override
   public String toDot() {
     String FREE = "[style=filled color=yellow]";
     String RUNNING = "[style=filled color=green]";

--- a/testng-core/src/main/java/org/testng/internal/MethodSorting.java
+++ b/testng-core/src/main/java/org/testng/internal/MethodSorting.java
@@ -34,7 +34,9 @@ public enum MethodSorting implements Comparator<ITestNGMethod> {
     }
   },
   NONE("none") {
+    // Comparator fixes the signature, and NONE compares nothing.
     @Override
+    @SuppressWarnings("unused")
     public int compare(ITestNGMethod o1, ITestNGMethod o2) {
       return 0;
     }

--- a/testng-core/src/main/java/org/testng/internal/ObjectBag.java
+++ b/testng-core/src/main/java/org/testng/internal/ObjectBag.java
@@ -7,7 +7,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
 import org.testng.ISuite;
-import org.testng.log4testng.Logger;
 import org.testng.xml.XmlSuite;
 
 /**
@@ -16,7 +15,6 @@ import org.testng.xml.XmlSuite;
  */
 public final class ObjectBag {
 
-  private static final Logger logger = Logger.getLogger(ObjectBag.class);
   private final Map<Class<?>, Object> bag = new ConcurrentHashMap<>();
 
   private static final Map<UUID, ObjectBag> instances = new ConcurrentHashMap<>();

--- a/testng-core/src/main/java/org/testng/internal/Parameters.java
+++ b/testng-core/src/main/java/org/testng/internal/Parameters.java
@@ -428,7 +428,7 @@ public class Parameters {
     if (parameterNames.length == 0) {
       // parameterNames is usually populated via the @Parameters annotation, so we would need to
       // apply our logic only when @Parameters annotation is not involved.
-      boolean invalid = (totalLength != 0) || (!validParameters(methodAnnotation, parameterTypes));
+      boolean invalid = (totalLength != 0) || !validParameters(methodAnnotation, parameterTypes);
       if (invalid) {
         String annotation = methodAnnotation;
         if (!methodAnnotation.startsWith("@")) {

--- a/testng-core/src/main/java/org/testng/internal/RegexpExpectedExceptionsHolder.java
+++ b/testng-core/src/main/java/org/testng/internal/RegexpExpectedExceptionsHolder.java
@@ -36,6 +36,7 @@ public class RegexpExpectedExceptionsHolder implements IExpectedExceptionsHolder
         && Pattern.compile(messageRegExp, Pattern.DOTALL).matcher(message).matches();
   }
 
+  @Override
   public String getWrongExceptionMessage(Throwable ite) {
     return "The exception was thrown with the wrong message:"
         + " expected \""

--- a/testng-core/src/main/java/org/testng/internal/ScriptSelectorFactory.java
+++ b/testng-core/src/main/java/org/testng/internal/ScriptSelectorFactory.java
@@ -1,6 +1,7 @@
 package org.testng.internal;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.ServiceLoader;
@@ -20,12 +21,12 @@ public final class ScriptSelectorFactory {
       throw new IllegalArgumentException("Language name must not be null");
     }
 
-    String languageName = script.getLanguage().toLowerCase();
+    String languageName = script.getLanguage().toLowerCase(Locale.ROOT);
     ScriptEngineFactory engineFactory = ENGINE_FACTORIES.get(languageName);
     if (engineFactory == null) {
       ServiceLoader<ScriptEngineFactory> loader = ServiceLoader.load(ScriptEngineFactory.class);
       for (ScriptEngineFactory factory : loader) {
-        ENGINE_FACTORIES.put(factory.getLanguageName().toLowerCase(), factory);
+        ENGINE_FACTORIES.put(factory.getLanguageName().toLowerCase(Locale.ROOT), factory);
       }
 
       engineFactory = ENGINE_FACTORIES.get(languageName);

--- a/testng-core/src/main/java/org/testng/internal/TestMethodContainer.java
+++ b/testng-core/src/main/java/org/testng/internal/TestMethodContainer.java
@@ -22,6 +22,7 @@ public final class TestMethodContainer implements IContainer<ITestNGMethod> {
     this.supplier = supplier;
   }
 
+  @Override
   public ITestNGMethod[] getItems() {
     if (isCleared()) {
       // If the cached data was cleared, no longer try to refer to it, but instead
@@ -40,6 +41,7 @@ public final class TestMethodContainer implements IContainer<ITestNGMethod> {
     return isCleared;
   }
 
+  @Override
   public void clearItems() {
     if (isCleared) {
       return;

--- a/testng-core/src/main/java/org/testng/internal/TestNGMethodFinder.java
+++ b/testng-core/src/main/java/org/testng/internal/TestNGMethodFinder.java
@@ -40,8 +40,6 @@ public class TestNGMethodFinder implements ITestMethodFinder {
     AFTER_GROUPS
   }
 
-  private static final Comparator<ITestNGMethod> NO_COMPARISON = (o1, o2) -> 0;
-
   private final ITestObjectFactory objectFactory;
   private final RunInfo runInfo;
   private final IAnnotationFinder annotationFinder;
@@ -49,7 +47,7 @@ public class TestNGMethodFinder implements ITestMethodFinder {
 
   public TestNGMethodFinder(
       ITestObjectFactory objectFactory, RunInfo runInfo, IAnnotationFinder annotationFinder) {
-    this(objectFactory, runInfo, annotationFinder, NO_COMPARISON);
+    this(objectFactory, runInfo, annotationFinder, MethodSorting.NONE);
   }
 
   public TestNGMethodFinder(

--- a/testng-core/src/main/java/org/testng/internal/annotations/AnnotationHelper.java
+++ b/testng-core/src/main/java/org/testng/internal/annotations/AnnotationHelper.java
@@ -258,7 +258,7 @@ public class AnnotationHelper {
                   || isAnnotationPresent(annotationFinder, m);
           boolean isPublic = Modifier.isPublic(m.getModifiers());
           boolean isSynthetic = m.isSynthetic();
-          if ((isPublic && hasClassAnnotation && !isSynthetic && (!hasTestNGAnnotation))
+          if ((isPublic && hasClassAnnotation && !isSynthetic && !hasTestNGAnnotation)
               || hasMethodAnnotation) {
 
             // Small hack to allow users to specify @Configuration classes even though

--- a/testng-core/src/main/java/org/testng/internal/annotations/ConfigurationAnnotation.java
+++ b/testng-core/src/main/java/org/testng/internal/annotations/ConfigurationAnnotation.java
@@ -198,6 +198,7 @@ public class ConfigurationAnnotation extends TestOrConfiguration
     return m_lastTimeOnly;
   }
 
+  @Override
   public boolean isIgnoreFailure() {
     return m_ignoreFailure;
   }

--- a/testng-core/src/main/java/org/testng/internal/annotations/DataProviderAnnotation.java
+++ b/testng-core/src/main/java/org/testng/internal/annotations/DataProviderAnnotation.java
@@ -67,6 +67,7 @@ public class DataProviderAnnotation extends BaseAnnotation implements IDataProvi
     return retryUsing;
   }
 
+  @Override
   public void cacheDataForTestRetries(boolean cache) {
     this.cachedDataForTestRetries = cache;
   }

--- a/testng-core/src/main/java/org/testng/internal/annotations/FactoryAnnotation.java
+++ b/testng-core/src/main/java/org/testng/internal/annotations/FactoryAnnotation.java
@@ -25,6 +25,7 @@ public class FactoryAnnotation extends BaseAnnotation implements IFactoryAnnotat
     m_dataProvider = dataProvider;
   }
 
+  @Override
   public void setDataProviderClass(@Nullable Class<?> dataProviderClass) {
     m_dataProviderClass = dataProviderClass;
   }

--- a/testng-core/src/main/java/org/testng/internal/annotations/IBaseBeforeAfter.java
+++ b/testng-core/src/main/java/org/testng/internal/annotations/IBaseBeforeAfter.java
@@ -6,9 +6,11 @@ import org.testng.annotations.ITestOrConfiguration;
 /** Base interface for IBeforeSuite, IAfterSuite, etc... */
 public interface IBaseBeforeAfter extends ITestOrConfiguration {
   /** Whether methods on this class/method are enabled. */
+  @Override
   boolean getEnabled();
 
   /** The list of groups this class/method belongs to. */
+  @Override
   String[] getGroups();
 
   /**
@@ -16,6 +18,7 @@ public interface IBaseBeforeAfter extends ITestOrConfiguration {
    * guaranteed to have been invoked before this method. Furthermore, if any of these methods was
    * not a SUCCESS, this test method will not be run and will be flagged as a SKIP.
    */
+  @Override
   String[] getDependsOnGroups();
 
   /**
@@ -26,6 +29,7 @@ public interface IBaseBeforeAfter extends ITestOrConfiguration {
    *
    * <p>If some of these methods have been overloaded, all the overloaded versions will be run.
    */
+  @Override
   String[] getDependsOnMethods();
 
   /**
@@ -47,6 +51,7 @@ public interface IBaseBeforeAfter extends ITestOrConfiguration {
    * The description for this method. The string used will appear in the HTML report and also on
    * standard output if verbose &gt; 2.
    */
+  @Override
   @Nullable
   String getDescription();
 

--- a/testng-core/src/main/java/org/testng/internal/invokers/BaseInvoker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/BaseInvoker.java
@@ -103,7 +103,7 @@ class BaseInvoker {
   }
 
   private boolean noListenersPresent() {
-    return (m_invokedMethodListeners == null) || (m_invokedMethodListeners.isEmpty());
+    return (m_invokedMethodListeners == null) || m_invokedMethodListeners.isEmpty();
   }
 
   /**

--- a/testng-core/src/main/java/org/testng/internal/invokers/ConfigInvoker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/ConfigInvoker.java
@@ -44,7 +44,6 @@ import org.testng.internal.TestListenerHelper;
 import org.testng.internal.TestResult;
 import org.testng.internal.Utils;
 import org.testng.internal.annotations.AnnotationHelper;
-import org.testng.internal.invokers.ConfigMethodArguments.Builder;
 import org.testng.internal.thread.ThreadUtil;
 import org.testng.xml.XmlClass;
 import org.testng.xml.XmlSuite;
@@ -99,6 +98,7 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
    * @return false if this class has successfully run all its @Configuration method or true if at
    *     least one of these methods failed.
    */
+  @Override
   public boolean hasConfigurationFailureFor(
       @Nullable ITestNGMethod testNGMethod,
       String[] groups,
@@ -171,6 +171,7 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
    *
    * @param arguments - A {@link GroupConfigMethodArguments} object.
    */
+  @Override
   public void invokeBeforeGroupsConfigurations(GroupConfigMethodArguments arguments) {
     String[] groups = arguments.getTestMethod().getGroups();
 
@@ -192,7 +193,7 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
         // don't pass the IClass or the instance as the method may be external
         // the invocation must be similar to @BeforeTest/@BeforeSuite
         ConfigMethodArguments configMethodArguments =
-            new Builder()
+            new ConfigMethodArguments.Builder()
                 .usingConfigMethodsAs(filteredConfigurations)
                 .forSuite(arguments.getSuite())
                 .usingParameters(arguments.getParameters())
@@ -213,6 +214,7 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
     return itm.hasBeforeGroupsConfiguration() || itm.hasAfterGroupsConfiguration();
   }
 
+  @Override
   public void invokeAfterGroupsConfigurations(GroupConfigMethodArguments arguments) {
     // Skip this if the current method doesn't belong to any group
     // (only a method that belongs to a group can trigger the invocation
@@ -232,7 +234,7 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
       // don't pass the IClass or the instance as the method may be external
       // the invocation must be similar to @BeforeTest/@BeforeSuite
       ConfigMethodArguments configMethodArguments =
-          new Builder()
+          new ConfigMethodArguments.Builder()
               .usingConfigMethodsAs(filteredConfigurations)
               .forSuite(arguments.getSuite())
               .usingParameters(arguments.getParameters())
@@ -247,6 +249,7 @@ class ConfigInvoker extends BaseInvoker implements IConfigInvoker {
     arguments.getGroupMethods().removeAfterGroups(filteredGroups);
   }
 
+  @Override
   public void invokeConfigurations(ConfigMethodArguments arguments) {
     if (arguments.getConfigMethods().length == 0) {
       log(5, "No configuration methods found");

--- a/testng-core/src/main/java/org/testng/internal/invokers/ExceptionUtils.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/ExceptionUtils.java
@@ -45,7 +45,7 @@ final class ExceptionUtils {
   private static @Nullable Throwable getConfigFailureException(ITestContext context) {
     for (IInvokedMethod method : context.getSuite().getAllInvokedMethods()) {
       ITestNGMethod m = method.getTestMethod();
-      if (m.isBeforeSuiteConfiguration() && (!method.getTestResult().isSuccess())) {
+      if (m.isBeforeSuiteConfiguration() && !method.getTestResult().isSuccess()) {
         return method.getTestResult().getThrowable();
       }
     }

--- a/testng-core/src/main/java/org/testng/internal/invokers/Invoker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/Invoker.java
@@ -66,10 +66,12 @@ public class Invoker implements IInvoker {
             suiteRunner);
   }
 
+  @Override
   public IConfigInvoker getConfigInvoker() {
     return m_configInvoker;
   }
 
+  @Override
   public ITestInvoker getTestInvoker() {
     return m_testInvoker;
   }

--- a/testng-core/src/main/java/org/testng/internal/invokers/MethodRunner.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/MethodRunner.java
@@ -24,7 +24,6 @@ import org.testng.internal.IConfiguration;
 import org.testng.internal.ObjectBag;
 import org.testng.internal.Parameters;
 import org.testng.internal.invokers.ITestInvoker.FailureContext;
-import org.testng.internal.invokers.TestMethodArguments.Builder;
 import org.testng.internal.thread.Async;
 import org.testng.internal.thread.TestNGThreadFactory;
 import org.testng.internal.thread.ThreadUtil;
@@ -56,7 +55,7 @@ public class MethodRunner implements IMethodRunner {
       List<ITestResult> tmpResults = new ArrayList<>();
       int tmpResultsIndex = -1;
       TestMethodArguments tmArguments =
-          new Builder()
+          new TestMethodArguments.Builder()
               .usingArguments(arguments)
               .withParameterValues(parameterValues)
               .withParametersIndex(parametersIndex)

--- a/testng-core/src/main/java/org/testng/internal/invokers/TestInvoker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/TestInvoker.java
@@ -62,7 +62,6 @@ import org.testng.internal.RuntimeBehavior;
 import org.testng.internal.TestListenerHelper;
 import org.testng.internal.TestResult;
 import org.testng.internal.Utils;
-import org.testng.internal.invokers.GroupConfigMethodArguments.Builder;
 import org.testng.internal.invokers.InvokeMethodRunnable.TestNGRuntimeException;
 import org.testng.internal.thread.ThreadExecutionException;
 import org.testng.internal.thread.ThreadUtil;
@@ -105,6 +104,7 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
     return m_notifier;
   }
 
+  @Override
   public List<ITestResult> invokeTestMethods(
       ITestNGMethod testMethod,
       ConfigurationGroupMethods groupMethods,
@@ -181,7 +181,7 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
       }
       testMethod.incrementCurrentInvocationCount();
       GroupConfigMethodArguments args =
-          new Builder()
+          new GroupConfigMethodArguments.Builder()
               .forTestMethod(testMethod)
               .withGroupConfigMethods(groupMethods)
               .forInstance(instance)
@@ -241,6 +241,7 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
    * invoking @BeforeGroup, @BeforeMethod, @AfterMethod, @AfterGroup if it is the case for the
    * passed in @Test method.
    */
+  @Override
   public ITestResult invokeTestMethod(
       TestMethodArguments arguments, XmlSuite suite, FailureContext failureContext) {
     // Mark this method with the current thread id
@@ -249,6 +250,7 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
     return invokeMethod(arguments, suite, failureContext);
   }
 
+  @Override
   public FailureContext retryFailed(
       TestMethodArguments arguments,
       List<ITestResult> result,
@@ -308,6 +310,7 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
     return failure;
   }
 
+  @Override
   public void runTestResultListener(ITestResult tr) {
     // For onTestStart method, still run as insert order
     // but regarding
@@ -627,6 +630,7 @@ class TestInvoker extends BaseInvoker implements ITestInvoker {
     }
   }
 
+  @Override
   public void invokeListenersForSkippedTestResult(ITestResult r, IInvokedMethod invokedMethod) {
     if (m_configuration.alwaysRunListeners()) {
       runInvokedMethodListeners(BEFORE_INVOCATION, invokedMethod, r);

--- a/testng-core/src/main/java/org/testng/internal/invokers/TestMethodWithDataProviderMethodWorker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/TestMethodWithDataProviderMethodWorker.java
@@ -10,7 +10,6 @@ import org.testng.ITestContext;
 import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
 import org.testng.internal.ConfigurationGroupMethods;
-import org.testng.internal.invokers.TestMethodArguments.Builder;
 import org.testng.xml.XmlSuite;
 
 public class TestMethodWithDataProviderMethodWorker
@@ -75,7 +74,7 @@ public class TestMethodWithDataProviderMethodWorker
     try {
       tmpResults.add(
           m_testInvoker.invokeTestMethod(
-              new Builder()
+              new TestMethodArguments.Builder()
                   .usingInstance(m_instance)
                   .forTestMethod(m_testMethod)
                   .withParameterValues(m_parameterValues)
@@ -99,7 +98,7 @@ public class TestMethodWithDataProviderMethodWorker
           m_failureCount =
               m_testInvoker
                   .retryFailed(
-                      new Builder()
+                      new TestMethodArguments.Builder()
                           .usingInstance(instance)
                           .forTestMethod(m_testMethod)
                           .withParameterValues(m_parameterValues)

--- a/testng-core/src/main/java/org/testng/internal/invokers/TestMethodWorker.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/TestMethodWorker.java
@@ -30,7 +30,6 @@ import org.testng.internal.RuntimeBehavior;
 import org.testng.internal.TestMethodComparator;
 import org.testng.internal.TestMethodContainer;
 import org.testng.internal.Utils;
-import org.testng.internal.invokers.ConfigMethodArguments.Builder;
 import org.testng.thread.IWorker;
 
 /**
@@ -207,7 +206,7 @@ public class TestMethodWorker implements IWorker<ITestNGMethod> {
         listener.onBeforeClass(testClass);
       }
       ConfigMethodArguments attributes =
-          new Builder()
+          new ConfigMethodArguments.Builder()
               .forTestClass(testClass)
               .usingConfigMethodsAs(
                   ((ITestClassConfigInfo) testClass)
@@ -259,7 +258,7 @@ public class TestMethodWorker implements IWorker<ITestNGMethod> {
       ITestClass testClass, List<IMethodInstance> invokeInstances) {
     for (IMethodInstance invokeInstance : invokeInstances) {
       ConfigMethodArguments attributes =
-          new Builder()
+          new ConfigMethodArguments.Builder()
               .forTestClass(testClass)
               .forSuite(m_testContext.getSuite().getXmlSuite())
               .usingParameters(m_parameters)

--- a/testng-core/src/main/java/org/testng/internal/invokers/TestNgMethodUtils.java
+++ b/testng-core/src/main/java/org/testng/internal/invokers/TestNgMethodUtils.java
@@ -97,7 +97,7 @@ class TestNgMethodUtils {
     for (ITestNGMethod tm : methods) {
       String msg;
       if ((predicate.test(tm, testClass) && isSameInstance(tm, instance))
-          && (!TestNgMethodUtils.containsConfigurationMethod(tm, vResult))) {
+          && !TestNgMethodUtils.containsConfigurationMethod(tm, vResult)) {
         msg = Utils.getVerbose() < 10 ? "" : "Keeping method " + tm + " for class " + testClass;
         vResult.add(tm);
       } else {

--- a/testng-core/src/main/java/org/testng/reporters/EmailableReporter2.java
+++ b/testng-core/src/main/java/org/testng/reporters/EmailableReporter2.java
@@ -466,7 +466,7 @@ public class EmailableReporter2 implements IReporter {
     Object[] parameters = result.getParameters();
     boolean hasRows = dumpParametersInfo("Factory Parameter", result.getFactoryParameters());
     int parameterCount = parameters == null ? 0 : parameters.length;
-    hasRows |= dumpParametersInfo("Parameter", result.getParameters());
+    hasRows |= dumpParametersInfo("Parameter", parameters);
     dumpAttributesInfo(result.getMethod().getAttributes());
 
     // Write reporter messages (if any)

--- a/testng-core/src/main/java/org/testng/reporters/JUnitXMLReporter.java
+++ b/testng-core/src/main/java/org/testng/reporters/JUnitXMLReporter.java
@@ -218,7 +218,7 @@ public class JUnitXMLReporter implements IResultListener2 {
     if (t != null) {
       attrs.setProperty(XMLConstants.ATTR_TYPE, t.getClass().getName());
       String message = t.getMessage();
-      if ((message != null) && (!message.isEmpty())) {
+      if ((message != null) && !message.isEmpty()) {
         attrs.setProperty(XMLConstants.ATTR_MESSAGE, encodeAttr(message)); // ENCODE
       }
       doc.push(XMLConstants.FAILURE, attrs);

--- a/testng-core/src/main/java/org/testng/reporters/XMLSuiteResultWriter.java
+++ b/testng-core/src/main/java/org/testng/reporters/XMLSuiteResultWriter.java
@@ -161,7 +161,7 @@ public class XMLSuiteResultWriter {
     Properties attribs = getTestResultAttributes(testResult);
     attribs.setProperty(XMLReporterConfig.ATTR_STATUS, getStatusString(testResult.getStatus()));
     if (testResult.wasRetried()) {
-      attribs.setProperty(XMLReporterConfig.ATTR_RETRIED, Boolean.TRUE.toString());
+      attribs.setProperty(XMLReporterConfig.ATTR_RETRIED, "true");
     }
     xmlBuffer.push(XMLReporterConfig.TAG_TEST_METHOD, attribs);
     addTestMethodParams(xmlBuffer, testResult);

--- a/testng-core/src/main/java/org/testng/xml/TestNGContentHandler.java
+++ b/testng-core/src/main/java/org/testng/xml/TestNGContentHandler.java
@@ -144,7 +144,6 @@ public class TestNGContentHandler extends DefaultHandler implements LexicalHandl
 
   private final String m_fileName;
   private final boolean m_loadClasses;
-  private boolean m_validate = false;
   private boolean m_doctypeDeclared = false;
 
   /**
@@ -221,7 +220,6 @@ public class TestNGContentHandler extends DefaultHandler implements LexicalHandl
     m_doctypeDeclared = true;
 
     if (skipConsideringSystemId(systemId)) {
-      m_validate = true;
       InputStream stream = loadDtdUsingClassLoader();
       if (stream != null) {
         // Buffer the classpath DTD so this resolver, rather than SAX, owns and closes the stream.

--- a/testng-core/src/main/java/org/testng/xml/TestNGURLs.java
+++ b/testng-core/src/main/java/org/testng/xml/TestNGURLs.java
@@ -4,6 +4,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 final class TestNGURLs {
 
@@ -13,7 +14,7 @@ final class TestNGURLs {
 
   static boolean isDTDDomainInternallyKnownToTestNG(String publicId) {
     try {
-      URL url = new URL(publicId.toLowerCase().trim());
+      URL url = new URL(publicId.toLowerCase(Locale.ROOT).trim());
       return DOMAINS.contains(url.getHost());
     } catch (MalformedURLException e) {
       return false;

--- a/testng-core/src/test/java/org/testng/TestRunnerTest.java
+++ b/testng-core/src/test/java/org/testng/TestRunnerTest.java
@@ -10,6 +10,7 @@ import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 import org.testng.internal.Configuration;
 import org.testng.internal.IConfiguration;
+import org.testng.internal.MethodSorting;
 import org.testng.internal.objects.DefaultTestObjectFactory;
 import org.testng.xml.XmlClass;
 import org.testng.xml.XmlSuite;
@@ -96,7 +97,8 @@ public class TestRunnerTest {
                 listeners,
                 classListeners,
                 (ISuiteRunnerListener) suite);
-    SuiteRunner suite = new SuiteRunner(configuration, xmlSuite, outputDir, factory, (o1, o2) -> 0);
+    SuiteRunner suite =
+        new SuiteRunner(configuration, xmlSuite, outputDir, factory, MethodSorting.NONE);
     return factory.newTestRunner(suite, xmlTest, emptyList(), emptyList());
   }
 }

--- a/testng-core/src/test/java/org/testng/internal/UtilsTest.java
+++ b/testng-core/src/test/java/org/testng/internal/UtilsTest.java
@@ -1,6 +1,5 @@
 package org.testng.internal;
 
-import static java.lang.String.valueOf;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -21,7 +20,8 @@ public class UtilsTest {
   @Test
   public void escapeUnicode() {
     assertThat(Utils.escapeUnicode("test")).isEqualTo("test");
-    assertThat(Utils.escapeUnicode(valueOf(INVALID_CHAR))).isEqualTo(valueOf(REPLACEMENT_CHAR));
+    assertThat(Utils.escapeUnicode(String.valueOf(INVALID_CHAR)))
+        .isEqualTo(String.valueOf(REPLACEMENT_CHAR));
   }
 
   @Test

--- a/testng-core/src/test/java/org/testng/reporters/TestHTMLReporterTest.java
+++ b/testng-core/src/test/java/org/testng/reporters/TestHTMLReporterTest.java
@@ -33,7 +33,7 @@ public class TestHTMLReporterTest {
 
     StringWriter sw = new StringWriter();
     PrintWriter pw = new PrintWriter(sw, true);
-    TestHTMLReporter.generateTable(pw, "title", tests, "cssClass", (t1, t2) -> 0);
+    TestHTMLReporter.generateTable(pw, "title", tests, "cssClass", (unusedLeft, unusedRight) -> 0);
 
     assertThat(sw.toString())
         .contains("Parameters: org.testng.reporters.TestHTMLReporterTest$ThrowingOnToString@");

--- a/testng-core/src/test/java/org/testng/xml/SuiteXmlParserTest.java
+++ b/testng-core/src/test/java/org/testng/xml/SuiteXmlParserTest.java
@@ -28,7 +28,7 @@ public class SuiteXmlParserTest {
     SuiteXmlParser parser = new SuiteXmlParser();
 
     try (FileInputStream stream = new FileInputStream(new File(PARENT, fileName))) {
-      XmlSuite suite = parser.parse(fileName, stream, false);
+      parser.parse(fileName, stream, false);
       if (!shouldWork) {
         fail("Parsing of " + fileName + " is supposed to fail");
       }

--- a/testng-core/src/test/java/org/testng/xml/XmlSuiteTest.java
+++ b/testng-core/src/test/java/org/testng/xml/XmlSuiteTest.java
@@ -244,6 +244,7 @@ public class XmlSuiteTest extends SimpleBaseTest {
     }
 
     // Netbeans IDE automatically overrides this toString()
+    @Override
     public String toString() {
       return this.string.toString();
     }

--- a/testng-core/src/test/java/test/FileStringBufferTest.java
+++ b/testng-core/src/test/java/test/FileStringBufferTest.java
@@ -19,7 +19,6 @@ public class FileStringBufferTest {
     {
       FileStringBuffer fsb = new FileStringBuffer(5);
       String s = "0123456789";
-      String s3 = s + s + s;
 
       fsb.append(s);
       fsb.append(s);

--- a/testng-core/src/test/java/test/annotationtransformer/AnnotationTransformerDataProviderSampleTest.java
+++ b/testng-core/src/test/java/test/annotationtransformer/AnnotationTransformerDataProviderSampleTest.java
@@ -1,6 +1,5 @@
 package test.annotationtransformer;
 
-import static java.lang.Integer.valueOf;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.testng.annotations.DataProvider;
@@ -17,6 +16,6 @@ public class AnnotationTransformerDataProviderSampleTest {
 
   @Test(dataProvider = "dataProvider")
   public void f(Integer n) {
-    assertThat(n).isEqualTo(valueOf(42));
+    assertThat(n).isEqualTo(Integer.valueOf(42));
   }
 }

--- a/testng-core/src/test/java/test/annotationtransformer/issue2312/RetryListener.java
+++ b/testng-core/src/test/java/test/annotationtransformer/issue2312/RetryListener.java
@@ -9,6 +9,7 @@ public class RetryListener implements IAnnotationTransformer {
 
   private static int executedNrOfTimes = 0;
 
+  @Override
   public void transform(
       ITestAnnotation annotation, Class testClass, Constructor testConstructor, Method testMethod) {
     executedNrOfTimes++;

--- a/testng-core/src/test/java/test/attributes/issue2346/LocalTestListener.java
+++ b/testng-core/src/test/java/test/attributes/issue2346/LocalTestListener.java
@@ -8,21 +8,25 @@ import org.testng.ITestResult;
 public class LocalTestListener implements ITestListener {
   public static Map<String, Boolean> data = new HashMap<>();
 
+  @Override
   public void onTestStart(ITestResult iTestResult) {
     String key = "onTestStart_" + iTestResult.getMethod().getQualifiedName();
     data.putIfAbsent(key, iTestResult.getAttributeNames().isEmpty());
   }
 
+  @Override
   public void onTestSuccess(ITestResult iTestResult) {
     String key = "onTestSuccess_" + iTestResult.getMethod().getQualifiedName();
     data.putIfAbsent(key, iTestResult.getAttributeNames().isEmpty());
   }
 
+  @Override
   public void onTestFailure(ITestResult iTestResult) {
     String key = "onTestFailure_" + iTestResult.getMethod().getQualifiedName();
     data.putIfAbsent(key, iTestResult.getAttributeNames().isEmpty());
   }
 
+  @Override
   public void onTestSkipped(ITestResult iTestResult) {
     String key = "onTestSkipped_" + iTestResult.getMethod().getQualifiedName();
     data.putIfAbsent(key, iTestResult.getAttributeNames().isEmpty());

--- a/testng-core/src/test/java/test/configuration/MultipleBeforeGroupTest.java
+++ b/testng-core/src/test/java/test/configuration/MultipleBeforeGroupTest.java
@@ -14,7 +14,7 @@ public class MultipleBeforeGroupTest {
     m_count++;
   }
 
-  @Test()
+  @Test
   public void test() {}
 
   @Test(dependsOnMethods = "test")

--- a/testng-core/src/test/java/test/configuration/issue2664/cls/GroupDependenciesChildSample.java
+++ b/testng-core/src/test/java/test/configuration/issue2664/cls/GroupDependenciesChildSample.java
@@ -15,6 +15,6 @@ public class GroupDependenciesChildSample extends GroupDependenciesBaseClass {
       dependsOnGroups = "g1")
   public void s1() {}
 
-  @Test()
+  @Test
   public void test3() {}
 }

--- a/testng-core/src/test/java/test/configuration/issue2664/cls/GroupDependenciesSample.java
+++ b/testng-core/src/test/java/test/configuration/issue2664/cls/GroupDependenciesSample.java
@@ -18,6 +18,6 @@ public class GroupDependenciesSample {
       dependsOnGroups = "g1")
   public void s1() {}
 
-  @Test()
+  @Test
   public void test3() {}
 }

--- a/testng-core/src/test/java/test/configuration/issue2664/suite/GroupDependenciesChildSample.java
+++ b/testng-core/src/test/java/test/configuration/issue2664/suite/GroupDependenciesChildSample.java
@@ -15,6 +15,6 @@ public class GroupDependenciesChildSample extends GroupDependenciesBaseClass {
       dependsOnGroups = "g1")
   public void s1() {}
 
-  @Test()
+  @Test
   public void test3() {}
 }

--- a/testng-core/src/test/java/test/configuration/issue2664/suite/GroupDependenciesSample.java
+++ b/testng-core/src/test/java/test/configuration/issue2664/suite/GroupDependenciesSample.java
@@ -18,6 +18,6 @@ public class GroupDependenciesSample {
       dependsOnGroups = "g1")
   public void s1() {}
 
-  @Test()
+  @Test
   public void test3() {}
 }

--- a/testng-core/src/test/java/test/configuration/issue2664/test/GroupDependenciesChildSample.java
+++ b/testng-core/src/test/java/test/configuration/issue2664/test/GroupDependenciesChildSample.java
@@ -15,6 +15,6 @@ public class GroupDependenciesChildSample extends GroupDependenciesBaseClass {
       dependsOnGroups = "g1")
   public void s1() {}
 
-  @Test()
+  @Test
   public void test3() {}
 }

--- a/testng-core/src/test/java/test/configuration/issue2664/test/GroupDependenciesSample.java
+++ b/testng-core/src/test/java/test/configuration/issue2664/test/GroupDependenciesSample.java
@@ -18,6 +18,6 @@ public class GroupDependenciesSample {
       dependsOnGroups = "g1")
   public void s1() {}
 
-  @Test()
+  @Test
   public void test3() {}
 }

--- a/testng-core/src/test/java/test/configuration/issue2729/BeforeConfigTestSample.java
+++ b/testng-core/src/test/java/test/configuration/issue2729/BeforeConfigTestSample.java
@@ -9,8 +9,9 @@ import org.testng.annotations.Test;
 public class BeforeConfigTestSample {
   @BeforeClass
   public void beforeClass() {
+    // The division is the point: this @BeforeClass has to fail.
     @SuppressWarnings("ConstantOverflow")
-    int i = 5 / 0;
+    int unused = 5 / 0;
   }
 
   @BeforeMethod

--- a/testng-core/src/test/java/test/configuration/issue3000/MyBaseTestSample.java
+++ b/testng-core/src/test/java/test/configuration/issue3000/MyBaseTestSample.java
@@ -5,6 +5,7 @@ import org.testng.annotations.BeforeClass;
 abstract class MyBaseTestSample implements MyInterface {
   protected Object dependency;
 
+  @Override
   public void setDependency(Object ignored) {}
 
   @BeforeClass

--- a/testng-core/src/test/java/test/dataprovider/InstanceDataProviderSample.java
+++ b/testng-core/src/test/java/test/dataprovider/InstanceDataProviderSample.java
@@ -1,6 +1,5 @@
 package test.dataprovider;
 
-import static java.lang.Integer.valueOf;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.testng.annotations.DataProvider;
@@ -15,6 +14,6 @@ public class InstanceDataProviderSample {
 
   @Test(dataProvider = "dp")
   public void f(Integer n) {
-    assertThat(n).isEqualTo(valueOf(hashCode()));
+    assertThat(n).isEqualTo(Integer.valueOf(hashCode()));
   }
 }

--- a/testng-core/src/test/java/test/dataprovider/UnnamedDataProviderSample.java
+++ b/testng-core/src/test/java/test/dataprovider/UnnamedDataProviderSample.java
@@ -10,6 +10,6 @@ public class UnnamedDataProviderSample {
 
   @DataProvider
   public Object[][] unnamedDataProvider() {
-    return new Object[][] {{Boolean.TRUE}, {Boolean.FALSE}};
+    return new Object[][] {{true}, {false}};
   }
 }

--- a/testng-core/src/test/java/test/enable/A.java
+++ b/testng-core/src/test/java/test/enable/A.java
@@ -11,7 +11,7 @@ public class A {
   @Test
   public void testA2() {}
 
-  @Test()
+  @Test
   public void testA3() {}
 
   @Test(enabled = false)
@@ -20,16 +20,16 @@ public class A {
   @BeforeSuite
   public void beforeSuiteA() {}
 
-  @BeforeSuite()
+  @BeforeSuite
   public void beforeSuiteA2() {}
 
   @BeforeSuite(enabled = false)
   public void disabledBeforeSuiteA() {}
 
-  @BeforeSuite()
+  @BeforeSuite
   public void beforeSuiteNoRunA() {}
 
-  @BeforeSuite()
+  @BeforeSuite
   public void beforeSuiteNoRunA2() {}
 
   @BeforeSuite(enabled = false)
@@ -47,16 +47,16 @@ public class A {
   @AfterSuite
   public void afterSuiteA() {}
 
-  @AfterSuite()
+  @AfterSuite
   public void afterSuiteA2() {}
 
   @AfterSuite(enabled = false)
   public void disabledAfterSuiteA() {}
 
-  @AfterSuite()
+  @AfterSuite
   public void afterSuiteNoRunA() {}
 
-  @AfterSuite()
+  @AfterSuite
   public void afterSuiteNoRunA2() {}
 
   @AfterSuite(enabled = false)

--- a/testng-core/src/test/java/test/enable/B.java
+++ b/testng-core/src/test/java/test/enable/B.java
@@ -12,13 +12,13 @@ public class B {
   @Test
   public void testB2() {}
 
-  @Test()
+  @Test
   public void testB3() {}
 
   @Test(enabled = false)
   public void disabledB() {}
 
-  @BeforeSuite()
+  @BeforeSuite
   public void disabledBeforeSuiteB() {}
 
   @BeforeSuite
@@ -27,10 +27,10 @@ public class B {
   @BeforeSuite(enabled = false)
   public void disabledBeforeSuiteB3() {}
 
-  @BeforeSuite()
+  @BeforeSuite
   public void beforeSuiteNoRunB() {}
 
-  @BeforeSuite()
+  @BeforeSuite
   public void beforeSuiteNoRunB2() {}
 
   @BeforeSuite(enabled = false)
@@ -48,16 +48,16 @@ public class B {
   @AfterSuite
   public void afterSuiteB() {}
 
-  @AfterSuite()
+  @AfterSuite
   public void afterSuiteB2() {}
 
   @AfterSuite(enabled = false)
   public void disabledAfterSuiteB() {}
 
-  @AfterSuite()
+  @AfterSuite
   public void afterSuiteNoRunB() {}
 
-  @AfterSuite()
+  @AfterSuite
   public void afterSuiteNoRunB2() {}
 
   @AfterSuite(enabled = false)

--- a/testng-core/src/test/java/test/enable/C.java
+++ b/testng-core/src/test/java/test/enable/C.java
@@ -12,7 +12,7 @@ public class C {
   @Test
   public void testC2() {}
 
-  @Test()
+  @Test
   public void testC3() {}
 
   @Test(enabled = false)
@@ -21,16 +21,16 @@ public class C {
   @BeforeSuite
   public void beforeSuiteC() {}
 
-  @BeforeSuite()
+  @BeforeSuite
   public void beforeSuiteC2() {}
 
   @BeforeSuite(enabled = false)
   public void disabledBeforeSuiteC() {}
 
-  @BeforeSuite()
+  @BeforeSuite
   public void beforeSuiteNoRunC() {}
 
-  @BeforeSuite()
+  @BeforeSuite
   public void beforeSuiteNoRunC2() {}
 
   @BeforeSuite(enabled = false)
@@ -48,16 +48,16 @@ public class C {
   @AfterSuite
   public void afterSuiteC() {}
 
-  @AfterSuite()
+  @AfterSuite
   public void afterSuiteC2() {}
 
   @AfterSuite(enabled = false)
   public void disabledAfterSuiteC() {}
 
-  @AfterSuite()
+  @AfterSuite
   public void afterSuiteNoRunC() {}
 
-  @AfterSuite()
+  @AfterSuite
   public void afterSuiteNoRunC2() {}
 
   @AfterSuite(enabled = false)

--- a/testng-core/src/test/java/test/enable/Issue420BaseTestCase.java
+++ b/testng-core/src/test/java/test/enable/Issue420BaseTestCase.java
@@ -8,10 +8,10 @@ public abstract class Issue420BaseTestCase {
   @BeforeSuite(alwaysRun = true)
   public static void alwaysBeforeSuite() {}
 
-  @BeforeSuite()
+  @BeforeSuite
   public static void beforeSuite() {}
 
-  @AfterSuite()
+  @AfterSuite
   public static void afterSuite() {}
 
   @AfterSuite(alwaysRun = true)

--- a/testng-core/src/test/java/test/factory/FactoryAndTestMethodTest.java
+++ b/testng-core/src/test/java/test/factory/FactoryAndTestMethodTest.java
@@ -11,7 +11,7 @@ public class FactoryAndTestMethodTest {
 
   @Factory(dataProvider = "data")
   public Object[] ohNo(String s) {
-    return makeNullArgTests(s);
+    return new Object[0];
   }
 
   public static class NullArgsTest {
@@ -25,10 +25,6 @@ public class FactoryAndTestMethodTest {
     public void test() {
       assertThat(s).isNotNull();
     }
-  }
-
-  private Object[] makeNullArgTests(String s) {
-    return new Object[0];
   }
 
   @DataProvider(name = "data")

--- a/testng-core/src/test/java/test/factory/FactoryDataProviderSample.java
+++ b/testng-core/src/test/java/test/factory/FactoryDataProviderSample.java
@@ -18,6 +18,7 @@ public class FactoryDataProviderSample extends BaseFactorySample {
     };
   }
 
+  @Override
   @Test
   public void f() {}
 }

--- a/testng-core/src/test/java/test/factory/github2428/Reporter.java
+++ b/testng-core/src/test/java/test/factory/github2428/Reporter.java
@@ -15,6 +15,7 @@ public class Reporter implements IReporter {
     return results;
   }
 
+  @Override
   public void generateReport(
       List<XmlSuite> xmlSuites, List<ISuite> suites, String outputDirectory) {
     suites

--- a/testng-core/src/test/java/test/factory/sample/Factory2TestSample.java
+++ b/testng-core/src/test/java/test/factory/sample/Factory2TestSample.java
@@ -8,7 +8,7 @@ import org.testng.annotations.Factory;
  */
 public class Factory2TestSample {
 
-  @Factory()
+  @Factory
   public Object[] createObjects() {
     return new Object[] {new Factory2Sample(), new Factory2Sample()};
   }

--- a/testng-core/src/test/java/test/github1461/MemoryLeakTestNg.java
+++ b/testng-core/src/test/java/test/github1461/MemoryLeakTestNg.java
@@ -48,8 +48,10 @@ public class MemoryLeakTestNg {
     // create TestNG class
     TestNG testng =
         new TestNG() {
+          // Overriding finalize is the observation: the log line is how this test shows the
+          // TestNG instance is never reclaimed.
           @Override
-          @SuppressWarnings("deprecation")
+          @SuppressWarnings({"deprecation", "Finalize"})
           protected void finalize() {
             // it seems that this object will never be finalized !!!
             log.debug("TestNG finalized");

--- a/testng-core/src/test/java/test/github1461/MyTestClassWithGlobalReferenceCounterSample.java
+++ b/testng-core/src/test/java/test/github1461/MyTestClassWithGlobalReferenceCounterSample.java
@@ -27,8 +27,10 @@ public class MyTestClassWithGlobalReferenceCounterSample {
     log.debug("test method 2");
   }
 
+  // The finalizer is what decrements the counter MemoryLeakTestNg spins on. Without it that
+  // loop never reaches zero and the test fails on its timeOut.
   @Override
-  @SuppressWarnings("deprecation")
+  @SuppressWarnings({"deprecation", "Finalize"})
   protected void finalize() {
     log.debug("finalize");
     // this will be called when this object is removed from the heap

--- a/testng-core/src/test/java/test/github765/DuplicateCallsSample.java
+++ b/testng-core/src/test/java/test/github765/DuplicateCallsSample.java
@@ -7,6 +7,7 @@ import org.testng.annotations.Test;
 
 public class DuplicateCallsSample extends TestTemplate<Integer> {
 
+  @Override
   @Test(dataProvider = "testParameters")
   public void callExecuteTest(Integer testParameters) {
     assertThat(testParameters > 0).isTrue();

--- a/testng-core/src/test/java/test/guice/issue2343/SampleA.java
+++ b/testng-core/src/test/java/test/guice/issue2343/SampleA.java
@@ -7,7 +7,9 @@ import org.testng.annotations.Test;
 @Guice
 public class SampleA {
 
+  // Guice must be able to inject this; nothing needs to read it.
   @Inject
+  @SuppressWarnings("unused")
   public SampleA(final Person person) {}
 
   @Test

--- a/testng-core/src/test/java/test/guice/issue2343/SampleB.java
+++ b/testng-core/src/test/java/test/guice/issue2343/SampleB.java
@@ -7,7 +7,9 @@ import org.testng.annotations.Test;
 @Guice
 public class SampleB {
 
+  // Guice must be able to inject this; nothing needs to read it.
   @Inject
+  @SuppressWarnings("unused")
   public SampleB(final Person person) {}
 
   @Test

--- a/testng-core/src/test/java/test/guice/issue2427/Test1.java
+++ b/testng-core/src/test/java/test/guice/issue2427/Test1.java
@@ -5,7 +5,7 @@ import org.testng.annotations.Test;
 import test.guice.issue2427.modules.TestModuleOne;
 
 @Guice(modules = {TestModuleOne.class})
-@Test()
+@Test
 public class Test1 {
   public void shouldInstatiateModulesOnlyOnce() {
     // do nothing as test is about configuration part

--- a/testng-core/src/test/java/test/guice/issue2427/Test2.java
+++ b/testng-core/src/test/java/test/guice/issue2427/Test2.java
@@ -5,7 +5,7 @@ import org.testng.annotations.Test;
 import test.guice.issue2427.modules.TestModuleTwo;
 
 @Guice(modules = {TestModuleTwo.class})
-@Test()
+@Test
 public class Test2 {
   public void shouldInstatiateModulesOnlyOnce() {
     // do nothing as test is about configuration part

--- a/testng-core/src/test/java/test/invocationcount/DataProviderFalseFalseTest.java
+++ b/testng-core/src/test/java/test/invocationcount/DataProviderFalseFalseTest.java
@@ -4,9 +4,9 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 
 public class DataProviderFalseFalseTest extends DataProviderBase {
-  @BeforeMethod()
+  @BeforeMethod
   public void beforeMethod() {}
 
-  @AfterMethod()
+  @AfterMethod
   public void afterMethod() {}
 }

--- a/testng-core/src/test/java/test/invocationcount/DataProviderFalseTrueTest.java
+++ b/testng-core/src/test/java/test/invocationcount/DataProviderFalseTrueTest.java
@@ -4,7 +4,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 
 public class DataProviderFalseTrueTest extends DataProviderBase {
-  @BeforeMethod()
+  @BeforeMethod
   public void beforeMethod() {}
 
   @AfterMethod(lastTimeOnly = true)

--- a/testng-core/src/test/java/test/invocationcount/DataProviderTrueFalseTest.java
+++ b/testng-core/src/test/java/test/invocationcount/DataProviderTrueFalseTest.java
@@ -7,6 +7,6 @@ public class DataProviderTrueFalseTest extends DataProviderBase {
   @BeforeMethod(firstTimeOnly = true)
   public void beforeMethod() {}
 
-  @AfterMethod()
+  @AfterMethod
   public void afterMethod() {}
 }

--- a/testng-core/src/test/java/test/invocationcount/InvocationCountFalseFalseTest.java
+++ b/testng-core/src/test/java/test/invocationcount/InvocationCountFalseFalseTest.java
@@ -4,9 +4,9 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 
 public class InvocationCountFalseFalseTest extends InvocationBase {
-  @BeforeMethod()
+  @BeforeMethod
   public void beforeMethod() {}
 
-  @AfterMethod()
+  @AfterMethod
   public void afterMethod() {}
 }

--- a/testng-core/src/test/java/test/invocationcount/InvocationCountFalseTrueTest.java
+++ b/testng-core/src/test/java/test/invocationcount/InvocationCountFalseTrueTest.java
@@ -4,7 +4,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 
 public class InvocationCountFalseTrueTest extends InvocationBase {
-  @BeforeMethod()
+  @BeforeMethod
   public void beforeMethod() {}
 
   @AfterMethod(lastTimeOnly = true)

--- a/testng-core/src/test/java/test/invocationcount/InvocationCountTrueFalseTest.java
+++ b/testng-core/src/test/java/test/invocationcount/InvocationCountTrueFalseTest.java
@@ -7,6 +7,6 @@ public class InvocationCountTrueFalseTest extends InvocationBase {
   @BeforeMethod(firstTimeOnly = true)
   public void beforeMethod() {}
 
-  @AfterMethod()
+  @AfterMethod
   public void afterMethod() {}
 }

--- a/testng-core/src/test/java/test/invocationcount/issue1719/DummyReporter.java
+++ b/testng-core/src/test/java/test/invocationcount/issue1719/DummyReporter.java
@@ -14,6 +14,7 @@ public class DummyReporter implements IReporter {
   private final Set<ITestResult> success = new HashSet<>();
   private final Set<ITestResult> failedWithinSuccessPercentage = new HashSet<>();
 
+  @Override
   public void generateReport(
       List<XmlSuite> xmlSuites, List<ISuite> suites, String outputDirectory) {
     suites.forEach(

--- a/testng-core/src/test/java/test/invocationcount/issue3180/RetryAnalyzer.java
+++ b/testng-core/src/test/java/test/invocationcount/issue3180/RetryAnalyzer.java
@@ -11,6 +11,7 @@ public class RetryAnalyzer implements IRetryAnalyzer {
   /*
    * Retry method
    */
+  @Override
   public boolean retry(ITestResult result) {
     return counter++ < retryLimit;
   }

--- a/testng-core/src/test/java/test/invokedmethodlistener/A.java
+++ b/testng-core/src/test/java/test/invokedmethodlistener/A.java
@@ -4,6 +4,6 @@ import org.testng.annotations.BeforeSuite;
 
 public class A {
 
-  @BeforeSuite()
+  @BeforeSuite
   public static void someMethod1() {}
 }

--- a/testng-core/src/test/java/test/issue107/MySuiteListener.java
+++ b/testng-core/src/test/java/test/issue107/MySuiteListener.java
@@ -6,6 +6,7 @@ import org.testng.ISuiteListener;
 import org.testng.xml.XmlSuite;
 
 public class MySuiteListener implements ISuiteListener {
+  @Override
   public void onStart(ISuite suite) {
     final XmlSuite xmlSuite = suite.getXmlSuite();
     final Map<String, String> parameters = xmlSuite.getParameters();

--- a/testng-core/src/test/java/test/junitreports/LocalJUnitReportReporter.java
+++ b/testng-core/src/test/java/test/junitreports/LocalJUnitReportReporter.java
@@ -20,6 +20,7 @@ public class LocalJUnitReportReporter extends JUnitReportReporter implements Tes
     testsuites.addAll(LocalJUnitXMLReporter.getSuites(files));
   }
 
+  @Override
   public Testsuite getTestsuite(String name) {
     for (Testsuite suite : testsuites) {
       if (suite.getName().equals(name)) {

--- a/testng-core/src/test/java/test/junitreports/LocalJUnitXMLReporter.java
+++ b/testng-core/src/test/java/test/junitreports/LocalJUnitXMLReporter.java
@@ -11,6 +11,7 @@ import org.testng.reporters.JUnitXMLReporter;
 public class LocalJUnitXMLReporter extends JUnitXMLReporter implements TestsuiteRetriever {
   private final List<Testsuite> testsuites = new ArrayList<>();
 
+  @Override
   protected void generateReport(ITestContext context) {
     super.generateReport(context);
     String dir = context.getOutputDirectory();
@@ -19,6 +20,7 @@ public class LocalJUnitXMLReporter extends JUnitXMLReporter implements Testsuite
     testsuites.addAll(getSuites(files));
   }
 
+  @Override
   public Testsuite getTestsuite(String name) {
     for (Testsuite suite : testsuites) {
       if (suite.getName().equals(name)) {

--- a/testng-core/src/test/java/test/listeners/AlterSuiteListenerTest.java
+++ b/testng-core/src/test/java/test/listeners/AlterSuiteListenerTest.java
@@ -1,6 +1,5 @@
 package test.listeners;
 
-import static java.lang.String.valueOf;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
@@ -63,7 +62,7 @@ public class AlterSuiteListenerTest extends SimpleBaseTest {
         List<XmlTest> tests = xmlSuite.getTests();
         int i = 1;
         for (XmlTest xmlTest : tests) {
-          assertThat(xmlTest.getParameter("param")).isEqualTo(valueOf(i));
+          assertThat(xmlTest.getParameter("param")).isEqualTo(String.valueOf(i));
           i++;
         }
       }

--- a/testng-core/src/test/java/test/listeners/ResultContextListener.java
+++ b/testng-core/src/test/java/test/listeners/ResultContextListener.java
@@ -8,6 +8,7 @@ public class ResultContextListener implements ITestListener {
 
   public static boolean contextProvided = false;
 
+  @Override
   public void onTestStart(ITestResult result) {
     ITestContext context = result.getTestContext();
     if (context != null) {

--- a/testng-core/src/test/java/test/listeners/github1130/MyListener.java
+++ b/testng-core/src/test/java/test/listeners/github1130/MyListener.java
@@ -19,10 +19,12 @@ public class MyListener implements ISuiteListener, IClassListener {
     }
   }
 
+  @Override
   public void onStart(ISuite suite) {
     beforeSuiteCount.add(this.toString());
   }
 
+  @Override
   public void onBeforeClass(ITestClass testClass) {
     beforeClassCount.add(this.toString());
   }

--- a/testng-core/src/test/java/test/listeners/github1284/Listener1284.java
+++ b/testng-core/src/test/java/test/listeners/github1284/Listener1284.java
@@ -21,10 +21,12 @@ public class Listener1284 implements IClassListener {
     return instance;
   }
 
+  @Override
   public void onBeforeClass(ITestClass iTestClass) {
     Listener1284.testList.add(iTestClass.getRealClass().getName() + " - Before Invocation");
   }
 
+  @Override
   public void onAfterClass(ITestClass iTestClass) {
     Listener1284.testList.add(iTestClass.getRealClass().getName() + " - After Invocation");
   }

--- a/testng-core/src/test/java/test/listeners/github1319/TestSample.java
+++ b/testng-core/src/test/java/test/listeners/github1319/TestSample.java
@@ -54,14 +54,17 @@ public class TestSample {
   public static class Listener implements IConfigurationListener, ITestListener {
     public static Map<String, Object> maps = Maps.newConcurrentMap();
 
+    @Override
     public void onConfigurationSuccess(ITestResult itr) {
       maps.put(itr.getMethod().getMethodName(), itr.getInstance());
     }
 
+    @Override
     public void onConfigurationFailure(ITestResult itr) {
       maps.put(itr.getMethod().getMethodName(), itr.getInstance());
     }
 
+    @Override
     public void onConfigurationSkip(ITestResult itr) {
       maps.put(itr.getMethod().getMethodName(), itr.getInstance());
     }

--- a/testng-core/src/test/java/test/listeners/github1393/Listener1393.java
+++ b/testng-core/src/test/java/test/listeners/github1393/Listener1393.java
@@ -5,6 +5,7 @@ import org.testng.TestListenerAdapter;
 
 public class Listener1393 extends TestListenerAdapter {
 
+  @Override
   public void onTestStart(ITestResult testContext) {
     super.onTestStart(testContext);
     System.out.println("In onTestStart");

--- a/testng-core/src/test/java/test/listeners/github2522/SkipTestSample.java
+++ b/testng-core/src/test/java/test/listeners/github2522/SkipTestSample.java
@@ -5,12 +5,12 @@ import org.testng.annotations.Test;
 public class SkipTestSample {
   private static boolean flag = true;
 
-  @Test()
+  @Test
   public void oneTest() {
     flag = false;
   }
 
-  @Test()
+  @Test
   public void twoTest() {}
 
   public static boolean getFlag() {

--- a/testng-core/src/test/java/test/listeners/issue3238/BadUtility.java
+++ b/testng-core/src/test/java/test/listeners/issue3238/BadUtility.java
@@ -2,6 +2,9 @@ package test.listeners.issue3238;
 
 public class BadUtility {
 
+  // Never read on purpose: evaluating it is what makes class initialisation fail, which is
+  // the condition issue3238 is about.
+  @SuppressWarnings("unused")
   private static final int counter = evaluate();
 
   private static int evaluate() {

--- a/testng-core/src/test/java/test/listeners/ordering/ListenerInvocationDefaultBehaviorTest.java
+++ b/testng-core/src/test/java/test/listeners/ordering/ListenerInvocationDefaultBehaviorTest.java
@@ -625,10 +625,10 @@ public class ListenerInvocationDefaultBehaviorTest extends SimpleBaseTest {
             IEXECUTIONLISTENER_ON_EXECUTION_FINISH);
 
     try {
-      System.setProperty(RuntimeBehavior.SYMMETRIC_LISTENER_EXECUTION, Boolean.TRUE.toString());
+      System.setProperty(RuntimeBehavior.SYMMETRIC_LISTENER_EXECUTION, "true");
       runTest(symmetricExpected, SimpleTestClassWithBeforeAndAfterClass.class);
     } finally {
-      System.setProperty(RuntimeBehavior.SYMMETRIC_LISTENER_EXECUTION, Boolean.FALSE.toString());
+      System.setProperty(RuntimeBehavior.SYMMETRIC_LISTENER_EXECUTION, "false");
     }
   }
 

--- a/testng-core/src/test/java/test/listeners/ordering/UniversalListener.java
+++ b/testng-core/src/test/java/test/listeners/ordering/UniversalListener.java
@@ -51,18 +51,22 @@ public class UniversalListener
     return messages;
   }
 
+  @Override
   public void onConfigurationSuccess(ITestResult itr) {
     messages.add("org.testng.IConfigurationListener.onConfigurationSuccess(ITestResult itr)");
   }
 
+  @Override
   public void onConfigurationFailure(ITestResult itr) {
     messages.add("org.testng.IConfigurationListener.onConfigurationFailure(ITestResult itr)");
   }
 
+  @Override
   public void onConfigurationSkip(ITestResult itr) {
     messages.add("org.testng.IConfigurationListener.onConfigurationSkip(ITestResult itr)");
   }
 
+  @Override
   public void beforeConfiguration(ITestResult tr) {
     messages.add("org.testng.IConfigurationListener.beforeConfiguration(ITestResult tr)");
   }

--- a/testng-core/src/test/java/test/methodinterceptors/LockUpInterceptorSampleTest.java
+++ b/testng-core/src/test/java/test/methodinterceptors/LockUpInterceptorSampleTest.java
@@ -7,21 +7,11 @@ import org.testng.annotations.Test;
 public class LockUpInterceptorSampleTest {
 
   @Test
-  public void one() {
-    log("one");
-  }
+  public void one() {}
 
   @Test
-  public void two() {
-    log("two");
-  }
+  public void two() {}
 
   @Test
-  public void three() {
-    log("three");
-  }
-
-  private static void log(String s) {
-    //      System.out.println("[MITest] " + s);
-  }
+  public void three() {}
 }

--- a/testng-core/src/test/java/test/methodinterceptors/issue1726/PriorityInterceptor.java
+++ b/testng-core/src/test/java/test/methodinterceptors/issue1726/PriorityInterceptor.java
@@ -9,6 +9,7 @@ import org.testng.ITestContext;
 
 public class PriorityInterceptor implements IMethodInterceptor {
 
+  @Override
   public List<IMethodInstance> intercept(List<IMethodInstance> methods, ITestContext context) {
     Comparator<IMethodInstance> comparator =
         Comparator.comparingInt(PriorityInterceptor::getPriority);

--- a/testng-core/src/test/java/test/methodselectors/ScriptNegativeTest.java
+++ b/testng-core/src/test/java/test/methodselectors/ScriptNegativeTest.java
@@ -18,12 +18,12 @@ public class ScriptNegativeTest extends SimpleBaseTest {
 
   @BeforeMethod
   public void setup() {
-    System.setProperty("skip.caller.clsLoader", Boolean.TRUE.toString());
+    System.setProperty("skip.caller.clsLoader", "true");
   }
 
   @AfterMethod
   public void cleanup() {
-    System.setProperty("skip.caller.clsLoader", Boolean.FALSE.toString());
+    System.setProperty("skip.caller.clsLoader", "false");
   }
 
   @Test(

--- a/testng-core/src/test/java/test/name/github1046/TestClassSample.java
+++ b/testng-core/src/test/java/test/name/github1046/TestClassSample.java
@@ -33,7 +33,7 @@ public class TestClassSample implements IHookable {
 
   @Override
   public void run(IHookCallBack callBack, ITestResult testResult) {
-    if (!("dontChangeName".equals(testResult.getMethod().getMethodName()))) {
+    if (!"dontChangeName".equals(testResult.getMethod().getMethodName())) {
       Object param = "999";
       Object[] parameters = callBack.getParameters();
       if (parameters.length != 0) {

--- a/testng-core/src/test/java/test/nested/GarfTest.java
+++ b/testng-core/src/test/java/test/nested/GarfTest.java
@@ -8,7 +8,7 @@ import test.nested.foo.AccountTypeEnum;
 @Test(groups = {"unittest"})
 public class GarfTest {
 
-  @Test()
+  @Test
   public void testGarf() {
     AccountTypeEnum foo = AccountTypeEnum.ClearingMember;
     assertThat(foo).isEqualTo(AccountTypeEnum.ClearingMember);

--- a/testng-core/src/test/java/test/objectfactory/ClassObjectFactory.java
+++ b/testng-core/src/test/java/test/objectfactory/ClassObjectFactory.java
@@ -6,6 +6,7 @@ import org.testng.internal.objects.InstanceCreator;
 
 public class ClassObjectFactory implements ITestObjectFactory {
 
+  @Override
   public <T> T newInstance(Constructor<T> constructor, Object... parameters) {
     T object = InstanceCreator.newInstance(constructor, parameters);
     if (object instanceof ISetValue) {

--- a/testng-core/src/test/java/test/parameters/Issue1554TestClassSample.java
+++ b/testng-core/src/test/java/test/parameters/Issue1554TestClassSample.java
@@ -18,7 +18,7 @@ public class Issue1554TestClassSample {
     this.context = context;
   }
 
-  @Test()
+  @Test
   public void aTest() {
     assertThat(browser).isNotNull();
     assertThat(context).isNotNull();

--- a/testng-core/src/test/java/test/parameters/ParameterOverrideTest.java
+++ b/testng-core/src/test/java/test/parameters/ParameterOverrideTest.java
@@ -43,7 +43,7 @@ public class ParameterOverrideTest extends SimpleBaseTest {
     clazz.getLocalParameters().put("InheritedFromClass", "InheritedFromClass");
 
     XmlInclude includeF = createXmlInclude(clazz, "f");
-    XmlInclude includeG = createXmlInclude(clazz, "g");
+    createXmlInclude(clazz, "g");
 
     switch (status) {
       case PASS_TEST:

--- a/testng-core/src/test/java/test/parameters/ShadowTest.java
+++ b/testng-core/src/test/java/test/parameters/ShadowTest.java
@@ -6,7 +6,6 @@ import org.testng.ITestNGListener;
 import org.testng.TestNG;
 import org.testng.annotations.Test;
 import org.testng.xml.XmlClass;
-import org.testng.xml.XmlInclude;
 import org.testng.xml.XmlSuite;
 import org.testng.xml.XmlTest;
 import test.InvokedMethodNameListener;
@@ -21,11 +20,11 @@ public class ShadowTest extends SimpleBaseTest {
 
     XmlClass class1 = createXmlClass(test, Shadow1Sample.class);
     class1.getLocalParameters().put("a", "First");
-    XmlInclude include1 = createXmlInclude(class1, "test1");
+    createXmlInclude(class1, "test1");
 
     XmlClass class2 = createXmlClass(test, Shadow2Sample.class);
     class2.getLocalParameters().put("a", "Second");
-    XmlInclude include2 = createXmlInclude(class2, "test2");
+    createXmlInclude(class2, "test2");
 
     TestNG tng = create(suite);
 

--- a/testng-core/src/test/java/test/pkg2/Test2.java
+++ b/testng-core/src/test/java/test/pkg2/Test2.java
@@ -3,6 +3,11 @@ package test.pkg2;
 import test.pkg.PackageTest;
 
 public class Test2 {
+  // Never called, and the parameter is never read -- both on purpose, so both checks are named
+  // rather than left to the "unused" alias. PackageTest asserts this constructor does not run: it
+  // is how the test detects TestNG instantiating a class that holds no test methods. Dropping the
+  // parameter would turn it into a no-arg constructor and change what that assertion is exposed to.
+  @SuppressWarnings({"UnusedVariable", "UnusedMethod"})
   private Test2(float afloat) {
     PackageTest.NON_TEST_CONSTRUCTOR = true;
   }

--- a/testng-core/src/test/java/test/preserveorder/PreserveOrderTest.java
+++ b/testng-core/src/test/java/test/preserveorder/PreserveOrderTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import org.testng.ITestNGListener;
 import org.testng.TestNG;
 import org.testng.annotations.DataProvider;
@@ -43,9 +44,10 @@ public class PreserveOrderTest extends SimpleBaseTest {
     assertThat(listener.getInvokedMethodNames()).hasSize(9);
     Iterator<String> methods = listener.getInvokedMethodNames().iterator();
     for (Class<?> testClass : tests) {
+      String prefix = testClass.getSimpleName().toLowerCase(Locale.ROOT);
       for (int i = 1; i <= 3; i++) {
         String methodName = methods.next();
-        assertThat(methodName).isEqualTo(testClass.getSimpleName().toLowerCase() + i);
+        assertThat(methodName).isEqualTo(prefix + i);
       }
     }
   }

--- a/testng-core/src/test/java/test/priority/parallel/EfficientPriorityParallelizationTest.java
+++ b/testng-core/src/test/java/test/priority/parallel/EfficientPriorityParallelizationTest.java
@@ -6,10 +6,7 @@ import static test.thread.parallelization.TestNgRunStateTracker.getAllSuiteLevel
 import static test.thread.parallelization.TestNgRunStateTracker.getAllSuiteListenerStartEventLogs;
 import static test.thread.parallelization.TestNgRunStateTracker.getAllTestLevelEventLogs;
 import static test.thread.parallelization.TestNgRunStateTracker.getAllTestMethodLevelEventLogs;
-import static test.thread.parallelization.TestNgRunStateTracker.getSuiteAndTestLevelEventLogsForSuite;
 import static test.thread.parallelization.TestNgRunStateTracker.getSuiteLevelEventLogsForSuite;
-import static test.thread.parallelization.TestNgRunStateTracker.getSuiteListenerFinishEventLog;
-import static test.thread.parallelization.TestNgRunStateTracker.getSuiteListenerStartEventLog;
 import static test.thread.parallelization.TestNgRunStateTracker.getTestLevelEventLogsForSuite;
 import static test.thread.parallelization.TestNgRunStateTracker.getTestLevelEventLogsForTest;
 import static test.thread.parallelization.TestNgRunStateTracker.getTestListenerFinishEventLog;
@@ -46,16 +43,12 @@ public class EfficientPriorityParallelizationTest extends BaseParallelizationTes
   private List<EventLog> testLevelEventLogs;
   private List<EventLog> testMethodLevelEventLogs;
 
-  private List<EventLog> suiteOneSuiteAndTestLevelEventLogs;
   private List<EventLog> suiteOneSuiteLevelEventLogs;
   private List<EventLog> suiteOneTestLevelEventLogs;
   private List<EventLog> suiteOneTestMethodLevelEventLogs;
 
   private List<EventLog> suiteOneTestOneTestMethodLevelEventLogs;
   private List<EventLog> suiteOneTestTwoTestMethodLevelEventLogs;
-
-  private EventLog suiteOneSuiteListenerOnStartEventLog;
-  private EventLog suiteOneSuiteListenerOnFinishEventLog;
 
   private EventLog suiteOneTestOneListenerOnStartEventLog;
   private EventLog suiteOneTestOneListenerOnFinishEventLog;
@@ -120,7 +113,6 @@ public class EfficientPriorityParallelizationTest extends BaseParallelizationTes
     testLevelEventLogs = getAllTestLevelEventLogs();
     testMethodLevelEventLogs = getAllTestMethodLevelEventLogs();
 
-    suiteOneSuiteAndTestLevelEventLogs = getSuiteAndTestLevelEventLogsForSuite(SUITE_A);
     suiteOneSuiteLevelEventLogs = getSuiteLevelEventLogsForSuite(SUITE_A);
     suiteOneTestLevelEventLogs = getTestLevelEventLogsForSuite(SUITE_A);
 
@@ -133,9 +125,6 @@ public class EfficientPriorityParallelizationTest extends BaseParallelizationTes
 
     testEventLogsMap.put(SUITE_A_TEST_A, getTestLevelEventLogsForTest(SUITE_A, SUITE_A_TEST_A));
     testEventLogsMap.put(SUITE_A_TEST_B, getTestLevelEventLogsForTest(SUITE_A, SUITE_A_TEST_B));
-
-    suiteOneSuiteListenerOnStartEventLog = getSuiteListenerStartEventLog(SUITE_A);
-    suiteOneSuiteListenerOnFinishEventLog = getSuiteListenerFinishEventLog(SUITE_A);
 
     suiteOneTestOneListenerOnStartEventLog = getTestListenerStartEventLog(SUITE_A, SUITE_A_TEST_A);
     suiteOneTestOneListenerOnFinishEventLog =

--- a/testng-core/src/test/java/test/regression/MyTestngTest.java
+++ b/testng-core/src/test/java/test/regression/MyTestngTest.java
@@ -6,10 +6,10 @@ import org.testng.annotations.BeforeTest;
 
 public class MyTestngTest {
 
-  @BeforeSuite()
+  @BeforeSuite
   public void beforeSuite(ITestContext tc) throws Exception {}
 
-  @BeforeTest()
+  @BeforeTest
   public void beforeTest(ITestContext tc) throws Exception {
     throw new RuntimeException("barfing now");
   }

--- a/testng-core/src/test/java/test/regression/MyTestngTest2.java
+++ b/testng-core/src/test/java/test/regression/MyTestngTest2.java
@@ -7,14 +7,14 @@ import org.testng.annotations.Test;
 
 public class MyTestngTest2 extends MyTestngTest {
 
-  @BeforeClass()
+  @BeforeClass
   public void beforeClass(ITestContext tc) throws Exception {}
 
-  @BeforeMethod()
+  @BeforeMethod
   public void beforeMethod(ITestContext tc) throws Exception {
     // throw new Exception("fail me");
   }
 
-  @Test()
+  @Test
   public void test(ITestContext tc) {}
 }

--- a/testng-core/src/test/java/test/reports/EmailableReporterTest.java
+++ b/testng-core/src/test/java/test/reports/EmailableReporterTest.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
+import java.util.Locale;
 import org.testng.IReporter;
 import org.testng.ITestNGListener;
 import org.testng.TestNG;
@@ -76,7 +77,7 @@ public class EmailableReporterTest extends SimpleBaseTest {
 
   @DataProvider(name = "getReporterInstances")
   public Object[][] getReporterInstances(Method method) {
-    if (method.getName().toLowerCase().contains("jvmarguments")) {
+    if (method.getName().toLowerCase(Locale.ROOT).contains("jvmarguments")) {
       return new Object[][] {{new EmailableReporter2(), "emailable.report2.name"}};
     }
     return new Object[][] {{new EmailableReporter2()}};

--- a/testng-core/src/test/java/test/reports/issue1756/CustomTestNGReporter.java
+++ b/testng-core/src/test/java/test/reports/issue1756/CustomTestNGReporter.java
@@ -15,6 +15,7 @@ public class CustomTestNGReporter implements IReporter {
     return logs;
   }
 
+  @Override
   public void generateReport(
       List<XmlSuite> xmlSuites, List<ISuite> suites, String outputDirectory) {
     getTestMehodSummary(suites);

--- a/testng-core/src/test/java/test/reports/issue1756/SampleTestClass.java
+++ b/testng-core/src/test/java/test/reports/issue1756/SampleTestClass.java
@@ -27,6 +27,7 @@ public class SampleTestClass implements ITest {
   @Test(dependsOnMethods = "test1")
   public void test2() {}
 
+  @Override
   public String getTestName() {
     return uri;
   }

--- a/testng-core/src/test/java/test/retryAnalyzer/TestResultPruner.java
+++ b/testng-core/src/test/java/test/retryAnalyzer/TestResultPruner.java
@@ -19,7 +19,7 @@ public class TestResultPruner extends TestListenerAdapter {
       if (!passed.isEmpty() && !skipped.isEmpty()) {
         context.getSkippedTests().removeResult(method);
       }
-      if (((!failedWithinSuccess.isEmpty()) || (!failed.isEmpty())) && !skipped.isEmpty()) {
+      if ((!failedWithinSuccess.isEmpty() || !failed.isEmpty()) && !skipped.isEmpty()) {
         context.getSkippedTests().removeResult(method);
       }
     }

--- a/testng-core/src/test/java/test/retryAnalyzer/issue1946/RetryAnalyzer.java
+++ b/testng-core/src/test/java/test/retryAnalyzer/issue1946/RetryAnalyzer.java
@@ -13,6 +13,7 @@ public class RetryAnalyzer implements IRetryAnalyzer {
   private int retryCount = 0;
   private static final int MAX_RETRY_COUNT = 1;
 
+  @Override
   public boolean retry(ITestResult result) {
     String prefix = "Attempt #" + retryCount;
     if (retryCount < MAX_RETRY_COUNT) {

--- a/testng-core/src/test/java/test/sanitycheck/SampleTest1.java
+++ b/testng-core/src/test/java/test/sanitycheck/SampleTest1.java
@@ -3,6 +3,6 @@ package test.sanitycheck;
 import org.testng.annotations.Test;
 
 public class SampleTest1 {
-  @Test()
+  @Test
   public void test1() {}
 }

--- a/testng-core/src/test/java/test/sanitycheck/SampleTest2.java
+++ b/testng-core/src/test/java/test/sanitycheck/SampleTest2.java
@@ -3,6 +3,6 @@ package test.sanitycheck;
 import org.testng.annotations.Test;
 
 public class SampleTest2 {
-  @Test()
+  @Test
   public void test2() {}
 }

--- a/testng-core/src/test/java/test/sanitycheck/SampleTest3.java
+++ b/testng-core/src/test/java/test/sanitycheck/SampleTest3.java
@@ -3,6 +3,6 @@ package test.sanitycheck;
 import org.testng.annotations.Test;
 
 public class SampleTest3 {
-  @Test()
+  @Test
   public void test3() {}
 }

--- a/testng-core/src/test/java/test/testng674/ReportingListenerFor674.java
+++ b/testng-core/src/test/java/test/testng674/ReportingListenerFor674.java
@@ -13,6 +13,7 @@ import org.testng.xml.XmlSuite;
 public class ReportingListenerFor674 implements IReporter {
   private List<Throwable> errors = new ArrayList<>();
 
+  @Override
   public void generateReport(List<XmlSuite> list, List<ISuite> suites, String s) {
     for (ISuite suite : suites) {
       for (ISuiteResult suiteResult : suite.getResults().values()) {

--- a/testng-core/src/test/java/test/thread/parallelization/BaseParallelizationTest.java
+++ b/testng-core/src/test/java/test/thread/parallelization/BaseParallelizationTest.java
@@ -857,7 +857,7 @@ public class BaseParallelizationTest extends SimpleBaseTest {
                   + "pairs of a suite listener onStart event logger followed by a suite listener onFinish event logger: "
                   + suiteLevelEventLogs)
           .isTrue();
-      suiteListenerStartEventLogs.add((suiteLevelEventLogs.get(i)));
+      suiteListenerStartEventLogs.add(suiteLevelEventLogs.get(i));
     }
 
     for (int i = 0; i < suiteListenerStartEventLogs.size() - 1; i++) {

--- a/testng-core/src/test/java/test/thread/parallelization/TestNgRunStateListener.java
+++ b/testng-core/src/test/java/test/thread/parallelization/TestNgRunStateListener.java
@@ -102,7 +102,7 @@ public class TestNgRunStateListener implements ISuiteListener, ITestListener {
   private TestNgRunStateTracker.EventLogBuilder buildEventLog(
       ITestResult result, TestNgRunEvent event) {
 
-    return (buildEventLog(result.getTestContext(), event))
+    return buildEventLog(result.getTestContext(), event)
         .addData(METHOD_NAME, result.getMethod().getMethodName())
         .addData(CLASS_NAME, result.getMethod().getRealClass().getCanonicalName())
         .addData(CLASS_INSTANCE, result.getMethod().getInstance())

--- a/testng-core/src/test/java/test/thread/parallelization/TestNgRunStateTracker.java
+++ b/testng-core/src/test/java/test/thread/parallelization/TestNgRunStateTracker.java
@@ -6,7 +6,6 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -1009,7 +1008,6 @@ public class TestNgRunStateTracker {
         sb.append(", Data provider param: ").append(getData(EventInfo.DATA_PROVIDER_PARAM));
       }
 
-      Date now = new Date(timeOfEvent);
       SimpleDateFormat sdfDate = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
 
       sb.append(", Time of event: ").append(sdfDate.format(timeOfEvent));

--- a/testng-core/src/test/java/test/thread/parallelization/sample/TestClassAFiveMethodsWithFactoryUsingDataProviderAndNoDepsSample.java
+++ b/testng-core/src/test/java/test/thread/parallelization/sample/TestClassAFiveMethodsWithFactoryUsingDataProviderAndNoDepsSample.java
@@ -161,7 +161,7 @@ public class TestClassAFiveMethodsWithFactoryUsingDataProviderAndNoDepsSample {
 
     String dataProviderParam = params.get("dataProviderParam");
 
-    String[] dataProviderVals = null;
+    String[] dataProviderVals;
     String classNamePattern =
         TestClassAFiveMethodsWithFactoryUsingDataProviderAndNoDepsSample.class.getSimpleName()
             + "(";

--- a/testng-core/src/test/java/test/thread/parallelization/sample/TestClassBFourMethodsWithFactoryUsingDataProviderAndNoDepsSample.java
+++ b/testng-core/src/test/java/test/thread/parallelization/sample/TestClassBFourMethodsWithFactoryUsingDataProviderAndNoDepsSample.java
@@ -138,7 +138,7 @@ public class TestClassBFourMethodsWithFactoryUsingDataProviderAndNoDepsSample {
 
     String dataProviderParam = params.get("dataProviderParam");
 
-    String[] dataProviderVals = null;
+    String[] dataProviderVals;
     String classNamePattern =
         TestClassBFourMethodsWithFactoryUsingDataProviderAndNoDepsSample.class.getSimpleName()
             + "(";

--- a/testng-core/src/test/java/test/thread/parallelization/sample/TestClassCSixMethodsWithFactoryUsingDataProviderAndNoDepsSample.java
+++ b/testng-core/src/test/java/test/thread/parallelization/sample/TestClassCSixMethodsWithFactoryUsingDataProviderAndNoDepsSample.java
@@ -184,7 +184,7 @@ public class TestClassCSixMethodsWithFactoryUsingDataProviderAndNoDepsSample {
 
     String dataProviderParam = params.get("dataProviderParam");
 
-    String[] dataProviderVals = null;
+    String[] dataProviderVals;
     String classNamePattern =
         TestClassCSixMethodsWithFactoryUsingDataProviderAndNoDepsSample.class.getSimpleName() + "(";
 

--- a/testng-core/src/test/java/test/thread/parallelization/sample/TestClassDThreeMethodsWithFactoryUsingDataProviderAndNoDepsSample.java
+++ b/testng-core/src/test/java/test/thread/parallelization/sample/TestClassDThreeMethodsWithFactoryUsingDataProviderAndNoDepsSample.java
@@ -115,7 +115,7 @@ public class TestClassDThreeMethodsWithFactoryUsingDataProviderAndNoDepsSample {
 
     String dataProviderParam = params.get("dataProviderParam");
 
-    String[] dataProviderVals = null;
+    String[] dataProviderVals;
     String classNamePattern =
         TestClassDThreeMethodsWithFactoryUsingDataProviderAndNoDepsSample.class.getSimpleName()
             + "(";

--- a/testng-core/src/test/java/test/thread/parallelization/sample/TestClassFSixMethodsWithFactoryUsingDataProviderAndNoDepsSample.java
+++ b/testng-core/src/test/java/test/thread/parallelization/sample/TestClassFSixMethodsWithFactoryUsingDataProviderAndNoDepsSample.java
@@ -184,7 +184,7 @@ public class TestClassFSixMethodsWithFactoryUsingDataProviderAndNoDepsSample {
 
     String dataProviderParam = params.get("dataProviderParam");
 
-    String[] dataProviderVals = null;
+    String[] dataProviderVals;
     String classNamePattern =
         TestClassFSixMethodsWithFactoryUsingDataProviderAndNoDepsSample.class.getSimpleName() + "(";
 

--- a/testng-core/src/test/java/test/timeout/GitHub1314Sample.java
+++ b/testng-core/src/test/java/test/timeout/GitHub1314Sample.java
@@ -15,7 +15,7 @@ public class GitHub1314Sample {
   private void iHangHorribly() {
     System.out.println("Test2");
     while (true) {
-      int two = 1 + 1;
+      // hangs on purpose
     }
   }
 

--- a/testng-core/src/test/java/test/uniquesuite/TestAfter.java
+++ b/testng-core/src/test/java/test/uniquesuite/TestAfter.java
@@ -25,5 +25,3 @@ public class TestAfter {
     BaseBefore.m_afterCount = 0;
   }
 }
-
-/////

--- a/testng-core/src/test/java/test/xml/XmlVerifyTest.java
+++ b/testng-core/src/test/java/test/xml/XmlVerifyTest.java
@@ -63,9 +63,8 @@ public class XmlVerifyTest extends SimpleBaseTest {
     Node xmlSuite = allSuites.item(0);
     assertThat(xmlSuite.getNodeType()).isEqualTo(Node.ELEMENT_NODE);
     Element element = (Element) xmlSuite;
-    assertThat(element.getAttribute("use-global-thread-pool")).isEqualTo(Boolean.TRUE.toString());
-    assertThat(element.getAttribute("share-thread-pool-for-data-providers"))
-        .isEqualTo(Boolean.TRUE.toString());
+    assertThat(element.getAttribute("use-global-thread-pool")).isEqualTo("true");
+    assertThat(element.getAttribute("share-thread-pool-for-data-providers")).isEqualTo("true");
   }
 
   @AfterMethod

--- a/testng-jcommander/src/test/java/test/reports/EmailableReporterCommandLineTest.java
+++ b/testng-jcommander/src/test/java/test/reports/EmailableReporterCommandLineTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.util.Locale;
 import org.testng.TestNG;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ public class EmailableReporterCommandLineTest extends SimpleBaseTest {
 
   @DataProvider(name = "getReporterNames")
   public Object[][] getReporterNames(Method method) {
-    if (method.getName().toLowerCase().contains("jvmarguments")) {
+    if (method.getName().toLowerCase(Locale.ROOT).contains("jvmarguments")) {
       return new Object[][] {{EmailableReporter2.class.getName(), "emailable.report2.name"}};
     }
     return new Object[][] {{EmailableReporter2.class.getName()}};

--- a/testng-runner-api/src/main/java/org/testng/internal/LiteWeightTestNGMethod.java
+++ b/testng-runner-api/src/main/java/org/testng/internal/LiteWeightTestNGMethod.java
@@ -295,8 +295,8 @@ public class LiteWeightTestNGMethod implements ITestNGMethod {
   }
 
   @Override
-  public void setTimeOut(long timeOut) {
-    this.timeout = timeOut;
+  public void setTimeOut(long timeout) {
+    this.timeout = timeout;
   }
 
   @Override

--- a/testng-test-kit/src/main/java/test/groups/issue2232/samples/SampleTest.java
+++ b/testng-test-kit/src/main/java/test/groups/issue2232/samples/SampleTest.java
@@ -8,17 +8,11 @@ import org.testng.annotations.Test;
 @Test(groups = {"Group1", "Group2", "Group3"})
 public class SampleTest {
 
-  private int variable = 0;
-
   @BeforeClass
-  public void setUp() {
-    variable += 1;
-  }
+  public void setUp() {}
 
   @AfterMethod
-  public void tearDown() {
-    variable += 1;
-  }
+  public void tearDown() {}
 
   @DataProvider(name = "testData1")
   public Object[][] testData1() {
@@ -28,7 +22,5 @@ public class SampleTest {
   }
 
   @Test(dataProvider = "testData1")
-  public void test1(String test) {
-    variable += 1;
-  }
+  public void test1(String test) {}
 }

--- a/testng-test-kit/testng-test-kit-build.gradle.kts
+++ b/testng-test-kit/testng-test-kit-build.gradle.kts
@@ -1,8 +1,24 @@
+import net.ltgt.gradle.errorprone.errorprone
+
 plugins {
     id("testng.kotlin-library")
 }
 
 description = "Test fixtures shared by the TestNG modules. Never published."
+
+// Everything here is test code even though it lives in a main source set. testng.errorprone
+// reads this flag, and so does Error Prone itself -- several of its checks skip a compile
+// marked test-only -- so opting a module in is a coverage decision, not just a switch.
+//
+// Error Prone is optional: testng.java only applies it when -PskipErrorProne is off, and the
+// OpenRewrite job turns it off because Error Prone is a javac plugin OpenRewrite never sees.
+// Reaching for options.errorprone unconditionally fails task configuration in those builds, so
+// the option is registered only once the plugin that owns the extension is there.
+pluginManager.withPlugin("net.ltgt.errorprone") {
+    tasks.withType<JavaCompile>().configureEach {
+        options.errorprone.compilingTestOnlyCode.set(true)
+    }
+}
 
 dependencies {
     api(platform("org.jetbrains.kotlin:kotlin-bom:2.4.10"))

--- a/testng-yaml/src/main/java/org/testng/internal/YamlSchema.java
+++ b/testng-yaml/src/main/java/org/testng/internal/YamlSchema.java
@@ -324,12 +324,9 @@ final class YamlSchema {
      */
     <V> SchemaType<T> mapKey(
         String name, Function<Map<?, ?>, V> conversion, BiConsumer<T, V> setter) {
-      return add(
-          new SchemaProperty(
-              name,
-              Map.class,
-              (target, value) ->
-                  setter.accept(uncheckedCast(target), conversion.apply((Map<?, ?>) value))));
+      BiConsumer<T, Object> converting =
+          (target, value) -> setter.accept(target, conversion.apply((Map<?, ?>) value));
+      return add(new SchemaProperty(name, Map.class, cast(converting)));
     }
 
     /** An accepted spelling of {@code canonical} that warns when it is used. */
@@ -397,11 +394,6 @@ final class YamlSchema {
     private SchemaType<T> add(SchemaProperty property) {
       keys.put(property.getName(), property);
       return this;
-    }
-
-    @SuppressWarnings("unchecked")
-    private static <V> V uncheckedCast(Object value) {
-      return (V) value;
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})


### PR DESCRIPTION
Ten Error Prone checks have no unsuppressed site left in the build, so they are now errors
instead of warnings. Until now none of them failed anything: they printed into an output long
enough that nobody read it, which is the same as not running them.

## The measurement was wrong before this branch, and that is the main finding

**javac reports at most 100 warnings per compile task.** Four tasks here were past that, so
every warning count previously quoted for this repository was truncated — including the one
this work was scoped against. Fixing sites of one check made unrelated checks appear from
behind the cut-off, which is how it was noticed.

| | scoped against | actually |
|---|---|---|
| Error Prone warnings in a build | 345 | **1002** |
| sites across the ten checks below | 39 | **222** |
| `MissingSummary` | 158 | **361** |

Every number in this description comes from `--rerun-tasks` with `-Xmaxwarns` raised through
an untracked init script, with the javac error count published beside it — a plain javac
error silences the whole Error Prone pass, so a low warning count can mean the pass never
ran.

## Result

| | before | after |
|---|---|---|
| Error Prone warnings, uncapped | 1002 | 775 |
| warnings the build prints (capped at 100/task) | 345 | 338 |
| javac errors | 0 | 0 |
| sites across the ten promoted checks | 222 | **0** |

| check | before | after |
|---|---|---|
| `MissingOverride` | 76 | 0 |
| `UnnecessaryParentheses` | 67 | 0 |
| `UnusedVariable` | 35 | 0 |
| `BooleanLiteral` | 13 | 0 |
| `BadImport` | 11 | 0 |
| `StringCaseLocaleUsage` | 10 | 0 |
| `TypeParameterUnusedInFormals` | 4 | 0 |
| `Finalize` | 2 | 0 |
| `NotJavadoc` | 2 | 0 |
| `InconsistentCapitalization` | 2 | 0 |

The whole 1002 → 775 drop is accounted for: 222 from the checks above, 3 `MissingSummary` that
stop applying once `testng-test-kit` is correctly treated as test code, 1 `JavaUtilDate` on a
`Date` that nothing read, and 1 `UnusedMethod` on the constructor whose suppression names it
explicitly. No check anywhere in the build gained a warning.

## Both changes that are not sweeps

**The test-code gate no longer keys on the task name.** `name.contains("Test")` decided how
NullAway reads a compile, so `testng-test-kit` — test code living in a main source set — got
neither `HandleTestAssertionLibraries` nor the `SelfAssertion` opt-out, while its
`org.testng.xml` half was null-marked and checked. The Error Prone plugin already models
this: `compilingTestOnlyCode` takes its convention from the *source set* name and a module
can override it.

This has no other visible effect, so a green build could not prove it. A throwaway probe in
the marked package of `testng-test-kit` did:

```java
static int nullAwayProbe(@Nullable String s) {
  assertThat(s).isNotNull();
  return s.length();
}
```

| | `[NullAway]` | javac errors |
|---|---|---|
| before | **1** — `dereferenced expression 's' is @Nullable` | 0 |
| after | 0 | 0 |

**The promotion was verified by breaking it, not by reading the config.** One `@Test()` put
back into `test/enable/A.java`:

```
A.java:14: error: [UnnecessaryParentheses] These parentheses are unnecessary
BUILD FAILED
```

Both probes were removed before committing.

## Where the sweep needed judgement

`UnnecessaryParentheses` looked like it would cost fixture coverage: the `test.enable` samples
deliberately pair `@Test` with `@Test()`, and `EnableTest` asserts both run. They cannot
differ — JLS 9.7.2 defines a marker annotation as shorthand for the empty-parenthesis form, and
TestNG reads annotations reflectively — so the pair was a source-form duplicate and the
parentheses went. The now-visible duplication between those method pairs is left alone.

**Error Prone's patcher was used for `MissingOverride`, `UnnecessaryParentheses`, `BadImport`,
`BooleanLiteral` and `NotJavadoc`, and rejected for `UnusedVariable`.** It deletes the initialiser along
with the variable, so on this codebase it removed a `parser.parse` call that was the subject of
its own test, the factory-parameter rows from the emailable report, `createXmlInclude` calls
that build the XML the test then runs, and a static initialiser that throws on purpose. All of
it stayed green. Those 36 sites are by hand: where the value was dead it is gone, where only
the variable was dead the call stays.

The sweep also surfaced a real bug: `EmailableReporter2` overwrote `hasRows` instead of
accumulating into it, so a result carrying only factory parameters got a placeholder row it did
not need. That was out of scope for an inert sweep, so it was reported as #3418 rather than
fixed here — and it has since been fixed upstream by #3427, which this branch is rebased onto.

Ten sites are suppressed rather than fixed, each with the reason at the site — the two
finalizers the leak test spins on, two Guice-injected constructor parameters whose injection is
what the sample proves, a field whose evaluation is what makes class initialisation fail, a
constructor parameter whose absence would change what a `PackageTest` assertion is exposed to,
`Comparator.compare` on the enum constant that compares nothing, and the three
`<T> T newInstance(String, ...)` declarations — interface, implementation and override, one of
them public API — where the class is named rather than passed so the type variable cannot reach
the formals.

`Finalize` is the one check that cleaned nothing: both its sites are suppressed, so it is
promoted on the bet that a *new* violation is worth stopping rather than on cleanup it bought.
The build config says so. `TypeParameterUnusedInFormals` did clean one —
`YamlSchema.uncheckedCast` had a single call site and a sibling helper that already did the job,
so the method went instead of gaining a suppression.

Two further sites are named rather than annotated, which is what Error Prone's `unused` prefix
means: a `Comparator` lambda, where a parameter cannot carry an annotation at all, and the local
whose division by zero is what makes a `@BeforeClass` fail. The annotated sites are spelled
`"unused"` to match what is already in the tree — except `Test2`'s constructor, which names
`UnusedVariable` and `UnusedMethod` explicitly: it is never called *and* its parameter is never
read, both deliberately, and the alias would have hidden the second one, whose suggested fix is
the no-arg constructor the comment at that site says must not exist.

`StringCaseLocaleUsage` is **not** a bug fix at any of its sites, and that was checked rather
than assumed. Turkish lowercasing only moves an uppercase `I`. The entry names `Parser.canParse`
matches carry none (`.xml`, `.yml`, `.yaml`), and the two script engines on the test classpath
report `Groovy` and `BeanShell` — identical under `tr_TR`, as is every spelling a suite file
could use for them. `Locale.ROOT` is insurance against an engine or a suffix that does contain
one; no behaviour changes today.

## What this deliberately does not do

- **It does not reduce the warning output.** `MissingSummary` is 358 of the remaining 775 and
  stays a warning; #3417 tracks what to do about it. What the branch buys is that these ten
  checks cannot regrow.
- **The build still truncates at 100 warnings per task.** Raising it was tried and dropped to
  keep the printed output at its current size. Correctness does not depend on it — a promoted check
  emits *errors*, and any error fails the build whether or not it is among the first hundred
  reported — but anyone counting warnings from an ordinary build will undercount, and the
  configuration says so at the point where checks are promoted.
- Checks needing a per-site behavioural decision (`ReferenceEquality`, `EqualsGetClass`,
  `JdkObsolete`, `JavaUtilDate`, `StringSplitter`, `MixedMutabilityReturnType`) are untouched,
  as is the javac `deprecation`/`removal` backlog.

## Verification

`./gradlew build`: **0 failures, 0 errors**. Six commits, each formatted and each compiling
with both counters at zero.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed emailable reports so factory-only results no longer include an unnecessary blank parameter row.
  * Improved locale-independent handling for archive detection, protocol parsing, script selection, URL processing, and report generation.

* **Refactor**
  * Improved code clarity and consistency across test execution, configuration, annotations, and object creation.

* **Chores**
  * Strengthened static analysis checks and cleaned up unused code, imports, and redundant test fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->