### PR TITLE
refactor(internal): deprecate the implementations of deprecated contracts

### DIFF
--- a/testng-core/src/main/java/org/testng/TestClass.java
+++ b/testng-core/src/main/java/org/testng/TestClass.java
@@ -148,11 +148,13 @@ class TestClass extends NoOpTestClass implements ITestClass, ITestClassConfigInf
     }
   }
 
+  @Deprecated
   @Override
   public Object[] getInstances(boolean create) {
     return iClass.getInstances(create);
   }
 
+  @Deprecated
   @Override
   public Object[] getInstances(boolean create, @Nullable String errorMsgPrefix) {
     return iClass.getInstances(create, this.m_errorMsgPrefix);
@@ -163,11 +165,14 @@ class TestClass extends NoOpTestClass implements ITestClass, ITestClassConfigInf
     return IObject.objects(iClass, create, errorMsgPrefix);
   }
 
+  // Deprecated as IClass.getInstanceHashCodes(); the IObject method it also serves is current.
+  @Deprecated
   @Override
   public long[] getInstanceHashCodes() {
     return IObject.instanceHashCodes(iClass);
   }
 
+  @Deprecated
   @Override
   public void addInstance(Object instance) {
     iClass.addInstance(instance);

--- a/testng-core/src/main/java/org/testng/TestNG.java
+++ b/testng-core/src/main/java/org/testng/TestNG.java
@@ -123,6 +123,12 @@ public class TestNG {
   /** The default name of the result's output directory (keep public, used by Eclipse). */
   public static final String DEFAULT_OUTPUTDIR = "test-output";
 
+  /** The suite file looked up inside a jar when none was named. */
+  private static final String DEFAULT_XML_PATH_IN_JAR = "testng.xml";
+
+  /** How many suites run at once when none was asked for: one, so suites run sequentially. */
+  private static final Integer DEFAULT_SUITE_THREAD_POOL_SIZE = 1;
+
   private static @Nullable TestNG m_instance;
 
   private @Nullable List<String> m_commandLineMethods;
@@ -175,7 +181,7 @@ public class TestNG {
 
   private @Nullable String m_jarPath;
   /** The path of the testng.xml file inside the jar file */
-  private String m_xmlPathInJar = CommandLineArgs.XML_PATH_IN_JAR_DEFAULT;
+  private String m_xmlPathInJar = DEFAULT_XML_PATH_IN_JAR;
 
   private List<String> m_stringSuites = new ArrayList<>();
   private final List<Class<? extends ITestNGListener>> m_listenerClasses = new ArrayList<>();
@@ -876,7 +882,7 @@ public class TestNG {
 
   private boolean m_ignoreMissedTestNames;
 
-  private Integer m_suiteThreadPoolSize = CommandLineArgs.SUITE_THREAD_POOL_SIZE_DEFAULT;
+  private Integer m_suiteThreadPoolSize = DEFAULT_SUITE_THREAD_POOL_SIZE;
 
   private boolean m_randomizeSuites = Boolean.FALSE;
 

--- a/testng-core/src/main/java/org/testng/internal/ClassImpl.java
+++ b/testng-core/src/main/java/org/testng/internal/ClassImpl.java
@@ -80,6 +80,8 @@ public class ClassImpl implements IClass, IObject {
     return m_class;
   }
 
+  // Deprecated as IClass.getInstanceHashCodes(); the IObject method it also serves is current.
+  @Deprecated
   @Override
   public long @Nullable [] getInstanceHashCodes() {
     return m_instanceHashCodes;
@@ -120,11 +122,13 @@ public class ClassImpl implements IClass, IObject {
     return m_defaultInstance;
   }
 
+  @Deprecated
   @Override
   public Object[] getInstances(boolean create) {
     return getInstances(create, "");
   }
 
+  @Deprecated
   @Override
   public Object[] getInstances(boolean create, @Nullable String errorMsgPrefix) {
     return Arrays.stream(getObjects(create, errorMsgPrefix))
@@ -163,6 +167,7 @@ public class ClassImpl implements IClass, IObject {
     return Objects.toStringHelper(getClass()).add("class", m_class.getName()).toString();
   }
 
+  @Deprecated
   @Override
   public void addInstance(Object instance) {
     addObject(new IdentifiableObject(instance));

--- a/testng-core/src/main/java/org/testng/internal/NoOpTestClass.java
+++ b/testng-core/src/main/java/org/testng/internal/NoOpTestClass.java
@@ -127,11 +127,14 @@ public class NoOpTestClass implements ITestClass, IObject {
   }
 
   /** @see org.testng.internal.IObject#getInstanceHashCodes() */
+  // Deprecated as IClass.getInstanceHashCodes(); the IObject method it also serves is current.
+  @Deprecated
   @Override
   public long[] getInstanceHashCodes() {
     return m_instanceHashes;
   }
 
+  @Deprecated
   @Override
   public Object[] getInstances(boolean reuse) {
     return m_instances;
@@ -152,6 +155,7 @@ public class NoOpTestClass implements ITestClass, IObject {
     return testClass;
   }
 
+  @Deprecated
   @Override
   public void addInstance(Object instance) {}
 


### PR DESCRIPTION
## What this changes

`IClass` deprecated `getInstances`, `getInstanceHashCodes` and `addInstance` in 7.10.0, but
`TestClass`, `ClassImpl` and `NoOpTestClass` went on implementing them unmarked. javac therefore
reported every implementation, and every call delegating to the next one down, as a fresh use of a
deprecated API — thirteen warnings for a decision that was taken years ago.

Marking the implementations states what is already true of the contract they serve. It also silences
the delegating calls in their bodies for free, since a deprecated method may use deprecated API.

`TestNG` separately read two defaults off `CommandLineArgs`, whose own javadoc schedules it for
removal in 8.0. It now declares them itself.

## What to look at in review

**`getInstanceHashCodes` is the one that needs a decision.** The same method body satisfies two
contracts:

- `IClass.getInstanceHashCodes()` — deprecated since 7.10.0
- `IObject.getInstanceHashCodes()` — current, and still reached from the non-deprecated
  `ITestNGMethod.getInstanceHashCodes()` by way of `BaseTestMethod` and `IObject.instanceHashCodes`

So `@Deprecated` on those three implementations is half true. Each carries a comment saying which
half, because the annotation alone reads as if the whole method were dead — and `org.testng.internal`
is an exported OSGi package, so a downstream holding a `NoOpTestClass` now sees a deprecation on a
method whose `IObject` contract is current.

The clean fix is to stop the two interfaces sharing a name, and **#3424 now does exactly that**: it
renames `IObject.getInstanceHashCodes()` to `getObjectHashCodes()`, after which these annotations are
simply true and the three comments go away. It is stacked on this branch, so this PR still reads on
its own; #3424 also turned up a nullness gap in `ClassImpl` that the shared name had been hiding.

**The two `TestNG` defaults are runner defaults, not CLI defaults.** `CliConfigurer` overwrites both
unconditionally (`setXmlPathInJar`, `setSuiteThreadPoolSize`), so the CLI path never observes these
field initializers; they exist for the programmatic path, where `m_xmlPathInJar` feeds
`JarFileUtils` and `m_suiteThreadPoolSize` picks the sequential-versus-parallel branch. Reading them
off a class scheduled for deletion was the compiler pointing that out. They are now declared next to
`DEFAULT_OUTPUTDIR`, private like `DEFAULT_THREADPOOL_FACTORY`. Say the word if you would rather
they were public, so callers keep a supported way to read the default after 8.0.

The remaining `CommandLineArgs` uses in `TestNG` all sit inside `@Deprecated` methods and are
already silent.

## Scope

The annotated types are package-private (`TestClass`) or live in `org.testng.internal`, which
javadoc already excludes. No published API changes shape, and no behaviour changes.

## Effect on the build's warning output

Counters read from `./gradlew testClasses --rerun-tasks` with Error Prone and autostyle switched
off, so the numbers are javac's alone:

| | before | after |
|---|---|---|
| `warning: [deprecation]` | 108 | 95 |
| `warning: [removal]` | 7 | 7 |

The thirteen this removes are every deprecation warning the `main` source set produced. The
remainder are in test sources and are back-compatibility coverage — tests that exercise a deprecated
API on purpose, which should keep doing so.

## Verification

`./gradlew build` passes on this branch: no failures and no errors across the test result files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Deprecations**
  - Marked several legacy test-instance management APIs as deprecated.
  - Existing behavior remains unchanged; newer object-based APIs should be used instead.

- **Configuration**
  - Added local defaults for test JAR XML paths and suite thread-pool sizing.
  - Default initialization is now handled directly by the test runner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
