### PR TITLE
fix: pass known test methods to IMethodSelector.setTestMethods

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 Current (7.13.0)
+Fixed: GITHUB-2927: IMethodSelector.setTestMethods now receives the known test methods after they are bound to their ITestClass, and before selectors are consulted for test or configuration methods. A selector that snapshots the list sees the methods; includeMethod is never called first. (Burak Kalaycı)
 Fixed: GITHUB-3437: ClassHelper.getAvailableMethods now memoizes the hierarchy scan per class in a ClassValue, so data-provider and configuration lookups no longer rescan the same class on every call. Callers still receive a fresh set (Burak Kalaycı)
 Fixed: GITHUB-3239, GITHUB-2714: configuration-method inheritance is kept whenever the explicit dependency graph has no path between the two methods. A child @BeforeClass no longer runs between two base methods, including when it only has an unrelated groups= value, and a base @AfterMethod no longer runs before the child's. An inheritance edge is omitted when it would close a cycle with an existing dependsOnGroups or dependsOnMethods chain (Burak Kalaycı)
 Fixed: GITHUB-2333: skip module-info.class and META-INF/versions entries when discovering classes in a test jar (Burak Kalaycı)

--- a/testng-core-api/src/main/java/org/testng/IMethodSelector.java
+++ b/testng-core-api/src/main/java/org/testng/IMethodSelector.java
@@ -23,7 +23,12 @@ public interface IMethodSelector {
    * Invoked when all the test methods are known so that the method selector can perform additional
    * work, such as adding the transitive closure of all the groups being included and depended upon.
    *
-   * @param testMethods The test methods
+   * <p>The list is the known test methods of this {@code <test>}, each already bound to its {@link
+   * ITestClass}. It is not the subset that will run after {@link #includeMethod} filtering. This
+   * callback runs before the first {@code includeMethod} invocation, including those for
+   * configuration methods.
+   *
+   * @param testMethods The known test methods
    */
   void setTestMethods(List<ITestNGMethod> testMethods);
 }

--- a/testng-core/src/main/java/org/testng/TestClass.java
+++ b/testng-core/src/main/java/org/testng/TestClass.java
@@ -134,7 +134,7 @@ class TestClass extends NoOpTestClass implements ITestClass, ITestClassConfigInf
     this.testMethodFinder = testMethodFinder;
     this.annotationFinder = annotationFinder;
     initTestClassesAndInstances();
-    initMethods();
+    initTestMethods();
   }
 
   private void initTestClassesAndInstances() {
@@ -189,15 +189,24 @@ class TestClass extends NoOpTestClass implements ITestClass, ITestClassConfigInf
     IObject.cast(iClass).ifPresent(it -> it.addObject(instance));
   }
 
-  private void initMethods() {
+  private void initTestMethods() {
     Class<?> realClass = getRealClass();
     ITestNGMethod[] methods = testMethodFinder.getTestMethods(realClass, xmlTest);
     IdentifiableObject[] instances = IObject.objects(iClass, false);
     m_testMethods = createTestMethods(methods, instances);
+  }
+
+  /**
+   * Configuration filtering consults {@link IMethodSelector#includeMethod}, so it runs after {@link
+   * IMethodSelector#setTestMethods} has received the known test methods.
+   */
+  void initConfigurationMethods() {
+    IdentifiableObject[] instances = IObject.objects(iClass, false);
     if (instances.length == 0) {
       return;
     }
 
+    Class<?> realClass = getRealClass();
     // Every one of these lookups rescans the whole class hierarchy and none of them depends on the
     // instance, so look each configuration category up once for the test class and bind the
     // templates it answers to each instance in turn. A @Factory used to pay for all ten of them

--- a/testng-core/src/main/java/org/testng/TestRunner.java
+++ b/testng-core/src/main/java/org/testng/TestRunner.java
@@ -484,10 +484,8 @@ public class TestRunner
     ITestMethodFinder testMethodFinder =
         new TestNGMethodFinder(m_objectFactory, m_runInfo, m_annotationFinder, comparator);
 
-    m_runInfo.setTestMethods(testMethods);
-
     //
-    // Initialize TestClasses
+    // Initialize TestClasses (test methods only)
     //
     IClass[] classes = m_testClassFinder.findTestClasses();
 
@@ -506,6 +504,17 @@ public class TestRunner
       m_classMap.put(ic.getRealClass(), tc);
     }
 
+    // Discover and bind test methods, tell selectors, then filter configuration.
+    for (ITestClass tc : m_classMap.values()) {
+      fixMethodsWithClass(tc.getTestMethods(), tc, testMethods);
+    }
+    m_runInfo.setTestMethods(testMethods);
+    for (ITestClass tc : m_classMap.values()) {
+      if (tc instanceof TestClass) {
+        ((TestClass) tc).initConfigurationMethods();
+      }
+    }
+
     //
     // Calculate groups methods
     //
@@ -520,7 +529,6 @@ public class TestRunner
     //
 
     for (ITestClass tc : m_classMap.values()) {
-      fixMethodsWithClass(tc.getTestMethods(), tc, testMethods);
       fixMethodsWithClass(beforeClassConfigMethods(tc), tc, beforeClassMethods);
       fixMethodsWithClass(tc.getBeforeTestMethods(), tc, null);
       fixMethodsWithClass(tc.getAfterTestMethods(), tc, null);

--- a/testng-core/src/main/java/org/testng/internal/XmlMethodSelector.java
+++ b/testng-core/src/main/java/org/testng/internal/XmlMethodSelector.java
@@ -362,8 +362,7 @@ public class XmlMethodSelector implements IMethodSelector {
 
   @Override
   public void setTestMethods(List<ITestNGMethod> testMethods) {
-    // Caution: this variable is initialized with an empty list first and then modified
-    // externally by the caller (TestRunner#fixMethodWithClass). Ugly.
+    // Known methods for this <test>, already bound. Not the selected subset.
     m_testMethods = testMethods;
   }
 

--- a/testng-core/src/test/java/org/testng/TestClassConfigurationLookupTest.java
+++ b/testng-core/src/test/java/org/testng/TestClassConfigurationLookupTest.java
@@ -210,14 +210,17 @@ public class TestClassConfigurationLookupTest {
   }
 
   private TestClass newTestClass(ITestMethodFinder finder, FakeClass fakeClass) {
-    return new TestClass(
-        objectFactory,
-        fakeClass,
-        finder,
-        annotationFinder,
-        xmlTest,
-        Collections.singletonList(xmlClass),
-        null);
+    TestClass testClass =
+        new TestClass(
+            objectFactory,
+            fakeClass,
+            finder,
+            annotationFinder,
+            xmlTest,
+            Collections.singletonList(xmlClass),
+            null);
+    testClass.initConfigurationMethods();
+    return testClass;
   }
 
   /**

--- a/testng-core/src/test/java/test/methodselectors/MethodSelectorTest.java
+++ b/testng-core/src/test/java/test/methodselectors/MethodSelectorTest.java
@@ -8,6 +8,8 @@ import test.methodselectors.issue1985.FilteringMethodSelector;
 import test.methodselectors.issue1985.TestClassSample;
 import test.methodselectors.issue2595.Issue2595Sample;
 import test.methodselectors.issue2595.OnlyDoNothingSelector;
+import test.methodselectors.issue2927.Issue2927Sample;
+import test.methodselectors.issue2927.SnapshottingMethodSelector;
 
 public class MethodSelectorTest extends BaseTest {
 
@@ -97,6 +99,19 @@ public class MethodSelectorTest extends BaseTest {
     run();
     verifyTests("Passed", new String[] {"doNothing"}, getPassedTests());
     verifyTests("Failed", new String[] {}, getFailedTests());
+  }
+
+  @Test(description = "GITHUB-2927")
+  public void setTestMethodsReceivesTheKnownTestMethods() {
+    SnapshottingMethodSelector.reset();
+    Issue2927Sample.reset();
+    addClass(Issue2927Sample.class);
+    addMethodSelector(SnapshottingMethodSelector.class.getName(), 10);
+    run();
+    assertThat(SnapshottingMethodSelector.snapshot()).containsExactlyInAnyOrder("alpha", "beta");
+    assertThat(SnapshottingMethodSelector.receivedMethodsHaveTestClass()).isTrue();
+    assertThat(SnapshottingMethodSelector.includeMethodRanBeforeSetTestMethods()).isFalse();
+    assertThat(Issue2927Sample.beforeMethodRan()).isTrue();
   }
 
   @Test(description = "GITHUB-1985")

--- a/testng-core/src/test/java/test/methodselectors/issue2927/Issue2927Sample.java
+++ b/testng-core/src/test/java/test/methodselectors/issue2927/Issue2927Sample.java
@@ -1,0 +1,28 @@
+package test.methodselectors.issue2927;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class Issue2927Sample {
+
+  private static boolean beforeMethodRan;
+
+  public static boolean beforeMethodRan() {
+    return beforeMethodRan;
+  }
+
+  public static void reset() {
+    beforeMethodRan = false;
+  }
+
+  @BeforeMethod
+  public void prepare() {
+    beforeMethodRan = true;
+  }
+
+  @Test
+  public void alpha() {}
+
+  @Test
+  public void beta() {}
+}

--- a/testng-core/src/test/java/test/methodselectors/issue2927/SnapshottingMethodSelector.java
+++ b/testng-core/src/test/java/test/methodselectors/issue2927/SnapshottingMethodSelector.java
@@ -1,0 +1,63 @@
+package test.methodselectors.issue2927;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.testng.IMethodSelector;
+import org.testng.IMethodSelectorContext;
+import org.testng.ITestNGMethod;
+
+/**
+ * Copies the {@code setTestMethods} argument instead of keeping the live list. A selector that
+ * retains the reference would see later {@code add}s and hide GITHUB-2927.
+ *
+ * <p>Requires that snapshot before {@code includeMethod}, including for configuration methods.
+ */
+public class SnapshottingMethodSelector implements IMethodSelector {
+
+  private static final List<String> SNAPSHOT = new ArrayList<>();
+  private static boolean setCalled;
+  private static boolean includeBeforeSet;
+  private static boolean allBoundToTestClass;
+
+  public static List<String> snapshot() {
+    return List.copyOf(SNAPSHOT);
+  }
+
+  public static boolean includeMethodRanBeforeSetTestMethods() {
+    return includeBeforeSet;
+  }
+
+  public static boolean receivedMethodsHaveTestClass() {
+    return allBoundToTestClass;
+  }
+
+  public static void reset() {
+    SNAPSHOT.clear();
+    setCalled = false;
+    includeBeforeSet = false;
+    allBoundToTestClass = false;
+  }
+
+  @Override
+  public boolean includeMethod(
+      IMethodSelectorContext context, ITestNGMethod method, boolean isTestMethod) {
+    if (!setCalled) {
+      includeBeforeSet = true;
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public void setTestMethods(List<ITestNGMethod> testMethods) {
+    setCalled = true;
+    SNAPSHOT.clear();
+    allBoundToTestClass = !testMethods.isEmpty();
+    for (ITestNGMethod method : testMethods) {
+      SNAPSHOT.add(method.getMethodName());
+      if (method.getTestClass() == null) {
+        allBoundToTestClass = false;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Discover and bind test methods first, then call `IMethodSelector.setTestMethods` with that complete list, then consult selectors for test and configuration methods.
- A selector that snapshots the argument now sees the known methods, matching the `IMethodSelector` contract (known methods, not the selected subset).

Fixes #2927

## Test Plan
- `./gradlew :testng-core:test --tests test.methodselectors.MethodSelectorTest` (9/9, including GITHUB-2927 with @BeforeMethod)
- `./gradlew :testng-core:test --tests org.testng.TestClassConfigurationLookupTest`
- `./gradlew autostyleApply`
- `./gradlew :testng-core-api:compileJava --rerun :testng-core:compileJava --rerun :testng-core:compileTestJava --rerun`
- `./gradlew rewriteDryRun --no-configuration-cache` (no recipe changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved method selection so selectors receive the complete, correctly associated list of test methods before filtering.
  * Ensured configuration methods are initialized before group-method calculations.

* **Documentation**
  * Clarified method-selector callback behavior and the scope of the provided test-method list.

* **Tests**
  * Added regression coverage confirming method selectors receive all known test methods and configuration setup runs correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->