### PR TITLE
docs(labels): document the label taxonomy and prepare its migration

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -26,6 +26,26 @@ Maybe you can write a runnable test case (check the `src/test/` folder for examp
 Don't worry if the CI fails because it is the expected behavior.
 This pull request will be a perfect start to find the fix :)
 
+# Issue labels
+
+Issues are classified with prefixed labels: `type:` for the nature of the report, `area:` and
+`runner:` for the affected scope, `status:` for what is currently needed to move it forward, and
+`aspect:`, `platform:`, `contribution:` and `resolution:` for everything else.
+
+Two of them are worth knowing before you start:
+
+* [`contribution: good first issue`](https://github.com/testng-team/testng/labels/contribution%3A%20good%20first%20issue)
+  lists small, well-scoped issues with clear acceptance criteria.
+* [`contribution: help wanted`](https://github.com/testng-team/testng/labels/contribution%3A%20help%20wanted)
+  lists issues that are ready for someone to pick up.
+
+The labels are being renamed to this scheme. Until that lands, the two links above come back empty
+even though the issues exist; browse the [full label list](https://github.com/testng-team/testng/labels)
+to find them under their current names.
+
+Maintainers: the full taxonomy, the colors, and the rules for adding, renaming, merging, and
+deleting labels are in [LABELS.md](LABELS.md).
+
 # We encourage pull requests that:
   
   * Add new features to TestNG (or)

--- a/.github/LABELS.md
+++ b/.github/LABELS.md
@@ -1,0 +1,370 @@
+# Label management
+
+Labels provide a shared vocabulary for triaging issues and pull requests. Maintainers must keep label
+names, descriptions, colors, and automation rules consistent so contributors can understand and
+filter the backlog reliably.
+
+## Classification rules
+
+Every triaged issue must have:
+
+1. Exactly one `type:` label.
+2. At least one `area:` or `runner:` label when the affected scope is known.
+3. Any applicable `status:`, `platform:`, `aspect:`, or `contribution:` labels.
+
+Pull requests receive scope labels only. Automated dependency pull requests use `dependency:` labels
+instead of `type:` labels.
+
+Remove obsolete workflow labels when an issue changes state. Closed issues may retain classification
+labels, but maintainers should replace temporary `status:` labels with a `resolution:` label when the
+reason for closure is relevant.
+
+## Label families
+
+Each prefix represents one classification dimension.
+
+| Prefix | Purpose | Color |
+|---|---|---|
+| `type:` | Nature of an issue | `#8250DF` |
+| `status:` | Current triage or workflow state | `#BF8700` |
+| `area:` | TestNG feature or code area | `#0969DA` |
+| `runner:` | Runner or external execution integration | `#1B7C83` |
+| `platform:` | Runtime or operating environment | `#1A7F37` |
+| `aspect:` | Cross-cutting concern | `#BC4C00` |
+| `contribution:` | Contributor accessibility | `#2DA44E` |
+| `resolution:` | Reason an issue was closed | `#57606A` |
+| `dependency:` | Automated dependency pull request | `#5A32A3` |
+
+Use the exact family color unless a documented exception is necessary. Do not create a different
+shade for every label in one family.
+
+One prefix falls outside these families; see [Tooling markers](#tooling-markers).
+
+## Type labels
+
+Apply exactly one `type:` label to every triaged issue.
+
+| Label | Description |
+|---|---|
+| `type: bug` | Reported behavior that differs from the intended behavior |
+| `type: enhancement` | Request for new or improved behavior |
+| `type: question` | Usage question redirected to community support and closed |
+| `type: documentation` | Missing, incorrect, or unclear documentation, including testng.org |
+| `type: maintenance` | Internal maintenance without a user-facing behavior change |
+| `type: epic` | Umbrella issue coordinating several related changes |
+
+A regression is still a bug. Apply `type: bug` together with `aspect: regression`.
+
+A documentation request is `type: documentation`, not `type: enhancement`. The two never coexist.
+
+## Status labels
+
+Status labels describe the current action required to move an issue forward.
+
+| Label | Description |
+|---|---|
+| `status: needs triage` | Awaiting initial review by a maintainer |
+| `status: needs reproducer` | Awaiting a minimal reproducible example from the reporter |
+| `status: waiting for reporter` | Awaiting additional information from the reporter |
+| `status: needs discussion` | Awaiting a maintainer decision on scope or design |
+| `status: confirmed` | Validated as reproducible or otherwise confirmed by a maintainer |
+| `status: blocked` | Blocked by another issue, project, or external dependency |
+
+Use no more than one waiting or blocking status at a time. `status: confirmed` may coexist with one
+actionable status such as `status: needs discussion`.
+
+Remove `status: needs triage` after assigning the initial type and scope labels.
+
+## Scope labels
+
+`area:` labels are the backbone of the taxonomy: they are what makes the backlog searchable years
+later. Apply multiple area labels only when the issue genuinely crosses those boundaries.
+
+| Label | Description |
+|---|---|
+| `area: annotations` | IAnnotationTransformer and annotation rewriting |
+| `area: assertions` | Assert, assertEquals, and the assertion utilities |
+| `area: configuration methods` | @BeforeX / @AfterX, alwaysRun, and configfailurepolicy |
+| `area: data provider` | @DataProvider and data-driven tests |
+| `area: dependency injection` | Guice and other third-party injection |
+| `area: execution order` | priority, preserve-order, and group-by-instances |
+| `area: factory` | @Factory and IObjectFactory instantiation |
+| `area: groups` | Test groups, include and exclude |
+| `area: inheritance` | Behavior involving class or method inheritance |
+| `area: internal tests` | TestNG's own test suite |
+| `area: invocation count` | invocationCount and repeated invocations |
+| `area: junit` | JUnit mode and JUnit compatibility |
+| `area: listeners` | Listeners, method interceptors, and invocation callbacks |
+| `area: logging` | log4testng and internal logging |
+| `area: method dependencies` | dependsOnMethods and dependsOnGroups ordering |
+| `area: naming` | Test and method naming, ITest, and custom names |
+| `area: parallel execution` | Parallel modes, thread pools, and custom executors |
+| `area: parameters` | @Parameters and native injection of test parameters |
+| `area: public api` | Public API changes, compatibility, and ITestContext attributes |
+| `area: reporting` | Reporters, report generation, and testng-failed.xml |
+| `area: retry analyzer` | IRetryAnalyzer retrying of failed tests |
+| `area: skipped tests` | SkipException, skipped results, and @Ignore |
+| `area: test selection` | Method selectors, filtering, and BeanShell scripts |
+| `area: timeout` | Test and suite timeout handling |
+| `area: xml suites` | testng.xml parsing and multi-suite runs |
+| `area: yaml suites` | YAML suite file parsing |
+
+`area: method dependencies` is deliberately not named `area: dependencies`: that name collides with
+the `dependency:` family in GitHub's label autocompletion.
+
+Use `runner:` when behavior depends on how TestNG is launched:
+
+| Label | Description |
+|---|---|
+| `runner: ant` | Running TestNG via the Ant task |
+| `runner: cli` | Running TestNG from the command line |
+| `runner: custom` | Custom or programmatic TestNG runner |
+| `runner: eclipse` | Eclipse plugin, tracked in the testng-eclipse repository |
+| `runner: gradle` | Running TestNG via Gradle |
+| `runner: maven` | Running TestNG via Maven Surefire |
+
+Use `platform:` for environment-specific behavior:
+
+| Label | Description |
+|---|---|
+| `platform: jdk 11` | Specific to JDK 11 |
+| `platform: jdk 21` | Specific to JDK 21 |
+
+Add a `platform:` label for a JDK version only once an issue actually turns on it.
+
+## Cross-cutting labels
+
+Use `aspect:` for concerns that can affect several areas. An aspect combines with any `type:`.
+
+| Label | Description |
+|---|---|
+| `aspect: architecture` | Internal architecture or refactoring concern |
+| `aspect: performance` | Execution time or memory behavior |
+| `aspect: regression` | Worked in an earlier version and is now broken |
+| `aspect: security` | Security-related concern |
+
+Use contribution labels to advertise suitable work:
+
+| Label | Description |
+|---|---|
+| `contribution: help wanted` | Ready for a contributor to investigate or implement |
+| `contribution: good first issue` | Small, well-scoped issue suitable for a new contributor |
+
+Apply `contribution: good first issue` only when the expected outcome, affected files, and
+acceptance criteria are clear.
+
+## Resolution labels
+
+Resolution labels explain why an issue was closed without a code change.
+
+| Label | Description |
+|---|---|
+| `resolution: external dependency` | Closed because the root cause belongs to another project |
+| `resolution: not reproducible` | Closed because maintainers could not reproduce the behavior |
+| `resolution: won't fix` | Closed because the behavior is intentional or out of scope |
+| `resolution: duplicate` | Closed in favor of another issue |
+
+Do not use a resolution label as an active workflow status.
+
+## Tooling markers
+
+| Label | Description |
+|---|---|
+| `triage: ai-reviewed` | Triage assisted by tooling, not part of the classification families |
+
+Tooling markers record that a process ran. They are applied by tooling rather than by human triage,
+they satisfy none of the [classification rules](#classification-rules), and they must never be
+treated as a `status:`. Keep them to a minimum: a marker that no tool applies any more is dead
+weight and should be deleted.
+
+## Dependency pull requests
+
+Dependabot assigns labels automatically. Custom labels must already exist before they are referenced
+in `.github/dependabot.yml`; otherwise, Dependabot ignores them.
+
+| Label | Description |
+|---|---|
+| `dependency: update` | Automated pull request updating a dependency |
+| `dependency: java` | Automated update of a Gradle or Java dependency |
+| `dependency: github actions` | Automated update of a GitHub Actions dependency |
+| `dependency: npm` | Automated update of an npm dependency |
+
+Configure every package ecosystem explicitly:
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependency: update"
+      - "dependency: github actions"
+
+  - package-ecosystem: "npm"
+    directory: "/.github/workflows"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependency: update"
+      - "dependency: npm"
+
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "00:00"
+    labels:
+      - "dependency: update"
+      - "dependency: java"
+```
+
+Defining custom Dependabot labels replaces its default `dependencies` and ecosystem labels, and a
+label that does not exist in the repository is silently ignored -- declaring only labels that have
+yet to be created leaves the pull requests with no label at all. When renaming, list the old and the
+new names together until the rename has landed, the same way Label Commenter carries both. Preserve
+every classification required by repository filters or automation.
+
+Dependabot cannot label per dependency, only per ecosystem. The Gradle wrapper is bumped by the
+`gradle` ecosystem, so a wrapper pull request is labeled `dependency: java` like any other Gradle
+update; it is recognizable by its branch and title. Do not add a label that nothing applies.
+
+## Automated label behavior
+
+The Label Commenter workflow reacts to exact label names configured in
+`.github/label-commenter-config.yml`.
+
+The following behaviors must remain covered:
+
+| Label | Automated behavior |
+|---|---|
+| `status: needs reproducer` | Requests a minimal reproducible example and environment details |
+| `type: question` | Redirects the reporter to community support and closes the issue |
+| `contribution: help wanted` | Invites contributors to work on the issue |
+
+Treat these label names as automation interfaces. A rename is incomplete until the configuration and
+behavior have been updated and verified.
+
+The main test workflow does not use labels to select or skip CI jobs. The Combine PRs workflow
+selects bot pull requests by branch name (`dependabot/*`) rather than label.
+
+## Writing label descriptions
+
+Every label must have a description.
+
+Descriptions must:
+
+- Use English and sentence case.
+- Explain when the label applies.
+- Avoid repeating only the label name.
+- Distinguish issues from pull requests when relevant.
+- Remain concise, preferably under 80 characters.
+- Omit a final period for consistency.
+
+Prefer:
+
+```text
+Awaiting a minimal reproducible example from the reporter
+```
+
+Avoid:
+
+```text
+Needs reproducer
+```
+
+## Adding a label
+
+Before adding a label:
+
+1. Confirm that an existing label does not cover the same concept.
+2. Select the correct family and its standard color.
+3. Write a description that explains the application criteria.
+4. Search workflows, configuration files, saved searches, and external bots for related names.
+5. Document any automated behavior.
+6. Add the label to this guide if it introduces a new rule or category.
+
+Avoid creating labels for values that belong in issue content, milestones, projects, or assignees.
+
+## Renaming a label
+
+A GitHub label rename preserves its associations with existing issues and pull requests: one API
+call moves every issue at once, whatever their number or state. Automation that matches the old text
+does not update automatically.
+
+Use this migration sequence:
+
+1. Search the repository and GitHub settings for the exact old label name.
+2. Update automation to recognize both the old and new names.
+3. Create or rename the destination label.
+4. Verify the new name on an issue or pull request.
+5. Remove support for the old name after the migration is complete.
+
+For automation-sensitive labels, merge the compatibility change before performing the rename.
+
+## Merging labels
+
+A merge requires migrating associations because GitHub does not provide a native label merge
+operation. Unlike a rename, its cost is proportional to the number of issues and pull requests
+carrying the source labels, closed ones included.
+
+1. Create the destination label, or rename the most used source label to it.
+2. Add it to every issue and pull request carrying a source label.
+3. Remove the source labels.
+4. Verify that no source label remains in use.
+5. Update workflows, bots, templates, documentation, and saved searches.
+6. Delete the source labels.
+
+Do not delete labels before migrating their associations.
+
+## Deleting a label
+
+Delete a label only when:
+
+- No open issue or pull request uses it.
+- Its historical associations have been migrated when needed.
+- No workflow or bot references it.
+- No external repository setting depends on it.
+- Another label or GitHub feature covers its purpose.
+
+Repository files cannot reveal every external GitHub App or saved search. Check repository settings
+before deleting labels previously created by bots.
+
+## Validation checklist
+
+Run this checklist once a label change is **complete**: the renames and merges have run, and the old
+names have been dropped from the automation. Three of these items cannot hold while a compatibility
+window is open, so do not treat them as failures before then.
+
+- [ ] Every target label exists with the intended color and description.
+- [ ] Existing issues and pull requests retain their classifications.
+- [ ] No issue carries two `type:` labels.
+- [ ] Label Commenter responds to `status: needs reproducer`.
+- [ ] Label Commenter closes an issue labeled `type: question`.
+- [ ] Label Commenter responds to `contribution: help wanted`.
+- [ ] New Dependabot pull requests receive only the intended `dependency:` labels.
+- [ ] Combine PRs still discovers Dependabot branches, checked in its log rather than its conclusion.
+- [ ] No workflow or repository configuration references a retired label.
+- [ ] Temporary test issues are closed or removed.
+
+While a compatibility window is open -- both the old and the new names are live, see
+[Renaming a label](#renaming-a-label) -- check instead that:
+
+- [ ] The automation still answers to the old names, which are the ones issues actually carry.
+- [ ] Automated pull requests still receive their labels, the old names included.
+- [ ] Both configuration files already list the new names, ready for the rename.
+
+## Periodic review
+
+Review the label set at least twice a year.
+
+During the review:
+
+- Find labels with no open usage.
+- Find open issues without a `type:` label.
+- Find issues that still carry `status: needs triage`.
+- Identify overlapping area labels.
+- Check that every label has a description and the correct family color.
+- Recheck workflow, Dependabot, and GitHub App dependencies.
+- Update this document when the taxonomy or automation changes.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,22 @@
 version: 2
+
+# Declaring `labels` replaces Dependabot's defaults (dependencies, java, github_actions), and a
+# label that does not exist in the repository is silently ignored. The old names are therefore
+# listed alongside the new ones until the rename to the `dependency:` family has landed: during the
+# window the old names apply, afterwards they no longer exist and are ignored. Drop them then.
+# The taxonomy is documented in .github/LABELS.md.
 updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "dependency: update"
+      - "dependency: github actions"
+      # Migration window, see below.
+      - "dependencies"
+      - "github_actions"
 
   # The workflow matrix generator (.github/workflows/matrix.mjs) is a real npm project with its
   # own package.json and lock file. The github-actions ecosystem above does not look at it.
@@ -12,6 +24,11 @@ updates:
     directory: "/.github/workflows"
     schedule:
       interval: "weekly"
+    labels:
+      - "dependency: update"
+      - "dependency: npm"
+      # Migration window, see above.
+      - "dependencies"
 
   - package-ecosystem: "gradle"
     directory: "/"
@@ -19,6 +36,12 @@ updates:
       interval: "daily"
       # Check for updates at 00:00 UTC
       time: "00:00"
+    labels:
+      - "dependency: update"
+      - "dependency: java"
+      # Migration window, see below.
+      - "dependencies"
+      - "java"
     ignore:
       # Autostyle 4.0.1 bundles a google-java-format that reaches into javac internals without
       # the --add-exports JPMS flags, so every module fails on JDK 25 with:

--- a/.github/label-commenter-config.yml
+++ b/.github/label-commenter-config.yml
@@ -1,6 +1,32 @@
 # Configuration for Label Commenter - https://github.com/peaceiris/actions-label-commenter
+#
+# Migration window: the label names below are being renamed to the `prefix: value` taxonomy
+# documented in .github/LABELS.md. Both the old and the new name are listed so that the automation
+# keeps working while the labels themselves are renamed. Delete the old-name entries once the
+# rename has landed and been verified.
+#
+# The bodies are duplicated on purpose rather than shared through a YAML anchor: this file is an
+# automation interface, and a parsing surprise here fails silently.
 labels:
   - name: "Need: sample"
+    labeled:
+      issue:
+        body: |
+          Hi, @{{ issue.user.login }}.
+          We need more information to reproduce the issue.
+
+          Please help share a [Minimal, Reproducible Example](https://stackoverflow.com/help/minimal-reproducible-example) that can be used to recreate the issue.
+
+          In addition to sharing a sample, please also add the following details:
+
+          * TestNG version being used.
+          * JDK version being used.
+          * How was the test run (IDE/Build Tools)?
+          * How does your build file (`pom.xml` | `build.gradle` | `build.gradle.kts`) look like ?
+
+          It would be better if you could share a sample project that can be directly used to reproduce the problem.
+          Reply to this issue when all information is provided, thank you.
+  - name: "status: needs reproducer"
     labeled:
       issue:
         body: |
@@ -26,7 +52,22 @@ labels:
           * 📫 The [TestNG user group](https://groups.google.com/forum/#!forum/testng-users)
           * 📮 [StackOverflow](https://stackoverflow.com/questions/tagged/testng)
         action: close
+  - name: "type: question"
+    labeled:
+      issue:
+        body: |
+          💬 Please ask questions at:
+          * 📫 The [TestNG user group](https://groups.google.com/forum/#!forum/testng-users)
+          * 📮 [StackOverflow](https://stackoverflow.com/questions/tagged/testng)
+        action: close
   - name: "Need: help"
+    labeled:
+      issue:
+        body: |
+          This issue is looking for contributors.
+
+          Please comment below if you are interested.
+  - name: "contribution: help wanted"
     labeled:
       issue:
         body: |

--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -19,4 +19,4 @@ jobs:
         id: combine-prs
         uses: github/combine-prs@2909f404763c3177a456e052bdb7f2e85d3a7cb3 # v5.2.0
         with:
-          branch_regex: ^(dependa|wrapper)bot\/.*$
+          branch_regex: ^dependabot\/.*$


### PR DESCRIPTION
## Why

The label set grew by sedimentation. Five naming conventions coexist -- `Feature: x`, `Runner: x`,
`Type: X`, `Need: x`, `Issue: X` -- next to a dozen bare labels (`xml`, `architecture`,
`inheritance`, `good first issue`, `Won't fix`, `3rd-party-issue`, ...). Colors diverge inside a
family. Four labels overlap on test selection alone (`Feature: test selection`,
`Feature: method-selector`, `Feature: test-filtering`, `Feature: script`). And nothing recorded the
convention, so every triage decision was re-derived from scratch.

This pull request writes the convention down and makes the automation ready for the rename. **It
changes files only: no label is created, renamed, or deleted here.**

## What

### `.github/LABELS.md` (new)

Nine prefixed families with one color each, and the rules for classifying, adding, renaming,
merging, and deleting a label.

| Prefix | Count | Purpose |
|---|---|---|
| `type:` | 6 | Nature of an issue -- exactly one per triaged issue |
| `status:` | 6 | What is currently needed to move it forward |
| `area:` | 26 | TestNG feature or code area |
| `runner:` | 6 | How TestNG is launched |
| `platform:` | 2 | Runtime environment |
| `aspect:` | 4 | Cross-cutting concern, combines with any `type:` |
| `contribution:` | 2 | Contributor accessibility |
| `resolution:` | 4 | Why an issue was closed |
| `dependency:` | 4 | Automated dependency pull requests |

The 26 `area:` labels consolidate the 41 scope labels in use today; every one of them carries a
description. The taxonomy it describes is the **target** of a migration, not the current state.

Two naming choices worth flagging for review:

* `area: method dependencies`, not `area: dependencies` -- the shorter name collides with the
  `dependency:` family in GitHub's label autocompletion.
* `triage: ai-reviewed` is kept as a documented *tooling marker*, outside the nine families: it
  records that a process ran, satisfies none of the classification rules, and is applied by tooling
  rather than by human triage.

### `.github/CONTRIBUTING.md`

A short "Issue labels" section pointing contributors at `contribution: good first issue` and
`contribution: help wanted`, and maintainers at the guide.

### `.github/label-commenter-config.yml` and `.github/dependabot.yml`

Both automations match label names exactly, so they have to accept the new names **before** the
rename happens -- otherwise `Type: Question` stops auto-closing the moment it becomes
`type: question`, with nothing to signal it.

Label Commenter now carries both names for its three behaviors. The bodies are duplicated rather
than shared through a YAML anchor: this file is an automation interface, and a parsing surprise here
fails quietly.

Dependabot needs the same treatment for a different reason. Per the [`labels`
reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#labels-),
declaring `labels` *replaces* the defaults, and a label that does not exist in the repository is
**ignored rather than created**. Naming only the `dependency:` labels would leave every automated
pull request unlabeled until the rename lands, so both sets are listed; the old names stop existing
once the rename runs and are ignored from then on.

### `.github/workflows/combine-prs.yml`

`branch_regex` accepted `wrapperbot/*`, but no branch has ever carried that prefix. The wrapper
bumps came from `gradle-update/update-gradle-wrapper-action` on `gradlew-update-<version>` branches,
which the regex never matched either -- so wrapper pull requests were never combined. That action
was removed in fde454294 and Dependabot has bumped the wrapper since (#3413, on
`dependabot/gradle/gradle-wrapper-9.7.1`), which the remaining half of the regex already covers.

## Verified

No Java is touched and Autostyle only covers Java, so no build is involved. Checked instead:

* the three YAML files parse, and the Autostyle 4.0.1 `ignore:` block is intact;
* the Label Commenter bodies are byte-identical between each old/new pair and unchanged against
  `master`; `action: close` is present on both question entries;
* the guide's example `dependabot.yml` block is a subset of the real file, the surplus being the
  migration window;
* the three documented behaviors each have a config entry;
* 64 label descriptions, none over 80 characters or ending in a period;
* no reference to `wrapperbot` remains under `.github/`.

## What comes next

1. **This pull request** -- guide and compatibility, files only.
2. **Migration** -- create the labels that have no source, resolve the `site/doc` x `Type:`
   collision, apply ~60 renames (a rename preserves every association, closed issues included),
   ~17 merges, and add `type: bug` to the 20 issues that carried `Type: Regression`.
3. **Cleanup** -- drop the old names from both configuration files.

Backfilling `type: bug` onto the ~130 open issues that carry no `Type:` today is deliberately out of
scope: it needs a judgement call per issue, not a script.

Related to #3447, which needs exactly this kind of allow-list for its triage validator. Note that
the auto-close on `type: question` is preserved as-is here; revisiting it is that issue's item, not
this one's.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance for issue labels, including naming conventions, categories, workflows, and maintenance procedures.
  * Updated contribution guidance with links to label documentation and highlighted helpful contribution labels.

* **Chores**
  * Added explicit dependency labels for automated updates across supported ecosystems.
  * Expanded issue-label automation to support the label migration.
  * Limited automated pull request combining to Dependabot branches; wrapperbot branches are no longer included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->