### PR TITLE
ci(labels): drop the legacy label names now the rename has landed

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -39,10 +39,6 @@ Two of them are worth knowing before you start:
 * [`contribution: help wanted`](https://github.com/testng-team/testng/labels/contribution%3A%20help%20wanted)
   lists issues that are ready for someone to pick up.
 
-The labels are being renamed to this scheme. Until that lands, the two links above come back empty
-even though the issues exist; browse the [full label list](https://github.com/testng-team/testng/labels)
-to find them under their current names.
-
 Maintainers: the full taxonomy, the colors, and the rules for adding, renaming, merging, and
 deleting labels are in [LABELS.md](LABELS.md).
 

--- a/.github/LABELS.md
+++ b/.github/LABELS.md
@@ -223,7 +223,7 @@ updates:
 Defining custom Dependabot labels replaces its default `dependencies` and ecosystem labels, and a
 label that does not exist in the repository is silently ignored -- declaring only labels that have
 yet to be created leaves the pull requests with no label at all. When renaming, list the old and the
-new names together until the rename has landed, the same way Label Commenter carries both. Preserve
+new names together until the rename has landed, as Label Commenter also has to. Preserve
 every classification required by repository filters or automation.
 
 Dependabot cannot label per dependency, only per ecosystem. The Gradle wrapper is bumped by the

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,8 @@
 version: 2
 
 # Declaring `labels` replaces Dependabot's defaults (dependencies, java, github_actions), and a
-# label that does not exist in the repository is silently ignored. The old names are therefore
-# listed alongside the new ones until the rename to the `dependency:` family has landed: during the
-# window the old names apply, afterwards they no longer exist and are ignored. Drop them then.
-# The taxonomy is documented in .github/LABELS.md.
+# label that does not exist in the repository is silently ignored, so these names must stay in step
+# with the repository. The taxonomy is documented in .github/LABELS.md.
 updates:
 
   - package-ecosystem: "github-actions"
@@ -14,9 +12,6 @@ updates:
     labels:
       - "dependency: update"
       - "dependency: github actions"
-      # Migration window, see below.
-      - "dependencies"
-      - "github_actions"
 
   # The workflow matrix generator (.github/workflows/matrix.mjs) is a real npm project with its
   # own package.json and lock file. The github-actions ecosystem above does not look at it.
@@ -27,8 +22,6 @@ updates:
     labels:
       - "dependency: update"
       - "dependency: npm"
-      # Migration window, see above.
-      - "dependencies"
 
   - package-ecosystem: "gradle"
     directory: "/"
@@ -39,9 +32,6 @@ updates:
     labels:
       - "dependency: update"
       - "dependency: java"
-      # Migration window, see below.
-      - "dependencies"
-      - "java"
     ignore:
       # Autostyle 4.0.1 bundles a google-java-format that reaches into javac internals without
       # the --add-exports JPMS flags, so every module fails on JDK 25 with:

--- a/.github/label-commenter-config.yml
+++ b/.github/label-commenter-config.yml
@@ -1,31 +1,8 @@
 # Configuration for Label Commenter - https://github.com/peaceiris/actions-label-commenter
 #
-# Migration window: the label names below are being renamed to the `prefix: value` taxonomy
-# documented in .github/LABELS.md. Both the old and the new name are listed so that the automation
-# keeps working while the labels themselves are renamed. Delete the old-name entries once the
-# rename has landed and been verified.
-#
-# The bodies are duplicated on purpose rather than shared through a YAML anchor: this file is an
-# automation interface, and a parsing surprise here fails silently.
+# These label names are an automation interface: renaming one here without renaming it in the
+# repository, or the other way round, silently stops the behaviour. See .github/LABELS.md.
 labels:
-  - name: "Need: sample"
-    labeled:
-      issue:
-        body: |
-          Hi, @{{ issue.user.login }}.
-          We need more information to reproduce the issue.
-
-          Please help share a [Minimal, Reproducible Example](https://stackoverflow.com/help/minimal-reproducible-example) that can be used to recreate the issue.
-
-          In addition to sharing a sample, please also add the following details:
-
-          * TestNG version being used.
-          * JDK version being used.
-          * How was the test run (IDE/Build Tools)?
-          * How does your build file (`pom.xml` | `build.gradle` | `build.gradle.kts`) look like ?
-
-          It would be better if you could share a sample project that can be directly used to reproduce the problem.
-          Reply to this issue when all information is provided, thank you.
   - name: "status: needs reproducer"
     labeled:
       issue:
@@ -44,14 +21,6 @@ labels:
 
           It would be better if you could share a sample project that can be directly used to reproduce the problem.
           Reply to this issue when all information is provided, thank you.
-  - name: "Type: Question"
-    labeled:
-      issue:
-        body: |
-          💬 Please ask questions at:
-          * 📫 The [TestNG user group](https://groups.google.com/forum/#!forum/testng-users)
-          * 📮 [StackOverflow](https://stackoverflow.com/questions/tagged/testng)
-        action: close
   - name: "type: question"
     labeled:
       issue:
@@ -60,13 +29,6 @@ labels:
           * 📫 The [TestNG user group](https://groups.google.com/forum/#!forum/testng-users)
           * 📮 [StackOverflow](https://stackoverflow.com/questions/tagged/testng)
         action: close
-  - name: "Need: help"
-    labeled:
-      issue:
-        body: |
-          This issue is looking for contributors.
-
-          Please comment below if you are interested.
   - name: "contribution: help wanted"
     labeled:
       issue:


### PR DESCRIPTION
## Why

Third and last step of the label taxonomy migration, after #3461.

The migration is done. The repository now holds exactly the **61 labels** described in
[LABELS.md](https://github.com/testng-team/testng/blob/master/.github/LABELS.md) -- 54 renames, 18
merges into 26 `area:` labels, and 6 new ones -- with no legacy name left.

#3461 carried the old names alongside the new ones in both automations, so that neither would break
while the rename ran. They are inert now: the labels they name no longer exist, and Dependabot
ignores a label that is not defined in the repository. This removes them.

## What

* `.github/label-commenter-config.yml` -- one entry per behaviour instead of two.
* `.github/dependabot.yml` -- each ecosystem declares only its `dependency:` labels.
* `.github/CONTRIBUTING.md` -- drops the note warning that the two label links came back empty
  during the rename. They resolve now: 16 and 5 issues respectively.
* `.github/LABELS.md` -- one sentence reworded; it described Label Commenter as currently carrying
  both names, which is no longer true. The rule it states, list both names until a rename has
  landed, still holds and is unchanged.

## Verified

**Label Commenter, on a real issue.** #3462 was opened as a throwaway and the three labels applied
one at a time, **before** this cleanup, while the old names were still in place:

| Label applied | Result |
|---|---|
| `status: needs reproducer` | commented, asking for a minimal reproducible example |
| `contribution: help wanted` | commented, inviting contributors |
| `type: question` | commented with the support links **and closed the issue** |

The issue was then stripped of its labels and left closed so it does not skew the counts.

**Dependabot.** The three open automated pull requests carry the intended labels and nothing else:
#3457 and #3458 `dependency: update + dependency: java`, #3460 `dependency: update +
dependency: github actions`.

**Configuration against the repository.** Checked mechanically on this branch:

* the example `dependabot.yml` block in LABELS.md is now byte-identical to the real file, where
  #3461 could only make it a subset;
* every one of the 7 label names cited by the two configuration files exists in the repository;
* no configuration file declares a retired name any more;
* the Label Commenter bodies are unchanged against `master`, and `action: close` is still on
  `type: question`.

**Migration itself.** Associations were snapshotted before the run (2028 issue-to-label pairs) and
compared after: no association lost or invented across the 56 targets, no issue carrying two `type:`
labels, and the 20 issues that carried `Type: Regression` now carry both `type: bug` and
`aspect: regression`.

Two apparent discrepancies turned out to be GitHub's list and search index lagging behind a rename:
`GET /labels/Feature: report` returns 404 while `issues?labels=Feature%3A%20report` still returns
one item. Both were checked by direct fetch and hold the right labels. The 55 issue numbers invisible
to the index were fetched one by one to rule out a silent loss during the merges: 32 do not exist and
none of the remaining 23 carries a label.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidance to reflect the current issue-label naming scheme.
  * Clarified that label references should remain aligned with the repository’s label taxonomy.

* **Configuration**
  * Updated automated labeling to use current status, type, and contribution labels.
  * Dependabot configurations now reference only the current dependency label family.
  * Removed temporary legacy label names from automated workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->