### PR TITLE
fix(jar): skip module-info when scanning a test jar

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current (7.13.0)
+Fixed: GITHUB-2333: skip module-info.class and META-INF/versions entries when discovering classes in a test jar (Burak Kalaycı)
 Fixed: GITHUB-2595: A programmatic IMethodSelector at priority 10 is no longer dropped as a duplicate of the built-in XmlMethodSelector. RunInfo stored selectors in a TreeSet ordered only by priority, so two descriptors with the same priority compared equal and one was discarded. Equal-priority selectors now keep insertion order (Burak Kalaycı)
 Fixed: GITHUB-3222: dependsOnMethods in a static nested test class now resolves sibling methods, including methods inherited onto that nested class. MethodHelper.findDependedUponMethods() used to drop every method whose class had an enclosing class, so the nested class never saw its own tests (Burak Kalaycı)
 Fixed: GITHUB-3388: XmlSuite.toXml() now reports an unnamed XmlDefine reached through a test-level <groups> with "<define> has no name", matching the unnamed XmlPackage path, instead of a bare NullPointerException from Properties.setProperty (Burak Kalaycı)

--- a/testng-core/src/main/java/org/testng/JarFileUtils.java
+++ b/testng-core/src/main/java/org/testng/JarFileUtils.java
@@ -153,7 +153,14 @@ class JarFileUtils {
   }
 
   private static boolean isJavaClass(JarEntry je) {
-    return je.getName().endsWith(".class");
+    String name = je.getName();
+    if (je.isDirectory() || !name.endsWith(".class")) {
+      return false;
+    }
+    // module-info.class is a module descriptor (ACC_MODULE), not a loadable class.
+    // META-INF/versions/** is multi-release layout; naive discovery would turn those
+    // paths into invalid class names such as META-INF.versions.9.module-info.
+    return !name.startsWith("META-INF/") && !name.endsWith("module-info.class");
   }
 
   private static String constructClassName(JarEntry je) {

--- a/testng-core/src/test/java/org/testng/JarFileUtilsTest.java
+++ b/testng-core/src/test/java/org/testng/JarFileUtilsTest.java
@@ -5,17 +5,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
 import org.jspecify.annotations.Nullable;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import org.testng.jarfileutils.org.testng.SampleTest1;
 import org.testng.testhelper.JarCreator;
 import org.testng.xml.IPostProcessor;
 import org.testng.xml.XmlClass;
@@ -106,6 +111,16 @@ public class JarFileUtilsTest {
     JarFileUtils utils = newJarFileUtils(testNames, ignoreMissedTestNames);
     // 3 tests from 3 suites, the first suite has one test is given
     runTest(utils, 1, 3, expectedTestNames, expectedClassNames, "testng-tests-suite");
+  }
+
+  @Test(description = "GITHUB-2333")
+  public void moduleInfoClassEntriesAreNotTreatedAsTestClasses() throws IOException {
+    File jarWithModuleInfo = jarWithModuleInfoDescriptors();
+    JarFileUtils utils = new JarFileUtils(new FakeProcessor(), "missing-suite.xml", null);
+    List<XmlSuite> suites = utils.extractSuitesFrom(jarWithModuleInfo);
+    List<String> classNames = new ArrayList<>();
+    extractClassNames(suites, new ArrayList<>(), classNames);
+    assertThat(classNames).containsExactly("org.testng.jarfileutils.org.testng.SampleTest1");
   }
 
   @Test
@@ -239,6 +254,26 @@ public class JarFileUtilsTest {
     if (expectedClassNames != null) {
       assertThat(classNames).contains(expectedClassNames);
     }
+  }
+
+  private static File jarWithModuleInfoDescriptors() throws IOException {
+    File jarFile = File.createTempFile("testng-module-info", ".jar");
+    jarFile.deleteOnExit();
+    String classEntry = SampleTest1.class.getName().replace('.', '/') + ".class";
+    try (JarOutputStream jos = new JarOutputStream(Files.newOutputStream(jarFile.toPath()));
+        InputStream classBytes =
+            SampleTest1.class.getClassLoader().getResourceAsStream(classEntry)) {
+      jos.putNextEntry(new JarEntry(classEntry));
+      requireNonNull(classBytes, classEntry).transferTo(jos);
+      jos.closeEntry();
+      jos.putNextEntry(new JarEntry("module-info.class"));
+      jos.write(new byte[] {0});
+      jos.closeEntry();
+      jos.putNextEntry(new JarEntry("META-INF/versions/9/module-info.class"));
+      jos.write(new byte[] {0});
+      jos.closeEntry();
+    }
+    return jarFile;
   }
 
   public static class FakeProcessor implements IPostProcessor {

--- a/testng-core/src/test/java/org/testng/JarFileUtilsTest.java
+++ b/testng-core/src/test/java/org/testng/JarFileUtilsTest.java
@@ -260,17 +260,24 @@ public class JarFileUtilsTest {
     File jarFile = File.createTempFile("testng-module-info", ".jar");
     jarFile.deleteOnExit();
     String classEntry = SampleTest1.class.getName().replace('.', '/') + ".class";
-    try (JarOutputStream jos = new JarOutputStream(Files.newOutputStream(jarFile.toPath()));
-        InputStream classBytes =
-            SampleTest1.class.getClassLoader().getResourceAsStream(classEntry)) {
+    byte[] sampleBytes;
+    try (InputStream classBytes =
+        SampleTest1.class.getClassLoader().getResourceAsStream(classEntry)) {
+      sampleBytes = requireNonNull(classBytes, classEntry).readAllBytes();
+    }
+    try (JarOutputStream jos = new JarOutputStream(Files.newOutputStream(jarFile.toPath()))) {
       jos.putNextEntry(new JarEntry(classEntry));
-      requireNonNull(classBytes, classEntry).transferTo(jos);
+      jos.write(sampleBytes);
       jos.closeEntry();
       jos.putNextEntry(new JarEntry("module-info.class"));
       jos.write(new byte[] {0});
       jos.closeEntry();
       jos.putNextEntry(new JarEntry("META-INF/versions/9/module-info.class"));
       jos.write(new byte[] {0});
+      jos.closeEntry();
+      // Regular multi-release class: filtered by META-INF/, not by the module-info suffix.
+      jos.putNextEntry(new JarEntry("META-INF/versions/9/" + classEntry));
+      jos.write(sampleBytes);
       jos.closeEntry();
     }
     return jarFile;


### PR DESCRIPTION
Fixes #2333.

### Did you remember to?

- [x] Add test case(s)
- [x] Update `CHANGES.txt`
- [x] Auto applied styling via `./gradlew autostyleApply`

`JarFileUtils` treated every `.class` entry as a test class. A fat test jar that also contains `module-info.class` (including the multi-release `META-INF/versions/9/module-info.class` form) therefore produced class names that `XmlClass` tried to load, and `Class.forName` threw `NoClassDefFoundError` because `ACC_MODULE` is set.

Class discovery now skips module descriptors and `META-INF/` entries, matching the existing `JarProcessor` filter.

Executed locally:

- `./gradlew :testng-core:test --tests org.testng.JarFileUtilsTest.moduleInfoClassEntriesAreNotTreatedAsTestClasses` (RED before the `isJavaClass` change, GREEN after)
- `./gradlew :testng-core:test --tests org.testng.JarFileUtilsTest` (10/10)
- `./gradlew autostyleCheck`
- `./gradlew rewriteDryRun` (no recipe changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved test class discovery in JAR files by ignoring module descriptors, multi-release metadata, directories, and other non-class entries.
  - Prevented invalid JAR entries from being treated as test classes, improving reliability when discovering tests in standard and multi-release JARs.

- **Documentation**
  - Added a changelog entry describing the JAR class discovery fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->