### PR TITLE
build(deps): group the OpenRewrite Dependabot updates and hold them at the last Maven Central release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,14 @@ updates:
     labels:
       - "dependency: update"
       - "dependency: java"
+    groups:
+      # The recipe BOM and the Gradle plugin are released together upstream: rewrite-recipe-bom
+      # 3.38.0 is the release that carries rewrite-gradle-plugin 7.41.0. Taken one at a time they
+      # leave the pair mismatched, and each pull request pays for its own rewriteDryRun run. The
+      # glob covers both names, since the plugin is reported without a group id.
+      openrewrite:
+        patterns:
+          - "org.openrewrite*"
     ignore:
       # Autostyle 4.0.1 bundles a google-java-format that reaches into javac internals without
       # the --add-exports JPMS flags, so every module fails on JDK 25 with:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,7 +36,9 @@ updates:
       # The recipe BOM and the Gradle plugin are released together upstream: rewrite-recipe-bom
       # 3.38.0 is the release that carries rewrite-gradle-plugin 7.41.0. Taken one at a time they
       # leave the pair mismatched, and each pull request pays for its own rewriteDryRun run. The
-      # glob covers both names, since the plugin is reported without a group id.
+      # glob covers both names, since the plugin is reported without a group id. The group is
+      # dormant while the ignore entry below holds every OpenRewrite version back; it is what
+      # these updates should look like once that entry is dropped.
       openrewrite:
         patterns:
           - "org.openrewrite*"
@@ -47,3 +49,27 @@ updates:
       # Drop this entry once a release fixes it. See testng-team/testng#3292.
       - dependency-name: "com.github.autostyle:autostyle-plugin-gradle"
         versions: ["4.0.1"]
+
+      # OpenRewrite left Maven Central in August 2026: Sonatype's new volume limits made ~80
+      # modules twice a month untenable, so 8.91.0 onwards is published only to the Code Genome
+      # Project registry, which needs a (free) account token to download from. rewrite-recipe-bom
+      # 3.38.0 and the Gradle plugin from 7.40.0 on still import org.openrewrite:rewrite-bom:8.91.0,
+      # which Central 404s -- its latest is 8.90.4 -- so they fail to resolve before any recipe runs:
+      #   Could not parse POM .../rewrite-recipe-bom-3.38.0.pom
+      #     > Could not find org.openrewrite:rewrite-bom:8.91.0
+      # Upstream calls that Plugin Portal release unintended and says to stay on the previous
+      # version: openrewrite/rewrite-gradle-plugin#476, openrewrite/rewrite-recipe-bom#68.
+      # 7.39.0 / 3.37.0 are the last Central-resolvable pair, and no later one can be, so this
+      # ignores every version rather than the three known-broken ones -- otherwise Dependabot
+      # reopens a pull request that cannot build on each upstream release, twice a month.
+      # The three semver levels scope that to version updates: a bare `dependency-name` would
+      # drop security update pull requests too, and while one would fail to resolve like the
+      # rest, declining an advisory is not what this entry is for.
+      # Drop this entry when the build points at https://artifacts.codegenomeproject.org/maven/,
+      # which means asking every contributor to hold a token, or when OpenRewrite is dropped.
+      # See testng-team/testng#3457 and testng-team/testng#3458.
+      - dependency-name: "org.openrewrite*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"


### PR DESCRIPTION
Dependabot treats the OpenRewrite Gradle plugin and the recipe BOM as two unrelated dependencies,
even though upstream releases them together — `rewrite-recipe-bom` 3.38.0 is the release that
carries `rewrite-gradle-plugin` 7.41.0. It opened one pull request for each: #3457 and #3458.

This adds a `groups` entry so they arrive in a single pull request from now on.

## The two updates cannot be integrated

Both #3457 and #3458 are red, for the same reason, and it is not something this repository can fix.

OpenRewrite stopped publishing to Maven Central in August 2026 — Sonatype's new volume limits made
~80 modules twice a month untenable — and moved to the Code Genome Project registry, which requires
a (free) account token to download from. `org.openrewrite:rewrite-bom:8.91.0` therefore never landed
on Central (its latest is 8.90.4, 2026-08-24), while both `rewrite-recipe-bom` 3.38.0 and every
plugin release from 7.40.0 on import it. Resolution fails before any recipe runs:

```
Could not parse POM .../rewrite-recipe-bom-3.38.0.pom
  > Could not find org.openrewrite:rewrite-bom:8.91.0
```

Verified today, not read off the CI logs:

```
$ curl -s -o /dev/null -w "%{http_code}\n" https://repo.maven.apache.org/maven2/org/openrewrite/rewrite-bom/8.91.0/rewrite-bom-8.91.0.pom
404
$ curl -sL https://plugins.gradle.org/m2/org/openrewrite/plugin/7.40.0/plugin-7.40.0.pom | grep -A3 rewrite-bom
<version>8.91.0</version>
```

Upstream calls the Plugin Portal release unintended and says to stay on the previous version:
openrewrite/rewrite-gradle-plugin#476, openrewrite/rewrite-recipe-bom#68.

So `build.gradle.kts` is left at plugin 7.39.0 / BOM 3.37.0, the last Central-resolvable pair, and
the dependency goes into `ignore` per the convention in `AGENTS.md` — closing the pull requests
alone makes them come back. The entry ignores every version rather than the three known-broken ones,
because no later version can resolve either until the build points at the Code Genome Project
registry and every contributor holds a token. That is a separate decision, and the reason is
recorded in place so the entry can be dropped when it is made.

The `groups` entry is dormant while that `ignore` holds; it is what these updates should look like
once the entry is dropped.

Supersedes #3457 and #3458 — Dependabot closes them itself on its next daily run.

## Verification

`.github/dependabot.yml` is the only file changed, and Gradle never reads it. The OpenRewrite gate
was run twice to establish the cause rather than assume it:

- with the two bumps applied: `BUILD FAILED`, `Could not find org.openrewrite:rewrite-bom:8.91.0`
- control, unbumped tree: `./gradlew rewriteDryRun -PfailOnRewriteDryRun=true` → `BUILD SUCCESSFUL`,
  empty patch

The grouping itself cannot be verified locally; GitHub validates the file on push, and the proof is
that the next OpenRewrite pull request carries both dependencies — whenever the `ignore` lifts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined automated dependency management for Gradle packages.
  * Grouped OpenRewrite-related updates for more consistent handling.
  * Held back non-security OpenRewrite version updates while allowing security updates to continue through automated workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->