### PR TITLE
refactor: stop calling the deprecated assert and collection helpers

### DIFF
--- a/testng-core/src/main/java/org/testng/internal/Graph.java
+++ b/testng-core/src/main/java/org/testng/internal/Graph.java
@@ -16,7 +16,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.jspecify.annotations.Nullable;
 import org.testng.TestNGException;
-import org.testng.collections.Maps;
 import org.testng.log4testng.Logger;
 
 /**
@@ -150,10 +149,7 @@ public class Graph<T> {
                   .sorted(comparator)
                   .collect(
                       Collectors.toMap(
-                          Node::getObject,
-                          Function.identity(),
-                          (a, b) -> a,
-                          Maps::newLinkedHashMap));
+                          Node::getObject, Function.identity(), (a, b) -> a, LinkedHashMap::new));
       m_independentNodes = independentNodes;
     }
     return independentNodes;

--- a/testng-core/src/test/java/org/testng/internal/listeners/parameterindex/TestWithProviderTest.java
+++ b/testng-core/src/test/java/org/testng/internal/listeners/parameterindex/TestWithProviderTest.java
@@ -1,6 +1,6 @@
 package org.testng.internal.listeners.parameterindex;
 
-import static org.testng.AssertJUnit.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Listeners;
@@ -16,6 +16,6 @@ public class TestWithProviderTest {
 
   @Test(dataProvider = "integerValues")
   public void ShouldBeLessThan5(int value) {
-    assertTrue(value < 5);
+    assertThat(value).isLessThan(5);
   }
 }

--- a/testng-core/src/test/java/test/MethodTest.java
+++ b/testng-core/src/test/java/test/MethodTest.java
@@ -1,7 +1,6 @@
 package test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.testng.AssertJUnit.assertEquals;
 
 import org.testng.annotations.Test;
 import test.sample.Sample2;
@@ -38,7 +37,7 @@ public class MethodTest extends BaseTest {
   @Test
   public void excludePackage() {
     addClass(CLASS_NAME);
-    assertEquals(getTest().getXmlClasses().size(), 1);
+    assertThat(getTest().getXmlClasses().size()).isEqualTo(1);
     addExcludedMethod(CLASS_NAME, ".*");
     run();
     String[] passed = {};

--- a/testng-core/src/test/java/test/dataprovider/issue3237/SampleCacheTestCase.java
+++ b/testng-core/src/test/java/test/dataprovider/issue3237/SampleCacheTestCase.java
@@ -1,8 +1,9 @@
 package test.dataprovider.issue3237;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.testng.Assert;
 import org.testng.IRetryAnalyzer;
 import org.testng.ITestResult;
 import org.testng.annotations.DataProvider;
@@ -16,7 +17,7 @@ public class SampleCacheTestCase {
   @Test(dataProvider = "dp", retryAnalyzer = MyRetry.class)
   public void testMethod(String uuid) {
     // Verify that fresh UUID is generated on each retry (no caching)
-    Assert.assertEquals(uuid, currentUuid, "Received stale data from DataProvider!");
+    assertThat(uuid).as("Received stale data from DataProvider!").isEqualTo(currentUuid);
 
     // Fail on first invocation to trigger retry, pass on second
     if (invocationCount.getAndIncrement() < 1) {

--- a/testng-core/src/test/java/test/dependent/DependentTest.java
+++ b/testng-core/src/test/java/test/dependent/DependentTest.java
@@ -7,7 +7,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
-import org.testng.Assert;
 import org.testng.ITestListener;
 import org.testng.ITestResult;
 import org.testng.TestNG;
@@ -207,10 +206,9 @@ public class DependentTest extends SimpleBaseTest {
     for (int i = 0; i < 12; i += 4) {
       String[] s = log.get(i).split("#");
       String instance = s[1];
-      Assert.assertEquals(log.get(i), "prepare#" + instance);
-      Assert.assertEquals(log.get(i + 1), "test1#" + instance);
-      Assert.assertEquals(log.get(i + 2), "test2#" + instance);
-      Assert.assertEquals(log.get(i + 3), "clean#" + instance);
+      assertThat(log.subList(i, i + 4))
+          .containsExactly(
+              "prepare#" + instance, "test1#" + instance, "test2#" + instance, "clean#" + instance);
     }
   }
 

--- a/testng-core/src/test/java/test/inheritance/VerifyTest.java
+++ b/testng-core/src/test/java/test/inheritance/VerifyTest.java
@@ -1,7 +1,7 @@
 package test.inheritance;
 
-import java.util.List;
-import org.testng.AssertJUnit;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.testng.annotations.Test;
 
 public class VerifyTest {
@@ -18,11 +18,6 @@ public class VerifyTest {
       "tearDownApplication"
     };
 
-    int i = 0;
-    List<String> l = ZBase_0.getMethodList();
-    AssertJUnit.assertEquals(expected.length, l.size());
-    for (String s : l) {
-      AssertJUnit.assertEquals(expected[i++], s);
-    }
+    assertThat(ZBase_0.getMethodList()).containsExactly(expected);
   }
 }

--- a/testng-core/src/test/java/test/listeners/factory/issue3120/FactoryListenerTestClassCombinedSample.java
+++ b/testng-core/src/test/java/test/listeners/factory/issue3120/FactoryListenerTestClassCombinedSample.java
@@ -1,6 +1,7 @@
 package test.listeners.factory.issue3120;
 
-import org.testng.Assert;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.testng.IExecutionListener;
 import org.testng.ITestNGListener;
 import org.testng.ITestNGListenerFactory;
@@ -27,7 +28,7 @@ public class FactoryListenerTestClassCombinedSample
 
   @Test
   public void sampleTestMethod() {
-    Assert.assertTrue(factoryInvoked, "Factory should have been invoked");
-    Assert.assertTrue(listenerInvoked, "Listener should have been invoked");
+    assertThat(factoryInvoked).as("Factory should have been invoked").isTrue();
+    assertThat(listenerInvoked).as("Listener should have been invoked").isTrue();
   }
 }

--- a/testng-core/src/test/java/test/listeners/factory/issue3120/TestClassSample.java
+++ b/testng-core/src/test/java/test/listeners/factory/issue3120/TestClassSample.java
@@ -1,6 +1,7 @@
 package test.listeners.factory.issue3120;
 
-import org.testng.Assert;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
@@ -9,7 +10,7 @@ public class TestClassSample {
 
   @Test
   public void sampleTestMethod() {
-    Assert.assertTrue(CustomFactory.factoryInvoked, "Factory should have been invoked");
-    Assert.assertTrue(CustomFactory.listenerInvoked, "Listener should have been invoked");
+    assertThat(CustomFactory.factoryInvoked).as("Factory should have been invoked").isTrue();
+    assertThat(CustomFactory.listenerInvoked).as("Listener should have been invoked").isTrue();
   }
 }

--- a/testng-core/src/test/java/test/listeners/issue3238/TestClassWithFailingTestMethodSample.java
+++ b/testng-core/src/test/java/test/listeners/issue3238/TestClassWithFailingTestMethodSample.java
@@ -1,6 +1,7 @@
 package test.listeners.issue3238;
 
-import org.testng.Assert;
+import static org.assertj.core.api.Assertions.fail;
+
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
@@ -9,6 +10,6 @@ public class TestClassWithFailingTestMethodSample {
 
   @Test
   public void failingTest() {
-    Assert.fail();
+    fail();
   }
 }

--- a/testng-core/src/test/java/test/retryAnalyzer/issue3231/InvocationCountRetrySample.java
+++ b/testng-core/src/test/java/test/retryAnalyzer/issue3231/InvocationCountRetrySample.java
@@ -1,7 +1,8 @@
 package test.retryAnalyzer.issue3231;
 
+import static org.assertj.core.api.Assertions.fail;
+
 import java.util.concurrent.atomic.AtomicInteger;
-import org.testng.Assert;
 import org.testng.IRetryAnalyzer;
 import org.testng.ITestResult;
 import org.testng.annotations.Test;
@@ -22,6 +23,6 @@ public class InvocationCountRetrySample {
   @Test(invocationCount = 2, retryAnalyzer = MyRetry.class)
   public void test() {
     invocationCount.incrementAndGet();
-    Assert.fail("fail");
+    fail("fail");
   }
 }

--- a/testng-core/src/test/java/test/retryAnalyzer/issue3231/MutationSample.java
+++ b/testng-core/src/test/java/test/retryAnalyzer/issue3231/MutationSample.java
@@ -1,9 +1,10 @@
 package test.retryAnalyzer.issue3231;
 
+import static org.assertj.core.api.Assertions.fail;
+
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.testng.Assert;
 import org.testng.IRetryAnalyzer;
 import org.testng.ITestResult;
 import org.testng.annotations.DataProvider;
@@ -67,6 +68,6 @@ public class MutationSample {
       return;
     }
     newObject.setId(UUID.randomUUID()); // Mutate!
-    Assert.fail();
+    fail();
   }
 }

--- a/testng-core/src/test/java/test/retryAnalyzer/issue3231/RetryLimitSample.java
+++ b/testng-core/src/test/java/test/retryAnalyzer/issue3231/RetryLimitSample.java
@@ -1,6 +1,7 @@
 package test.retryAnalyzer.issue3231;
 
-import org.testng.Assert;
+import static org.assertj.core.api.Assertions.fail;
+
 import org.testng.IRetryAnalyzer;
 import org.testng.ITestResult;
 import org.testng.annotations.DataProvider;
@@ -25,6 +26,6 @@ public class RetryLimitSample {
 
   @Test(dataProvider = "dp", retryAnalyzer = MyRetry.class)
   public void test(String s) {
-    Assert.fail("fail");
+    fail("fail");
   }
 }

--- a/testng-core/src/test/java/test/tmp/p1/ContainerTest.java
+++ b/testng-core/src/test/java/test/tmp/p1/ContainerTest.java
@@ -1,6 +1,6 @@
 package test.tmp.p1;
 
-import static org.testng.AssertJUnit.assertNotNull;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.testng.annotations.AfterSuite;
 import org.testng.annotations.BeforeSuite;
@@ -9,11 +9,11 @@ public class ContainerTest {
 
   @BeforeSuite
   public void startup() {
-    assertNotNull(null);
+    fail();
   }
 
   @AfterSuite
   public void shutdown() {
-    assertNotNull(null);
+    fail();
   }
 }

--- a/testng-core/src/test/java/test/tmp/p2/ServiceTest.java
+++ b/testng-core/src/test/java/test/tmp/p2/ServiceTest.java
@@ -1,12 +1,12 @@
 package test.tmp.p2;
 
-import static org.testng.AssertJUnit.assertNotNull;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.testng.annotations.Test;
 
 public class ServiceTest {
   @Test(groups = {"group1"})
   public void service() {
-    assertNotNull(null);
+    fail();
   }
 }


### PR DESCRIPTION
## What this changes

Two call sites of deprecated APIs, both driven by what javac actually reports rather than by a sweep.

**`Graph` no longer calls a helper TestNG marked for removal.** `initializeIndependentNodes()`
passed `Maps::newLinkedHashMap` to `Collectors.toMap`. That helper is
`@Deprecated(forRemoval = true, since = "7.13.0")` and its whole body is `return new
LinkedHashMap<>()`, so `LinkedHashMap::new` says the same thing without the countdown. This was the
last caller of any deprecated `Lists`/`Maps`/`Sets` helper left in the tree.

**Thirteen test files moved off `org.testng.Assert` and `org.testng.AssertJUnit`.** Those two
classes no longer live in this repository — they ship from the separate `org.testng:testng-asserts`
artifact, which deprecates both, and marks `AssertJUnit` `forRemoval`. Their call sites stop
compiling the day that artifact drops the class.

None of the migrated tests cover the assertion API itself; every one of them uses it only as a tool
to make a claim about something else. AssertJ is already the assertion idiom everywhere else in the
suite, so the migration converges on it rather than introducing a third one.

## What to look at in review

- **Argument order was reversed at the `AssertJUnit` sites.** `AssertJUnit.assertEquals` takes
  `(expected, actual)`; AssertJ takes the actual value first. Getting this wrong would leave the
  assertions passing while reporting the two values backwards on failure.
- **`VerifyTest` collapsed a hand-rolled loop.** A size check followed by an index-walking
  element-by-element comparison became one `containsExactly`. Same claim, and the failure message
  now names the whole mismatch instead of the first element.
- **`DependentTest` asserts a sublist** instead of four indexed reads whose `i + 1` … `i + 3`
  arithmetic had to stay in step with the loop's `i += 4`.
- **The deliberately-failing fixtures say `fail()`.** `ContainerTest` and `ServiceTest` expressed an
  unconditional failure as `assertNotNull(null)`; they now use the same plain `fail()` the other
  always-failing samples in the suite use.

The `testng-asserts` dependency stays: `org.testng.asserts.SoftAssert` is still used
(`test/configuration/issue2400/IssueTest.java`), and the Groovy and Kotlin samples deliberately
exercise TestNG's own `Assert`.

## Effect on the build's warning output

Counters read from `./gradlew testClasses --rerun-tasks` with Error Prone and autostyle switched
off, so the numbers are javac's alone and not read out of a mixed stream:

| | before | after |
|---|---|---|
| `warning: [deprecation]` | 108 | 95 |
| `warning: [removal]` | 7 | **0** |

Every `removal` warning in the build came from these two changes.

## Verification

`./gradlew build` passes on this branch: no failures and no errors across the test result files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified internal collection initialization without changing behavior.
  - Removed unused imports and streamlined assertion usage across the test suite.

- **Tests**
  - Standardized test assertions on AssertJ for clearer, more consistent validation.
  - Consolidated sequence checks into concise, exact-match assertions.
  - Preserved existing test coverage and expected pass/fail behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->