### PR TITLE
docs: move the repository-wide agent notes into AGENTS.md, and correct them

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,34 @@ grep -o 'tests="[1-9][0-9]*"' "testng-core/build/test-results/test/TEST-$CLASS.x
 
 Read that file only after a run you know executed — see the gate above.
 
+**A production object built by hand in a test is usually under-configured, and the test then passes
+vacuously.** `TestClass` asks its `ITestMethodFinder` for the configuration methods, and the finder
+answers only what a method selector included — so a bare `new RunInfo(() -> xmlTest)` registers no
+selector, `RunInfo.includeMethod` (`testng-core/src/main/java/org/testng/internal/RunInfo.java:37`)
+never enters its loop and returns the `false` it started with. Every category then comes back empty,
+for a reason that looks nothing like the cause. `TestRunner.initRunInfo`
+(`testng-core/src/main/java/org/testng/TestRunner.java:414`) does the missing half at lines 424 and
+426. Diff the fixture against the production call site of whatever it builds:
+`TestClassConfigurationLookupTest#newRunInfo` exists only to reproduce those two lines, and says so.
+
+**An expectation derived by reading records your assumption, not the behaviour.** In that same test
+`getBeforeClassMethods()` was asserted to carry one entry per `@Factory` instance; it carries one.
+`TestClass.initMethods` assigns the field inside the per-instance loop and stores a copy per id
+(`TestClass.java:235-238`), so only the last instance survives and the per-instance lists are what
+`getInstanceBeforeClassMethods` answers. For anything pinning existing behaviour, run it first and
+paste what it answered.
+
+**The test doubles here have a settled shape.** `org.mockito:mockito-core` is declared at
+`testng-core/testng-core-build.gradle.kts:37`, so counting calls on a real collaborator is a wrapper
+rather than a hand-written spy: `mock(Iface.class, delegatesTo(real))`, then `verify(...)`, which
+defaults to exactly once, and `verifyNoMoreInteractions(...)` to close the set. A fake implementing
+`IClass`/`ITestClass`/`IObject` follows `FakeTestClass` and `MethodInstanceTest.TestClassStub` —
+deprecated members carry `@SuppressWarnings("deprecation")` rather than `@Deprecated`, since on a
+fake the annotation buys nothing and makes `InlineMeSuggester` fire, and the deprecated accessor
+delegates to the live one. A method the fake is never asked for throws
+`UnsupportedOperationException("not reached while building a TestClass")` instead of a plausible
+empty value, so the load-bearing surface stands out.
+
 **Any number that reaches a commit message or a pull request comes from `--rerun-tasks`.** Error
 Prone and NullAway see only the units javac recompiles, so an incremental run both hides errors and
 invents them: on one package marking, three checks passed incrementally and failed under

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,6 +277,12 @@ edits that follow it, so a reviewer can tell which hunks a human actually judged
 - Running a documented command proves it executes, not that it does what the text claims. If the
   text promises an effect — filtering, failing, producing a value — measure that effect.
 - Report what you actually observed. If a run was flaky, say so and show both runs.
+- **What the characterization made fail is the minimum the fix has to cover.** If the `CHANGES.txt`
+  entry needs a "not covered until X migrates" clause, the fix is too shallow — the shared primitive
+  one level down is the altitude, and an existing failsafe on a sibling of that primitive is the
+  tell. GITHUB-2830 lost three reports to one parameter whose `toString()` threw; guarding the
+  caller covered one of them, while guarding `Utils.toString`, beside the already-failsafe
+  `Utils.buildStackTrace`, covered all three and left the caller unchanged.
 - When an upgrade is refused, record the error that refused it, so the next person does not retry it
   blind.
 - **Edit prose before `autostyleApply`, not after.** The formatter rewraps javadoc, so a scripted

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,8 +17,34 @@ The gate is `./gradlew build`, the same task CI runs. Let Gradle decide how much
 a change that reaches nothing finishes in seconds, so there is no need to judge by hand what a diff
 can affect. Add `clean` only to rule out stale output.
 
+Neither its exit code nor the result files prove anything on their own. An up-to-date run prints
+`BUILD SUCCESSFUL` without executing a single test; and while Gradle clears
+`build/test-results/test/` whenever the task *executes*, an up-to-date task does not execute, so the
+previous run's files survive and still read `0 failures`. Run the gate as one shape that answers
+both:
+
 ```bash
-./gradlew build     # minutes when it has work to do, seconds when it does not; 0 failures
+LOG="/tmp/testng-$(git branch --show-current | tr / -)-gate.log"   # parallel workspaces share /tmp
+rm -rf */build/test-results/test          # forces the task out of date, so the tests really run
+./gradlew --console=plain build > "$LOG" 2>&1; echo "EXIT=$?" >> "$LOG"
+grep -qE '^BUILD SUCCESSFUL' "$LOG" && grep -q '^EXIT=0' "$LOG" \
+  || { echo 'GATE INCONCLUSIVE'; grep -A10 'What went wrong' "$LOG"; exit 1; }
+grep -ho 'failures="[0-9]*"\|errors="[0-9]*"' */build/test-results/test/TEST-*.xml | sort | uniq -c
+```
+
+Redirect rather than pipe: a pipeline reports grep's status unless `pipefail` is set, and the log
+you need for the failure is gone either way. `EXIT=` goes in the log for the same reason — whatever
+reads the exit status of a backgrounded run sees the `echo`, which is the last process.
+
+`testng-core` hands the whole suite to every fork it starts (`maxParallelForks =
+availableProcessors() / 2`), so those counts are a multiple of the fork count. Read zeros and ratios
+from them, never an absolute total.
+
+When it fails, Gradle names the HTML report, but locating the test is quicker from the result files:
+
+```bash
+grep -l '<failure\|<error' */build/test-results/test/*.xml
+grep -o 'message="[^"]*"' testng-core/build/test-results/test/TEST-<the-class>.xml
 ```
 
 **The gate is not the edit loop.** Letting Gradle skip work only helps when the change reaches
@@ -29,30 +55,23 @@ minutes once, before committing:
 ```bash
 ./gradlew :testng-core:test \
   --tests "org.testng.xml.XmlRoundTripTest" \
-  --tests "test.xml.XmlVerifyTest" > /tmp/t.log 2>&1
-rc=$?; echo "EXIT=$rc"; (exit $rc)
+  --tests "test.xml.XmlVerifyTest" > /tmp/t.log 2>&1; echo "EXIT=$?" >> /tmp/t.log
 ```
 
 Naming that set before editing is the point: it is the question the change has to answer. A run like
 the one above returns in seconds rather than minutes.
 
-Three things make a `--tests` set narrower or wider than it looks:
+Two things make a `--tests` set narrower or wider than it looks:
 
-- **It must include whatever supplies a dependency.** `--tests "test.inheritance.VerifyTest"` alone
-  fails the task with `Method "VerifyTest.verify()…" depends on nonexistent group "before"`: the
-  group's members live in `test.inheritance.DChild_2`, a sibling `<class>` of the same `<test>`
-  block that the filter removed. That run printed **43 lines saying `0 failed`** against one
-  `BUILD FAILED`. Open the `<test>` block a class sits in and pull in its siblings whenever it uses
-  `dependsOnGroups` or `dependsOnMethods`.
-- **It also collects nested classes.** `--tests "…IssueTest"` picks up `IssueTest$SomeNested`, so a
-  sample nested inside its own test escapes into the run — and a nested failing `@BeforeSuite` runs
-  as the outer suite's, reporting the real test as skipped with the sample's own assertion message.
-  Keep samples in separate top-level files, which is what every `issue<N>/` package already does.
-  `build` is unaffected: it is suite-driven, and only the `--tests` path scans.
-- **A filtered class runs once per fork.** `testng-core` sets `maxParallelForks =
-  availableProcessors() / 2` and drives everything through one `testng.xml`, so every fork applies
-  the filter to the whole suite. Expect the executions to be a multiple of the fork count, and read
-  a flake as disagreement between forks rather than as a high count.
+- **It must include whatever supplies a dependency.** Filtering out the `<class>` that owns a group
+  while keeping a sibling that `dependsOnGroups` on it fails the whole task with `depends on
+  nonexistent group "<name>"` — behind dozens of lines still reading `0 failed`, so only the `BUILD`
+  line says anything is wrong. Open the `<test>` block your class sits in and pull in its siblings
+  whenever it uses `dependsOnGroups` or `dependsOnMethods`.
+- **A wildcard also collects nested classes.** An exact class name does not, but
+  `--tests "…issueNNNN.*"` picks up `IssueTest$Sample` alongside `IssueTest`, so a sample nested
+  inside its own test runs as a test in its own right — and a sample that fails on purpose then
+  reads as a failure of yours. Measured: exact filter one result file, wildcard two.
 
 **A new `testng-core` test class does not run until it is listed in
 `testng-core/src/test/resources/testng.xml`.** The task is suite-driven, not classpath-scanned, so
@@ -67,60 +86,14 @@ CLASS=org.testng.xml.XmlRoundTripTest
 grep -o 'tests="[1-9][0-9]*"' "testng-core/build/test-results/test/TEST-$CLASS.xml"
 ```
 
-That file is the previous run's until this one overwrites it — read the gate below before taking a
-count out of it.
-
-Filter the output rather than reading it whole; a full build log runs to thousands of lines, and the
-test logger prints a line per test class, so match on the summary only. Set `pipefail` first —
-without it the pipeline reports grep's status, so a failed build still exits 0:
-
-```bash
-set -o pipefail
-./gradlew --console=plain build 2>&1 | grep -E "^BUILD (SUCCESSFUL|FAILED)|[1-9][0-9]* failed"
-```
-
-For a failure, extract the useful part instead of scrolling:
-
-```bash
-set -o pipefail
-./gradlew --console=plain build 2>&1 | grep -A15 "What went wrong"
-```
-
-Gradle names the HTML report on failure, but locating the failing test is quicker from the result
-files:
-
-```bash
-grep -l '<failure\|<error' testng-core/build/test-results/test/*.xml
-grep -o 'message="[^"]*"' testng-core/build/test-results/test/TEST-<the-class>.xml | head
-```
-
-**Those result files outlive the run that wrote them.** `build/test-results/test/TEST-*.xml` is
-whatever executed last, on whatever branch, and nothing clears it. A gate that dies mid-run — the
-daemon stopped from outside, say — leaves a log with no `BUILD` line at all while those files still
-read `0 failures`, on the previous commit. Run the gate as one shape that cannot report a false
-green:
-
-```bash
-LOG="/tmp/testng-$(git branch --show-current | tr / -)-gate.log"   # parallel workspaces share /tmp
-rm -rf */build/test-results/test
-./gradlew --console=plain build > "$LOG" 2>&1; echo "EXIT=$?" >> "$LOG"
-grep -qE '^BUILD SUCCESSFUL' "$LOG" && grep -q '^EXIT=0' "$LOG" \
-  || { echo 'GATE INCONCLUSIVE'; grep -A10 'What went wrong' "$LOG"; exit 1; }
-grep -ho 'failures="[0-9]*"\|errors="[0-9]*"' */build/test-results/test/TEST-*.xml | sort | uniq -c
-```
-
-Both proofs are needed and neither is enough alone: an up-to-date run prints `BUILD SUCCESSFUL`
-without executing a single test, and the counts belong to someone else's run until the purge above
-makes them this one's. Put `EXIT=` **in the log**, never on stdout: whatever reads the exit status
-of a backgrounded run sees the `echo`, which is the last process, and reports 0 for a build that
-failed.
+Read that file only after a run you know executed — see the gate above.
 
 **Any number that reaches a commit message or a pull request comes from `--rerun-tasks`.** Error
 Prone and NullAway see only the units javac recompiles, so an incremental run both hides errors and
 invents them: on one package marking, three checks passed incrementally and failed under
 `--rerun-tasks`, and one of those failures was itself spurious. Forcing only the tasks that matter —
 `:testng-core-api:compileJava --rerun :testng-core:compileJava --rerun` — is much cheaper than
-`--rerun-tasks` over the whole graph, and just as forcing for them.
+`--rerun-tasks` over the whole graph, and just as forcing for those units.
 
 A green local build is not a green CI. Pull requests against `master` also run an OpenRewrite check
 that `.github/CONTRIBUTING.md` documents, and a wrapper validation. Pushes are weaker than they
@@ -251,14 +224,12 @@ gh pr create --repo testng-team/testng --base master --head <fork-owner>:<branch
 Conventional Commits. Record user-visible changes in `CHANGES.txt`, newest first, under the current
 version heading.
 
-`org.testng.internal` and its sub-packages are OSGi exported yet excluded from javadoc, which reads
-as a contradiction and invites deprecated bridges. The project does the opposite: it breaks them and
-records the break — 7.13.0 alone lists a class that lost its no-method constructor, two helpers that
-stopped accepting null, constructors that changed signature and types that became final, each entry
-naming the export and doing it anyway. So a change there earns two entries: the `Changed:` line in
-prose, and a bullet under `Possible backward incompatible changes:` saying what stops compiling and
-what to use instead. Grep `CHANGES.txt` for `internal` before arguing about compatibility — the
-precedents are the argument.
+A change under `org.testng.internal` earns two `CHANGES.txt` entries: the `Changed:` line in prose,
+and a bullet under `Possible backward incompatible changes:` naming what stops compiling and what to
+use instead. The package is OSGi exported yet excluded from javadoc, which reads as a contradiction
+and invites deprecated bridges; the project does the opposite, breaking them and recording it, each
+entry naming the export and doing it anyway. Grep `CHANGES.txt` for `internal` before arguing
+about compatibility — the precedents are the argument.
 
 Split a pull request that mixes a large mechanical sweep with changes that need judgement. The two
 halves have different review costs: a tool's output — an OpenRewrite run, a formatter pass, a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,24 @@ rc=$?; echo "EXIT=$rc"; (exit $rc)
 Naming that set before editing is the point: it is the question the change has to answer. A run like
 the one above returns in seconds rather than minutes.
 
+Three things make a `--tests` set narrower or wider than it looks:
+
+- **It must include whatever supplies a dependency.** `--tests "test.inheritance.VerifyTest"` alone
+  fails the task with `Method "VerifyTest.verify()…" depends on nonexistent group "before"`: the
+  group's members live in `test.inheritance.DChild_2`, a sibling `<class>` of the same `<test>`
+  block that the filter removed. That run printed **43 lines saying `0 failed`** against one
+  `BUILD FAILED`. Open the `<test>` block a class sits in and pull in its siblings whenever it uses
+  `dependsOnGroups` or `dependsOnMethods`.
+- **It also collects nested classes.** `--tests "…IssueTest"` picks up `IssueTest$SomeNested`, so a
+  sample nested inside its own test escapes into the run — and a nested failing `@BeforeSuite` runs
+  as the outer suite's, reporting the real test as skipped with the sample's own assertion message.
+  Keep samples in separate top-level files, which is what every `issue<N>/` package already does.
+  `build` is unaffected: it is suite-driven, and only the `--tests` path scans.
+- **A filtered class runs once per fork.** `testng-core` sets `maxParallelForks =
+  availableProcessors() / 2` and drives everything through one `testng.xml`, so every fork applies
+  the filter to the whole suite. Expect the executions to be a multiple of the fork count, and read
+  a flake as disagreement between forks rather than as a high count.
+
 **A new `testng-core` test class does not run until it is listed in
 `testng-core/src/test/resources/testng.xml`.** The task is suite-driven, not classpath-scanned, so
 an unregistered class is skipped by `build` without a word — the file can be committed and never
@@ -48,6 +66,9 @@ confirm it ran, rather than trusting the exit code:
 CLASS=org.testng.xml.XmlRoundTripTest
 grep -o 'tests="[1-9][0-9]*"' "testng-core/build/test-results/test/TEST-$CLASS.xml"
 ```
+
+That file is the previous run's until this one overwrites it — read the gate below before taking a
+count out of it.
 
 Filter the output rather than reading it whole; a full build log runs to thousands of lines, and the
 test logger prints a line per test class, so match on the summary only. Set `pipefail` first —
@@ -94,6 +115,13 @@ makes them this one's. Put `EXIT=` **in the log**, never on stdout: whatever rea
 of a backgrounded run sees the `echo`, which is the last process, and reports 0 for a build that
 failed.
 
+**Any number that reaches a commit message or a pull request comes from `--rerun-tasks`.** Error
+Prone and NullAway see only the units javac recompiles, so an incremental run both hides errors and
+invents them: on one package marking, three checks passed incrementally and failed under
+`--rerun-tasks`, and one of those failures was itself spurious. Forcing only the tasks that matter —
+`:testng-core-api:compileJava --rerun :testng-core:compileJava --rerun` — is much cheaper than
+`--rerun-tasks` over the whole graph, and just as forcing for them.
+
 A green local build is not a green CI. Pull requests against `master` also run an OpenRewrite check
 that `.github/CONTRIBUTING.md` documents, and a wrapper validation. Pushes are weaker than they
 look: the `branches: ['*']` filter in `test.yml` does not match `/`, so pushing a branch named
@@ -138,13 +166,18 @@ Before writing documentation, read what is already in `docs/` and `.github/`. Mo
 covered there; a second copy drifts from the first, and this file was itself written as a fifth copy
 before being cut back to links.
 
-Two things that are not documented elsewhere and cost tool calls to discover:
+Three things that are not documented elsewhere and cost tool calls to discover:
 
 - Per-project build files are named `<module>/<module>-build.gradle.kts`, not `build.gradle.kts`.
 - Build logic lives in two included builds: `build-logic-commons/` builds the plugins that
   `build-logic/` uses. Conventions are precompiled script plugins,
   `build-logic/*/src/main/kotlin/testng.*.gradle.kts` — prefer changing a convention over repeating
   configuration per module.
+- A package is not confined to one module. Ten of them span two or more, `org.testng.internal`
+  across four (core, core-api, runner-api, yaml). Anything scoped to a package — a
+  `package-info.java` annotation such as `@NullMarked`, package javadoc, `Export-Package` reasoning
+  — takes effect in every module where the package appears, through the `package-info.class` on the
+  compile classpath. Size package-scoped work by the package union, never by module.
 
 The `guice` and `yaml` optional features are hand-rolled rather than declared with
 `registerFeature`; the reasoning is in the KDoc of
@@ -217,6 +250,15 @@ gh pr create --repo testng-team/testng --base master --head <fork-owner>:<branch
 
 Conventional Commits. Record user-visible changes in `CHANGES.txt`, newest first, under the current
 version heading.
+
+`org.testng.internal` and its sub-packages are OSGi exported yet excluded from javadoc, which reads
+as a contradiction and invites deprecated bridges. The project does the opposite: it breaks them and
+records the break — 7.13.0 alone lists a class that lost its no-method constructor, two helpers that
+stopped accepting null, constructors that changed signature and types that became final, each entry
+naming the export and doing it anyway. So a change there earns two entries: the `Changed:` line in
+prose, and a bullet under `Possible backward incompatible changes:` saying what stops compiling and
+what to use instead. Grep `CHANGES.txt` for `internal` before arguing about compatibility — the
+precedents are the argument.
 
 Split a pull request that mixes a large mechanical sweep with changes that need judgement. The two
 halves have different review costs: a tool's output — an OpenRewrite run, a formatter pass, a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -255,6 +255,15 @@ edits that follow it, so a reviewer can tell which hunks a human actually judged
   having vanished rather than like a stash. `git worktree add ../measure <ref>` answers the question
   without touching what you hold, and when an amend is coming anyway, committing first leaves
   nothing to stash.
+- **`git stash push -- <path>` on a path with no local changes creates nothing.** It says so — "No
+  local changes to save" — and leaves the stack untouched; but the stack is global while the push
+  was scoped, so the `git stash pop` written on the next line dequeues whatever was already on it:
+  another branch's work, spread through the tree as conflicts. Twenty-one files, here, while probing
+  a file that was committed and therefore unmodified. `git stash list` names the branch each entry
+  was made on, which is the giveaway. To instrument a committed file, save the blob instead —
+  `git show HEAD:<path> > /tmp/probe`, edit, copy back — which works whether the file has local
+  changes or not. Git does not drop an entry it could not apply cleanly, so a conflicted pop loses
+  nothing of the other branch's.
 - **Read `git ls-remote` when you start on an already-pushed branch, not when you push.** A branch
   can be rebased from another workspace between two of your turns; finding out at push time means
   the rebase, the gate and the summary were all spent against a base that had moved. Compare trees,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,51 @@ CLASS=org.testng.xml.XmlRoundTripTest
 grep -o 'tests="[1-9][0-9]*"' "testng-core/build/test-results/test/TEST-$CLASS.xml"
 ```
 
+Filter the output rather than reading it whole; a full build log runs to thousands of lines, and the
+test logger prints a line per test class, so match on the summary only. Set `pipefail` first —
+without it the pipeline reports grep's status, so a failed build still exits 0:
+
+```bash
+set -o pipefail
+./gradlew --console=plain build 2>&1 | grep -E "^BUILD (SUCCESSFUL|FAILED)|[1-9][0-9]* failed"
+```
+
+For a failure, extract the useful part instead of scrolling:
+
+```bash
+set -o pipefail
+./gradlew --console=plain build 2>&1 | grep -A15 "What went wrong"
+```
+
+Gradle names the HTML report on failure, but locating the failing test is quicker from the result
+files:
+
+```bash
+grep -l '<failure\|<error' testng-core/build/test-results/test/*.xml
+grep -o 'message="[^"]*"' testng-core/build/test-results/test/TEST-<the-class>.xml | head
+```
+
+**Those result files outlive the run that wrote them.** `build/test-results/test/TEST-*.xml` is
+whatever executed last, on whatever branch, and nothing clears it. A gate that dies mid-run — the
+daemon stopped from outside, say — leaves a log with no `BUILD` line at all while those files still
+read `0 failures`, on the previous commit. Run the gate as one shape that cannot report a false
+green:
+
+```bash
+LOG="/tmp/testng-$(git branch --show-current | tr / -)-gate.log"   # parallel workspaces share /tmp
+rm -rf */build/test-results/test
+./gradlew --console=plain build > "$LOG" 2>&1; echo "EXIT=$?" >> "$LOG"
+grep -qE '^BUILD SUCCESSFUL' "$LOG" && grep -q '^EXIT=0' "$LOG" \
+  || { echo 'GATE INCONCLUSIVE'; grep -A10 'What went wrong' "$LOG"; exit 1; }
+grep -ho 'failures="[0-9]*"\|errors="[0-9]*"' */build/test-results/test/TEST-*.xml | sort | uniq -c
+```
+
+Both proofs are needed and neither is enough alone: an up-to-date run prints `BUILD SUCCESSFUL`
+without executing a single test, and the counts belong to someone else's run until the purge above
+makes them this one's. Put `EXIT=` **in the log**, never on stdout: whatever reads the exit status
+of a backgrounded run sees the `echo`, which is the last process, and reports 0 for a build that
+failed.
+
 A green local build is not a green CI. Pull requests against `master` also run an OpenRewrite check
 that `.github/CONTRIBUTING.md` documents, and a wrapper validation. Pushes are weaker than they
 look: the `branches: ['*']` filter in `test.yml` does not match `/`, so pushing a branch named
@@ -115,6 +160,15 @@ rather than assuming them:
 grep -E '^jdkBuildVersion|^targetJavaVersion' gradle.properties
 ```
 
+The ambient `java` is whatever the version manager resolved for the session, not necessarily what
+the build wants. With `mise`, derive it from the property so it stays correct across bumps:
+
+```bash
+export JAVA_HOME="$(mise where java@$(sed -n 's/^jdkBuildVersion=//p' gradle.properties))"
+```
+
+This needs the `java@<N>` alias to point at an installed version; `mise where` fails otherwise.
+
 The root `gradle.properties` drives local builds, but it is **not** the only place the build JDK
 appears. Moving it means updating all of:
 
@@ -180,6 +234,25 @@ The pull request then shows only the delta, and GitHub retargets it to `master` 
 merges. Within each pull request, keep the machine output in its own commit, separate from the hand
 edits that follow it, so a reviewer can tell which hunks a human actually judged.
 
+- **Chain staging to the commit**: `git add <paths> && git commit …`. `git add` aborts the whole
+  invocation on one bad path — a file already removed with `git rm`, say — so nothing is staged,
+  and a bare `git commit` afterwards still succeeds on whatever the index already held. The result
+  is a commit that is not the one the message describes.
+- **Never `git stash` and switch branches just to look at another commit.** Forgetting the `pop` is
+  easy, and the tree then reads as it was before your edits — which looks exactly like your work
+  having vanished rather than like a stash. `git worktree add ../measure <ref>` answers the question
+  without touching what you hold, and when an amend is coming anyway, committing first leaves
+  nothing to stash.
+- **Read `git ls-remote` when you start on an already-pushed branch, not when you push.** A branch
+  can be rebased from another workspace between two of your turns; finding out at push time means
+  the rebase, the gate and the summary were all spent against a base that had moved. Compare trees,
+  not shas — a server-side rebase gives a different sha for identical content, so
+  `git diff <remote-sha> HEAD` is the question that matters. If it shows only the hunks you added
+  since, your branch is a strict superset and forcing is safe.
+- **Publish deltas and zeros in durable text, not absolute counts.** Upstream moves fast enough that
+  an `8 → 6` in a commit message is stale by the next rebase and has to be remeasured; `−82`,
+  `0 failures, 0 errors` and "down to zero" survive it.
+
 ## Working style
 
 - **Verify claims before acting on them** — including your own. A pull request description, an issue
@@ -193,3 +266,21 @@ edits that follow it, so a reviewer can tell which hunks a human actually judged
 - Report what you actually observed. If a run was flaky, say so and show both runs.
 - When an upgrade is refused, record the error that refused it, so the next person does not retry it
   blind.
+- **Edit prose before `autostyleApply`, not after.** The formatter rewraps javadoc, so a scripted
+  replacement written against the pre-format text silently stops matching. When patching after a
+  format pass, re-read the exact lines with `sed -n '<a>,<b>p'` rather than reusing the string you
+  wrote earlier.
+- **An absolute claim about the repository is paid for with a command, before it is written.**
+  "the only caller", "no other test", "all three", "two of the six" — each is one grep, and each
+  one written from memory has been wrong. Sweep what is about to be committed:
+
+  ```bash
+  git diff --cached -U0 | grep -nE \
+    '^\+.*\b(only|no other|nothing else|never|always|every|all|[0-9]+ of|the (two|three))\b'
+  ```
+
+  Every hit needs the command that settles it, run in this session, before the commit lands.
+- **Say the ordering out loud before spending the first gate.** A gate is six minutes, so a review
+  or `/simplify` round that arrives after it buys another one. When a cleanup pass is plausible,
+  propose "guard set, then the review, then one gate" up front: the cost is yours to know, not the
+  reader's to guess.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,11 +146,10 @@ Three things that are not documented elsewhere and cost tool calls to discover:
   `build-logic/` uses. Conventions are precompiled script plugins,
   `build-logic/*/src/main/kotlin/testng.*.gradle.kts` — prefer changing a convention over repeating
   configuration per module.
-- A package is not confined to one module. Ten of them span two or more, `org.testng.internal`
-  across four (core, core-api, runner-api, yaml). Anything scoped to a package — a
-  `package-info.java` annotation such as `@NullMarked`, package javadoc, `Export-Package` reasoning
-  — takes effect in every module where the package appears, through the `package-info.class` on the
-  compile classpath. Size package-scoped work by the package union, never by module.
+- **Size package-scoped work by the package union, never by module.** A package is not confined to
+  one module: ten span two or more, `org.testng.internal` across four (core, core-api, runner-api,
+  yaml). Where a `package-info.java` annotation then lands decides which half is covered — see
+  *Declaring a package null-marked* below.
 
 The `guice` and `yaml` optional features are hand-rolled rather than declared with
 `registerFeature`; the reasoning is in the KDoc of
@@ -277,12 +276,12 @@ edits that follow it, so a reviewer can tell which hunks a human actually judged
 - Running a documented command proves it executes, not that it does what the text claims. If the
   text promises an effect — filtering, failing, producing a value — measure that effect.
 - Report what you actually observed. If a run was flaky, say so and show both runs.
-- **What the characterization made fail is the minimum the fix has to cover.** If the `CHANGES.txt`
-  entry needs a "not covered until X migrates" clause, the fix is too shallow — the shared primitive
-  one level down is the altitude, and an existing failsafe on a sibling of that primitive is the
-  tell. GITHUB-2830 lost three reports to one parameter whose `toString()` threw; guarding the
-  caller covered one of them, while guarding `Utils.toString`, beside the already-failsafe
-  `Utils.buildStackTrace`, covered all three and left the caller unchanged.
+- **What the characterization made fail is the minimum the fix has to cover.** A `CHANGES.txt`
+  entry that has to disclaim part of it — "not covered until X migrates" — is the tell that the fix
+  sits too high. Count the failing sites, then enumerate the callers of the shared primitive one
+  level down. On GITHUB-2830 that primitive was `Utils.toString`, located by its already-failsafe
+  sibling `Utils.buildStackTrace`; guarding it covered all three lost reports and left the caller
+  unchanged.
 - When an upgrade is refused, record the error that refused it, so the next person does not retry it
   blind.
 - **Edit prose before `autostyleApply`, not after.** The formatter rewraps javadoc, so a scripted
@@ -299,7 +298,7 @@ edits that follow it, so a reviewer can tell which hunks a human actually judged
   ```
 
   Every hit needs the command that settles it, run in this session, before the commit lands.
-- **Say the ordering out loud before spending the first gate.** A gate is six minutes, so a review
+- **Say the ordering out loud before spending the first gate.** A gate is five minutes, so a review
   or `/simplify` round that arrives after it buys another one. When a cleanup pass is plausible,
   propose "guard set, then the review, then one gate" up front: the cost is yours to know, not the
   reader's to guess.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,31 @@ grep -l '<failure\|<error' testng-core/build/test-results/test/*.xml
 grep -o 'message="[^"]*"' testng-core/build/test-results/test/TEST-<the-class>.xml | head
 ```
 
+**Those result files outlive the run that wrote them.** `build/test-results/test/TEST-*.xml` is
+whatever executed last, on whatever branch, and nothing clears it. A gate that dies mid-run — the
+daemon stopped from outside, say — leaves a log with no `BUILD` line at all while those files still
+read `0 failures`, on the previous commit. Run the gate as one shape that cannot report a false
+green:
+
+```bash
+LOG="/tmp/testng-$(git branch --show-current | tr / -)-gate.log"   # parallel workspaces share /tmp
+rm -rf */build/test-results/test
+./gradlew --console=plain build > "$LOG" 2>&1; echo "EXIT=$?" >> "$LOG"
+grep -qE '^BUILD SUCCESSFUL' "$LOG" && grep -q '^EXIT=0' "$LOG" \
+  || { echo 'GATE INCONCLUSIVE'; grep -A10 'What went wrong' "$LOG"; exit 1; }
+grep -ho 'failures="[0-9]*"\|errors="[0-9]*"' */build/test-results/test/TEST-*.xml | sort | uniq -c
+```
+
+Both proofs are needed and neither is enough alone: an up-to-date run prints `BUILD SUCCESSFUL`
+without executing a single test, and the counts belong to someone else's run until the purge above
+makes them this one's. Put `EXIT=` **in the log**, never on stdout — in a backgrounded run the
+`echo` is the last process, so the harness reports 0 for a build that failed.
+
+**Say the ordering out loud before spending the first gate.** A gate is six minutes, so a review or
+`/simplify` round that arrives after it buys another one. When a cleanup pass is plausible, propose
+"guard set, then the review, then one gate" up front: the cost is yours to know, not the reader's
+to guess.
+
 ## Subagents
 
 A dispatched agent reports back on its own: the harness re-invokes you when it completes.
@@ -81,6 +106,17 @@ false positives, and real defects whose stated cause was not the cause.
   ```
 
   Every hit needs the command that settles it, run in this session, before the commit lands.
+- **Never `git stash` and switch branches just to look at another commit.** Forgetting the `pop` is
+  easy, and the tree then reads as it was before your edits — which looks exactly like your work
+  having vanished rather than like a stash. `git worktree add ../measure <ref>` answers the question
+  without touching what you hold, and when an amend is coming anyway, committing first leaves
+  nothing to stash.
+- **Read `git ls-remote` when you start on an already-pushed branch, not when you push.** A branch
+  can be rebased from another workspace between two of your turns; finding out at push time means
+  the rebase, the gate and the summary were all spent against a base that had moved. Compare trees,
+  not shas — a server-side rebase gives a different sha for identical content, so
+  `git diff <remote-sha> HEAD` is the question that matters. If it shows only the hunks you added
+  since, your branch is a strict superset and forcing is safe.
 - **Publish deltas and zeros in durable text, not absolute counts.** Upstream moves fast enough that
   an `8 → 6` in a commit message is stale by the next rebase and has to be remeasured; `−82`,
   `0 failures, 0 errors` and "down to zero" survive it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,9 +7,10 @@ what is specific to Claude Code.
 
 Run the gate with `run_in_background: true`, not with an explicit `timeout`. The `Bash` tool's
 documented maximum is 600000 ms and it clamps anything larger silently, so `timeout: 900000` reads
-like fifteen minutes and is ten. A gate that overruns is not lost — the tool moves it to the
-background anyway and notifies you — but it has held the turn open for the whole ten minutes first,
-and the foreground read is cut off mid-build. Backgrounding deliberately costs none of that.
+like fifteen minutes and is ten — and ten is not a comfortable ceiling for this gate. A cold build
+after a rebase that pulled twenty-two commits took 8m17s; warm ones on the same branch, 5m43s and
+6m48s. Backgrounding has no ceiling, leaves the turn free while it runs, and re-invokes you when the
+build exits.
 
 Guard-set runs need no `timeout` at all: the two-class set printed in `AGENTS.md` § *Verification*
 finishes in about ten seconds, an order of magnitude inside the default.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,44 @@ grep -l '<failure\|<error' testng-core/build/test-results/test/*.xml
 grep -o 'message="[^"]*"' testng-core/build/test-results/test/TEST-<the-class>.xml | head
 ```
 
+## Subagents
+
+A dispatched agent reports back on its own: the harness re-invokes you when it completes.
+Polling for it re-sends the whole conversation on every filler turn, and a review wave costs
+dozens of them — easily the largest avoidable cost in a session. Dispatch, run the independent
+work you already know you need, then stop and let the notification arrive.
+
+If plan mode is what makes you keep the turn alive, that is the signal to ask the question now
+rather than to manufacture another `echo waiting`.
+
+An agent's finding is a hypothesis. Reproduce it here before acting on it, and before relaying
+it — the reproduction is usually one command, and findings have been wrong in both directions:
+false positives, and real defects whose stated cause was not the cause.
+
+## Editing and committing
+
+- **Chain staging to the commit**: `git add <paths> && git commit …`. `git add` aborts the whole
+  invocation on one bad path — a file already removed with `git rm`, say — so nothing is staged,
+  and a bare `git commit` afterwards still succeeds on whatever the index already held. The result
+  is a commit that is not the one the message describes.
+- **Edit prose before `autostyleApply`, not after.** The formatter rewraps javadoc, so a scripted
+  replacement written against the pre-format text silently stops matching. When patching after a
+  format pass, re-read the exact lines with `sed -n '<a>,<b>p'` rather than reusing the string you
+  wrote earlier.
+- **An absolute claim about the repository is paid for with a command, before it is written.**
+  "the only caller", "no other test", "all three", "two of the six" — each is one grep, and each
+  one written from memory has been wrong. Sweep what is about to be committed:
+
+  ```bash
+  git diff --cached -U0 | grep -nE \
+    '^\+.*\b(only|no other|nothing else|never|always|every|all|[0-9]+ of|the (two|three))\b'
+  ```
+
+  Every hit needs the command that settles it, run in this session, before the commit lands.
+- **Publish deltas and zeros in durable text, not absolute counts.** Upstream moves fast enough that
+  an `8 → 6` in a commit message is stale by the next rebase and has to be remeasured; `−82`,
+  `0 failures, 0 errors` and "down to zero" survive it.
+
 ## Environment
 
 - The workspace may be reset to an older commit between sessions. Run the staleness check from

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,8 @@ what is specific to Claude Code.
 timeout: 900000
 ```
 
-Put `EXIT=` **in the log**, never on stdout — see the gate shape in `AGENTS.md`. In a backgrounded
-run the `echo` is the last process, so the harness reports exit 0 for a build that failed.
+A build started with `run_in_background` reports the status of its **last** process, so an `echo`
+after `./gradlew` masks a failure as exit 0. Use the gate shape in `AGENTS.md` as written.
 
 ## Subagents
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,15 +5,25 @@ what is specific to Claude Code.
 
 ## Long-running commands
 
-`./gradlew build` takes several minutes whenever it has real work to do — well over the default
-`Bash` timeout. Pass an explicit one:
+The `Bash` tool caps `timeout` at **600000 ms** and clamps anything larger without saying so, so
+`timeout: 900000` is not a longer timeout — it is the same ten minutes, written in a way that reads
+like fifteen. Passing an explicit timeout is therefore the wrong mechanism for the gate: it cannot
+be given more than the cap. Background it instead, which has no cap and re-invokes you when the
+build exits:
 
 ```text
-timeout: 900000
+run_in_background: true
 ```
 
+A cold `clean build` measured 6m39s here, so ten minutes is a margin rather than a wall — but it is
+a margin that shrinks as the suite grows, and the runs that go long are the ones you cannot predict,
+such as the first build after a rebase that pulled a batch of commits. Keep an explicit `timeout`
+for what it is actually good for: the filtered guard-set runs in `AGENTS.md` § *Verification*, which
+finish in tens of seconds.
+
 A build started with `run_in_background` reports the status of its **last** process, so an `echo`
-after `./gradlew` masks a failure as exit 0. Use the gate shape in `AGENTS.md` as written.
+after `./gradlew` masks a failure as exit 0. That is exactly why the gate shape in `AGENTS.md`
+writes `EXIT=` into the log rather than to stdout — use it as written and backgrounding is safe.
 
 ## Subagents
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,25 +5,18 @@ what is specific to Claude Code.
 
 ## Long-running commands
 
-The `Bash` tool caps `timeout` at **600000 ms** and clamps anything larger without saying so, so
-`timeout: 900000` is not a longer timeout — it is the same ten minutes, written in a way that reads
-like fifteen. Passing an explicit timeout is therefore the wrong mechanism for the gate: it cannot
-be given more than the cap. Background it instead, which has no cap and re-invokes you when the
-build exits:
+Run the gate with `run_in_background: true`, not with an explicit `timeout`. The `Bash` tool's
+documented maximum is 600000 ms and it clamps anything larger silently, so `timeout: 900000` reads
+like fifteen minutes and is ten. A gate that overruns is not lost — the tool moves it to the
+background anyway and notifies you — but it has held the turn open for the whole ten minutes first,
+and the foreground read is cut off mid-build. Backgrounding deliberately costs none of that.
 
-```text
-run_in_background: true
-```
-
-A cold `clean build` measured 6m39s here, so ten minutes is a margin rather than a wall — but it is
-a margin that shrinks as the suite grows, and the runs that go long are the ones you cannot predict,
-such as the first build after a rebase that pulled a batch of commits. Keep an explicit `timeout`
-for what it is actually good for: the filtered guard-set runs in `AGENTS.md` § *Verification*, which
-finish in tens of seconds.
+Guard-set runs need no `timeout` at all: the two-class set printed in `AGENTS.md` § *Verification*
+finishes in about ten seconds, an order of magnitude inside the default.
 
 A build started with `run_in_background` reports the status of its **last** process, so an `echo`
-after `./gradlew` masks a failure as exit 0. That is exactly why the gate shape in `AGENTS.md`
-writes `EXIT=` into the log rather than to stdout — use it as written and backgrounding is safe.
+after `./gradlew` masks a failure as exit 0. The gate shape in `AGENTS.md` already accounts for
+that — use it as written and backgrounding is safe.
 
 ## Subagents
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,17 +3,6 @@
 Read [AGENTS.md](AGENTS.md) first — it holds everything about this repository. This file only adds
 what is specific to Claude Code.
 
-## Selecting the build JDK
-
-The ambient `java` is whatever the version manager resolved for the session, not necessarily what
-the build wants. With `mise`, derive it from the property so it stays correct across bumps:
-
-```bash
-export JAVA_HOME="$(mise where java@$(sed -n 's/^jdkBuildVersion=//p' gradle.properties))"
-```
-
-This needs the `java@<N>` alias to point at an installed version; `mise where` fails otherwise.
-
 ## Long-running commands
 
 `./gradlew build` takes several minutes whenever it has real work to do — well over the default
@@ -23,54 +12,8 @@ This needs the `java@<N>` alias to point at an installed version; `mise where` f
 timeout: 900000
 ```
 
-Filter the output rather than reading it whole; a full build log runs to thousands of lines, and the
-test logger prints a line per test class, so match on the summary only. Set `pipefail` first —
-without it the pipeline reports grep's status, so a failed build still exits 0:
-
-```bash
-set -o pipefail
-./gradlew --console=plain build 2>&1 | grep -E "^BUILD (SUCCESSFUL|FAILED)|[1-9][0-9]* failed"
-```
-
-For a failure, extract the useful part instead of scrolling:
-
-```bash
-set -o pipefail
-./gradlew --console=plain build 2>&1 | grep -A15 "What went wrong"
-```
-
-Gradle names the HTML report on failure, but locating the failing test is quicker from the result
-files:
-
-```bash
-grep -l '<failure\|<error' testng-core/build/test-results/test/*.xml
-grep -o 'message="[^"]*"' testng-core/build/test-results/test/TEST-<the-class>.xml | head
-```
-
-**Those result files outlive the run that wrote them.** `build/test-results/test/TEST-*.xml` is
-whatever executed last, on whatever branch, and nothing clears it. A gate that dies mid-run — the
-daemon stopped from outside, say — leaves a log with no `BUILD` line at all while those files still
-read `0 failures`, on the previous commit. Run the gate as one shape that cannot report a false
-green:
-
-```bash
-LOG="/tmp/testng-$(git branch --show-current | tr / -)-gate.log"   # parallel workspaces share /tmp
-rm -rf */build/test-results/test
-./gradlew --console=plain build > "$LOG" 2>&1; echo "EXIT=$?" >> "$LOG"
-grep -qE '^BUILD SUCCESSFUL' "$LOG" && grep -q '^EXIT=0' "$LOG" \
-  || { echo 'GATE INCONCLUSIVE'; grep -A10 'What went wrong' "$LOG"; exit 1; }
-grep -ho 'failures="[0-9]*"\|errors="[0-9]*"' */build/test-results/test/TEST-*.xml | sort | uniq -c
-```
-
-Both proofs are needed and neither is enough alone: an up-to-date run prints `BUILD SUCCESSFUL`
-without executing a single test, and the counts belong to someone else's run until the purge above
-makes them this one's. Put `EXIT=` **in the log**, never on stdout — in a backgrounded run the
-`echo` is the last process, so the harness reports 0 for a build that failed.
-
-**Say the ordering out loud before spending the first gate.** A gate is six minutes, so a review or
-`/simplify` round that arrives after it buys another one. When a cleanup pass is plausible, propose
-"guard set, then the review, then one gate" up front: the cost is yours to know, not the reader's
-to guess.
+Put `EXIT=` **in the log**, never on stdout — see the gate shape in `AGENTS.md`. In a backgrounded
+run the `echo` is the last process, so the harness reports exit 0 for a build that failed.
 
 ## Subagents
 
@@ -85,41 +28,6 @@ rather than to manufacture another `echo waiting`.
 An agent's finding is a hypothesis. Reproduce it here before acting on it, and before relaying
 it — the reproduction is usually one command, and findings have been wrong in both directions:
 false positives, and real defects whose stated cause was not the cause.
-
-## Editing and committing
-
-- **Chain staging to the commit**: `git add <paths> && git commit …`. `git add` aborts the whole
-  invocation on one bad path — a file already removed with `git rm`, say — so nothing is staged,
-  and a bare `git commit` afterwards still succeeds on whatever the index already held. The result
-  is a commit that is not the one the message describes.
-- **Edit prose before `autostyleApply`, not after.** The formatter rewraps javadoc, so a scripted
-  replacement written against the pre-format text silently stops matching. When patching after a
-  format pass, re-read the exact lines with `sed -n '<a>,<b>p'` rather than reusing the string you
-  wrote earlier.
-- **An absolute claim about the repository is paid for with a command, before it is written.**
-  "the only caller", "no other test", "all three", "two of the six" — each is one grep, and each
-  one written from memory has been wrong. Sweep what is about to be committed:
-
-  ```bash
-  git diff --cached -U0 | grep -nE \
-    '^\+.*\b(only|no other|nothing else|never|always|every|all|[0-9]+ of|the (two|three))\b'
-  ```
-
-  Every hit needs the command that settles it, run in this session, before the commit lands.
-- **Never `git stash` and switch branches just to look at another commit.** Forgetting the `pop` is
-  easy, and the tree then reads as it was before your edits — which looks exactly like your work
-  having vanished rather than like a stash. `git worktree add ../measure <ref>` answers the question
-  without touching what you hold, and when an amend is coming anyway, committing first leaves
-  nothing to stash.
-- **Read `git ls-remote` when you start on an already-pushed branch, not when you push.** A branch
-  can be rebased from another workspace between two of your turns; finding out at push time means
-  the rebase, the gate and the summary were all spent against a base that had moved. Compare trees,
-  not shas — a server-side rebase gives a different sha for identical content, so
-  `git diff <remote-sha> HEAD` is the question that matters. If it shows only the hunks you added
-  since, your branch is a strict superset and forcing is safe.
-- **Publish deltas and zeros in durable text, not absolute counts.** Upstream moves fast enough that
-  an `8 → 6` in a commit message is stale by the next rebase and has to be remeasured; `−82`,
-  `0 failures, 0 errors` and "down to zero" survive it.
 
 ## Environment
 


### PR DESCRIPTION
Documentation only — `AGENTS.md` and `CLAUDE.md`. No source, no build script.

## Why

`CLAUDE.md` opens with *"Read AGENTS.md first — it holds everything about this repository. This file
only adds what is specific to Claude Code."* It had stopped doing that: the build gate, the log
filtering, the git habits and the `mise`/`JAVA_HOME` snippet are true for anyone working here, not
for one tool.

That is not merely untidy. A trap written down in `CLAUDE.md` leaves every other reader still
walking into it — which is exactly what had happened with the stale test-result files below.

## What moves

`CLAUDE.md` goes from 131 lines to 39 and keeps only what it can justify: the `Bash` timeout, the
subagent notes, and the facts about this kind of workspace. The rest lands in the `AGENTS.md`
section a reader would actually search:

| moved | to |
|---|---|
| the gate, log filtering, failure triage | `## Verification` |
| `git add` chaining, stash, `ls-remote`, deltas rather than counts | `## Git` |
| editing prose before `autostyleApply`, absolute claims, review ordering | `## Working style` |
| deriving `JAVA_HOME` from `jdkBuildVersion` with `mise` | `## Changing the build JDK` |

That commit is +93/−94: content constant, apart from wording that named the Claude harness where a
general file needs a general subject.

## What is new

Traps that read as green. Each has cost a wasted cycle here:

- **The gate can report a false green two ways.** An up-to-date run prints `BUILD SUCCESSFUL`
  without executing a test; and an up-to-date *task* never clears `build/test-results/test/`, so the
  previous run's XMLs survive and still read `0 failures`. `## Verification` now gives one command
  shape that answers both, instead of three recipes the reader has to rank.
- **A `--tests` filter that drops the class supplying a `dependsOnGroups` target** aborts the task
  behind dozens of lines still reading `0 failed`; only the `BUILD` line says anything is wrong.
- **A wildcard `--tests` pattern also collects nested classes**, so a sample nested inside its own
  test runs as a test in its own right, and one that fails on purpose reads as a failure of yours.
- **`testng-core` hands the whole suite to every fork it starts**, so the counts in the result files
  are a multiple of the fork count. Read zeros and ratios from them, never an absolute total.
- **Any number that reaches a commit message comes from a forced recompile.** Error Prone and
  NullAway see only the units javac recompiled, so an incremental run both hides errors and invents
  them.
- **`org.testng.internal` is OSGi exported yet broken on purpose**, so a compatibility question
  there is answered by two `CHANGES.txt` entries rather than by a deprecated bridge.
- **Ten packages span two or more modules**, `org.testng.internal` across four — package-scoped work
  sized by module is sized wrong.

## The last commit corrects the ones before it

A review pass measured three of those claims and found them wrong as first written. Rather than
leave them standing, the last commit fixes them:

- the nested-class trap is a **wildcard** filter, not an exact class name — measured: exact filter
  produced one result file, wildcard produced two;
- the result files are not left behind because "nothing clears them" — Gradle clears the directory
  whenever the task *executes*. What the `rm -rf` buys is forcing an up-to-date task to run at all:
  re-running the same filter without it printed `:testng-core:test UP-TO-DATE` and left the previous
  run's files in place;
- the fork multiplication is not a `--tests` artefact — every fork gets the whole suite, which
  inflates the gate's own counts.

The same pass deleted a piped-build recipe superseded by the gate twenty lines below it, and moved
the gate up to where the reader first meets the word. That commit is −78/+49, so the branch ends
smaller than it was before the review.

## Added after the first review round

Two more, both about a claim these files were making that does not hold:

- **`CLAUDE.md` asked for `timeout: 900000`** on a task the tool caps at **600000 ms**, clamping
  anything larger silently — so the number read like fifteen minutes and bought ten. The mechanism
  was wrong rather than the number: an explicit timeout cannot be raised past the cap, and
  backgrounding has none. The section now backgrounds the gate and keeps an explicit timeout for the
  filtered guard-set runs. Measured rather than assumed: a cold `clean build` took **6m39s** here,
  comfortably under the cap, so the text calls ten minutes a margin rather than a wall — the case
  rests on `900000 > 600000`, which needs no build at all.
- **One `## Working style` bullet on the altitude of a fix.** GITHUB-2830 lost three reports to a
  single parameter whose `toString()` threw; guarding the caller covered one, and the other two went
  into `CHANGES.txt` as "not covered until they migrate". That disclaimer is the tell, and so is a
  failsafe already sitting on a sibling of the primitive underneath — `Utils.buildStackTrace` had
  carried one for the same cause all along. Guarding `Utils.toString` covered all three and left the
  caller unchanged, so the deeper fix was also the smaller one.

## Two more corrections, both reproduced here

- **`AGENTS.md` § *Git* gains the stash trap that costs a tree.** The section warned about
  forgetting a `pop`; the sibling is worse. `git stash push -- <path>` on a path with no local
  changes creates **no entry**, while the stack it left alone is global — so the `pop` on the next
  line dequeues another branch's work into the tree. Reproduced in a scratch repository rather than
  taken on trust: the scoped push printed `No local changes to save` and left the stack at one
  entry, and the pop then wrote the foreign content out. `git stash list` names the branch each
  entry was made on, which is the giveaway before the fact; the blob (`git show HEAD:<path>`) is the
  replacement, since it does not care whether the file is modified.
- **`CLAUDE.md` sizes the ten-minute ceiling against a cold build, not a warm one.** A build after a
  rebase that pulled twenty-two commits took 8m17s, against 5m43s and 6m48s warm on the same branch.
  The sentence now supports backgrounding the gate rather than softening the case for it.

## A block on tests that build TestNG objects by hand

`## Verification` gains three rules, beside the `testng.xml` registration note because they are the
same failure family — a test that looks like it works and does not. All three come from writing
`TestClassConfigurationLookupTest` (#3434), each having cost a build cycle:

- **A hand-built production object is usually under-configured.** `TestClass` asks its
  `ITestMethodFinder` for the configuration methods and the finder answers only what a selector
  included, so a bare `RunInfo` registers none and `includeMethod` returns the `false` it started
  with — every category empty, for a reason resembling nothing. `TestRunner.initRunInfo` does the
  missing half in two lines, which is all the test's `newRunInfo` exists to reproduce.
- **An expectation written from reading the code records the assumption, not the behaviour.**
  `getBeforeClassMethods()` was asserted to hold one entry per `@Factory` instance and holds one,
  because `initMethods` assigns the field inside the per-instance loop.
- **The test doubles already have a shape**: Mockito is a declared dependency, so a delegating spy
  is `mock(..., delegatesTo(real))` rather than a hand-written class; the `IClass` fakes suppress
  the deprecation instead of declaring it; and a method a fake is never asked for throws rather than
  answering plausibly.

Every file, line and symbol was re-checked against the current tree before being written — the
commit that produced the case also rewrote `initMethods`, so the field assignment had moved since.

## Verification

Nothing here for `./gradlew build` to cover. Every shell snippet added was checked with `bash -n`,
and the gate's guard was exercised against four log shapes — a success, a `BUILD FAILED`, a run that
died with no `BUILD` line at all, and a log with no `EXIT=`. Only the first is accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance for verifying builds and tests, diagnosing failures, and avoiding misleading results from filtered or vacuous test runs.
  * Added recommendations for multi-module changes, build JDK configuration, Git workflows, change tracking, and command-backed claims.
  * Clarified background command status reporting and proper handling of delegated tasks, including reproducing findings before acting on them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



